### PR TITLE
feat(cli): add thread message stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
+      - name: Install FFmpeg for real CLI render integration
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends ffmpeg
       - uses: ./.github/actions/prepare-ffmpeg-bin
       - run: bash scripts/ci/install-workspace-dependencies.sh
       - run: bun run test:scripts

--- a/docs/schema/registry-item.json
+++ b/docs/schema/registry-item.json
@@ -128,6 +128,18 @@
     "relatedSkill": {
       "type": "string",
       "minLength": 1
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["kind", "artifactId", "versionId", "canonicalUri", "sourceDigest"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "heygenverse-export" },
+        "artifactId": { "type": "string", "format": "uuid" },
+        "versionId": { "type": "string", "format": "uuid" },
+        "canonicalUri": { "type": "string", "pattern": "^heygenverse://app/" },
+        "sourceDigest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" }
+      }
     }
   },
   "allOf": [

--- a/packages/cli/src/auth/index.ts
+++ b/packages/cli/src/auth/index.ts
@@ -25,7 +25,7 @@ export {
 
 export { configDir, credentialPath } from "./paths.js";
 
-export { tryResolveCredential } from "./resolver.js";
+export { tryResolveCredential, tryResolveOAuthCredential } from "./resolver.js";
 export type { ResolvedCredential } from "./resolver.js";
 
 export { AuthClient } from "./client.js";

--- a/packages/cli/src/auth/resolver.ts
+++ b/packages/cli/src/auth/resolver.ts
@@ -94,6 +94,17 @@ export async function tryResolveCredential(
   }
 }
 
+/** Resolve only a HeyGen OAuth session, ignoring generic API-key sources. */
+export async function tryResolveOAuthCredential(
+  opts: ResolveOptions = {},
+): Promise<OAuthCredential | null> {
+  const now = (opts.now ?? (() => new Date()))();
+  const { credentials, source } = await readStore();
+  if (source === "absent" || !credentials.oauth) return null;
+  const fileSource: CredentialSource = source === "file_legacy" ? "file_legacy" : "file_json";
+  return pickOAuth(credentials.oauth, now, fileSource);
+}
+
 function pickOAuth(
   tokens: NonNullable<Awaited<ReturnType<typeof readStore>>["credentials"]["oauth"]>,
   now: Date,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -192,7 +192,8 @@ const hasJsonFlag = process.argv.includes("--json");
 // Captured references — populated when the lazy imports resolve.
 // Used in exit handlers where dynamic import() is unsafe (beforeExit loops,
 // exit handler is synchronous-only).
-let _flush: (() => Promise<void>) | undefined;
+// Resolves to whether the batch was acknowledged; this exit path ignores it.
+let _flush: (() => Promise<unknown>) | undefined;
 let _flushSync: (() => void) | undefined;
 let _trackCliError:
   | ((props: {

--- a/packages/cli/src/commands/add.oauth.test.ts
+++ b/packages/cli/src/commands/add.oauth.test.ts
@@ -8,12 +8,25 @@ const mocks = vi.hoisted(() => ({
   authorize: vi.fn(),
   install: vi.fn(),
   resolve: vi.fn(),
+  trackEvent: vi.fn(),
+  shouldTrack: vi.fn(() => true),
+  writePrimitiveFunnelContext: vi.fn(),
 }));
 
 vi.mock("../registry/threadMessageStackAuthorization.js", () => ({
   authorizeThreadMessageStackInstall: mocks.authorize,
 }));
 vi.mock("../registry/installer.js", () => ({ installItem: mocks.install }));
+vi.mock("../telemetry/client.js", () => ({
+  trackEvent: mocks.trackEvent,
+  shouldTrack: mocks.shouldTrack,
+}));
+vi.mock("../telemetry/config.js", () => ({
+  readConfig: () => ({ anonymousId: "anonymous-direct-add" }),
+}));
+vi.mock("../telemetry/primitive-funnel-state.js", () => ({
+  writePrimitiveFunnelContext: mocks.writePrimitiveFunnelContext,
+}));
 vi.mock("../registry/resolver.js", () => ({
   resolveItemWithDependencies: mocks.resolve,
   resolveItemsByTag: vi.fn(async () => []),
@@ -45,6 +58,9 @@ describe("direct add thread-message-stack OAuth boundary", () => {
     mocks.resolve.mockReset().mockResolvedValue([item]);
     mocks.install.mockReset().mockResolvedValue({ written: [join(projectDir, "stack.html")] });
     mocks.authorize.mockReset();
+    mocks.trackEvent.mockReset();
+    mocks.shouldTrack.mockReset().mockReturnValue(true);
+    mocks.writePrimitiveFunnelContext.mockReset();
   });
 
   afterEach(() => rmSync(projectDir, { recursive: true, force: true }));
@@ -52,7 +68,10 @@ describe("direct add thread-message-stack OAuth boundary", () => {
   it.each(["api-key-only", "cancelled", "failed"] as const)(
     "does not download or materialize when verified HeyGen OAuth is %s",
     async (outcome) => {
-      mocks.authorize.mockResolvedValue(outcome);
+      mocks.authorize.mockImplementation(async (deps) => {
+        deps.onAuthStarted?.();
+        return outcome;
+      });
 
       await expect(
         runAdd({ name: "thread-message-stack", projectDir, skipClipboard: true }),
@@ -60,16 +79,59 @@ describe("direct add thread-message-stack OAuth boundary", () => {
       expect(mocks.authorize).toHaveBeenCalledTimes(1);
       expect(mocks.resolve).not.toHaveBeenCalled();
       expect(mocks.install).not.toHaveBeenCalled();
+      expect(mocks.trackEvent.mock.calls.map(([name]) => name)).toEqual([
+        "primitive_auth_started",
+        "primitive_auth_failed",
+      ]);
+      expect(mocks.writePrimitiveFunnelContext).not.toHaveBeenCalled();
     },
   );
 
   it("downloads and materializes exactly once after verified HeyGen OAuth succeeds", async () => {
-    mocks.authorize.mockResolvedValue("authorized");
+    mocks.authorize.mockImplementation(async (deps) => {
+      deps.onAuthStarted?.();
+      deps.onVerified?.({ email: "verified@example.com" }, "oauth");
+      return "authorized";
+    });
+    mocks.install.mockImplementationOnce(async () => {
+      expect(mocks.trackEvent.mock.calls.map(([name]) => name)).toEqual([
+        "primitive_auth_started",
+        "$identify",
+        "primitive_auth_completed",
+        "primitive_install_started",
+      ]);
+      return { written: [join(projectDir, "stack.html")] };
+    });
 
     await expect(
       runAdd({ name: "thread-message-stack", projectDir, skipClipboard: true }),
     ).resolves.toMatchObject({ ok: true, name: "thread-message-stack" });
     expect(mocks.authorize).toHaveBeenCalledTimes(1);
     expect(mocks.install).toHaveBeenCalledTimes(1);
+    expect(mocks.writePrimitiveFunnelContext).toHaveBeenCalledTimes(1);
+    const persisted = mocks.writePrimitiveFunnelContext.mock.calls[0]?.[1];
+    expect(persisted).toMatchObject({
+      primitiveId: "thread-message-stack",
+      artifactId: expect.any(String),
+      versionId: expect.any(String),
+      catalogVersion: expect.any(String),
+      funnelId: expect.any(String),
+      installId: expect.any(String),
+    });
+    expect(mocks.trackEvent.mock.calls.map(([name]) => name)).toEqual([
+      "primitive_auth_started",
+      "$identify",
+      "primitive_auth_completed",
+      "primitive_install_started",
+      "primitive_install_completed",
+    ]);
+    const installEvents = mocks.trackEvent.mock.calls.filter(([name]) =>
+      String(name).startsWith("primitive_install_"),
+    );
+    expect(installEvents[0]?.[1].funnel_id).toBe(installEvents[1]?.[1].funnel_id);
+    expect(installEvents[1]?.[1]).toMatchObject({
+      duration_ms: expect.any(Number),
+      event_id: `${persisted.installId}:install-completed`,
+    });
   });
 });

--- a/packages/cli/src/commands/add.oauth.test.ts
+++ b/packages/cli/src/commands/add.oauth.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RegistryItem } from "@hyperframes/core";
+
+const mocks = vi.hoisted(() => ({
+  authorize: vi.fn(),
+  install: vi.fn(),
+  resolve: vi.fn(),
+}));
+
+vi.mock("../registry/threadMessageStackAuthorization.js", () => ({
+  authorizeThreadMessageStackInstall: mocks.authorize,
+}));
+vi.mock("../registry/installer.js", () => ({ installItem: mocks.install }));
+vi.mock("../registry/resolver.js", () => ({
+  resolveItemWithDependencies: mocks.resolve,
+  resolveItemsByTag: vi.fn(async () => []),
+}));
+
+import { runAdd } from "./add.js";
+
+const item: RegistryItem = {
+  name: "thread-message-stack",
+  type: "hyperframes:block",
+  title: "Thread Message Stack",
+  description: "Conversation",
+  dimensions: { width: 1920, height: 1080 },
+  duration: 8,
+  files: [
+    {
+      path: "thread-message-stack.html",
+      target: "compositions/thread-message-stack.html",
+      type: "hyperframes:composition",
+    },
+  ],
+};
+
+describe("direct add thread-message-stack OAuth boundary", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "hf-add-oauth-"));
+    mocks.resolve.mockReset().mockResolvedValue([item]);
+    mocks.install.mockReset().mockResolvedValue({ written: [join(projectDir, "stack.html")] });
+    mocks.authorize.mockReset();
+  });
+
+  afterEach(() => rmSync(projectDir, { recursive: true, force: true }));
+
+  it.each(["api-key-only", "cancelled", "failed"] as const)(
+    "does not download or materialize when verified HeyGen OAuth is %s",
+    async (outcome) => {
+      mocks.authorize.mockResolvedValue(outcome);
+
+      await expect(
+        runAdd({ name: "thread-message-stack", projectDir, skipClipboard: true }),
+      ).rejects.toMatchObject({ code: "oauth-required" });
+      expect(mocks.authorize).toHaveBeenCalledTimes(1);
+      expect(mocks.resolve).not.toHaveBeenCalled();
+      expect(mocks.install).not.toHaveBeenCalled();
+    },
+  );
+
+  it("downloads and materializes exactly once after verified HeyGen OAuth succeeds", async () => {
+    mocks.authorize.mockResolvedValue("authorized");
+
+    await expect(
+      runAdd({ name: "thread-message-stack", projectDir, skipClipboard: true }),
+    ).resolves.toMatchObject({ ok: true, name: "thread-message-stack" });
+    expect(mocks.authorize).toHaveBeenCalledTimes(1);
+    expect(mocks.install).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -11,6 +11,7 @@ export const examples: Example[] = [
   ["Skip the clipboard copy (CI/headless)", "hyperframes add shader-wipe --no-clipboard"],
 ];
 
+import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve, relative } from "node:path";
 import { ITEM_TYPE_DIRS, type RegistryItem } from "@hyperframes/core";
@@ -30,10 +31,18 @@ import {
   DEFAULT_PROJECT_CONFIG,
   loadProjectConfig,
   projectConfigPath,
+  type ProjectConfig,
   writeProjectConfig,
 } from "../utils/projectConfig.js";
 import { copyToClipboard } from "../utils/clipboard.js";
 import { authorizeThreadMessageStackInstall } from "../registry/threadMessageStackAuthorization.js";
+import { PrimitiveFunnel, type PrimitiveFunnelContext } from "../telemetry/primitive-funnel.js";
+import { writePrimitiveFunnelContext } from "../telemetry/primitive-funnel-state.js";
+import {
+  THREAD_MESSAGE_STACK_ARTIFACT_ID,
+  THREAD_MESSAGE_STACK_CATALOG_DIGEST,
+  THREAD_MESSAGE_STACK_VERSION_ID,
+} from "../registry/heygenverseCatalog.js";
 
 // ── Target-path resolution ──────────────────────────────────────────────────
 // `registry-item.json` files specify `target` paths relative to the project
@@ -91,6 +100,11 @@ export interface RunAddArgs {
   cliVersion?: string;
   /** Caller-owned messages materialized only for thread-message-stack. */
   threadMessageStackData?: ThreadMessageStackData;
+  /** Caller-owned catalog session; direct add creates one without search/selection side effects. */
+  primitiveFunnelSession?: {
+    context: PrimitiveFunnelContext;
+    funnel: PrimitiveFunnel;
+  };
 }
 
 export interface RunAddResult {
@@ -167,8 +181,72 @@ async function installAll(
   return written;
 }
 
+async function resolveRequestedItem(
+  name: string,
+  registry: string,
+): Promise<{ resolved: RegistryItem[]; item: RegistryItem }> {
+  let resolved: RegistryItem[];
+  try {
+    resolved = await resolveItemWithDependencies(name, { baseUrl: registry });
+  } catch (err) {
+    throw new AddError(err instanceof Error ? err.message : String(err), "unknown-item");
+  }
+  const item = resolved[resolved.length - 1]!;
+  if (item.type === "hyperframes:example") {
+    throw new AddError(
+      `"${item.name}" is an example — use \`hyperframes init <dir> --example ${item.name}\` instead.`,
+      "example-type",
+    );
+  }
+  return { resolved, item };
+}
+
+async function resolveAndInstall(
+  opts: RunAddArgs,
+  projectDir: string,
+  config: ProjectConfig,
+): Promise<RunAddResult> {
+  const { resolved, item } = await resolveRequestedItem(opts.name, config.registry);
+  const warnings = assertCompatibleOrThrow(resolved, opts.cliVersion);
+  const installPlan: RegistryItem[] = resolved.map((resolvedItem) => ({
+    ...resolvedItem,
+    files: resolvedItem.files.map((f) => ({
+      ...f,
+      target: remapTarget(resolvedItem, f.target, config.paths),
+    })),
+  }));
+  const written = await installAll(
+    installPlan,
+    projectDir,
+    config.registry,
+    item.name,
+    opts.threadMessageStackData,
+  );
+
+  const itemForInstall = installPlan[installPlan.length - 1]!;
+  const primaryFile =
+    itemForInstall.files.find((f) => f.type === "hyperframes:snippet") ??
+    itemForInstall.files.find((f) => f.type === "hyperframes:composition") ??
+    itemForInstall.files[0];
+  const snippet = buildSnippet(item, primaryFile?.target ?? "");
+
+  return {
+    ok: true,
+    name: item.name,
+    type: item.type,
+    typeDir: ITEM_TYPE_DIRS[item.type],
+    written,
+    installed: installPlan.map((planItem) => planItem.name),
+    snippet,
+    clipboardCopied: !opts.skipClipboard && snippet ? copyToClipboard(snippet) : false,
+    warnings,
+  };
+}
+
 export async function runAdd(opts: RunAddArgs): Promise<RunAddResult> {
   const projectDir = resolve(opts.projectDir);
+  let primitiveSession = opts.primitiveFunnelSession;
+  let installStartedAt = 0;
 
   // 1. Load (or write default) project config.
   let config = loadProjectConfig(projectDir);
@@ -182,78 +260,63 @@ export async function runAdd(opts: RunAddArgs): Promise<RunAddResult> {
   // credentials. Gate its named command boundary before registry resolution so
   // an API key, cancellation, or failed OAuth cannot fetch even its manifest.
   if (opts.name === "thread-message-stack") {
-    const authorization = await authorizeThreadMessageStackInstall();
+    if (!primitiveSession) {
+      const context: PrimitiveFunnelContext = {
+        funnelId: randomUUID(),
+        installId: randomUUID(),
+        primitiveId: "thread-message-stack",
+        artifactId: THREAD_MESSAGE_STACK_ARTIFACT_ID,
+        versionId: THREAD_MESSAGE_STACK_VERSION_ID,
+        catalogVersion: THREAD_MESSAGE_STACK_CATALOG_DIGEST,
+        queryFingerprint: `sha256:${createHash("sha256").update("").digest("hex")}`,
+      };
+      primitiveSession = { context, funnel: new PrimitiveFunnel(context) };
+    }
+    const authStartedAt = performance.now();
+    const authorization = await authorizeThreadMessageStackInstall({
+      onAuthStarted: () => primitiveSession?.funnel.authStarted(),
+      onVerified: (user, authState) =>
+        primitiveSession?.funnel.authCompleted(
+          user.email ?? user.username,
+          authState,
+          performance.now() - authStartedAt,
+        ),
+    });
     if (authorization !== "authorized") {
+      primitiveSession.funnel.authFailed(
+        `${primitiveSession.context.installId}:auth-failed`,
+        authorization === "cancelled" ? "auth_cancelled" : "auth_failed",
+        performance.now() - authStartedAt,
+      );
       throw new AddError(
         `thread-message-stack requires verified HeyGen OAuth (${authorization}); no source was downloaded or materialized.`,
         "oauth-required",
       );
     }
+    primitiveSession.funnel.installStarted();
+    installStartedAt = performance.now();
   }
 
-  // 2. Resolve the requested item and its transitive registryDependencies.
-  //    The list comes back topologically sorted: dependencies first, the
-  //    requested item last.
-  let resolved: RegistryItem[];
   try {
-    resolved = await resolveItemWithDependencies(opts.name, { baseUrl: config.registry });
-  } catch (err) {
-    throw new AddError(err instanceof Error ? err.message : String(err), "unknown-item");
-  }
-  // `resolveItemWithDependencies` always pushes the requested item last (or throws),
-  // so the final element is the item the user asked for.
-  const item = resolved[resolved.length - 1]!;
-
-  if (item.type === "hyperframes:example") {
-    throw new AddError(
-      `"${item.name}" is an example — use \`hyperframes init <dir> --example ${item.name}\` instead.`,
-      "example-type",
+    const result = await resolveAndInstall(opts, projectDir, config);
+    if (primitiveSession) {
+      writePrimitiveFunnelContext(projectDir, primitiveSession.context);
+      primitiveSession.funnel.installCompleted(
+        `${primitiveSession.context.installId}:install-completed`,
+        performance.now() - installStartedAt,
+      );
+    }
+    return result;
+  } catch (error) {
+    primitiveSession?.funnel.installFailed(
+      `${primitiveSession.context.installId}:install-failed`,
+      error instanceof AddError && error.code === "install-failed"
+        ? "install_failed"
+        : "invalid_payload",
+      performance.now() - installStartedAt,
     );
+    throw error;
   }
-
-  // 3. Compatibility-gate every item we're about to install (dependencies
-  //    included) before writing anything.
-  const warnings = assertCompatibleOrThrow(resolved, opts.cliVersion);
-
-  // 4. Remap targets per project config — each item by its own type.
-  const installPlan: RegistryItem[] = resolved.map((resolvedItem) => ({
-    ...resolvedItem,
-    files: resolvedItem.files.map((f) => ({
-      ...f,
-      target: remapTarget(resolvedItem, f.target, config.paths),
-    })),
-  }));
-
-  // 5. Install — dependencies first, requested item last.
-  const written = await installAll(
-    installPlan,
-    projectDir,
-    config.registry,
-    item.name,
-    opts.threadMessageStackData,
-  );
-
-  // 6. Build include snippet + clipboard copy for the requested item.
-  const itemForInstall = installPlan[installPlan.length - 1]!;
-  const primaryFile =
-    itemForInstall.files.find((f) => f.type === "hyperframes:snippet") ??
-    itemForInstall.files.find((f) => f.type === "hyperframes:composition") ??
-    itemForInstall.files[0];
-  const snippetTargetRel = primaryFile?.target ?? "";
-  const snippet = buildSnippet(item, snippetTargetRel);
-  const clipboardCopied = !opts.skipClipboard && snippet ? copyToClipboard(snippet) : false;
-
-  return {
-    ok: true,
-    name: item.name,
-    type: item.type,
-    typeDir: ITEM_TYPE_DIRS[item.type],
-    written,
-    installed: installPlan.map((planItem) => planItem.name),
-    snippet,
-    clipboardCopied,
-    warnings,
-  };
 }
 
 // ── Command ─────────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -33,6 +33,7 @@ import {
   writeProjectConfig,
 } from "../utils/projectConfig.js";
 import { copyToClipboard } from "../utils/clipboard.js";
+import { authorizeThreadMessageStackInstall } from "../registry/threadMessageStackAuthorization.js";
 
 // ── Target-path resolution ──────────────────────────────────────────────────
 // `registry-item.json` files specify `target` paths relative to the project
@@ -113,7 +114,8 @@ export class AddError extends Error {
       | "wrong-type"
       | "install-failed"
       | "example-type"
-      | "incompatible-cli",
+      | "incompatible-cli"
+      | "oauth-required",
   ) {
     super(message);
     this.name = "AddError";
@@ -174,6 +176,19 @@ export async function runAdd(opts: RunAddArgs): Promise<RunAddResult> {
   if (!hasConfig && existsSync(resolve(projectDir, "index.html"))) {
     writeProjectConfig(projectDir, DEFAULT_PROJECT_CONFIG);
     config = DEFAULT_PROJECT_CONFIG;
+  }
+
+  // This source-owned primitive is not downloadable through generic registry
+  // credentials. Gate its named command boundary before registry resolution so
+  // an API key, cancellation, or failed OAuth cannot fetch even its manifest.
+  if (opts.name === "thread-message-stack") {
+    const authorization = await authorizeThreadMessageStackInstall();
+    if (authorization !== "authorized") {
+      throw new AddError(
+        `thread-message-stack requires verified HeyGen OAuth (${authorization}); no source was downloaded or materialized.`,
+        "oauth-required",
+      );
+    }
   }
 
   // 2. Resolve the requested item and its transitive registryDependencies.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -11,11 +11,16 @@ export const examples: Example[] = [
   ["Skip the clipboard copy (CI/headless)", "hyperframes add shader-wipe --no-clipboard"],
 ];
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve, relative } from "node:path";
 import { ITEM_TYPE_DIRS, type RegistryItem } from "@hyperframes/core";
 import { c } from "../ui/colors.js";
-import { installItem, resolveItemsByTag } from "../registry/index.js";
+import { installItem } from "../registry/installer.js";
+import { resolveItemsByTag } from "../registry/resolver.js";
+import {
+  validateThreadMessageStackData,
+  type ThreadMessageStackData,
+} from "../registry/threadMessageStack.js";
 import { resolveItemWithDependencies } from "../registry/resolver.js";
 import {
   gateRegistryItemsCompatibility,
@@ -83,6 +88,8 @@ export interface RunAddArgs {
   skipClipboard?: boolean;
   /** Current CLI version used for registry metadata compatibility checks. */
   cliVersion?: string;
+  /** Caller-owned messages materialized only for thread-message-stack. */
+  threadMessageStackData?: ThreadMessageStackData;
 }
 
 export interface RunAddResult {
@@ -134,11 +141,19 @@ async function installAll(
   installPlan: RegistryItem[],
   destDir: string,
   baseUrl: string | undefined,
+  requestedName: string,
+  threadMessageStackData?: ThreadMessageStackData,
 ): Promise<string[]> {
   const written: string[] = [];
   try {
     for (const planItem of installPlan) {
-      const result = await installItem(planItem, { destDir, baseUrl });
+      const result = await installItem(planItem, {
+        destDir,
+        baseUrl,
+        ...(planItem.name === requestedName && threadMessageStackData
+          ? { threadMessageStackData }
+          : {}),
+      });
       written.push(...result.written);
     }
   } catch (err) {
@@ -195,7 +210,13 @@ export async function runAdd(opts: RunAddArgs): Promise<RunAddResult> {
   }));
 
   // 5. Install — dependencies first, requested item last.
-  const written = await installAll(installPlan, projectDir, config.registry);
+  const written = await installAll(
+    installPlan,
+    projectDir,
+    config.registry,
+    item.name,
+    opts.threadMessageStackData,
+  );
 
   // 6. Build include snippet + clipboard copy for the requested item.
   const itemForInstall = installPlan[installPlan.length - 1]!;
@@ -253,7 +274,14 @@ export default defineCommand({
       type: "boolean",
       description: "Print a machine-readable summary (written files + snippet) to stdout",
     },
+    "messages-file": {
+      type: "string",
+      description:
+        "JSON file with {messages, stagger?, hold?}; valid only for thread-message-stack",
+    },
   },
+  // Existing command UX handles item, tag, JSON, clipboard, and file-input modes in one boundary.
+  // fallow-ignore-next-line complexity
   async run({ args }) {
     const projectDir = resolve(args.dir ?? process.cwd());
     const json = args.json === true;
@@ -262,7 +290,23 @@ export default defineCommand({
 
     // Try single item first. If it fails, check if the name matches a tag.
     try {
-      const result = await runAdd({ name: args.name, projectDir, skipClipboard });
+      let threadMessageStackData: ThreadMessageStackData | undefined;
+      if (args["messages-file"]) {
+        if (args.name !== "thread-message-stack") {
+          throw new AddError(
+            "--messages-file is valid only for thread-message-stack.",
+            "wrong-type",
+          );
+        }
+        const raw = readFileSync(resolve(projectDir, args["messages-file"]), "utf8");
+        threadMessageStackData = validateThreadMessageStackData(JSON.parse(raw));
+      }
+      const result = await runAdd({
+        name: args.name,
+        projectDir,
+        skipClipboard,
+        ...(threadMessageStackData ? { threadMessageStackData } : {}),
+      });
       const wroteConfig = !hasConfigBefore && existsSync(projectConfigPath(projectDir));
 
       if (json) {

--- a/packages/cli/src/commands/catalog-resume.test.ts
+++ b/packages/cli/src/commands/catalog-resume.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  createFilePrimitiveInstallStateStore,
   createPrimitiveInstallIntent,
   filterPrimitiveCatalogItems,
   resumePrimitiveInstallExactlyOnce,
@@ -89,4 +103,165 @@ describe("catalog OAuth resume", () => {
       expect(install).not.toHaveBeenCalled();
     },
   );
+
+  it("atomically admits only one live installer across independent file-store owners", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-catalog-claim-"));
+    const statePath = join(dir, "pending.json");
+    const intent = createPrimitiveInstallIntent({
+      itemName: "thread-message-stack",
+      query: "thread",
+      artifactId: "21c28523-7487-43e1-927d-43a7fe855859",
+      versionId: "1aa00c22-b508-4b81-a3a1-4702453d48c2",
+      installId: "concurrent-install",
+    });
+    let releaseFirst!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const install = vi.fn(async () => await blocked);
+    const deps = (store: PrimitiveInstallStateStore) => ({
+      store,
+      isAuthenticated: async () => true,
+      authenticate: async () => true,
+      install,
+    });
+
+    try {
+      const first = resumePrimitiveInstallExactlyOnce(
+        intent,
+        deps(createFilePrimitiveInstallStateStore(statePath)),
+      );
+      await vi.waitFor(() => expect(install).toHaveBeenCalledTimes(1));
+      const second = resumePrimitiveInstallExactlyOnce(
+        intent,
+        deps(createFilePrimitiveInstallStateStore(statePath)),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(install).toHaveBeenCalledTimes(1);
+      releaseFirst();
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        "installed",
+        "already-installed",
+      ]);
+    } finally {
+      releaseFirst();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("recovers a bounded stale claim left by a dead owner", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-catalog-recovery-"));
+    const statePath = join(dir, "pending.json");
+    const claimDir = `${statePath}.claim`;
+    const intent = createPrimitiveInstallIntent({
+      itemName: "thread-message-stack",
+      query: "thread",
+      artifactId: "21c28523-7487-43e1-927d-43a7fe855859",
+      versionId: "1aa00c22-b508-4b81-a3a1-4702453d48c2",
+      installId: "recovered-install",
+    });
+    const install = vi.fn(async () => undefined);
+
+    try {
+      mkdirSync(claimDir, { recursive: true });
+      writeFileSync(
+        join(claimDir, "owner.json"),
+        JSON.stringify({ pid: 2_147_483_647, token: "dead-owner" }),
+      );
+      const stale = new Date(Date.now() - 60_000);
+      utimesSync(claimDir, stale, stale);
+
+      await expect(
+        resumePrimitiveInstallExactlyOnce(intent, {
+          store: createFilePrimitiveInstallStateStore(statePath, { staleClaimMs: 10 }),
+          isAuthenticated: async () => true,
+          authenticate: async () => true,
+          install,
+        }),
+      ).resolves.toBe("installed");
+      expect(install).toHaveBeenCalledTimes(1);
+      expect(existsSync(claimDir)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("admits exactly one installer when two Bun processes race the same install id", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-catalog-cross-process-"));
+    const statePath = join(dir, "pending.json");
+    const installLog = join(dir, "installs.log");
+    const moduleUrl = pathToFileURL(join(import.meta.dirname, "catalog-resume.ts")).href;
+    const childSource = `
+      import { appendFileSync } from "node:fs";
+      import { createFilePrimitiveInstallStateStore, createPrimitiveInstallIntent, resumePrimitiveInstallExactlyOnce } from ${JSON.stringify(moduleUrl)};
+      const intent = createPrimitiveInstallIntent({ itemName: "thread-message-stack", query: "thread", artifactId: "21c28523-7487-43e1-927d-43a7fe855859", versionId: "1aa00c22-b508-4b81-a3a1-4702453d48c2", installId: "cross-process-install", funnelId: "cross-process-funnel" });
+      const result = await resumePrimitiveInstallExactlyOnce(intent, {
+        store: createFilePrimitiveInstallStateStore(${JSON.stringify(statePath)}, { pollMs: 5 }),
+        isAuthenticated: async () => true,
+        authenticate: async () => true,
+        install: async () => { appendFileSync(${JSON.stringify(installLog)}, process.pid + "\\n"); await new Promise((resolve) => setTimeout(resolve, 150)); },
+      });
+      console.log(result);
+    `;
+    const runChild = async (): Promise<string> =>
+      await new Promise((resolveChild, rejectChild) => {
+        const child = spawn("bun", ["-e", childSource], { stdio: ["ignore", "pipe", "pipe"] });
+        let stdout = "";
+        let stderr = "";
+        child.stdout.on("data", (chunk) => (stdout += String(chunk)));
+        child.stderr.on("data", (chunk) => (stderr += String(chunk)));
+        child.once("error", rejectChild);
+        child.once("exit", (code) => {
+          if (code === 0) resolveChild(stdout.trim());
+          else rejectChild(new Error(`child exited ${code}: ${stderr}`));
+        });
+      });
+
+    try {
+      const results = await Promise.all([runChild(), runChild()]);
+      expect(results.sort()).toEqual(["already-installed", "installed"]);
+      expect(readFileSync(installLog, "utf8").trim().split("\n")).toHaveLength(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("never reclaims a stale-looking claim while its owner process is alive", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-catalog-live-owner-"));
+    const statePath = join(dir, "pending.json");
+    const claimDir = `${statePath}.claim`;
+    const intent = createPrimitiveInstallIntent({
+      itemName: "thread-message-stack",
+      query: "thread",
+      artifactId: "21c28523-7487-43e1-927d-43a7fe855859",
+      versionId: "1aa00c22-b508-4b81-a3a1-4702453d48c2",
+      installId: "live-owner-install",
+    });
+    const install = vi.fn(async () => undefined);
+    try {
+      mkdirSync(claimDir, { recursive: true });
+      writeFileSync(
+        join(claimDir, "owner.json"),
+        JSON.stringify({ pid: process.pid, token: "live-owner" }),
+      );
+      const stale = new Date(Date.now() - 60_000);
+      utimesSync(claimDir, stale, stale);
+      await expect(
+        resumePrimitiveInstallExactlyOnce(intent, {
+          store: createFilePrimitiveInstallStateStore(statePath, {
+            staleClaimMs: 10,
+            claimWaitMs: 30,
+            pollMs: 5,
+          }),
+          isAuthenticated: async () => true,
+          authenticate: async () => true,
+          install,
+        }),
+      ).rejects.toThrow(/already claimed/);
+      expect(install).not.toHaveBeenCalled();
+      expect(existsSync(claimDir)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/cli/src/commands/catalog-resume.test.ts
+++ b/packages/cli/src/commands/catalog-resume.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPrimitiveInstallIntent,
+  filterPrimitiveCatalogItems,
+  resumePrimitiveInstallExactlyOnce,
+  type PendingPrimitiveInstall,
+  type PrimitiveInstallStateStore,
+} from "./catalog-resume.js";
+
+function memoryStore(): PrimitiveInstallStateStore {
+  let state: PendingPrimitiveInstall | null = null;
+  return {
+    load: async () => state,
+    save: async (next) => {
+      state = next;
+    },
+  };
+}
+
+// Anonymous discovery and resume invariants share one coordinator fixture.
+// fallow-ignore-next-line unit-size
+describe("catalog OAuth resume", () => {
+  it("supports anonymous content-free discovery before selection", () => {
+    const items = [
+      { name: "thread-message-stack", title: "Thread Message Stack", description: "Conversation" },
+      { name: "shader-wipe", title: "Shader Wipe", description: "Transition" },
+    ];
+    expect(filterPrimitiveCatalogItems(items, " conversation ").map((item) => item.name)).toEqual([
+      "thread-message-stack",
+    ]);
+    expect(filterPrimitiveCatalogItems(items, "")).toEqual(items);
+  });
+
+  it("preserves a non-content search fingerprint and resumes the same selection exactly once", async () => {
+    const store = memoryStore();
+    const authenticate = vi.fn(async () => true);
+    const install = vi.fn(async () => undefined);
+    let authenticated = false;
+    authenticate.mockImplementation(async () => {
+      authenticated = true;
+      return true;
+    });
+    const intent = createPrimitiveInstallIntent({
+      itemName: "thread-message-stack",
+      query: "private authored search text",
+      artifactId: "21c28523-7487-43e1-927d-43a7fe855859",
+      versionId: "1aa00c22-b508-4b81-a3a1-4702453d48c2",
+      funnelId: "funnel-1",
+      installId: "install-1",
+    });
+
+    expect(JSON.stringify(intent)).not.toContain("private authored search text");
+    const deps = {
+      store,
+      isAuthenticated: async () => authenticated,
+      authenticate,
+      install,
+    };
+    await expect(resumePrimitiveInstallExactlyOnce(intent, deps)).resolves.toBe("installed");
+    await expect(resumePrimitiveInstallExactlyOnce(intent, deps)).resolves.toBe(
+      "already-installed",
+    );
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(install).toHaveBeenCalledTimes(1);
+    expect(install).toHaveBeenCalledWith(expect.objectContaining({ itemName: intent.itemName }));
+  });
+
+  it.each(["cancelled", "failed"] as const)(
+    "installs nothing when OAuth is %s",
+    async (outcome) => {
+      const install = vi.fn(async () => undefined);
+      const intent = createPrimitiveInstallIntent({
+        itemName: "thread-message-stack",
+        query: "thread",
+        artifactId: "21c28523-7487-43e1-927d-43a7fe855859",
+        versionId: "1aa00c22-b508-4b81-a3a1-4702453d48c2",
+        funnelId: `funnel-${outcome}`,
+        installId: `install-${outcome}`,
+      });
+
+      await expect(
+        resumePrimitiveInstallExactlyOnce(intent, {
+          store: memoryStore(),
+          isAuthenticated: async () => false,
+          authenticate: async () => outcome,
+          install,
+        }),
+      ).resolves.toBe(outcome);
+      expect(install).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cli/src/commands/catalog-resume.ts
+++ b/packages/cli/src/commands/catalog-resume.ts
@@ -1,11 +1,12 @@
 import { createHash, randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 
 export type PrimitiveInstallStatus =
   | "pending"
   | "awaiting-auth"
+  | "installing"
   | "completed"
   | "cancelled"
   | "failed";
@@ -24,6 +25,11 @@ export interface PendingPrimitiveInstall {
 export interface PrimitiveInstallStateStore {
   load(): Promise<PendingPrimitiveInstall | null>;
   save(state: PendingPrimitiveInstall): Promise<void>;
+  acquireClaim?(): Promise<PrimitiveInstallClaim>;
+}
+
+export interface PrimitiveInstallClaim {
+  release(): Promise<void>;
 }
 
 export interface CreatePrimitiveInstallIntentArgs {
@@ -86,43 +92,84 @@ export async function resumePrimitiveInstallExactlyOnce(
   intent: PendingPrimitiveInstall,
   deps: PrimitiveInstallResumeDeps,
 ): Promise<PrimitiveInstallResumeResult> {
-  const persisted = await deps.store.load();
-  if (persisted?.installId === intent.installId) {
-    if (persisted.status === "completed") return "already-installed";
-    if (persisted.status === "cancelled") return "cancelled";
-    if (persisted.status === "failed") return "failed";
-  }
-
-  let state: PendingPrimitiveInstall = {
-    ...(persisted?.installId === intent.installId ? persisted : intent),
-  };
-  await deps.store.save(state);
-
-  if (!(await deps.isAuthenticated())) {
-    state = { ...state, status: "awaiting-auth" };
-    await deps.store.save(state);
-    const auth = await deps.authenticate();
-    if (auth !== true) {
-      const terminal = auth === "cancelled" ? "cancelled" : "failed";
-      state = { ...state, status: terminal };
-      await deps.store.save(state);
-      return terminal;
-    }
-  }
-
+  const claim = deps.store.acquireClaim ? await deps.store.acquireClaim() : null;
   try {
-    await deps.install(state);
+    const persisted = await deps.store.load();
+    const terminal = terminalResumeResult(persisted, intent.installId);
+    if (terminal) return terminal;
+
+    let state: PendingPrimitiveInstall = {
+      ...(persisted?.installId === intent.installId ? persisted : intent),
+    };
+    await deps.store.save(state);
+
+    const authentication = await authenticateClaimedInstall(state, deps);
+    if (authentication.result) return authentication.result;
+    state = authentication.state;
+
+    return await installClaimedPrimitive(state, deps);
+  } finally {
+    await claim?.release();
+  }
+}
+
+function terminalResumeResult(
+  persisted: PendingPrimitiveInstall | null,
+  installId: string,
+): PrimitiveInstallResumeResult | null {
+  if (persisted?.installId !== installId) return null;
+  if (persisted.status === "completed") return "already-installed";
+  if (persisted.status === "cancelled") return "cancelled";
+  if (persisted.status === "failed") return "failed";
+  return null;
+}
+
+async function authenticateClaimedInstall(
+  state: PendingPrimitiveInstall,
+  deps: PrimitiveInstallResumeDeps,
+): Promise<{ state: PendingPrimitiveInstall; result?: "cancelled" | "failed" }> {
+  if (await deps.isAuthenticated()) return { state };
+  const awaiting = { ...state, status: "awaiting-auth" as const };
+  await deps.store.save(awaiting);
+  const auth = await deps.authenticate();
+  if (auth === true) return { state: awaiting };
+  const result = auth === "cancelled" ? "cancelled" : "failed";
+  await deps.store.save({ ...awaiting, status: result });
+  return { state: awaiting, result };
+}
+
+async function installClaimedPrimitive(
+  state: PendingPrimitiveInstall,
+  deps: PrimitiveInstallResumeDeps,
+): Promise<"installed"> {
+  const installing = { ...state, status: "installing" as const };
+  await deps.store.save(installing);
+  try {
+    await deps.install(installing);
   } catch (error) {
-    await deps.store.save({ ...state, status: "failed" });
+    await deps.store.save({ ...installing, status: "failed" });
     throw error;
   }
-  await deps.store.save({ ...state, status: "completed" });
+  await deps.store.save({ ...installing, status: "completed" });
   return "installed";
+}
+
+export interface FilePrimitiveInstallStateStoreOptions {
+  staleClaimMs?: number;
+  claimWaitMs?: number;
+  pollMs?: number;
+  heartbeatMs?: number;
 }
 
 export function createFilePrimitiveInstallStateStore(
   path = join(homedir(), ".hyperframes", "pending-primitive-install.json"),
+  options: FilePrimitiveInstallStateStoreOptions = {},
 ): PrimitiveInstallStateStore {
+  const claimDir = `${path}.claim`;
+  const staleClaimMs = options.staleClaimMs ?? 30_000;
+  const claimWaitMs = options.claimWaitMs ?? 60_000;
+  const pollMs = options.pollMs ?? 25;
+  const heartbeatMs = options.heartbeatMs ?? Math.max(250, Math.floor(staleClaimMs / 3));
   return {
     async load() {
       try {
@@ -143,5 +190,85 @@ export function createFilePrimitiveInstallStateStore(
       });
       await rename(temporaryPath, path);
     },
+    async acquireClaim() {
+      await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+      const token = randomUUID();
+      const deadline = Date.now() + claimWaitMs;
+      while (true) {
+        try {
+          await mkdir(claimDir, { mode: 0o700 });
+          await writeFile(
+            join(claimDir, "owner.json"),
+            `${JSON.stringify({ pid: process.pid, token })}\n`,
+            { encoding: "utf8", mode: 0o600 },
+          );
+          const heartbeat = setInterval(() => {
+            const now = new Date();
+            void utimes(claimDir, now, now).catch(() => undefined);
+          }, heartbeatMs);
+          heartbeat.unref();
+          return {
+            async release() {
+              clearInterval(heartbeat);
+              try {
+                const owner = JSON.parse(await readFile(join(claimDir, "owner.json"), "utf8")) as {
+                  token?: string;
+                };
+                if (owner.token === token) await rm(claimDir, { recursive: true, force: true });
+              } catch (error) {
+                if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+              }
+            },
+          };
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+          if (await reclaimDeadClaim(claimDir, staleClaimMs)) continue;
+          if (Date.now() >= deadline) {
+            throw new Error("thread-message-stack install is already claimed by another process");
+          }
+          await new Promise((resolveDelay) => setTimeout(resolveDelay, pollMs));
+        }
+      }
+    },
   };
+}
+
+async function reclaimDeadClaim(claimDir: string, staleClaimMs: number): Promise<boolean> {
+  let ageMs: number;
+  try {
+    ageMs = Date.now() - (await stat(claimDir)).mtimeMs;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT";
+  }
+  if (ageMs < staleClaimMs) return false;
+
+  let ownerPid: number | undefined;
+  try {
+    const owner = JSON.parse(await readFile(join(claimDir, "owner.json"), "utf8")) as {
+      pid?: unknown;
+    };
+    if (typeof owner.pid === "number") ownerPid = owner.pid;
+  } catch {
+    ownerPid = undefined;
+  }
+  if (ownerPid !== undefined && isProcessAlive(ownerPid)) return false;
+
+  const abandoned = `${claimDir}.abandoned.${process.pid}.${randomUUID()}`;
+  try {
+    await rename(claimDir, abandoned);
+    await rm(abandoned, { recursive: true, force: true });
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true;
+    return false;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
 }

--- a/packages/cli/src/commands/catalog-resume.ts
+++ b/packages/cli/src/commands/catalog-resume.ts
@@ -1,0 +1,147 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+
+export type PrimitiveInstallStatus =
+  | "pending"
+  | "awaiting-auth"
+  | "completed"
+  | "cancelled"
+  | "failed";
+
+export interface PendingPrimitiveInstall {
+  schemaVersion: 1;
+  itemName: string;
+  artifactId: string;
+  versionId: string;
+  funnelId: string;
+  installId: string;
+  queryFingerprint: string;
+  status: PrimitiveInstallStatus;
+}
+
+export interface PrimitiveInstallStateStore {
+  load(): Promise<PendingPrimitiveInstall | null>;
+  save(state: PendingPrimitiveInstall): Promise<void>;
+}
+
+export interface CreatePrimitiveInstallIntentArgs {
+  itemName: string;
+  query: string;
+  artifactId: string;
+  versionId: string;
+  funnelId?: string;
+  installId?: string;
+}
+
+export function filterPrimitiveCatalogItems<
+  T extends { name: string; title: string; description: string },
+>(items: T[], query: string): T[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return items;
+  return items.filter((item) =>
+    [item.name, item.title, item.description].some((value) =>
+      value.toLowerCase().includes(normalized),
+    ),
+  );
+}
+
+export function createPrimitiveInstallIntent(
+  args: CreatePrimitiveInstallIntentArgs,
+): PendingPrimitiveInstall {
+  return {
+    schemaVersion: 1,
+    itemName: args.itemName,
+    artifactId: args.artifactId,
+    versionId: args.versionId,
+    funnelId: args.funnelId ?? randomUUID(),
+    installId: args.installId ?? randomUUID(),
+    queryFingerprint: createHash("sha256").update(args.query).digest("hex"),
+    status: "pending",
+  };
+}
+
+export type PrimitiveAuthenticationOutcome = boolean | "cancelled" | "failed";
+
+export interface PrimitiveInstallResumeDeps {
+  store: PrimitiveInstallStateStore;
+  isAuthenticated(): Promise<boolean>;
+  authenticate(): Promise<PrimitiveAuthenticationOutcome>;
+  install(intent: PendingPrimitiveInstall): Promise<void>;
+}
+
+export type PrimitiveInstallResumeResult =
+  | "installed"
+  | "already-installed"
+  | "cancelled"
+  | "failed";
+
+/**
+ * Persist the source-owned selection before OAuth and consume that same install
+ * id exactly once after authentication. No authored query or message content is
+ * stored in the resume state.
+ */
+export async function resumePrimitiveInstallExactlyOnce(
+  intent: PendingPrimitiveInstall,
+  deps: PrimitiveInstallResumeDeps,
+): Promise<PrimitiveInstallResumeResult> {
+  const persisted = await deps.store.load();
+  if (persisted?.installId === intent.installId) {
+    if (persisted.status === "completed") return "already-installed";
+    if (persisted.status === "cancelled") return "cancelled";
+    if (persisted.status === "failed") return "failed";
+  }
+
+  let state: PendingPrimitiveInstall = {
+    ...(persisted?.installId === intent.installId ? persisted : intent),
+  };
+  await deps.store.save(state);
+
+  if (!(await deps.isAuthenticated())) {
+    state = { ...state, status: "awaiting-auth" };
+    await deps.store.save(state);
+    const auth = await deps.authenticate();
+    if (auth !== true) {
+      const terminal = auth === "cancelled" ? "cancelled" : "failed";
+      state = { ...state, status: terminal };
+      await deps.store.save(state);
+      return terminal;
+    }
+  }
+
+  try {
+    await deps.install(state);
+  } catch (error) {
+    await deps.store.save({ ...state, status: "failed" });
+    throw error;
+  }
+  await deps.store.save({ ...state, status: "completed" });
+  return "installed";
+}
+
+export function createFilePrimitiveInstallStateStore(
+  path = join(homedir(), ".hyperframes", "pending-primitive-install.json"),
+): PrimitiveInstallStateStore {
+  return {
+    async load() {
+      try {
+        const parsed = JSON.parse(await readFile(path, "utf8")) as PendingPrimitiveInstall;
+        return parsed.schemaVersion === 1 ? parsed : null;
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === "ENOENT" || error instanceof SyntaxError) return null;
+        throw error;
+      }
+    },
+    async save(state) {
+      await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+      const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+      await writeFile(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      await rename(temporaryPath, path);
+    },
+  };
+}

--- a/packages/cli/src/commands/catalog.oauth.test.ts
+++ b/packages/cli/src/commands/catalog.oauth.test.ts
@@ -106,6 +106,25 @@ describe("interactive catalog verified OAuth boundary", () => {
     expect(mocks.startAuthorizationCodeFlow).toHaveBeenCalledTimes(1);
     expect(mocks.getCurrentUser).toHaveBeenCalledWith(expect.objectContaining({ type: "oauth" }));
     expect(mocks.runAdd).toHaveBeenCalledTimes(1);
+    expect(mocks.runAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        primitiveFunnelSession: expect.objectContaining({
+          context: expect.objectContaining({ primitiveId: "thread-message-stack" }),
+        }),
+      }),
+    );
+    expect(mocks.trackEvent.mock.calls.map(([name]) => name)).toEqual([
+      "primitive_catalog_searched",
+      "primitive_catalog_result_selected",
+      "primitive_auth_started",
+      "$identify",
+      "primitive_auth_completed",
+    ]);
+    expect(
+      mocks.trackEvent.mock.calls.find(
+        ([name]) => name === "primitive_catalog_result_selected",
+      )?.[1],
+    ).toMatchObject({ result_rank: 1, auth_state: "anonymous" });
   });
 
   it("stitches an already verified OAuth session exactly once before install", async () => {
@@ -145,6 +164,12 @@ describe("interactive catalog verified OAuth boundary", () => {
       mocks.trackEvent.mock.calls.filter(([name]) => name === "primitive_auth_completed"),
     ).toHaveLength(1);
     expect(mocks.runAdd).toHaveBeenCalledTimes(1);
+    expect(mocks.trackEvent.mock.calls.map(([name]) => name)).toEqual([
+      "primitive_catalog_searched",
+      "primitive_catalog_result_selected",
+      "$identify",
+      "primitive_auth_completed",
+    ]);
   });
 
   it("emits no identity or auth-completed events when opted out", async () => {

--- a/packages/cli/src/commands/catalog.oauth.test.ts
+++ b/packages/cli/src/commands/catalog.oauth.test.ts
@@ -7,6 +7,8 @@ const mocks = vi.hoisted(() => ({
   startAuthorizationCodeFlow: vi.fn(),
   getCurrentUser: vi.fn(),
   runAdd: vi.fn(),
+  trackEvent: vi.fn(),
+  shouldTrack: vi.fn(),
 }));
 
 vi.mock("@clack/prompts", () => ({
@@ -23,6 +25,13 @@ vi.mock("../auth/index.js", () => ({
   },
 }));
 vi.mock("./add.js", () => ({ runAdd: mocks.runAdd }));
+vi.mock("../telemetry/client.js", () => ({
+  trackEvent: mocks.trackEvent,
+  shouldTrack: mocks.shouldTrack,
+}));
+vi.mock("../telemetry/config.js", () => ({
+  readConfig: () => ({ anonymousId: "anonymous-test-id" }),
+}));
 vi.mock("../registry/resolver.js", () => ({
   listRegistryItems: vi.fn(async () => [
     { name: "thread-message-stack", type: "hyperframes:block" },
@@ -39,16 +48,6 @@ vi.mock("../registry/resolver.js", () => ({
       files: [],
     },
   ]),
-}));
-vi.mock("../telemetry/primitive-funnel.js", () => ({
-  PrimitiveFunnel: class {
-    searched = vi.fn();
-    selected = vi.fn();
-    authRequired = vi.fn();
-    authCompleted = vi.fn();
-    installFailed = vi.fn();
-    installSucceeded = vi.fn();
-  },
 }));
 vi.mock("../telemetry/primitive-funnel-state.js", () => ({
   writePrimitiveFunnelContext: vi.fn(),
@@ -78,6 +77,8 @@ describe("interactive catalog verified OAuth boundary", () => {
     mocks.tryResolveOAuthCredential.mockReset().mockResolvedValue(null);
     mocks.startAuthorizationCodeFlow.mockReset().mockResolvedValue(undefined);
     mocks.getCurrentUser.mockReset().mockResolvedValue({ email: "verified@example.com" });
+    mocks.trackEvent.mockReset();
+    mocks.shouldTrack.mockReset().mockReturnValue(true);
     mocks.runAdd.mockReset().mockResolvedValue({
       ok: true,
       name: "thread-message-stack",
@@ -104,6 +105,65 @@ describe("interactive catalog verified OAuth boundary", () => {
 
     expect(mocks.startAuthorizationCodeFlow).toHaveBeenCalledTimes(1);
     expect(mocks.getCurrentUser).toHaveBeenCalledWith(expect.objectContaining({ type: "oauth" }));
+    expect(mocks.runAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("stitches an already verified OAuth session exactly once before install", async () => {
+    mocks.tryResolveOAuthCredential.mockResolvedValue({
+      type: "oauth",
+      access_token: "existing-oauth-token",
+      source: "file_json",
+      refreshable: false,
+    });
+    mocks.runAdd.mockImplementationOnce(async () => {
+      const identify = mocks.trackEvent.mock.calls.filter(([name]) => name === "$identify");
+      const authCompleted = mocks.trackEvent.mock.calls.filter(
+        ([name]) => name === "primitive_auth_completed",
+      );
+      expect(identify).toHaveLength(1);
+      expect(authCompleted).toHaveLength(1);
+      expect(identify[0]?.[1].funnel_id).toBe(authCompleted[0]?.[1].funnel_id);
+      return {
+        ok: true,
+        name: "thread-message-stack",
+        type: "hyperframes:block",
+        written: [],
+        warnings: [],
+        snippet: "",
+      };
+    });
+
+    await catalogCommand.run!({
+      args: { "human-friendly": true },
+      rawArgs: [],
+      cmd: catalogCommand,
+    } as never);
+
+    expect(mocks.startAuthorizationCodeFlow).not.toHaveBeenCalled();
+    expect(mocks.trackEvent.mock.calls.filter(([name]) => name === "$identify")).toHaveLength(1);
+    expect(
+      mocks.trackEvent.mock.calls.filter(([name]) => name === "primitive_auth_completed"),
+    ).toHaveLength(1);
+    expect(mocks.runAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits no identity or auth-completed events when opted out", async () => {
+    mocks.shouldTrack.mockReturnValue(false);
+    mocks.tryResolveOAuthCredential.mockResolvedValue({
+      type: "oauth",
+      access_token: "existing-oauth-token",
+      source: "file_json",
+      refreshable: false,
+    });
+
+    await catalogCommand.run!({
+      args: { "human-friendly": true },
+      rawArgs: [],
+      cmd: catalogCommand,
+    } as never);
+
+    expect(mocks.startAuthorizationCodeFlow).not.toHaveBeenCalled();
+    expect(mocks.trackEvent).not.toHaveBeenCalled();
     expect(mocks.runAdd).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/commands/catalog.oauth.test.ts
+++ b/packages/cli/src/commands/catalog.oauth.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  tryResolveCredential: vi.fn(),
+  tryResolveOAuthCredential: vi.fn(),
+  startAuthorizationCodeFlow: vi.fn(),
+  getCurrentUser: vi.fn(),
+  runAdd: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => ({
+  select: mocks.select,
+  isCancel: () => false,
+  cancel: vi.fn(),
+}));
+vi.mock("../auth/index.js", () => ({
+  tryResolveCredential: mocks.tryResolveCredential,
+  tryResolveOAuthCredential: mocks.tryResolveOAuthCredential,
+  startAuthorizationCodeFlow: mocks.startAuthorizationCodeFlow,
+  AuthClient: class {
+    getCurrentUser = mocks.getCurrentUser;
+  },
+}));
+vi.mock("./add.js", () => ({ runAdd: mocks.runAdd }));
+vi.mock("../registry/resolver.js", () => ({
+  listRegistryItems: vi.fn(async () => [
+    { name: "thread-message-stack", type: "hyperframes:block" },
+  ]),
+  loadAllItems: vi.fn(async () => [
+    {
+      name: "thread-message-stack",
+      type: "hyperframes:block",
+      title: "Thread Message Stack",
+      description: "Conversation",
+      tags: [],
+      dimensions: { width: 1920, height: 1080 },
+      duration: 8,
+      files: [],
+    },
+  ]),
+}));
+vi.mock("../telemetry/primitive-funnel.js", () => ({
+  PrimitiveFunnel: class {
+    searched = vi.fn();
+    selected = vi.fn();
+    authRequired = vi.fn();
+    authCompleted = vi.fn();
+    installFailed = vi.fn();
+    installSucceeded = vi.fn();
+  },
+}));
+vi.mock("../telemetry/primitive-funnel-state.js", () => ({
+  writePrimitiveFunnelContext: vi.fn(),
+}));
+vi.mock("./catalog-resume.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./catalog-resume.js")>();
+  return {
+    ...actual,
+    createFilePrimitiveInstallStateStore: vi.fn(() => ({})),
+    resumePrimitiveInstallExactlyOnce: vi.fn(async (_intent, deps) => {
+      if (!(await deps.isAuthenticated())) {
+        const outcome = await deps.authenticate();
+        if (outcome !== true) return outcome;
+      }
+      await deps.install(_intent);
+      return "installed";
+    }),
+  };
+});
+
+import catalogCommand from "./catalog.js";
+
+describe("interactive catalog verified OAuth boundary", () => {
+  beforeEach(() => {
+    mocks.select.mockReset().mockResolvedValue("thread-message-stack");
+    mocks.tryResolveCredential.mockReset().mockResolvedValue({ type: "api_key", key: "key" });
+    mocks.tryResolveOAuthCredential.mockReset().mockResolvedValue(null);
+    mocks.startAuthorizationCodeFlow.mockReset().mockResolvedValue(undefined);
+    mocks.getCurrentUser.mockReset().mockResolvedValue({ email: "verified@example.com" });
+    mocks.runAdd.mockReset().mockResolvedValue({
+      ok: true,
+      name: "thread-message-stack",
+      type: "hyperframes:block",
+      written: [],
+      warnings: [],
+      snippet: "",
+    });
+  });
+
+  it("does not let an API key suppress HeyGen OAuth before catalog install", async () => {
+    mocks.tryResolveOAuthCredential.mockResolvedValueOnce(null).mockResolvedValue({
+      type: "oauth",
+      access_token: "oauth-token",
+      source: "file_json",
+      refreshable: false,
+    });
+
+    await catalogCommand.run!({
+      args: { "human-friendly": true },
+      rawArgs: [],
+      cmd: catalogCommand,
+    } as never);
+
+    expect(mocks.startAuthorizationCodeFlow).toHaveBeenCalledTimes(1);
+    expect(mocks.getCurrentUser).toHaveBeenCalledWith(expect.objectContaining({ type: "oauth" }));
+    expect(mocks.runAdd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/commands/catalog.telemetry.test.ts
+++ b/packages/cli/src/commands/catalog.telemetry.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  trackEvent: vi.fn(),
+  shouldTrack: vi.fn(() => true),
+  startAuthorizationCodeFlow: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => ({
+  select: vi.fn(),
+  isCancel: () => false,
+  cancel: vi.fn(),
+}));
+vi.mock("../telemetry/client.js", () => ({
+  trackEvent: mocks.trackEvent,
+  shouldTrack: mocks.shouldTrack,
+}));
+vi.mock("../telemetry/config.js", () => ({
+  readConfig: () => ({ anonymousId: "anonymous-catalog" }),
+}));
+vi.mock("../auth/index.js", () => ({
+  tryResolveOAuthCredential: vi.fn(),
+  startAuthorizationCodeFlow: mocks.startAuthorizationCodeFlow,
+  AuthClient: class {},
+}));
+vi.mock("./add.js", () => ({ runAdd: vi.fn() }));
+vi.mock("../registry/resolver.js", () => ({
+  listRegistryItems: vi.fn(async () => [
+    { name: "thread-message-stack", type: "hyperframes:block" },
+    { name: "data-chart", type: "hyperframes:block" },
+  ]),
+  loadAllItems: vi.fn(async () => [
+    {
+      name: "thread-message-stack",
+      type: "hyperframes:block",
+      title: "Thread Message Stack",
+      description: "Conversation messages",
+      tags: ["social"],
+      dimensions: { width: 1920, height: 1080 },
+      duration: 8,
+      files: [],
+    },
+    {
+      name: "data-chart",
+      type: "hyperframes:block",
+      title: "Data Chart",
+      description: "Animated chart",
+      tags: ["data"],
+      dimensions: { width: 1920, height: 1080 },
+      duration: 8,
+      files: [],
+    },
+  ]),
+}));
+
+import catalogCommand from "./catalog.js";
+
+describe("anonymous catalog result-delivery telemetry", () => {
+  beforeEach(() => {
+    mocks.trackEvent.mockReset();
+    mocks.shouldTrack.mockReset().mockReturnValue(true);
+    mocks.startAuthorizationCodeFlow.mockReset();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+  });
+
+  it.each([
+    ["JSON", { json: true, query: "messages" }],
+    ["noninteractive table", { query: "messages" }],
+  ])("emits one privacy-safe canonical search event on %s result delivery", async (_name, args) => {
+    await catalogCommand.run!({ args, rawArgs: [], cmd: catalogCommand } as never);
+
+    expect(mocks.startAuthorizationCodeFlow).not.toHaveBeenCalled();
+    expect(mocks.trackEvent).toHaveBeenCalledTimes(1);
+    expect(mocks.trackEvent).toHaveBeenCalledWith(
+      "primitive_catalog_searched",
+      expect.objectContaining({
+        primitive_id: "thread-message-stack",
+        result_count: 1,
+        auth_state: "anonymous",
+        funnel_id: expect.any(String),
+        event_id: expect.any(String),
+      }),
+    );
+    const payload = JSON.stringify(mocks.trackEvent.mock.calls[0]?.[1]);
+    expect(payload).not.toContain("messages");
+    expect(payload).not.toMatch(/raw_query|query_text|credential|token/);
+  });
+});

--- a/packages/cli/src/commands/catalog.ts
+++ b/packages/cli/src/commands/catalog.ts
@@ -16,7 +16,6 @@ import { c } from "../ui/colors.js";
 import { listRegistryItems, loadAllItems } from "../registry/resolver.js";
 import { loadProjectConfig, DEFAULT_PROJECT_CONFIG } from "../utils/projectConfig.js";
 import { resolve } from "node:path";
-import { randomUUID } from "node:crypto";
 import { runAdd } from "./add.js";
 import {
   createFilePrimitiveInstallStateStore,
@@ -30,7 +29,6 @@ import {
   tryResolveOAuthCredential,
 } from "../auth/index.js";
 import { PrimitiveFunnel } from "../telemetry/primitive-funnel.js";
-import { writePrimitiveFunnelContext } from "../telemetry/primitive-funnel-state.js";
 import {
   THREAD_MESSAGE_STACK_ARTIFACT_ID,
   THREAD_MESSAGE_STACK_CATALOG_DIGEST,
@@ -107,6 +105,36 @@ export default defineCommand({
       return;
     }
 
+    const primitiveResultRank =
+      matching.findIndex((item) => item.name === "thread-message-stack") + 1;
+    let primitiveSession:
+      | {
+          intent: ReturnType<typeof createPrimitiveInstallIntent>;
+          context: ConstructorParameters<typeof PrimitiveFunnel>[0];
+          funnel: PrimitiveFunnel;
+        }
+      | undefined;
+    if (primitiveResultRank > 0) {
+      const intent = createPrimitiveInstallIntent({
+        itemName: "thread-message-stack",
+        query: args.query ?? "",
+        artifactId: THREAD_MESSAGE_STACK_ARTIFACT_ID,
+        versionId: THREAD_MESSAGE_STACK_VERSION_ID,
+      });
+      const context = {
+        funnelId: intent.funnelId,
+        installId: intent.installId,
+        primitiveId: "thread-message-stack",
+        artifactId: intent.artifactId,
+        versionId: intent.versionId,
+        catalogVersion: THREAD_MESSAGE_STACK_CATALOG_DIGEST,
+        queryFingerprint: `sha256:${intent.queryFingerprint}`,
+      };
+      const funnel = new PrimitiveFunnel(context);
+      funnel.catalogSearched(matching.length);
+      primitiveSession = { intent, context, funnel };
+    }
+
     if (json) {
       const output = matching.map((item) => ({
         name: item.name,
@@ -141,23 +169,11 @@ export default defineCommand({
       const selectedName = selected as string;
       let result: Awaited<ReturnType<typeof runAdd>> | undefined;
       if (selectedName === "thread-message-stack") {
-        const intent = createPrimitiveInstallIntent({
-          itemName: selectedName,
-          query: args.query ?? "",
-          artifactId: THREAD_MESSAGE_STACK_ARTIFACT_ID,
-          versionId: THREAD_MESSAGE_STACK_VERSION_ID,
-        });
-        const funnelContext = {
-          funnelId: intent.funnelId,
-          installId: intent.installId,
-          artifactId: intent.artifactId,
-          versionId: intent.versionId,
-          catalogVersion: THREAD_MESSAGE_STACK_CATALOG_DIGEST,
-          queryFingerprint: `sha256:${intent.queryFingerprint}`,
-        };
-        const funnel = new PrimitiveFunnel(funnelContext);
-        funnel.searched();
-        funnel.selected();
+        if (!primitiveSession)
+          throw new Error("Selected primitive is absent from catalog results.");
+        const { intent, context: funnelContext, funnel } = primitiveSession;
+        funnel.catalogResultSelected(primitiveResultRank);
+        const authStartedAt = performance.now();
         const outcome = await resumePrimitiveInstallExactlyOnce(intent, {
           store: createFilePrimitiveInstallStateStore(),
           isAuthenticated: async () => {
@@ -165,38 +181,50 @@ export default defineCommand({
             if (!credential) return false;
             try {
               const user = await new AuthClient().getCurrentUser(credential);
-              funnel.authCompleted(user.email ?? user.username);
+              funnel.authCompleted(
+                user.email ?? user.username,
+                "existing_session",
+                performance.now() - authStartedAt,
+              );
               return true;
             } catch {
               return false;
             }
           },
           authenticate: async () => {
-            funnel.authRequired();
+            funnel.authStarted();
             try {
               await startAuthorizationCodeFlow();
               const credential = await tryResolveOAuthCredential();
               if (!credential) return "failed";
               const user = await new AuthClient().getCurrentUser(credential);
-              funnel.authCompleted(user.email ?? user.username);
+              funnel.authCompleted(
+                user.email ?? user.username,
+                "oauth",
+                performance.now() - authStartedAt,
+              );
               return true;
             } catch {
               return "failed";
             }
           },
           install: async () => {
-            result = await runAdd({ name: selectedName, projectDir: dir, skipClipboard: false });
-            writePrimitiveFunnelContext(dir, funnelContext);
+            result = await runAdd({
+              name: selectedName,
+              projectDir: dir,
+              skipClipboard: false,
+              primitiveFunnelSession: primitiveSession,
+            });
           },
         });
         if (outcome === "failed" || outcome === "cancelled") {
-          funnel.installFailed(
-            randomUUID(),
+          funnel.authFailed(
+            `${funnelContext.installId}:auth-failed`,
             outcome === "cancelled" ? "auth_cancelled" : "auth_failed",
+            performance.now() - authStartedAt,
           );
           throw new Error(`Catalog authentication ${outcome}; no primitive was installed.`);
         }
-        if (outcome === "installed") funnel.installSucceeded(randomUUID());
         if (!result) {
           console.log(`${c.success("✓")} ${c.accent(selectedName)} was already installed.`);
           return;

--- a/packages/cli/src/commands/catalog.ts
+++ b/packages/cli/src/commands/catalog.ts
@@ -164,7 +164,8 @@ export default defineCommand({
             const credential = await tryResolveOAuthCredential();
             if (!credential) return false;
             try {
-              await new AuthClient().getCurrentUser(credential);
+              const user = await new AuthClient().getCurrentUser(credential);
+              funnel.authCompleted(user.email ?? user.username);
               return true;
             } catch {
               return false;

--- a/packages/cli/src/commands/catalog.ts
+++ b/packages/cli/src/commands/catalog.ts
@@ -24,7 +24,11 @@ import {
   filterPrimitiveCatalogItems,
   resumePrimitiveInstallExactlyOnce,
 } from "./catalog-resume.js";
-import { AuthClient, startAuthorizationCodeFlow, tryResolveCredential } from "../auth/index.js";
+import {
+  AuthClient,
+  startAuthorizationCodeFlow,
+  tryResolveOAuthCredential,
+} from "../auth/index.js";
 import { PrimitiveFunnel } from "../telemetry/primitive-funnel.js";
 import { writePrimitiveFunnelContext } from "../telemetry/primitive-funnel-state.js";
 import {
@@ -156,22 +160,24 @@ export default defineCommand({
         funnel.selected();
         const outcome = await resumePrimitiveInstallExactlyOnce(intent, {
           store: createFilePrimitiveInstallStateStore(),
-          isAuthenticated: async () => (await tryResolveCredential()) !== null,
+          isAuthenticated: async () => {
+            const credential = await tryResolveOAuthCredential();
+            if (!credential) return false;
+            try {
+              await new AuthClient().getCurrentUser(credential);
+              return true;
+            } catch {
+              return false;
+            }
+          },
           authenticate: async () => {
             funnel.authRequired();
             try {
               await startAuthorizationCodeFlow();
-              const credential = await tryResolveCredential();
-              if (credential) {
-                try {
-                  const user = await new AuthClient().getCurrentUser(credential);
-                  funnel.authCompleted(user.email ?? user.username);
-                } catch {
-                  funnel.authCompleted();
-                }
-              } else {
-                funnel.authCompleted();
-              }
+              const credential = await tryResolveOAuthCredential();
+              if (!credential) return "failed";
+              const user = await new AuthClient().getCurrentUser(credential);
+              funnel.authCompleted(user.email ?? user.username);
               return true;
             } catch {
               return "failed";

--- a/packages/cli/src/commands/catalog.ts
+++ b/packages/cli/src/commands/catalog.ts
@@ -16,7 +16,22 @@ import { c } from "../ui/colors.js";
 import { listRegistryItems, loadAllItems } from "../registry/resolver.js";
 import { loadProjectConfig, DEFAULT_PROJECT_CONFIG } from "../utils/projectConfig.js";
 import { resolve } from "node:path";
+import { randomUUID } from "node:crypto";
 import { runAdd } from "./add.js";
+import {
+  createFilePrimitiveInstallStateStore,
+  createPrimitiveInstallIntent,
+  filterPrimitiveCatalogItems,
+  resumePrimitiveInstallExactlyOnce,
+} from "./catalog-resume.js";
+import { AuthClient, startAuthorizationCodeFlow, tryResolveCredential } from "../auth/index.js";
+import { PrimitiveFunnel } from "../telemetry/primitive-funnel.js";
+import { writePrimitiveFunnelContext } from "../telemetry/primitive-funnel-state.js";
+import {
+  THREAD_MESSAGE_STACK_ARTIFACT_ID,
+  THREAD_MESSAGE_STACK_CATALOG_DIGEST,
+  THREAD_MESSAGE_STACK_VERSION_ID,
+} from "../registry/heygenverseCatalog.js";
 
 export default defineCommand({
   meta: {
@@ -32,6 +47,10 @@ export default defineCommand({
       type: "string",
       description: "Filter by tag (e.g. social, transition, text)",
     },
+    query: {
+      type: "string",
+      description: "Filter by name, title, or description",
+    },
     json: {
       type: "boolean",
       description: "Print matching items as JSON to stdout",
@@ -41,6 +60,8 @@ export default defineCommand({
       description: "Interactive picker — select an item to install",
     },
   },
+  // Catalog output and interactive installation intentionally share the command boundary.
+  // fallow-ignore-next-line complexity
   async run({ args }) {
     const json = args.json === true;
     const interactive = args["human-friendly"] === true;
@@ -69,12 +90,15 @@ export default defineCommand({
     const items = await loadAllItems(filtered, { baseUrl: config.registry });
 
     const tagFilter = args.tag?.toLowerCase();
-    const matching = tagFilter
+    const tagged = tagFilter
       ? items.filter((item) => item.tags?.some((t) => t.toLowerCase() === tagFilter))
       : items;
+    const normalizedQuery = args.query?.trim().toLowerCase() ?? "";
+    const matching = filterPrimitiveCatalogItems(tagged, normalizedQuery);
 
     if (matching.length === 0) {
       if (json) console.log("[]");
+      else if (normalizedQuery) console.log(`No items match query "${args.query}".`);
       else console.log(`No items match tag "${args.tag}".`);
       return;
     }
@@ -110,11 +134,69 @@ export default defineCommand({
         finishCommand(0);
       }
 
-      const result = await runAdd({
-        name: selected as string,
-        projectDir: dir,
-        skipClipboard: false,
-      });
+      const selectedName = selected as string;
+      let result: Awaited<ReturnType<typeof runAdd>> | undefined;
+      if (selectedName === "thread-message-stack") {
+        const intent = createPrimitiveInstallIntent({
+          itemName: selectedName,
+          query: args.query ?? "",
+          artifactId: THREAD_MESSAGE_STACK_ARTIFACT_ID,
+          versionId: THREAD_MESSAGE_STACK_VERSION_ID,
+        });
+        const funnelContext = {
+          funnelId: intent.funnelId,
+          installId: intent.installId,
+          artifactId: intent.artifactId,
+          versionId: intent.versionId,
+          catalogVersion: THREAD_MESSAGE_STACK_CATALOG_DIGEST,
+          queryFingerprint: `sha256:${intent.queryFingerprint}`,
+        };
+        const funnel = new PrimitiveFunnel(funnelContext);
+        funnel.searched();
+        funnel.selected();
+        const outcome = await resumePrimitiveInstallExactlyOnce(intent, {
+          store: createFilePrimitiveInstallStateStore(),
+          isAuthenticated: async () => (await tryResolveCredential()) !== null,
+          authenticate: async () => {
+            funnel.authRequired();
+            try {
+              await startAuthorizationCodeFlow();
+              const credential = await tryResolveCredential();
+              if (credential) {
+                try {
+                  const user = await new AuthClient().getCurrentUser(credential);
+                  funnel.authCompleted(user.email ?? user.username);
+                } catch {
+                  funnel.authCompleted();
+                }
+              } else {
+                funnel.authCompleted();
+              }
+              return true;
+            } catch {
+              return "failed";
+            }
+          },
+          install: async () => {
+            result = await runAdd({ name: selectedName, projectDir: dir, skipClipboard: false });
+            writePrimitiveFunnelContext(dir, funnelContext);
+          },
+        });
+        if (outcome === "failed" || outcome === "cancelled") {
+          funnel.installFailed(
+            randomUUID(),
+            outcome === "cancelled" ? "auth_cancelled" : "auth_failed",
+          );
+          throw new Error(`Catalog authentication ${outcome}; no primitive was installed.`);
+        }
+        if (outcome === "installed") funnel.installSucceeded(randomUUID());
+        if (!result) {
+          console.log(`${c.success("✓")} ${c.accent(selectedName)} was already installed.`);
+          return;
+        }
+      } else {
+        result = await runAdd({ name: selectedName, projectDir: dir, skipClipboard: false });
+      }
 
       for (const warning of result.warnings) {
         console.warn(c.warn(`Warning: ${warning}`));

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -211,6 +211,7 @@ export default defineCommand({
     },
   },
   async run({ args }) {
+    const primitiveCommandStartedAt = performance.now();
     const browserGpuMode = resolveLocalBrowserGpuMode(args["browser-gpu"] as boolean | undefined);
     if (args["browser-gpu"] === true) process.env.PRODUCER_BROWSER_GPU_MODE = "hardware";
     if (args["browser-gpu"] === false) process.env.PRODUCER_BROWSER_GPU_MODE = "software";
@@ -399,7 +400,11 @@ export default defineCommand({
           browserGpuMode,
         });
       } catch (error) {
-        trackPrimitivePreviewFailed(dir, "preview_failed");
+        await trackPrimitivePreviewFailed(
+          dir,
+          "preview_failed",
+          performance.now() - primitiveCommandStartedAt,
+        );
         clack.log.error(errorMessage(error));
         setCommandExitCode(1);
         return;
@@ -422,7 +427,7 @@ export default defineCommand({
         remoteDebuggingPort,
         browserNoGpu,
       });
-      trackPrimitivePreviewSucceeded(dir);
+      await trackPrimitivePreviewSucceeded(dir, performance.now() - primitiveCommandStartedAt);
       return;
     }
 
@@ -918,11 +923,15 @@ function attachStudioReadyHandler(
   spinner: ReturnType<typeof clack.spinner>,
   projectName: string,
   projectDir: string,
+  primitiveCommandStartedAt: number,
   options?: BrowserLaunchOptions,
 ): void {
   let detected = false;
 
-  function handleOutput(data: Buffer): void {
+  // Async because the terminal funnel event awaits delivery before its claim is
+  // considered spent. `detected` is latched before the await, so a second chunk
+  // arriving mid-flight still short-circuits.
+  async function handleOutput(data: Buffer): Promise<void> {
     const url = data.toString().match(/Local:\s+(http:\/\/localhost:\d+)/)?.[1];
     if (!url || detected) return;
 
@@ -930,15 +939,19 @@ function attachStudioReadyHandler(
     spinner.stop(c.success("Studio running"));
     printStudioSummary(projectName, url, { footer: "Press Ctrl+C to stop" });
     openStudioBrowser(url, projectName, projectDir, options);
-    trackPrimitivePreviewSucceeded(projectDir);
+    await trackPrimitivePreviewSucceeded(projectDir, performance.now() - primitiveCommandStartedAt);
     child.stdout.removeListener("data", handleOutput);
     child.stderr.removeListener("data", handleOutput);
   }
 
   child.stdout.on("data", handleOutput);
   child.stderr.on("data", handleOutput);
-  child.on("error", (err) => {
-    trackPrimitivePreviewFailed(projectDir, "preview_failed");
+  child.on("error", async (err) => {
+    await trackPrimitivePreviewFailed(
+      projectDir,
+      "preview_failed",
+      performance.now() - primitiveCommandStartedAt,
+    );
     spinner.stop(c.error("Failed to start studio"));
     console.error(c.dim(err.message));
   });
@@ -948,6 +961,7 @@ function attachStudioReadyHandler(
  * Dev mode: spawn the studio dev server from the monorepo.
  */
 async function runDevMode(dir: string, options?: StudioLaunchOptions): Promise<void> {
+  const primitiveCommandStartedAt = performance.now();
   // Find monorepo root by navigating from packages/cli/src/commands/
   const thisFile = fileURLToPath(import.meta.url);
   const repoRoot = resolve(dirname(thisFile), "..", "..", "..", "..");
@@ -970,7 +984,7 @@ async function runDevMode(dir: string, options?: StudioLaunchOptions): Promise<v
     env: studioProxyEnv(options?.autoProxy ?? true),
   });
 
-  attachStudioReadyHandler(child, s, pName, dir, options);
+  attachStudioReadyHandler(child, s, pName, dir, primitiveCommandStartedAt, options);
   removeSymlinkOnExit(createdSymlink, symlinkPath);
 
   // Kill the child's entire process tree on SIGTERM/SIGINT. Ctrl+C sends
@@ -1001,6 +1015,7 @@ function hasLocalStudio(dir: string): boolean {
  * Provides full Vite HMR and the complete studio experience.
  */
 async function runLocalStudioMode(dir: string, options?: StudioLaunchOptions): Promise<void> {
+  const primitiveCommandStartedAt = performance.now();
   const req = createRequire(join(dir, "package.json"));
   const studioPkgPath = dirname(req.resolve("@hyperframes/studio/package.json"));
   const pName = options?.projectName ?? basename(dir);
@@ -1020,7 +1035,7 @@ async function runLocalStudioMode(dir: string, options?: StudioLaunchOptions): P
     env: studioProxyEnv(options?.autoProxy ?? true),
   });
 
-  attachStudioReadyHandler(child, s, pName, dir, options);
+  attachStudioReadyHandler(child, s, pName, dir, primitiveCommandStartedAt, options);
   removeSymlinkOnExit(createdSymlink, symlinkPath);
 
   // Same tree-kill handler as dev mode. No-op on Windows (see comment above).
@@ -1040,6 +1055,7 @@ async function runEmbeddedMode(
   startPort: number,
   options?: EmbeddedStudioOptions,
 ): Promise<void> {
+  const primitiveCommandStartedAt = performance.now();
   const { createStudioServer, loadPreviewServerBuildSignature, resolveStudioBundle } =
     await import("../server/studioServer.js");
 
@@ -1084,7 +1100,11 @@ async function runEmbeddedMode(
       options?.browserGpuMode,
     );
   } catch (err: unknown) {
-    trackPrimitivePreviewFailed(dir, "preview_failed");
+    await trackPrimitivePreviewFailed(
+      dir,
+      "preview_failed",
+      performance.now() - primitiveCommandStartedAt,
+    );
     s.stop(c.error("Failed to start studio"));
     console.error();
     console.error(`  ${(err as Error).message}`);
@@ -1100,7 +1120,7 @@ async function runEmbeddedMode(
       details: ["Reusing existing server. Use --force-new to start a fresh instance."],
     });
     openStudioBrowser(url, pName, dir, options);
-    trackPrimitivePreviewSucceeded(dir);
+    await trackPrimitivePreviewSucceeded(dir, performance.now() - primitiveCommandStartedAt);
     return;
   }
 
@@ -1119,7 +1139,7 @@ async function runEmbeddedMode(
     footer: "Press Ctrl+C to stop",
   });
   openStudioBrowser(url, pName, dir, options);
-  trackPrimitivePreviewSucceeded(dir);
+  await trackPrimitivePreviewSucceeded(dir, performance.now() - primitiveCommandStartedAt);
 
   // Block until Ctrl+C. Node would normally exit on SIGINT, but the listening
   // HTTP server keeps handles open, so the event loop stays alive after the

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -70,6 +70,10 @@ import {
   stopBackgroundPreview,
 } from "./previewLifecycle.js";
 import { resolveLocalBrowserGpuMode, type BrowserGpuMode } from "../browser/gpuPolicy.js";
+import {
+  trackPrimitivePreviewFailed,
+  trackPrimitivePreviewSucceeded,
+} from "../telemetry/primitive-funnel-command.js";
 
 interface BrowserLaunchOptions {
   noOpen?: boolean;
@@ -395,6 +399,7 @@ export default defineCommand({
           browserGpuMode,
         });
       } catch (error) {
+        trackPrimitivePreviewFailed(dir, "preview_failed");
         clack.log.error(errorMessage(error));
         setCommandExitCode(1);
         return;
@@ -417,6 +422,7 @@ export default defineCommand({
         remoteDebuggingPort,
         browserNoGpu,
       });
+      trackPrimitivePreviewSucceeded(dir);
       return;
     }
 
@@ -924,6 +930,7 @@ function attachStudioReadyHandler(
     spinner.stop(c.success("Studio running"));
     printStudioSummary(projectName, url, { footer: "Press Ctrl+C to stop" });
     openStudioBrowser(url, projectName, projectDir, options);
+    trackPrimitivePreviewSucceeded(projectDir);
     child.stdout.removeListener("data", handleOutput);
     child.stderr.removeListener("data", handleOutput);
   }
@@ -931,6 +938,7 @@ function attachStudioReadyHandler(
   child.stdout.on("data", handleOutput);
   child.stderr.on("data", handleOutput);
   child.on("error", (err) => {
+    trackPrimitivePreviewFailed(projectDir, "preview_failed");
     spinner.stop(c.error("Failed to start studio"));
     console.error(c.dim(err.message));
   });
@@ -1076,6 +1084,7 @@ async function runEmbeddedMode(
       options?.browserGpuMode,
     );
   } catch (err: unknown) {
+    trackPrimitivePreviewFailed(dir, "preview_failed");
     s.stop(c.error("Failed to start studio"));
     console.error();
     console.error(`  ${(err as Error).message}`);
@@ -1091,6 +1100,7 @@ async function runEmbeddedMode(
       details: ["Reusing existing server. Use --force-new to start a fresh instance."],
     });
     openStudioBrowser(url, pName, dir, options);
+    trackPrimitivePreviewSucceeded(dir);
     return;
   }
 
@@ -1109,6 +1119,7 @@ async function runEmbeddedMode(
     footer: "Press Ctrl+C to stop",
   });
   openStudioBrowser(url, pName, dir, options);
+  trackPrimitivePreviewSucceeded(dir);
 
   // Block until Ctrl+C. Node would normally exit on SIGINT, but the listening
   // HTTP server keeps handles open, so the event loop stays alive after the

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -70,6 +70,10 @@ import {
   type HyperframesConfig,
 } from "../telemetry/config.js";
 import { shouldTrack } from "../telemetry/client.js";
+import {
+  trackPrimitiveRenderFailed,
+  trackPrimitiveRenderSucceeded,
+} from "../telemetry/primitive-funnel-command.js";
 import { renderJobObservabilityTelemetryPayload } from "../telemetry/renderObservability.js";
 import { bytesToMb } from "../telemetry/system.js";
 import { VERSION } from "../version.js";
@@ -737,6 +741,7 @@ async function renderDocker(
       child.on("error", (err) => reject(err));
     });
   } catch (error: unknown) {
+    trackPrimitiveRenderFailed(projectDir, "render_failed");
     handleRenderError(error, options, startTime, true, "Check Docker is running: docker info");
   }
 
@@ -747,6 +752,7 @@ async function renderDocker(
   // so any late throw here (telemetry flush, feedback prompt) cannot flip
   // the exit code.
   markRenderSucceeded();
+  trackPrimitiveRenderSucceeded(projectDir);
 
   // Track metrics (no job object available from Docker — use a minimal stub)
   runPostRenderStep("trackRenderComplete", () =>
@@ -894,6 +900,7 @@ export async function renderLocal(
   try {
     await producer.executeRenderJob(job, projectDir, outputPath, onProgress);
   } catch (error: unknown) {
+    trackPrimitiveRenderFailed(projectDir, "render_failed");
     maybeConsumeDeParallelRouterTrial(deParallelRouterTrialArmed, job, options.quiet);
     handleRenderError(
       error,
@@ -912,6 +919,7 @@ export async function renderLocal(
   // the exit code. Field signal ts=1784169760 / ts=1784171150 / ts=1784172467
   // (win32/x64, CLI 0.7.58): valid MP4 on disk, exited 1 with no error print.
   markRenderSucceeded();
+  trackPrimitiveRenderSucceeded(projectDir);
 
   maybeConsumeDeParallelRouterTrial(deParallelRouterTrialArmed, job, options.quiet);
   const elapsed = Date.now() - startTime;

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -663,6 +663,7 @@ async function renderDocker(
   options: RenderOptions,
 ): Promise<SingleRenderResult> {
   const startTime = Date.now();
+  const primitiveCommandStartedAt = performance.now();
 
   // Dev mode (tsx/ts-node) uses "latest" since the local version isn't on npm
   const dockerVersion = isDevMode() ? "latest" : VERSION;
@@ -741,7 +742,11 @@ async function renderDocker(
       child.on("error", (err) => reject(err));
     });
   } catch (error: unknown) {
-    trackPrimitiveRenderFailed(projectDir, "render_failed");
+    await trackPrimitiveRenderFailed(
+      projectDir,
+      "render_failed",
+      performance.now() - primitiveCommandStartedAt,
+    );
     handleRenderError(error, options, startTime, true, "Check Docker is running: docker info");
   }
 
@@ -752,7 +757,7 @@ async function renderDocker(
   // so any late throw here (telemetry flush, feedback prompt) cannot flip
   // the exit code.
   markRenderSucceeded();
-  trackPrimitiveRenderSucceeded(projectDir);
+  await trackPrimitiveRenderSucceeded(projectDir, performance.now() - primitiveCommandStartedAt);
 
   // Track metrics (no job object available from Docker — use a minimal stub)
   runPostRenderStep("trackRenderComplete", () =>
@@ -853,6 +858,7 @@ export async function renderLocal(
   );
 
   const startTime = Date.now();
+  const primitiveCommandStartedAt = performance.now();
   const logger = createRenderTelemetryLogger(
     producer.createConsoleLogger?.(options.debug ? "debug" : "info") ?? createNoopProducerLogger(),
   );
@@ -900,7 +906,11 @@ export async function renderLocal(
   try {
     await producer.executeRenderJob(job, projectDir, outputPath, onProgress);
   } catch (error: unknown) {
-    trackPrimitiveRenderFailed(projectDir, "render_failed");
+    await trackPrimitiveRenderFailed(
+      projectDir,
+      "render_failed",
+      performance.now() - primitiveCommandStartedAt,
+    );
     maybeConsumeDeParallelRouterTrial(deParallelRouterTrialArmed, job, options.quiet);
     handleRenderError(
       error,
@@ -919,7 +929,7 @@ export async function renderLocal(
   // the exit code. Field signal ts=1784169760 / ts=1784171150 / ts=1784172467
   // (win32/x64, CLI 0.7.58): valid MP4 on disk, exited 1 with no error print.
   markRenderSucceeded();
-  trackPrimitiveRenderSucceeded(projectDir);
+  await trackPrimitiveRenderSucceeded(projectDir, performance.now() - primitiveCommandStartedAt);
 
   maybeConsumeDeParallelRouterTrial(deParallelRouterTrialArmed, job, options.quiet);
   const elapsed = Date.now() - startTime;

--- a/packages/cli/src/registry/heygenverseCatalog.test.ts
+++ b/packages/cli/src/registry/heygenverseCatalog.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  THREAD_MESSAGE_STACK_ARTIFACT_ID,
+  THREAD_MESSAGE_STACK_CANONICAL_URI,
+  THREAD_MESSAGE_STACK_VERSION_ID,
+  assertHeyGenVerseSourceDigest,
+  parseHeyGenVerseCatalogProjection,
+} from "./heygenverseCatalog.js";
+
+const projectionPath = resolve(
+  import.meta.dirname,
+  "../../../../registry/heygenverse-catalog.json",
+);
+const itemPath = resolve(
+  import.meta.dirname,
+  "../../../../registry/blocks/thread-message-stack/registry-item.json",
+);
+const sourcePath = resolve(
+  import.meta.dirname,
+  "../../../../registry/blocks/thread-message-stack/thread-message-stack.html",
+);
+
+describe("HeyGenVerse catalog projection", () => {
+  it("preserves the canonical artifact/version identity and immutable digest", () => {
+    const projection = parseHeyGenVerseCatalogProjection(readFileSync(projectionPath, "utf8"));
+    expect(projection.artifactId).toBe(THREAD_MESSAGE_STACK_ARTIFACT_ID);
+    expect(projection.versionId).toBe(THREAD_MESSAGE_STACK_VERSION_ID);
+    expect(projection.canonicalUri).toBe(THREAD_MESSAGE_STACK_CANONICAL_URI);
+    expect(projection.records).toEqual([
+      expect.objectContaining({ name: "thread-message-stack", type: "hyperframes:block" }),
+    ]);
+  });
+
+  it("rejects missing, altered, or divergent provenance", () => {
+    const source = JSON.parse(readFileSync(projectionPath, "utf8")) as Record<string, unknown>;
+    expect(() =>
+      parseHeyGenVerseCatalogProjection(JSON.stringify({ ...source, versionId: "changed" })),
+    ).toThrow(/version/);
+    expect(() =>
+      parseHeyGenVerseCatalogProjection(JSON.stringify({ ...source, catalogDigest: "sha256:00" })),
+    ).toThrow(/digest/);
+    expect(() =>
+      parseHeyGenVerseCatalogProjection(JSON.stringify({ ...source, artifactId: undefined })),
+    ).toThrow(/artifact/);
+  });
+
+  it("rejects source bytes that diverge from the projected immutable digest", () => {
+    const item = JSON.parse(readFileSync(itemPath, "utf8"));
+    const source = readFileSync(sourcePath, "utf8");
+    expect(() => assertHeyGenVerseSourceDigest(item, source)).not.toThrow();
+    expect(() => assertHeyGenVerseSourceDigest(item, `${source}\nchanged`)).toThrow(
+      /source digest/,
+    );
+  });
+});

--- a/packages/cli/src/registry/heygenverseCatalog.ts
+++ b/packages/cli/src/registry/heygenverseCatalog.ts
@@ -1,0 +1,142 @@
+import { createHash } from "node:crypto";
+import type { RegistryItem } from "@hyperframes/core";
+
+export const THREAD_MESSAGE_STACK_ARTIFACT_ID = "21c28523-7487-43e1-927d-43a7fe855859";
+export const THREAD_MESSAGE_STACK_VERSION_ID = "1aa00c22-b508-4b81-a3a1-4702453d48c2";
+export const THREAD_MESSAGE_STACK_CANONICAL_URI =
+  "heygenverse://app/21c28523-7487-43e1-927d-43a7fe855859/version/1aa00c22-b508-4b81-a3a1-4702453d48c2";
+export const THREAD_MESSAGE_STACK_CATALOG_DIGEST =
+  "sha256:c8c5a26a43564d30f4866b35a0f182820bc6906596afb8bbbf0935d4cef22365";
+
+export interface HeyGenVerseCatalogRecord {
+  name: "thread-message-stack";
+  type: "hyperframes:block";
+  sourceDigest: string;
+}
+
+export interface HeyGenVerseCatalogProjection {
+  schemaVersion: 1;
+  artifactId: string;
+  versionId: string;
+  canonicalUri: string;
+  exportedAt: string;
+  records: HeyGenVerseCatalogRecord[];
+  catalogDigest: string;
+}
+
+function isDigest(value: unknown): value is string {
+  return typeof value === "string" && /^sha256:[a-f0-9]{64}$/.test(value);
+}
+
+function projectionPayload(
+  projection: Omit<HeyGenVerseCatalogProjection, "catalogDigest">,
+): string {
+  return JSON.stringify({
+    schemaVersion: projection.schemaVersion,
+    artifactId: projection.artifactId,
+    versionId: projection.versionId,
+    canonicalUri: projection.canonicalUri,
+    exportedAt: projection.exportedAt,
+    records: projection.records.map((record) => ({
+      name: record.name,
+      type: record.type,
+      sourceDigest: record.sourceDigest,
+    })),
+  });
+}
+
+function catalogDigest(projection: Omit<HeyGenVerseCatalogProjection, "catalogDigest">): string {
+  return `sha256:${createHash("sha256").update(projectionPayload(projection)).digest("hex")}`;
+}
+
+// Strict validation intentionally keeps every immutable identity check explicit.
+// fallow-ignore-next-line complexity
+export function parseHeyGenVerseCatalogProjection(source: string): HeyGenVerseCatalogProjection {
+  let value: unknown;
+  try {
+    value = JSON.parse(source);
+  } catch {
+    throw new Error("HeyGenVerse catalog projection contains invalid JSON.");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("HeyGenVerse catalog projection must be an object.");
+  }
+  const record = value as Record<string, unknown>;
+  if (record.schemaVersion !== 1) throw new Error("Unsupported catalog schema version.");
+  if (record.artifactId !== THREAD_MESSAGE_STACK_ARTIFACT_ID) {
+    throw new Error("HeyGenVerse catalog artifact identity does not match the canonical artifact.");
+  }
+  if (record.versionId !== THREAD_MESSAGE_STACK_VERSION_ID) {
+    throw new Error("HeyGenVerse catalog version does not match the canonical version.");
+  }
+  if (record.canonicalUri !== THREAD_MESSAGE_STACK_CANONICAL_URI) {
+    throw new Error("HeyGenVerse catalog canonical URI does not match the canonical version.");
+  }
+  if (typeof record.exportedAt !== "string" || Number.isNaN(Date.parse(record.exportedAt))) {
+    throw new Error("HeyGenVerse catalog exportedAt must be an ISO timestamp.");
+  }
+  if (!Array.isArray(record.records) || record.records.length !== 1) {
+    throw new Error("HeyGenVerse catalog must project exactly one thread-message-stack record.");
+  }
+  const projected = record.records[0] as Record<string, unknown>;
+  if (
+    projected?.name !== "thread-message-stack" ||
+    projected.type !== "hyperframes:block" ||
+    !isDigest(projected.sourceDigest)
+  ) {
+    throw new Error("HeyGenVerse catalog record diverges from thread-message-stack provenance.");
+  }
+  if (!isDigest(record.catalogDigest)) {
+    throw new Error("HeyGenVerse catalog digest is missing or malformed.");
+  }
+  const projection: HeyGenVerseCatalogProjection = {
+    schemaVersion: 1,
+    artifactId: record.artifactId,
+    versionId: record.versionId,
+    canonicalUri: record.canonicalUri,
+    exportedAt: record.exportedAt,
+    records: [
+      {
+        name: "thread-message-stack",
+        type: "hyperframes:block",
+        sourceDigest: projected.sourceDigest,
+      },
+    ],
+    catalogDigest: record.catalogDigest,
+  };
+  const { catalogDigest: suppliedDigest, ...payload } = projection;
+  if (catalogDigest(payload) !== suppliedDigest) {
+    throw new Error("HeyGenVerse catalog digest does not match its immutable projection payload.");
+  }
+  if (suppliedDigest !== THREAD_MESSAGE_STACK_CATALOG_DIGEST) {
+    throw new Error("HeyGenVerse catalog digest does not match the canonical export version.");
+  }
+  return projection;
+}
+
+export function assertHeyGenVerseProjectedItem(
+  item: RegistryItem,
+  projection: HeyGenVerseCatalogProjection,
+): void {
+  if (item.name !== "thread-message-stack") return;
+  const provenance = item.provenance;
+  const projected = projection.records[0];
+  if (
+    provenance?.kind !== "heygenverse-export" ||
+    provenance.artifactId !== projection.artifactId ||
+    provenance.versionId !== projection.versionId ||
+    provenance.canonicalUri !== projection.canonicalUri ||
+    provenance.sourceDigest !== projected?.sourceDigest
+  ) {
+    throw new Error("thread-message-stack registry item diverges from its HeyGenVerse projection.");
+  }
+}
+
+export function assertHeyGenVerseSourceDigest(item: RegistryItem, source: string): void {
+  if (item.name !== "thread-message-stack") return;
+  const expected = item.provenance?.sourceDigest;
+  const actual = `sha256:${createHash("sha256").update(source).digest("hex")}`;
+  if (!expected || actual !== expected) {
+    throw new Error("thread-message-stack source digest diverges from its immutable projection.");
+  }
+}

--- a/packages/cli/src/registry/installer.ts
+++ b/packages/cli/src/registry/installer.ts
@@ -10,12 +10,20 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { resolve, relative, isAbsolute } from "node:path";
 import type { FileTarget, RegistryItem } from "@hyperframes/core";
 import { fetchItemFile, DEFAULT_REGISTRY_URL } from "./remote.js";
+import {
+  materializeThreadMessageStack,
+  THREAD_MESSAGE_STACK_ITEM_NAME,
+  type ThreadMessageStackData,
+} from "./threadMessageStack.js";
+import { assertHeyGenVerseSourceDigest } from "./heygenverseCatalog.js";
 
 export interface InstallOptions {
   /** Project root where files land. Every target resolves relative to this. */
   destDir: string;
   /** Base URL of the registry. Defaults to the official public registry. */
   baseUrl?: string;
+  /** Structured data materialized into the one source-owned primitive JSON seam. */
+  threadMessageStackData?: ThreadMessageStackData;
 }
 
 export interface InstallResult {
@@ -83,7 +91,13 @@ export async function installItem(
       const destPath = resolve(destDir, file.target);
       await fetchItemFile(item, file, destPath, baseUrl);
       if (isInstalledRegistryBlockComposition(item, file)) {
-        const source = readFileSync(destPath, "utf-8");
+        let source = readFileSync(destPath, "utf-8");
+        if (item.name === THREAD_MESSAGE_STACK_ITEM_NAME && item.provenance) {
+          assertHeyGenVerseSourceDigest(item, source);
+        }
+        if (item.name === THREAD_MESSAGE_STACK_ITEM_NAME && options.threadMessageStackData) {
+          source = materializeThreadMessageStack(source, options.threadMessageStackData);
+        }
         writeFileSync(destPath, addRegistryItemMarker(source, item), "utf-8");
       }
       return destPath;

--- a/packages/cli/src/registry/remote.heygenverse.test.ts
+++ b/packages/cli/src/registry/remote.heygenverse.test.ts
@@ -8,7 +8,10 @@ const projectionSource = readFileSync(
   "utf8",
 );
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env["HYPERFRAMES_LOCAL_REGISTRY"];
+});
 
 describe("canonical HeyGenVerse projection fetch", () => {
   it("cannot be redirected by a project registry URL", async () => {
@@ -20,6 +23,18 @@ describe("canonical HeyGenVerse projection fetch", () => {
     ).resolves.toMatchObject({ schemaVersion: 1 });
     expect(fetchMock).toHaveBeenCalledWith(
       `${DEFAULT_REGISTRY_URL}/heygenverse-catalog.json`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("supports the exact checked-out projection through the fixed loopback developer endpoint", async () => {
+    process.env["HYPERFRAMES_LOCAL_REGISTRY"] = "1";
+    const fetchMock = vi.fn(async () => new Response(projectionSource, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchHeyGenVerseCatalogProjection()).resolves.toMatchObject({ schemaVersion: 1 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:4173/heygenverse-catalog.json",
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });

--- a/packages/cli/src/registry/remote.heygenverse.test.ts
+++ b/packages/cli/src/registry/remote.heygenverse.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { DEFAULT_REGISTRY_URL, fetchHeyGenVerseCatalogProjection } from "./remote.js";
+
+const projectionSource = readFileSync(
+  resolve(import.meta.dirname, "../../../../registry/heygenverse-catalog.json"),
+  "utf8",
+);
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("canonical HeyGenVerse projection fetch", () => {
+  it("cannot be redirected by a project registry URL", async () => {
+    const fetchMock = vi.fn(async () => new Response(projectionSource, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchHeyGenVerseCatalogProjection("https://attacker.invalid/registry"),
+    ).resolves.toMatchObject({ schemaVersion: 1 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${DEFAULT_REGISTRY_URL}/heygenverse-catalog.json`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+});

--- a/packages/cli/src/registry/remote.ts
+++ b/packages/cli/src/registry/remote.ts
@@ -29,6 +29,7 @@ import {
 
 export const DEFAULT_REGISTRY_URL =
   "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry";
+const LOCAL_REGISTRY_PROJECTION_URL = "http://127.0.0.1:4173/heygenverse-catalog.json";
 
 const FETCH_TIMEOUT_MS = 10_000;
 
@@ -110,8 +111,14 @@ export async function fetchHeyGenVerseCatalogProjection(
   _baseUrl: string = DEFAULT_REGISTRY_URL,
 ): Promise<HeyGenVerseCatalogProjection> {
   // Keep the optional parameter for API compatibility, but never let project
-  // configuration redirect this immutable source-of-truth projection.
-  const response = await fetch(`${DEFAULT_REGISTRY_URL}/heygenverse-catalog.json`, {
+  // configuration redirect this immutable source-of-truth projection. An
+  // explicit developer switch may use only the fixed loopback endpoint; the
+  // projection still must pass its canonical identity and digest checks.
+  const projectionUrl =
+    process.env["HYPERFRAMES_LOCAL_REGISTRY"] === "1"
+      ? LOCAL_REGISTRY_PROJECTION_URL
+      : `${DEFAULT_REGISTRY_URL}/heygenverse-catalog.json`;
+  const response = await fetch(projectionUrl, {
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!response.ok) {

--- a/packages/cli/src/registry/remote.ts
+++ b/packages/cli/src/registry/remote.ts
@@ -107,9 +107,11 @@ export async function fetchRegistryManifest(
 
 /** Fetch and validate the immutable HeyGenVerse export projection. */
 export async function fetchHeyGenVerseCatalogProjection(
-  baseUrl: string = DEFAULT_REGISTRY_URL,
+  _baseUrl: string = DEFAULT_REGISTRY_URL,
 ): Promise<HeyGenVerseCatalogProjection> {
-  const response = await fetch(`${baseUrl}/heygenverse-catalog.json`, {
+  // Keep the optional parameter for API compatibility, but never let project
+  // configuration redirect this immutable source-of-truth projection.
+  const response = await fetch(`${DEFAULT_REGISTRY_URL}/heygenverse-catalog.json`, {
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!response.ok) {

--- a/packages/cli/src/registry/remote.ts
+++ b/packages/cli/src/registry/remote.ts
@@ -22,6 +22,10 @@ import {
   type RegistryItem,
   type RegistryManifest,
 } from "@hyperframes/core";
+import {
+  parseHeyGenVerseCatalogProjection,
+  type HeyGenVerseCatalogProjection,
+} from "./heygenverseCatalog.js";
 
 export const DEFAULT_REGISTRY_URL =
   "https://raw.githubusercontent.com/heygen-com/hyperframes/main/registry";
@@ -99,6 +103,19 @@ export async function fetchRegistryManifest(
   } catch {
     return undefined;
   }
+}
+
+/** Fetch and validate the immutable HeyGenVerse export projection. */
+export async function fetchHeyGenVerseCatalogProjection(
+  baseUrl: string = DEFAULT_REGISTRY_URL,
+): Promise<HeyGenVerseCatalogProjection> {
+  const response = await fetch(`${baseUrl}/heygenverse-catalog.json`, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`HeyGenVerse catalog projection fetch failed — HTTP ${response.status}`);
+  }
+  return parseHeyGenVerseCatalogProjection(await response.text());
 }
 
 /**

--- a/packages/cli/src/registry/resolver.ts
+++ b/packages/cli/src/registry/resolver.ts
@@ -5,7 +5,13 @@
  */
 
 import type { ItemType, RegistryItem, RegistryManifestEntry } from "@hyperframes/core";
-import { fetchItemManifest, fetchRegistryManifest, DEFAULT_REGISTRY_URL } from "./remote.js";
+import {
+  fetchHeyGenVerseCatalogProjection,
+  fetchItemManifest,
+  fetchRegistryManifest,
+  DEFAULT_REGISTRY_URL,
+} from "./remote.js";
+import { assertHeyGenVerseProjectedItem } from "./heygenverseCatalog.js";
 
 export interface ResolveOptions {
   baseUrl?: string;
@@ -54,6 +60,7 @@ export async function loadAllItems(
     entries.map((e) => fetchItemManifest(e.name, e.type, baseUrl)),
   );
   const items: RegistryItem[] = [];
+  let projection: Awaited<ReturnType<typeof fetchHeyGenVerseCatalogProjection>> | undefined;
   results.forEach((r, i) => {
     if (r.status === "fulfilled") {
       items.push(r.value);
@@ -62,6 +69,10 @@ export async function loadAllItems(
       warn(`skipped item "${name}": ${String(r.reason)}`);
     }
   });
+  if (items.some((item) => item.name === "thread-message-stack")) {
+    projection = await fetchHeyGenVerseCatalogProjection(baseUrl);
+    for (const item of items) assertHeyGenVerseProjectedItem(item, projection);
+  }
   return items;
 }
 
@@ -165,6 +176,12 @@ export async function resolveItemWithDependencies(
 
     visiting.add(itemName);
     const item = await getItem(itemName);
+    if (item.name === "thread-message-stack") {
+      const projection = await fetchHeyGenVerseCatalogProjection(
+        options.baseUrl ?? DEFAULT_REGISTRY_URL,
+      );
+      assertHeyGenVerseProjectedItem(item, projection);
+    }
     for (const dep of item.registryDependencies ?? []) {
       await visit(dep, [...path, itemName]);
     }

--- a/packages/cli/src/registry/threadMessageStack.integration.test.ts
+++ b/packages/cli/src/registry/threadMessageStack.integration.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { bundleToSingleHtml } from "@hyperframes/core/compiler";
+import { registerPreviewRoutes } from "../../../studio-server/src/routes/preview.js";
+import type { StudioApiAdapter } from "../../../studio-server/src/types.js";
+import { compileForRender } from "../../../producer/src/services/htmlCompiler.js";
+import {
+  createRenderJob,
+  executeRenderJob,
+} from "../../../producer/src/services/renderOrchestrator.js";
+import { resolveConfig } from "../../../producer/src/config.js";
+import type { RegistryItem } from "@hyperframes/core";
+import { installItem } from "./installer.js";
+import { parseThreadMessageStackData } from "./threadMessageStack.js";
+import { lintProject } from "../utils/lintProject.js";
+import { DEFAULT_CHECK_OPTIONS, runCheckPipeline } from "../utils/checkPipeline.js";
+
+const tempDirs: string[] = [];
+const sourcePath = resolve(
+  import.meta.dirname,
+  "../../../../registry/blocks/thread-message-stack/thread-message-stack.html",
+);
+
+const item: RegistryItem = {
+  name: "thread-message-stack",
+  type: "hyperframes:block",
+  title: "Thread Message Stack",
+  description: "A source-owned editable conversation stack.",
+  dimensions: { width: 1920, height: 1080 },
+  duration: 8,
+  files: [
+    {
+      path: "thread-message-stack.html",
+      target: "compositions/thread-message-stack.html",
+      type: "hyperframes:composition",
+    },
+  ],
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function createProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "hf-thread-stack-"));
+  tempDirs.push(dir);
+  mkdirSync(join(dir, "compositions"), { recursive: true });
+  writeFileSync(
+    join(dir, "index.html"),
+    `<!doctype html><html><head><style>html,body,#host{margin:0;width:1920px;height:1080px;overflow:hidden}</style></head><body>
+      <div id="host" data-composition-id="root" data-start="0" data-duration="8" data-width="1920" data-height="1080">
+        <div id="thread-message-stack-host" data-composition-id="thread-message-stack" data-composition-src="compositions/thread-message-stack.html" data-start="0" data-duration="8" data-track-index="0" data-width="1920" data-height="1080"></div>
+      </div><script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+      <script>window.__timelines=window.__timelines||{};window.__timelines.root=gsap.timeline({paused:true}).to("#host",{x:1,duration:8,ease:"none"});</script>
+    </body></html>`,
+  );
+  return dir;
+}
+
+function previewAdapter(projectDir: string): StudioApiAdapter {
+  return {
+    listProjects: () => [],
+    resolveProject: async (id) => ({ id, dir: projectDir }),
+    bundle: async () => await bundleToSingleHtml(projectDir),
+    lint: async () => ({ findings: [] }),
+    runtimeUrl: "/api/runtime.js",
+    rendersDir: () => join(projectDir, "renders"),
+    startRender: () => ({
+      id: "job-1",
+      status: "rendering",
+      progress: 0,
+      outputPath: join(projectDir, "renders/out.mp4"),
+    }),
+  };
+}
+
+function stubRegistrySource(source: string): void {
+  const realFetch = globalThis.fetch;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL, init?: RequestInit) => {
+      if (
+        String(input).includes("test.invalid/blocks/thread-message-stack/thread-message-stack.html")
+      ) {
+        return new Response(source, { status: 200 });
+      }
+      return await realFetch(input, init);
+    }),
+  );
+}
+
+// End-to-end boundary coverage intentionally stays together so every temp project is cleaned.
+// fallow-ignore-next-line unit-size
+describe("thread-message-stack install to preview/render parity", () => {
+  for (const count of [1, 6, 20]) {
+    it(`crosses the real installer, Studio preview route, and producer compiler for ${count} messages`, async () => {
+      const projectDir = createProject();
+      const source = readFileSync(sourcePath, "utf8");
+      stubRegistrySource(source);
+      const messages = Array.from({ length: count }, (_, index) => ({
+        side: index % 2 === 0 ? ("incoming" as const) : ("outgoing" as const),
+        text: index === count - 1 ? `${"long ".repeat(400)}${index}` : `message-${index}`,
+        sender: index === 0 ? "" : undefined,
+      }));
+
+      await installItem(item, {
+        destDir: projectDir,
+        baseUrl: "https://test.invalid",
+        threadMessageStackData: { messages, stagger: 0, hold: 0 },
+      });
+      const installedPath = join(projectDir, "compositions/thread-message-stack.html");
+      expect(parseThreadMessageStackData(readFileSync(installedPath, "utf8")).messages).toEqual(
+        messages,
+      );
+
+      const app = new Hono();
+      registerPreviewRoutes(app, previewAdapter(projectDir));
+      const previewResponse = await app.request("http://localhost/projects/demo/preview");
+      const previewHtml = await previewResponse.text();
+      expect(previewResponse.status).toBe(200);
+
+      const producerDir = join(projectDir, "producer-output");
+      mkdirSync(producerDir, { recursive: true });
+      const producerHtml = await compileForRender(
+        projectDir,
+        join(projectDir, "index.html"),
+        producerDir,
+      );
+      for (const message of messages) {
+        expect(previewHtml).toContain(message.text);
+        expect(producerHtml.html).toContain(message.text);
+      }
+      expect(previewHtml).toContain("thread-message-stack");
+      expect(previewHtml).toContain("__timelines");
+      expect(producerHtml.html).toContain("thread-message-stack");
+      expect(producerHtml.html).toContain("__timelines");
+      expect(producerHtml.html).toContain("hidden data-hf-primitive-data");
+      expect(producerHtml.html).not.toMatch(
+        /function\(document, gsap, window, __hyperframes\) \{\s*\{"messages"/,
+      );
+    });
+  }
+
+  it("produces a real deterministic frame chain and MP4 from the installed source", async () => {
+    const projectDir = createProject();
+    const source = readFileSync(sourcePath, "utf8");
+    stubRegistrySource(source);
+    await installItem(item, {
+      destDir: projectDir,
+      baseUrl: "https://test.invalid",
+      threadMessageStackData: {
+        messages: [
+          { side: "incoming", text: "first", sender: "" },
+          { side: "outgoing", text: "second" },
+        ],
+        stagger: 0,
+        hold: 0,
+      },
+    });
+    const lint = await lintProject(projectDir);
+    expect(lint.totalErrors).toBe(0);
+    const check = await runCheckPipeline(
+      {
+        dir: projectDir,
+        name: "thread-message-stack-smoke",
+        indexPath: join(projectDir, "index.html"),
+      },
+      { ...DEFAULT_CHECK_OPTIONS, samples: 3, contrast: false },
+    );
+    expect(check.ok, JSON.stringify(check, null, 2)).toBe(true);
+    expect(check.runtime.errorCount).toBe(0);
+    const output = join(projectDir, "thread-message-stack.mp4");
+    const job = createRenderJob({
+      fps: 1,
+      quality: "draft",
+      workers: 1,
+      producerConfig: resolveConfig({ forceScreenshot: true }),
+    });
+    await executeRenderJob(job, projectDir, output);
+    expect(job.status).toBe("complete");
+    expect(job.outcome).toBe("completed");
+    expect(job.warnings).toEqual([]);
+    expect(job.perfSummary?.totalFrames).toBe(8);
+    expect(statSync(output).size).toBeGreaterThan(0);
+  }, 120_000);
+});

--- a/packages/cli/src/registry/threadMessageStack.test.ts
+++ b/packages/cli/src/registry/threadMessageStack.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  THREAD_MESSAGE_STACK_DATA_SELECTOR,
+  materializeThreadMessageStack,
+  parseThreadMessageStackData,
+  type ThreadMessageStackData,
+} from "./threadMessageStack.js";
+
+const SOURCE = `<!doctype html>
+<html><body>
+<div hidden data-hf-primitive-data>{"messages":[],"stagger":0.7,"hold":1}</div>
+<script>window.keepEditable = true;</script>
+</body></html>`;
+
+function data(count: number): ThreadMessageStackData {
+  return {
+    messages: Array.from({ length: count }, (_, index) => ({
+      side: index % 2 === 0 ? "incoming" : "outgoing",
+      text: `message-${index}`,
+      sender: index === 0 ? "Support" : "",
+    })),
+    stagger: 0.42,
+    hold: 1.25,
+  };
+}
+
+function outsideDataBlock(source: string): string {
+  return source.replace(/(<div[^>]*data-hf-primitive-data[^>]*>)[\s\S]*?(<\/div>)/, "$1__DATA__$2");
+}
+
+describe("thread-message-stack materialization", () => {
+  for (const count of [1, 6, 20]) {
+    it(`preserves all ${count} messages in order without truncation`, () => {
+      const materialized = materializeThreadMessageStack(SOURCE, data(count));
+      const parsed = parseThreadMessageStackData(materialized);
+
+      expect(parsed.messages).toHaveLength(count);
+      expect(parsed.messages.map((message) => message.text)).toEqual(
+        data(count).messages.map((message) => message.text),
+      );
+      expect(outsideDataBlock(materialized)).toBe(outsideDataBlock(SOURCE));
+      expect(materialized).toContain(THREAD_MESSAGE_STACK_DATA_SELECTOR);
+    });
+  }
+
+  it("preserves deliberate long content and empty optional scalar values", () => {
+    const longText = "A".repeat(8_192);
+    const payload: ThreadMessageStackData = {
+      messages: [{ side: "incoming", text: longText, sender: "" }],
+      stagger: 0,
+      hold: 0,
+    };
+
+    const parsed = parseThreadMessageStackData(materializeThreadMessageStack(SOURCE, payload));
+    expect(parsed).toEqual(payload);
+  });
+
+  it("rejects malformed, oversized, or ambiguous data blocks", () => {
+    expect(() =>
+      materializeThreadMessageStack(SOURCE, {
+        messages: [{ side: "middle" as "incoming", text: "bad" }],
+      }),
+    ).toThrow(/side/);
+    expect(() =>
+      materializeThreadMessageStack(SOURCE, {
+        messages: [{ side: "incoming", text: "x".repeat(8_193) }],
+      }),
+    ).toThrow(/8192/);
+    expect(() => materializeThreadMessageStack(SOURCE, { messages: [] })).toThrow(/at least one/);
+    expect(() => materializeThreadMessageStack(SOURCE + SOURCE, data(1))).toThrow(/exactly one/);
+  });
+});

--- a/packages/cli/src/registry/threadMessageStack.ts
+++ b/packages/cli/src/registry/threadMessageStack.ts
@@ -1,0 +1,117 @@
+export const THREAD_MESSAGE_STACK_ITEM_NAME = "thread-message-stack";
+export const THREAD_MESSAGE_STACK_DATA_SELECTOR = "data-hf-primitive-data";
+
+const MAX_MESSAGES = 100;
+const MAX_TEXT_LENGTH = 8_192;
+const MAX_SENDER_LENGTH = 256;
+const DATA_BLOCK_RE =
+  /(<div\b(?=[^>]*\bdata-hf-primitive-data(?:\s|=|>))[^>]*>)([\s\S]*?)(<\/div>)/gi;
+
+export interface ThreadMessageStackMessage {
+  side: "incoming" | "outgoing";
+  text: string;
+  sender?: string;
+}
+
+export interface ThreadMessageStackData {
+  messages: ThreadMessageStackMessage[];
+  stagger?: number;
+  hold?: number;
+}
+
+function assertFiniteScalar(value: unknown, name: "stagger" | "hold"): asserts value is number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > 60) {
+    throw new Error(`thread-message-stack ${name} must be a finite number from 0 to 60.`);
+  }
+}
+
+// Validation enumerates every bounded authored field before any file mutation.
+// fallow-ignore-next-line complexity
+export function validateThreadMessageStackData(value: unknown): ThreadMessageStackData {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("thread-message-stack data must be an object.");
+  }
+  const record = value as Record<string, unknown>;
+  if (!Array.isArray(record.messages) || record.messages.length === 0) {
+    throw new Error("thread-message-stack messages must contain at least one message.");
+  }
+  if (record.messages.length > MAX_MESSAGES) {
+    throw new Error(`thread-message-stack supports at most ${MAX_MESSAGES} messages per install.`);
+  }
+
+  // Each authored message field is independently bounded before materialization.
+  // fallow-ignore-next-line complexity
+  const messages = record.messages.map((candidate, index): ThreadMessageStackMessage => {
+    if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+      throw new Error(`thread-message-stack messages[${index}] must be an object.`);
+    }
+    const message = candidate as Record<string, unknown>;
+    if (message.side !== "incoming" && message.side !== "outgoing") {
+      throw new Error(`thread-message-stack messages[${index}].side must be incoming or outgoing.`);
+    }
+    if (typeof message.text !== "string") {
+      throw new Error(`thread-message-stack messages[${index}].text must be a string.`);
+    }
+    if (message.text.length > MAX_TEXT_LENGTH) {
+      throw new Error(
+        `thread-message-stack messages[${index}].text must be at most ${MAX_TEXT_LENGTH} characters.`,
+      );
+    }
+    if (message.sender !== undefined && typeof message.sender !== "string") {
+      throw new Error(`thread-message-stack messages[${index}].sender must be a string.`);
+    }
+    if (typeof message.sender === "string" && message.sender.length > MAX_SENDER_LENGTH) {
+      throw new Error(
+        `thread-message-stack messages[${index}].sender must be at most ${MAX_SENDER_LENGTH} characters.`,
+      );
+    }
+    return {
+      side: message.side,
+      text: message.text,
+      ...(message.sender !== undefined ? { sender: message.sender } : {}),
+    };
+  });
+
+  if (record.stagger !== undefined) assertFiniteScalar(record.stagger, "stagger");
+  if (record.hold !== undefined) assertFiniteScalar(record.hold, "hold");
+  return {
+    messages,
+    ...(record.stagger !== undefined ? { stagger: record.stagger } : {}),
+    ...(record.hold !== undefined ? { hold: record.hold } : {}),
+  };
+}
+
+function locateDataBlock(source: string): RegExpMatchArray {
+  const matches = [...source.matchAll(DATA_BLOCK_RE)];
+  if (matches.length !== 1) {
+    throw new Error(
+      `thread-message-stack source must contain exactly one ${THREAD_MESSAGE_STACK_DATA_SELECTOR} JSON block; found ${matches.length}.`,
+    );
+  }
+  return matches[0]!;
+}
+
+export function materializeThreadMessageStack(
+  source: string,
+  input: ThreadMessageStackData,
+): string {
+  const data = validateThreadMessageStackData(input);
+  locateDataBlock(source);
+  const serialized = JSON.stringify(data).replace(/</g, "\\u003c");
+  DATA_BLOCK_RE.lastIndex = 0;
+  return source.replace(DATA_BLOCK_RE, (_match, open: string, _old: string, close: string) => {
+    return `${open}${serialized}${close}`;
+  });
+}
+
+export function parseThreadMessageStackData(source: string): ThreadMessageStackData {
+  const match = locateDataBlock(source);
+  try {
+    return validateThreadMessageStackData(JSON.parse(match[2] ?? ""));
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error("thread-message-stack data block contains invalid JSON.");
+    }
+    throw error;
+  }
+}

--- a/packages/cli/src/registry/threadMessageStackAuthorization.test.ts
+++ b/packages/cli/src/registry/threadMessageStackAuthorization.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setupTempAuthEnv } from "../auth/_test-utils.js";
+import { writeStore } from "../auth/store.js";
+import { authorizeThreadMessageStackInstall } from "./threadMessageStackAuthorization.js";
+
+describe("thread-message-stack verified OAuth authorization", () => {
+  let fixture: Awaited<ReturnType<typeof setupTempAuthEnv>>;
+
+  beforeEach(async () => {
+    fixture = await setupTempAuthEnv("hf-thread-oauth-");
+  });
+
+  afterEach(async () => await fixture.restore());
+
+  it("does not accept an API key as OAuth and preserves cancellation", async () => {
+    process.env["HEYGEN_API_KEY"] = "api-key-only";
+    const authenticate = vi.fn(async () => "cancelled" as const);
+    const verify = vi.fn();
+
+    await expect(authorizeThreadMessageStackInstall({ authenticate, verify })).resolves.toBe(
+      "cancelled",
+    );
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  it("requires the OAuth token to pass a current-user verification", async () => {
+    await writeStore({ oauth: { access_token: "oauth-access-token" } });
+    const verify = vi.fn(async () => ({ email: "verified@example.com" }));
+
+    await expect(authorizeThreadMessageStackInstall({ verify })).resolves.toBe("authorized");
+    expect(verify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "oauth", access_token: "oauth-access-token" }),
+    );
+  });
+
+  it("fails closed when OAuth identity verification fails", async () => {
+    await writeStore({ oauth: { access_token: "oauth-access-token" } });
+
+    await expect(
+      authorizeThreadMessageStackInstall({
+        verify: async () => {
+          throw new Error("unverified");
+        },
+      }),
+    ).resolves.toBe("failed");
+  });
+});

--- a/packages/cli/src/registry/threadMessageStackAuthorization.test.ts
+++ b/packages/cli/src/registry/threadMessageStackAuthorization.test.ts
@@ -45,4 +45,37 @@ describe("thread-message-stack verified OAuth authorization", () => {
       }),
     ).resolves.toBe("failed");
   });
+
+  it("reports auth start and the verified user's bounded auth path at the real boundary", async () => {
+    const onAuthStarted = vi.fn();
+    const onVerified = vi.fn();
+    const authenticate = vi.fn(async () => {
+      await writeStore({ oauth: { access_token: "fresh-oauth-token" } });
+      return true as const;
+    });
+    const user = { email: "verified@example.com" };
+
+    await expect(
+      authorizeThreadMessageStackInstall({
+        authenticate,
+        verify: async () => user,
+        onAuthStarted,
+        onVerified,
+      }),
+    ).resolves.toBe("authorized");
+    expect(onAuthStarted).toHaveBeenCalledTimes(1);
+    expect(onVerified).toHaveBeenCalledWith(user, "oauth");
+
+    onAuthStarted.mockClear();
+    onVerified.mockClear();
+    await expect(
+      authorizeThreadMessageStackInstall({
+        verify: async () => user,
+        onAuthStarted,
+        onVerified,
+      }),
+    ).resolves.toBe("authorized");
+    expect(onAuthStarted).not.toHaveBeenCalled();
+    expect(onVerified).toHaveBeenCalledWith(user, "existing_session");
+  });
 });

--- a/packages/cli/src/registry/threadMessageStackAuthorization.ts
+++ b/packages/cli/src/registry/threadMessageStackAuthorization.ts
@@ -1,0 +1,53 @@
+import {
+  AuthClient,
+  startAuthorizationCodeFlow,
+  tryResolveOAuthCredential,
+} from "../auth/index.js";
+import type { ResolvedCredential, UserInfo } from "../auth/index.js";
+
+export type ThreadMessageStackAuthorizationOutcome =
+  | "authorized"
+  | "api-key-only"
+  | "cancelled"
+  | "failed";
+
+interface AuthorizationDeps {
+  authenticate?: () => Promise<true | "cancelled" | "failed">;
+  verify?: (credential: ResolvedCredential) => Promise<UserInfo>;
+}
+
+async function defaultAuthenticate(): Promise<true | "failed"> {
+  try {
+    await startAuthorizationCodeFlow();
+    return true;
+  } catch {
+    return "failed";
+  }
+}
+
+/**
+ * Require a persisted HeyGen OAuth session and verify it against the current-user
+ * endpoint. Environment/file API keys never satisfy this primitive boundary.
+ */
+export async function authorizeThreadMessageStackInstall(
+  deps: AuthorizationDeps = {},
+): Promise<ThreadMessageStackAuthorizationOutcome> {
+  const authenticate = deps.authenticate ?? defaultAuthenticate;
+  const verify =
+    deps.verify ?? (async (credential) => await new AuthClient().getCurrentUser(credential));
+  let credential = await tryResolveOAuthCredential();
+
+  if (!credential) {
+    const outcome = await authenticate();
+    if (outcome !== true) return outcome;
+    credential = await tryResolveOAuthCredential();
+    if (!credential) return "api-key-only";
+  }
+
+  try {
+    await verify(credential);
+    return "authorized";
+  } catch {
+    return "failed";
+  }
+}

--- a/packages/cli/src/registry/threadMessageStackAuthorization.ts
+++ b/packages/cli/src/registry/threadMessageStackAuthorization.ts
@@ -14,6 +14,8 @@ export type ThreadMessageStackAuthorizationOutcome =
 interface AuthorizationDeps {
   authenticate?: () => Promise<true | "cancelled" | "failed">;
   verify?: (credential: ResolvedCredential) => Promise<UserInfo>;
+  onAuthStarted?: () => void;
+  onVerified?: (user: UserInfo, authState: "existing_session" | "oauth") => void;
 }
 
 async function defaultAuthenticate(): Promise<true | "failed"> {
@@ -36,16 +38,20 @@ export async function authorizeThreadMessageStackInstall(
   const verify =
     deps.verify ?? (async (credential) => await new AuthClient().getCurrentUser(credential));
   let credential = await tryResolveOAuthCredential();
+  let authState: "existing_session" | "oauth" = "existing_session";
 
   if (!credential) {
+    deps.onAuthStarted?.();
     const outcome = await authenticate();
     if (outcome !== true) return outcome;
     credential = await tryResolveOAuthCredential();
     if (!credential) return "api-key-only";
+    authState = "oauth";
   }
 
   try {
-    await verify(credential);
+    const user = await verify(credential);
+    deps.onVerified?.(user, authState);
     return "authorized";
   } catch {
     return "failed";

--- a/packages/cli/src/telemetry/primitive-funnel-command.test.ts
+++ b/packages/cli/src/telemetry/primitive-funnel-command.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const trackEvent = vi.fn();
+let delivered = true;
+let tracking = true;
+vi.mock("./client.js", () => ({
+  trackEvent: (...args: unknown[]) => trackEvent(...args),
+  shouldTrack: () => tracking,
+  flush: () => Promise.resolve(delivered),
+}));
+
+const { writePrimitiveFunnelContext } = await import("./primitive-funnel-state.js");
+const {
+  trackPrimitivePreviewSucceeded,
+  trackPrimitiveRenderFailed,
+  trackPrimitiveRenderSucceeded,
+} = await import("./primitive-funnel-command.js");
+
+function claimMarkerPath(projectDir: string, eventId: string): string {
+  const digest = createHash("sha256").update(eventId).digest("hex");
+  return join(projectDir, ".hyperframes", "primitive-funnel-claims", `${digest}.claim`);
+}
+
+function emittedEventIds(projectDir: string): string[] {
+  const state: unknown = JSON.parse(
+    readFileSync(join(projectDir, ".hyperframes", "primitive-funnel.json"), "utf8"),
+  );
+  return (state as { emittedEventIds: string[] }).emittedEventIds;
+}
+
+describe("persisted primitive funnel command continuity", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "hf-funnel-command-"));
+    trackEvent.mockReset();
+    delivered = true;
+    tracking = true;
+    writePrimitiveFunnelContext(projectDir, {
+      funnelId: "funnel-command",
+      installId: "install-command",
+      primitiveId: "thread-message-stack",
+      artifactId: "artifact-command",
+      versionId: "version-command",
+      catalogVersion: "catalog-command",
+      queryFingerprint: "sha256:query",
+    });
+  });
+
+  afterEach(() => rmSync(projectDir, { recursive: true, force: true }));
+
+  it("propagates bounded command duration and deduplicates preview/render terminals", async () => {
+    await trackPrimitivePreviewSucceeded(projectDir, 12.4);
+    await trackPrimitivePreviewSucceeded(projectDir, 98);
+    await trackPrimitiveRenderFailed(projectDir, "render_failed", 23.6);
+    await trackPrimitiveRenderSucceeded(projectDir, 99);
+
+    expect(trackEvent.mock.calls.map(([name]) => name)).toEqual([
+      "primitive_preview_succeeded",
+      "primitive_render_failed",
+    ]);
+    expect(trackEvent.mock.calls[0]?.[1]).toMatchObject({
+      funnel_id: "funnel-command",
+      primitive_id: "thread-message-stack",
+      duration_ms: 12,
+      event_id: "install-command:preview",
+      funnel_step: 7,
+    });
+    expect(trackEvent.mock.calls[1]?.[1]).toMatchObject({
+      funnel_id: "funnel-command",
+      duration_ms: 24,
+      error_code: "render_failed",
+      event_id: "install-command:render",
+      funnel_step: 8,
+    });
+  });
+
+  it("releases the claim when the batch is never acknowledged, so a later command retries", async () => {
+    delivered = false;
+    await trackPrimitivePreviewSucceeded(projectDir, 10);
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(existsSync(claimMarkerPath(projectDir, "install-command:preview"))).toBe(false);
+    expect(emittedEventIds(projectDir)).not.toContain("install-command:preview");
+
+    // Same install, later command: the step is emitted rather than lost forever.
+    delivered = true;
+    await trackPrimitivePreviewSucceeded(projectDir, 11);
+    expect(trackEvent.mock.calls.map(([name]) => name)).toEqual([
+      "primitive_preview_succeeded",
+      "primitive_preview_succeeded",
+    ]);
+    expect(existsSync(claimMarkerPath(projectDir, "install-command:preview"))).toBe(true);
+  });
+
+  it("keeps the claim when the batch is acknowledged", async () => {
+    await trackPrimitivePreviewSucceeded(projectDir, 10);
+
+    expect(existsSync(claimMarkerPath(projectDir, "install-command:preview"))).toBe(true);
+    expect(emittedEventIds(projectDir)).toContain("install-command:preview");
+  });
+
+  it("does not spend a claim while telemetry is opted out", async () => {
+    tracking = false;
+    await trackPrimitivePreviewSucceeded(projectDir, 10);
+
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(existsSync(claimMarkerPath(projectDir, "install-command:preview"))).toBe(false);
+
+    // Re-enabling tracking must still be able to emit the step.
+    tracking = true;
+    await trackPrimitivePreviewSucceeded(projectDir, 10);
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/telemetry/primitive-funnel-command.ts
+++ b/packages/cli/src/telemetry/primitive-funnel-command.ts
@@ -1,40 +1,71 @@
 import { PrimitiveFunnel, type PrimitiveFunnelErrorCode } from "./primitive-funnel.js";
-import { claimPrimitiveFunnelEvent, readPrimitiveFunnelContext } from "./primitive-funnel-state.js";
+import {
+  claimPrimitiveFunnelEvent,
+  readPrimitiveFunnelContext,
+  releasePrimitiveFunnelEvent,
+} from "./primitive-funnel-state.js";
+import { flush, shouldTrack } from "./client.js";
 
-function emitProjectTerminal(
+/**
+ * Emit one terminal funnel event for a project, at most once per install under
+ * concurrency, and await delivery.
+ *
+ * The await is the point. Terminal events are the only telemetry in the CLI
+ * that consumes a durable single-use claim, so the usual fire-and-forget exit
+ * flush is not good enough: the claim outlives the process, the detached flush
+ * child does not, and a send that never lands leaves a claim burned on an event
+ * PostHog never saw. Confirming delivery here lets us give the claim back.
+ */
+async function emitProjectTerminal(
   projectDir: string,
   suffix: "preview" | "render",
   emit: (funnel: PrimitiveFunnel, eventId: string) => void,
-): void {
+): Promise<void> {
+  // Claiming while telemetry is off would burn the claim on an event that is
+  // never enqueued, silently disabling the step if tracking is re-enabled.
+  if (!shouldTrack()) return;
   const context = readPrimitiveFunnelContext(projectDir);
   if (!context) return;
   const eventId = `${context.installId}:${suffix}`;
   if (!claimPrimitiveFunnelEvent(projectDir, eventId)) return;
   emit(new PrimitiveFunnel(context), eventId);
+  if (!(await flush())) releasePrimitiveFunnelEvent(projectDir, eventId);
 }
 
-export function trackPrimitivePreviewSucceeded(projectDir: string): void {
-  emitProjectTerminal(projectDir, "preview", (funnel, eventId) => funnel.previewSucceeded(eventId));
-}
-
-export function trackPrimitivePreviewFailed(
+export async function trackPrimitivePreviewSucceeded(
   projectDir: string,
-  errorCode: PrimitiveFunnelErrorCode,
-): void {
-  emitProjectTerminal(projectDir, "preview", (funnel, eventId) =>
-    funnel.previewFailed(eventId, errorCode),
+  durationMs: number,
+): Promise<void> {
+  await emitProjectTerminal(projectDir, "preview", (funnel, eventId) =>
+    funnel.previewSucceeded(eventId, durationMs),
   );
 }
 
-export function trackPrimitiveRenderSucceeded(projectDir: string): void {
-  emitProjectTerminal(projectDir, "render", (funnel, eventId) => funnel.renderSucceeded(eventId));
-}
-
-export function trackPrimitiveRenderFailed(
+export async function trackPrimitivePreviewFailed(
   projectDir: string,
   errorCode: PrimitiveFunnelErrorCode,
-): void {
-  emitProjectTerminal(projectDir, "render", (funnel, eventId) =>
-    funnel.renderFailed(eventId, errorCode),
+  durationMs: number,
+): Promise<void> {
+  await emitProjectTerminal(projectDir, "preview", (funnel, eventId) =>
+    funnel.previewFailed(eventId, errorCode, durationMs),
+  );
+}
+
+export async function trackPrimitiveRenderSucceeded(
+  projectDir: string,
+  durationMs: number,
+): Promise<void> {
+  await emitProjectTerminal(projectDir, "render", (funnel, eventId) =>
+    funnel.renderSucceeded(eventId, durationMs),
+  );
+}
+
+export async function trackPrimitiveRenderFailed(
+  projectDir: string,
+  errorCode: PrimitiveFunnelErrorCode,
+  durationMs: number,
+): Promise<void> {
+  await emitProjectTerminal(projectDir, "render", (funnel, eventId) =>
+    funnel.renderFailed(eventId, errorCode, durationMs),
   );
 }

--- a/packages/cli/src/telemetry/primitive-funnel-command.ts
+++ b/packages/cli/src/telemetry/primitive-funnel-command.ts
@@ -1,0 +1,40 @@
+import { PrimitiveFunnel, type PrimitiveFunnelErrorCode } from "./primitive-funnel.js";
+import { claimPrimitiveFunnelEvent, readPrimitiveFunnelContext } from "./primitive-funnel-state.js";
+
+function emitProjectTerminal(
+  projectDir: string,
+  suffix: "preview" | "render",
+  emit: (funnel: PrimitiveFunnel, eventId: string) => void,
+): void {
+  const context = readPrimitiveFunnelContext(projectDir);
+  if (!context) return;
+  const eventId = `${context.installId}:${suffix}`;
+  if (!claimPrimitiveFunnelEvent(projectDir, eventId)) return;
+  emit(new PrimitiveFunnel(context), eventId);
+}
+
+export function trackPrimitivePreviewSucceeded(projectDir: string): void {
+  emitProjectTerminal(projectDir, "preview", (funnel, eventId) => funnel.previewSucceeded(eventId));
+}
+
+export function trackPrimitivePreviewFailed(
+  projectDir: string,
+  errorCode: PrimitiveFunnelErrorCode,
+): void {
+  emitProjectTerminal(projectDir, "preview", (funnel, eventId) =>
+    funnel.previewFailed(eventId, errorCode),
+  );
+}
+
+export function trackPrimitiveRenderSucceeded(projectDir: string): void {
+  emitProjectTerminal(projectDir, "render", (funnel, eventId) => funnel.renderSucceeded(eventId));
+}
+
+export function trackPrimitiveRenderFailed(
+  projectDir: string,
+  errorCode: PrimitiveFunnelErrorCode,
+): void {
+  emitProjectTerminal(projectDir, "render", (funnel, eventId) =>
+    funnel.renderFailed(eventId, errorCode),
+  );
+}

--- a/packages/cli/src/telemetry/primitive-funnel-state.ts
+++ b/packages/cli/src/telemetry/primitive-funnel-state.ts
@@ -1,10 +1,19 @@
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
-import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
 import { join } from "node:path";
 import type { PrimitiveFunnelContext } from "./primitive-funnel.js";
 
 const FUNNEL_STATE_DIR = ".hyperframes";
 const FUNNEL_STATE_FILE = "primitive-funnel.json";
+const FUNNEL_CLAIM_DIR = "primitive-funnel-claims";
 
 interface PersistedPrimitiveFunnelContext extends PrimitiveFunnelContext {
   emittedEventIds: string[];
@@ -14,12 +23,33 @@ function statePath(projectDir: string): string {
   return join(projectDir, FUNNEL_STATE_DIR, FUNNEL_STATE_FILE);
 }
 
+function claimMarkerPath(projectDir: string, eventId: string): string {
+  const directory = join(projectDir, FUNNEL_STATE_DIR, FUNNEL_CLAIM_DIR);
+  const digest = createHash("sha256").update(eventId).digest("hex");
+  return join(directory, `${digest}.claim`);
+}
+
+function createClaimMarker(projectDir: string, eventId: string): boolean {
+  mkdirSync(join(projectDir, FUNNEL_STATE_DIR, FUNNEL_CLAIM_DIR), {
+    recursive: true,
+    mode: 0o700,
+  });
+  try {
+    const descriptor = openSync(claimMarkerPath(projectDir, eventId), "wx", 0o600);
+    closeSync(descriptor);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function isContext(value: unknown): value is PrimitiveFunnelContext {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const record = value as Record<string, unknown>;
   return [
     "funnelId",
     "installId",
+    "primitiveId",
     "artifactId",
     "versionId",
     "catalogVersion",
@@ -31,8 +61,24 @@ export function readPrimitiveFunnelContext(projectDir: string): PrimitiveFunnelC
   try {
     const value: unknown = JSON.parse(readFileSync(statePath(projectDir), "utf8"));
     if (!isContext(value)) return null;
-    const { funnelId, installId, artifactId, versionId, catalogVersion, queryFingerprint } = value;
-    return { funnelId, installId, artifactId, versionId, catalogVersion, queryFingerprint };
+    const {
+      funnelId,
+      installId,
+      primitiveId,
+      artifactId,
+      versionId,
+      catalogVersion,
+      queryFingerprint,
+    } = value;
+    return {
+      funnelId,
+      installId,
+      primitiveId,
+      artifactId,
+      versionId,
+      catalogVersion,
+      queryFingerprint,
+    };
   } catch {
     return null;
   }
@@ -57,23 +103,69 @@ export function writePrimitiveFunnelContext(
   writeState(projectDir, { ...context, emittedEventIds: [] });
 }
 
+function readEmittedEventIds(projectDir: string): string[] {
+  try {
+    const value: unknown = JSON.parse(readFileSync(statePath(projectDir), "utf8"));
+    if (!isContext(value)) return [];
+    const record = value as PrimitiveFunnelContext & { emittedEventIds?: unknown };
+    if (!Array.isArray(record.emittedEventIds)) return [];
+    return record.emittedEventIds.filter(
+      (candidate): candidate is string => typeof candidate === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
 /** Atomically claim a stable terminal id before enqueueing cross-command telemetry. */
 export function claimPrimitiveFunnelEvent(projectDir: string, eventId: string): boolean {
   try {
     const value: unknown = JSON.parse(readFileSync(statePath(projectDir), "utf8"));
     if (!isContext(value)) return false;
-    const record = value as PrimitiveFunnelContext & { emittedEventIds?: unknown };
-    const emittedEventIds = Array.isArray(record.emittedEventIds)
-      ? record.emittedEventIds.filter(
-          (candidate): candidate is string => typeof candidate === "string",
-        )
-      : [];
+    const emittedEventIds = readEmittedEventIds(projectDir);
     if (emittedEventIds.includes(eventId)) return false;
     const context = readPrimitiveFunnelContext(projectDir);
     if (!context) return false;
-    writeState(projectDir, { ...context, emittedEventIds: [...emittedEventIds, eventId] });
+    if (!createClaimMarker(projectDir, eventId)) return false;
+    try {
+      writeState(projectDir, { ...context, emittedEventIds: [...emittedEventIds, eventId] });
+    } catch {
+      // The permanent O_EXCL marker is the authoritative claim. Retaining it
+      // fails closed if the compatibility state rewrite cannot complete.
+    }
     return true;
   } catch {
     return false;
+  }
+}
+
+/**
+ * Hand a claim back after a delivery attempt PostHog never acknowledged.
+ *
+ * The claim has to be taken before the send, because its whole job is to stop
+ * two concurrent processes both emitting one terminal event. That ordering
+ * means an unacknowledged send would otherwise burn the claim permanently and
+ * the step could never be emitted again — the funnel loses it for good.
+ * Releasing trades that permanent loss for a possible duplicate on a later
+ * command, which is the cheaper failure: every funnel event carries a stable
+ * `event_id`, so duplicates collapse downstream while a loss is unrecoverable.
+ */
+export function releasePrimitiveFunnelEvent(projectDir: string, eventId: string): void {
+  try {
+    rmSync(claimMarkerPath(projectDir, eventId), { force: true });
+  } catch {
+    // Best effort. A retained marker only costs one un-emitted event, which is
+    // exactly the state we were already in.
+  }
+  try {
+    const context = readPrimitiveFunnelContext(projectDir);
+    if (!context) return;
+    writeState(projectDir, {
+      ...context,
+      emittedEventIds: readEmittedEventIds(projectDir).filter((id) => id !== eventId),
+    });
+  } catch {
+    // The marker is the authoritative claim; the id list is a compatibility
+    // mirror, so failing to prune it cannot resurrect a consumed claim.
   }
 }

--- a/packages/cli/src/telemetry/primitive-funnel-state.ts
+++ b/packages/cli/src/telemetry/primitive-funnel-state.ts
@@ -1,0 +1,79 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import type { PrimitiveFunnelContext } from "./primitive-funnel.js";
+
+const FUNNEL_STATE_DIR = ".hyperframes";
+const FUNNEL_STATE_FILE = "primitive-funnel.json";
+
+interface PersistedPrimitiveFunnelContext extends PrimitiveFunnelContext {
+  emittedEventIds: string[];
+}
+
+function statePath(projectDir: string): string {
+  return join(projectDir, FUNNEL_STATE_DIR, FUNNEL_STATE_FILE);
+}
+
+function isContext(value: unknown): value is PrimitiveFunnelContext {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return [
+    "funnelId",
+    "installId",
+    "artifactId",
+    "versionId",
+    "catalogVersion",
+    "queryFingerprint",
+  ].every((key) => typeof record[key] === "string" && record[key].length > 0);
+}
+
+export function readPrimitiveFunnelContext(projectDir: string): PrimitiveFunnelContext | null {
+  try {
+    const value: unknown = JSON.parse(readFileSync(statePath(projectDir), "utf8"));
+    if (!isContext(value)) return null;
+    const { funnelId, installId, artifactId, versionId, catalogVersion, queryFingerprint } = value;
+    return { funnelId, installId, artifactId, versionId, catalogVersion, queryFingerprint };
+  } catch {
+    return null;
+  }
+}
+
+function writeState(projectDir: string, state: PersistedPrimitiveFunnelContext): void {
+  const directory = join(projectDir, FUNNEL_STATE_DIR);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const path = statePath(projectDir);
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  renameSync(temporaryPath, path);
+}
+
+export function writePrimitiveFunnelContext(
+  projectDir: string,
+  context: PrimitiveFunnelContext,
+): void {
+  writeState(projectDir, { ...context, emittedEventIds: [] });
+}
+
+/** Atomically claim a stable terminal id before enqueueing cross-command telemetry. */
+export function claimPrimitiveFunnelEvent(projectDir: string, eventId: string): boolean {
+  try {
+    const value: unknown = JSON.parse(readFileSync(statePath(projectDir), "utf8"));
+    if (!isContext(value)) return false;
+    const record = value as PrimitiveFunnelContext & { emittedEventIds?: unknown };
+    const emittedEventIds = Array.isArray(record.emittedEventIds)
+      ? record.emittedEventIds.filter(
+          (candidate): candidate is string => typeof candidate === "string",
+        )
+      : [];
+    if (emittedEventIds.includes(eventId)) return false;
+    const context = readPrimitiveFunnelContext(projectDir);
+    if (!context) return false;
+    writeState(projectDir, { ...context, emittedEventIds: [...emittedEventIds, eventId] });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/telemetry/primitive-funnel-transport.test.ts
+++ b/packages/cli/src/telemetry/primitive-funnel-transport.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const posture = { enabled: true };
+const fetchMock = vi.fn(
+  async (_input: string | URL | Request, _init?: RequestInit) =>
+    new Response(null, { status: 200 }),
+);
+
+vi.mock("./config.js", () => ({
+  readConfig: () => ({
+    anonymousId: "anonymous-transport",
+    telemetryEnabled: posture.enabled,
+  }),
+  writeConfig: vi.fn(),
+}));
+vi.mock("./policy.js", () => ({ telemetryRuntimeOverride: () => null }));
+vi.mock("./system.js", () => ({
+  getSystemMeta: () => ({
+    os_release: "test",
+    cpu_count: 1,
+    memory_total_mb: 1,
+    is_docker: false,
+    is_ci: true,
+    is_wsl: false,
+    is_tty: false,
+  }),
+}));
+vi.mock("./canary.js", () => ({ canaryEventProperties: () => ({}) }));
+
+vi.stubGlobal("fetch", fetchMock);
+
+const { PrimitiveFunnel } = await import("./primitive-funnel.js");
+const { writePrimitiveFunnelContext } = await import("./primitive-funnel-state.js");
+const { trackPrimitivePreviewSucceeded, trackPrimitiveRenderSucceeded } =
+  await import("./primitive-funnel-command.js");
+const { flush, resetTelemetryPostureCache } = await import("./client.js");
+
+describe("primitive funnel queued transport boundary", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "hf-funnel-transport-"));
+    posture.enabled = true;
+    resetTelemetryPostureCache();
+    fetchMock.mockClear();
+  });
+
+  afterEach(() => rmSync(projectDir, { recursive: true, force: true }));
+
+  it("delivers one ordered privacy-safe journey with a stable identity", async () => {
+    const context = {
+      funnelId: "funnel-transport",
+      installId: "install-transport",
+      primitiveId: "thread-message-stack",
+      artifactId: "artifact-transport",
+      versionId: "version-transport",
+      catalogVersion: "catalog-transport",
+      queryFingerprint: "sha256:non-content",
+    };
+    const funnel = new PrimitiveFunnel(context);
+    funnel.catalogSearched(2);
+    funnel.catalogResultSelected(1);
+    funnel.authStarted();
+    funnel.authCompleted("verified@example.com", "oauth", 5);
+    funnel.installStarted();
+    writePrimitiveFunnelContext(projectDir, context);
+    funnel.installCompleted("install-transport:install-completed", 7);
+    // Terminal steps flush themselves, because they must know whether the send
+    // landed before their single-use claim counts as spent. So the journey is
+    // delivered across several batches; what has to hold is the ORDER, not the
+    // batch count.
+    await trackPrimitivePreviewSucceeded(projectDir, 11);
+    await trackPrimitivePreviewSucceeded(projectDir, 99);
+    await trackPrimitiveRenderSucceeded(projectDir, 13);
+
+    await flush();
+
+    type DeliveredEvent = {
+      event: string;
+      distinct_id: string;
+      properties: Record<string, unknown>;
+    };
+    const bodies = fetchMock.mock.calls.map((call) => JSON.parse(String(call?.[1]?.body)));
+    const events = bodies.flatMap((body) => body.batch as DeliveredEvent[]);
+    const body = { batch: events };
+    expect(events.map(({ event }) => event)).toEqual([
+      "primitive_catalog_searched",
+      "primitive_catalog_result_selected",
+      "primitive_auth_started",
+      "$identify",
+      "primitive_auth_completed",
+      "primitive_install_started",
+      "primitive_install_completed",
+      "primitive_preview_succeeded",
+      "primitive_render_succeeded",
+    ]);
+    expect(events.filter(({ event }) => event === "$identify")).toHaveLength(1);
+    expect(events.filter(({ event }) => event === "primitive_preview_succeeded")).toHaveLength(1);
+
+    // Timestamps cannot carry this order: auth completion and install start are
+    // emitted back to back and land in the same millisecond, so a consumer that
+    // sorts by time can report the install beginning before the auth that
+    // authorized it. funnel_step is what makes the order recoverable.
+    const steps = events
+      .filter(({ event }) => event !== "$identify")
+      .map(({ properties }) => properties.funnel_step as number);
+    expect(steps).toEqual([...steps].sort((a, b) => a - b));
+    expect(steps).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(events.every(({ properties }) => properties.funnel_id === "funnel-transport")).toBe(
+      true,
+    );
+    expect(events.at(-2)?.properties.duration_ms).toBe(11);
+    expect(events.at(-1)?.properties.duration_ms).toBe(13);
+    expect(JSON.stringify(body)).not.toMatch(
+      /raw_query|query_text|messages|html_source|css_source|javascript|credential|access_token|raw_error|rendered_media/,
+    );
+    expect(events.every(({ properties }) => properties.$ip === null)).toBe(true);
+  });
+
+  it("does not queue or fetch after opt-out", async () => {
+    posture.enabled = false;
+    resetTelemetryPostureCache();
+    const funnel = new PrimitiveFunnel({
+      funnelId: "funnel-opt-out",
+      installId: "install-opt-out",
+      primitiveId: "thread-message-stack",
+      artifactId: "artifact-opt-out",
+      versionId: "version-opt-out",
+      catalogVersion: "catalog-opt-out",
+      queryFingerprint: "sha256:non-content",
+    });
+    funnel.catalogSearched(1);
+    funnel.authCompleted("private@example.com", "existing_session", 0);
+    await flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/telemetry/primitive-funnel.test.ts
+++ b/packages/cli/src/telemetry/primitive-funnel.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -8,11 +9,62 @@ const shouldTrack = vi.fn(() => true);
 vi.mock("./client.js", () => ({
   trackEvent: (...args: unknown[]) => trackEvent(...args),
   shouldTrack: () => shouldTrack(),
+  flush: () => Promise.resolve(true),
 }));
 
 const { PrimitiveFunnel } = await import("./primitive-funnel.js");
 const { claimPrimitiveFunnelEvent, readPrimitiveFunnelContext, writePrimitiveFunnelContext } =
   await import("./primitive-funnel-state.js");
+
+async function runSynchronizedClaims(
+  projectDir: string,
+  eventId: string,
+  processCount: number,
+): Promise<number> {
+  const workerPath = join(projectDir, "primitive-funnel-claim.worker.ts");
+  const gatePath = join(projectDir, "primitive-funnel-claim.gate");
+  const stateModuleUrl = new URL("./primitive-funnel-state.ts", import.meta.url).href;
+  writeFileSync(
+    workerPath,
+    [
+      'import { existsSync, writeFileSync } from "node:fs";',
+      `import { claimPrimitiveFunnelEvent } from ${JSON.stringify(stateModuleUrl)};`,
+      "const [projectDir, eventId, gatePath, readyPath] = process.argv.slice(2);",
+      "writeFileSync(readyPath, String(process.pid));",
+      "while (!existsSync(gatePath)) await Bun.sleep(1);",
+      'process.stdout.write(claimPrimitiveFunnelEvent(projectDir, eventId) ? "true" : "false");',
+    ].join("\n"),
+  );
+
+  const readyPaths = Array.from({ length: processCount }, (_, index) =>
+    join(projectDir, `primitive-funnel-claim.ready-${index}`),
+  );
+  const exits = readyPaths.map((readyPath) => {
+    const child = spawn("bun", [workerPath, projectDir, eventId, gatePath, readyPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    return new Promise<string>((resolve, reject) => {
+      child.on("error", reject);
+      child.on("close", (code) => {
+        if (code === 0) resolve(Buffer.concat(stdout).toString("utf8"));
+        else reject(new Error(`claim worker exited ${code}: ${Buffer.concat(stderr)}`));
+      });
+    });
+  });
+
+  const readinessDeadline = Date.now() + 10_000;
+  while (!readyPaths.every((path) => existsSync(path))) {
+    if (Date.now() >= readinessDeadline) throw new Error("claim workers did not become ready");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  writeFileSync(gatePath, "go");
+  const outputs = await Promise.all(exits);
+  return outputs.filter((output) => output === "true").length;
+}
 
 // Funnel contract assertions intentionally share one mocked telemetry boundary.
 // fallow-ignore-next-line unit-size
@@ -26,39 +78,66 @@ describe("primitive discovery funnel", () => {
     const funnel = new PrimitiveFunnel({
       funnelId: "funnel-1",
       installId: "install-1",
+      primitiveId: "thread-message-stack",
       artifactId: "artifact-1",
       versionId: "version-1",
       catalogVersion: "catalog-1",
       queryFingerprint: "sha256:query",
     });
-    funnel.searched();
-    funnel.selected();
-    funnel.authRequired();
-    funnel.authCompleted("account-1");
-    funnel.authCompleted("account-1");
-    funnel.installSucceeded("event-install");
-    funnel.installSucceeded("event-install");
-    funnel.previewSucceeded("event-preview");
-    funnel.renderFailed("event-render", "capture_failed");
+    funnel.catalogSearched(4);
+    funnel.catalogResultSelected(2);
+    funnel.authStarted();
+    funnel.authCompleted("account-1", "oauth", 17);
+    funnel.authCompleted("account-1", "oauth", 17);
+    funnel.installStarted();
+    funnel.installCompleted("event-install", 23);
+    funnel.installCompleted("event-install", 23);
+    funnel.previewSucceeded("event-preview", 31);
+    funnel.renderFailed("event-render", "capture_failed", 41);
 
     const calls = trackEvent.mock.calls;
+    expect(calls.filter(([name]) => name !== "$identify").map(([name]) => name)).toEqual([
+      "primitive_catalog_searched",
+      "primitive_catalog_result_selected",
+      "primitive_auth_started",
+      "primitive_auth_completed",
+      "primitive_install_started",
+      "primitive_install_completed",
+      "primitive_preview_succeeded",
+      "primitive_render_failed",
+    ]);
     expect(calls.filter(([name]) => name === "$identify")).toHaveLength(1);
     expect(calls.filter(([name]) => name === "primitive_auth_completed")).toHaveLength(1);
     expect(calls.find(([name]) => name === "$identify")?.[2]).toBe("account-1");
-    expect(calls.filter(([name]) => name === "primitive_install_succeeded")).toHaveLength(1);
+    expect(calls.filter(([name]) => name === "primitive_install_completed")).toHaveLength(1);
     expect(calls.every(([, props]) => props.funnel_id === "funnel-1")).toBe(true);
+    expect(calls.find(([name]) => name === "primitive_catalog_searched")?.[1]).toMatchObject({
+      primitive_id: "thread-message-stack",
+      result_count: 4,
+      auth_state: "anonymous",
+      event_id: "funnel-1:catalog-searched",
+    });
+    expect(calls.find(([name]) => name === "primitive_catalog_result_selected")?.[1]).toMatchObject(
+      { result_rank: 2, event_id: "funnel-1:catalog-result-selected" },
+    );
+    expect(calls.find(([name]) => name === "primitive_install_completed")?.[1]).toMatchObject({
+      duration_ms: 23,
+      auth_state: "authenticated",
+      event_id: "event-install",
+    });
   });
 
   it("emits only allowlisted non-content properties and bounded errors", () => {
     const funnel = new PrimitiveFunnel({
       funnelId: "funnel-2",
       installId: "install-2",
+      primitiveId: "thread-message-stack",
       artifactId: "artifact-2",
       versionId: "version-2",
       catalogVersion: "catalog-2",
       queryFingerprint: "sha256:query",
     });
-    funnel.installFailed("event-1", "invalid_payload");
+    funnel.installFailed("event-1", "invalid_payload", Number.POSITIVE_INFINITY);
 
     const payload = trackEvent.mock.lastCall?.[1] as Record<string, unknown>;
     expect(Object.keys(payload).sort()).toEqual(
@@ -68,11 +147,16 @@ describe("primitive discovery funnel", () => {
         "error_code",
         "event_id",
         "funnel_id",
+        "funnel_step",
         "install_id",
+        "primitive_id",
         "query_fingerprint",
         "version_id",
+        "auth_state",
+        "duration_ms",
       ].sort(),
     );
+    expect(payload.duration_ms).toBe(86_400_000);
     expect(JSON.stringify(payload)).not.toMatch(
       /messages|html|css|javascript|asset|token|raw_error/,
     );
@@ -83,14 +167,15 @@ describe("primitive discovery funnel", () => {
     const funnel = new PrimitiveFunnel({
       funnelId: "funnel-3",
       installId: "install-3",
+      primitiveId: "thread-message-stack",
       artifactId: "artifact-3",
       versionId: "version-3",
       catalogVersion: "catalog-3",
       queryFingerprint: "sha256:query",
     });
-    funnel.searched();
-    funnel.authCompleted("account-3");
-    funnel.renderSucceeded("event-3");
+    funnel.catalogSearched(1);
+    funnel.authCompleted("account-3", "existing_session", 0);
+    funnel.renderSucceeded("event-3", 0);
     expect(trackEvent).not.toHaveBeenCalled();
   });
 
@@ -99,6 +184,7 @@ describe("primitive discovery funnel", () => {
     const context = {
       funnelId: "funnel-4",
       installId: "install-4",
+      primitiveId: "thread-message-stack",
       artifactId: "artifact-4",
       versionId: "version-4",
       catalogVersion: "catalog-4",
@@ -113,4 +199,31 @@ describe("primitive discovery funnel", () => {
     );
     rmSync(dir, { recursive: true, force: true });
   });
+
+  it("repeatedly claims one shared preview and render event across independent processes", async () => {
+    for (const suffix of ["preview", "render"] as const) {
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const dir = mkdtempSync(join(tmpdir(), `hf-funnel-${suffix}-race-`));
+        try {
+          const installId = `race-install-${suffix}-${attempt}`;
+          writePrimitiveFunnelContext(dir, {
+            funnelId: `race-funnel-${suffix}-${attempt}`,
+            installId,
+            primitiveId: "thread-message-stack",
+            artifactId: "race-artifact",
+            versionId: "race-version",
+            catalogVersion: "race-catalog",
+            queryFingerprint: "sha256:race",
+          });
+          const trueCount = await runSynchronizedClaims(dir, `${installId}:${suffix}`, 32);
+          console.log(
+            `primitive-funnel ${suffix} race ${attempt} observed true-count=${trueCount}`,
+          );
+          expect(trueCount).toBe(1);
+        } finally {
+          rmSync(dir, { recursive: true, force: true });
+        }
+      }
+    }
+  }, 30_000);
 });

--- a/packages/cli/src/telemetry/primitive-funnel.test.ts
+++ b/packages/cli/src/telemetry/primitive-funnel.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const trackEvent = vi.fn();
+const shouldTrack = vi.fn(() => true);
+vi.mock("./client.js", () => ({
+  trackEvent: (...args: unknown[]) => trackEvent(...args),
+  shouldTrack: () => shouldTrack(),
+}));
+
+const { PrimitiveFunnel } = await import("./primitive-funnel.js");
+const { claimPrimitiveFunnelEvent, readPrimitiveFunnelContext, writePrimitiveFunnelContext } =
+  await import("./primitive-funnel-state.js");
+
+// Funnel contract assertions intentionally share one mocked telemetry boundary.
+// fallow-ignore-next-line unit-size
+describe("primitive discovery funnel", () => {
+  beforeEach(() => {
+    trackEvent.mockClear();
+    shouldTrack.mockReturnValue(true);
+  });
+
+  it("uses one stable funnel id, identifies once, and deduplicates terminal ids", () => {
+    const funnel = new PrimitiveFunnel({
+      funnelId: "funnel-1",
+      installId: "install-1",
+      artifactId: "artifact-1",
+      versionId: "version-1",
+      catalogVersion: "catalog-1",
+      queryFingerprint: "sha256:query",
+    });
+    funnel.searched();
+    funnel.selected();
+    funnel.authRequired();
+    funnel.authCompleted("account-1");
+    funnel.authCompleted("account-1");
+    funnel.installSucceeded("event-install");
+    funnel.installSucceeded("event-install");
+    funnel.previewSucceeded("event-preview");
+    funnel.renderFailed("event-render", "capture_failed");
+
+    const calls = trackEvent.mock.calls;
+    expect(calls.filter(([name]) => name === "$identify")).toHaveLength(1);
+    expect(calls.filter(([name]) => name === "primitive_auth_completed")).toHaveLength(1);
+    expect(calls.find(([name]) => name === "$identify")?.[2]).toBe("account-1");
+    expect(calls.filter(([name]) => name === "primitive_install_succeeded")).toHaveLength(1);
+    expect(calls.every(([, props]) => props.funnel_id === "funnel-1")).toBe(true);
+  });
+
+  it("emits only allowlisted non-content properties and bounded errors", () => {
+    const funnel = new PrimitiveFunnel({
+      funnelId: "funnel-2",
+      installId: "install-2",
+      artifactId: "artifact-2",
+      versionId: "version-2",
+      catalogVersion: "catalog-2",
+      queryFingerprint: "sha256:query",
+    });
+    funnel.installFailed("event-1", "invalid_payload");
+
+    const payload = trackEvent.mock.lastCall?.[1] as Record<string, unknown>;
+    expect(Object.keys(payload).sort()).toEqual(
+      [
+        "artifact_id",
+        "catalog_version",
+        "error_code",
+        "event_id",
+        "funnel_id",
+        "install_id",
+        "query_fingerprint",
+        "version_id",
+      ].sort(),
+    );
+    expect(JSON.stringify(payload)).not.toMatch(
+      /messages|html|css|javascript|asset|token|raw_error/,
+    );
+  });
+
+  it("does not enqueue or identify when telemetry is opted out", () => {
+    shouldTrack.mockReturnValue(false);
+    const funnel = new PrimitiveFunnel({
+      funnelId: "funnel-3",
+      installId: "install-3",
+      artifactId: "artifact-3",
+      versionId: "version-3",
+      catalogVersion: "catalog-3",
+      queryFingerprint: "sha256:query",
+    });
+    funnel.searched();
+    funnel.authCompleted("account-3");
+    funnel.renderSucceeded("event-3");
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it("bridges commands with only allowlisted non-content metadata", () => {
+    const dir = mkdtempSync(join(tmpdir(), "hf-funnel-"));
+    const context = {
+      funnelId: "funnel-4",
+      installId: "install-4",
+      artifactId: "artifact-4",
+      versionId: "version-4",
+      catalogVersion: "catalog-4",
+      queryFingerprint: "sha256:query",
+    };
+    writePrimitiveFunnelContext(dir, context);
+    expect(readPrimitiveFunnelContext(dir)).toEqual(context);
+    expect(claimPrimitiveFunnelEvent(dir, "install-4:preview")).toBe(true);
+    expect(claimPrimitiveFunnelEvent(dir, "install-4:preview")).toBe(false);
+    expect(readFileSync(join(dir, ".hyperframes", "primitive-funnel.json"), "utf8")).not.toMatch(
+      /messages|html|css|javascript|asset|token|raw_error/,
+    );
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/packages/cli/src/telemetry/primitive-funnel.ts
+++ b/packages/cli/src/telemetry/primitive-funnel.ts
@@ -1,0 +1,112 @@
+import { shouldTrack, trackEvent } from "./client.js";
+import { readConfig } from "./config.js";
+
+export type PrimitiveFunnelErrorCode =
+  | "invalid_payload"
+  | "auth_failed"
+  | "auth_cancelled"
+  | "install_failed"
+  | "preview_failed"
+  | "compile_failed"
+  | "capture_failed"
+  | "render_failed";
+
+export interface PrimitiveFunnelContext {
+  funnelId: string;
+  installId: string;
+  artifactId: string;
+  versionId: string;
+  catalogVersion: string;
+  queryFingerprint: string;
+}
+
+type PrimitiveFunnelBaseProperties = {
+  funnel_id: string;
+  install_id: string;
+  artifact_id: string;
+  version_id: string;
+  catalog_version: string;
+  query_fingerprint: string;
+};
+
+/** Privacy-safe telemetry for one catalog-selection lifecycle. */
+export class PrimitiveFunnel {
+  readonly #base: PrimitiveFunnelBaseProperties;
+  readonly #terminalEventIds = new Set<string>();
+  #identified = false;
+
+  constructor(context: PrimitiveFunnelContext) {
+    this.#base = {
+      funnel_id: context.funnelId,
+      install_id: context.installId,
+      artifact_id: context.artifactId,
+      version_id: context.versionId,
+      catalog_version: context.catalogVersion,
+      query_fingerprint: context.queryFingerprint,
+    };
+  }
+
+  searched(): void {
+    this.#track("primitive_searched");
+  }
+
+  selected(): void {
+    this.#track("primitive_selected");
+  }
+
+  authRequired(): void {
+    this.#track("primitive_auth_required");
+  }
+
+  authCompleted(accountId?: string): void {
+    if (!shouldTrack() || this.#identified) return;
+    this.#identified = true;
+    if (accountId) {
+      trackEvent(
+        "$identify",
+        { ...this.#base, $anon_distinct_id: readConfig().anonymousId },
+        accountId,
+      );
+    }
+    trackEvent("primitive_auth_completed", this.#base);
+  }
+
+  installSucceeded(eventId: string): void {
+    this.#trackTerminal("primitive_install_succeeded", eventId);
+  }
+
+  installFailed(eventId: string, errorCode: PrimitiveFunnelErrorCode): void {
+    this.#trackTerminal("primitive_install_failed", eventId, errorCode);
+  }
+
+  previewSucceeded(eventId: string): void {
+    this.#trackTerminal("primitive_preview_succeeded", eventId);
+  }
+
+  previewFailed(eventId: string, errorCode: PrimitiveFunnelErrorCode): void {
+    this.#trackTerminal("primitive_preview_failed", eventId, errorCode);
+  }
+
+  renderSucceeded(eventId: string): void {
+    this.#trackTerminal("primitive_render_succeeded", eventId);
+  }
+
+  renderFailed(eventId: string, errorCode: PrimitiveFunnelErrorCode): void {
+    this.#trackTerminal("primitive_render_failed", eventId, errorCode);
+  }
+
+  #track(name: string): void {
+    if (!shouldTrack()) return;
+    trackEvent(name, this.#base);
+  }
+
+  #trackTerminal(name: string, eventId: string, errorCode?: PrimitiveFunnelErrorCode): void {
+    if (!shouldTrack() || this.#terminalEventIds.has(eventId)) return;
+    this.#terminalEventIds.add(eventId);
+    trackEvent(name, {
+      ...this.#base,
+      event_id: eventId,
+      ...(errorCode ? { error_code: errorCode } : {}),
+    });
+  }
+}

--- a/packages/cli/src/telemetry/primitive-funnel.ts
+++ b/packages/cli/src/telemetry/primitive-funnel.ts
@@ -14,6 +14,7 @@ export type PrimitiveFunnelErrorCode =
 export interface PrimitiveFunnelContext {
   funnelId: string;
   installId: string;
+  primitiveId: string;
   artifactId: string;
   versionId: string;
   catalogVersion: string;
@@ -23,11 +24,64 @@ export interface PrimitiveFunnelContext {
 type PrimitiveFunnelBaseProperties = {
   funnel_id: string;
   install_id: string;
+  primitive_id: string;
   artifact_id: string;
   version_id: string;
   catalog_version: string;
   query_fingerprint: string;
 };
+
+type PrimitiveFunnelAuthState =
+  | "anonymous"
+  | "oauth_required"
+  | "existing_session"
+  | "oauth"
+  | "authenticated";
+
+/**
+ * Single source of truth for canonical lifecycle side effects, stable event-id
+ * suffixes, and each step's position in the canonical order.
+ *
+ * `step` exists because timestamps cannot express this order. Auth completion
+ * and install start are emitted back to back inside one command and land in the
+ * same millisecond, so ordering by timestamp resolves them arbitrarily and can
+ * report an install that began before the auth that authorized it. Consumers
+ * order by `funnel_step`; the terminal steps share no number with a step that
+ * can co-occur, so ties are impossible rather than merely unlikely.
+ *
+ * Failure steps carry the number of the step they terminate, since a funnel
+ * either reaches that step or fails at it. Never renumber a shipped step:
+ * historical events keep the number they were emitted with.
+ */
+const PRIMITIVE_FUNNEL_SIDE_EFFECTS = {
+  catalogSearched: { event: "primitive_catalog_searched", suffix: "catalog-searched", step: 1 },
+  catalogResultSelected: {
+    event: "primitive_catalog_result_selected",
+    suffix: "catalog-result-selected",
+    step: 2,
+  },
+  authStarted: { event: "primitive_auth_started", suffix: "auth-started", step: 3 },
+  authCompleted: { event: "primitive_auth_completed", suffix: "auth-completed", step: 4 },
+  authFailed: { event: "primitive_auth_failed", suffix: "auth-failed", step: 4 },
+  installStarted: { event: "primitive_install_started", suffix: "install-started", step: 5 },
+  installCompleted: { event: "primitive_install_completed", suffix: "install-completed", step: 6 },
+  installFailed: { event: "primitive_install_failed", suffix: "install-failed", step: 6 },
+  previewSucceeded: { event: "primitive_preview_succeeded", suffix: "preview", step: 7 },
+  previewFailed: { event: "primitive_preview_failed", suffix: "preview", step: 7 },
+  renderSucceeded: { event: "primitive_render_succeeded", suffix: "render", step: 8 },
+  renderFailed: { event: "primitive_render_failed", suffix: "render", step: 8 },
+} as const;
+
+type PrimitiveFunnelSideEffect =
+  (typeof PRIMITIVE_FUNNEL_SIDE_EFFECTS)[keyof typeof PRIMITIVE_FUNNEL_SIDE_EFFECTS];
+
+const MAX_RESULT_COUNT = 1_000;
+const MAX_DURATION_MS = 86_400_000;
+
+function boundedInteger(value: number, minimum: number, maximum: number): number {
+  if (!Number.isFinite(value)) return value < 0 ? minimum : maximum;
+  return Math.min(maximum, Math.max(minimum, Math.round(value)));
+}
 
 /** Privacy-safe telemetry for one catalog-selection lifecycle. */
 export class PrimitiveFunnel {
@@ -39,6 +93,7 @@ export class PrimitiveFunnel {
     this.#base = {
       funnel_id: context.funnelId,
       install_id: context.installId,
+      primitive_id: context.primitiveId,
       artifact_id: context.artifactId,
       version_id: context.versionId,
       catalog_version: context.catalogVersion,
@@ -46,66 +101,148 @@ export class PrimitiveFunnel {
     };
   }
 
-  searched(): void {
-    this.#track("primitive_searched");
+  catalogSearched(resultCount: number): void {
+    this.#track(PRIMITIVE_FUNNEL_SIDE_EFFECTS.catalogSearched, {
+      result_count: boundedInteger(resultCount, 0, MAX_RESULT_COUNT),
+      auth_state: "anonymous",
+    });
   }
 
-  selected(): void {
-    this.#track("primitive_selected");
+  catalogResultSelected(resultRank: number): void {
+    this.#track(PRIMITIVE_FUNNEL_SIDE_EFFECTS.catalogResultSelected, {
+      result_rank: boundedInteger(resultRank, 1, MAX_RESULT_COUNT),
+      auth_state: "anonymous",
+    });
   }
 
-  authRequired(): void {
-    this.#track("primitive_auth_required");
+  authStarted(): void {
+    this.#track(PRIMITIVE_FUNNEL_SIDE_EFFECTS.authStarted, {
+      auth_state: "oauth_required",
+    });
   }
 
-  authCompleted(accountId?: string): void {
+  authCompleted(
+    accountId: string | undefined,
+    authState: "existing_session" | "oauth",
+    durationMs: number,
+  ): void {
     if (!shouldTrack() || this.#identified) return;
     this.#identified = true;
+    const properties = {
+      ...this.#base,
+      event_id: `${this.#base.funnel_id}:${PRIMITIVE_FUNNEL_SIDE_EFFECTS.authCompleted.suffix}`,
+      funnel_step: PRIMITIVE_FUNNEL_SIDE_EFFECTS.authCompleted.step,
+      auth_state: authState,
+      duration_ms: boundedInteger(durationMs, 0, MAX_DURATION_MS),
+    };
     if (accountId) {
       trackEvent(
         "$identify",
-        { ...this.#base, $anon_distinct_id: readConfig().anonymousId },
+        { ...properties, $anon_distinct_id: readConfig().anonymousId },
         accountId,
       );
     }
-    trackEvent("primitive_auth_completed", this.#base);
+    trackEvent(PRIMITIVE_FUNNEL_SIDE_EFFECTS.authCompleted.event, properties);
   }
 
-  installSucceeded(eventId: string): void {
-    this.#trackTerminal("primitive_install_succeeded", eventId);
+  authFailed(eventId: string, errorCode: PrimitiveFunnelErrorCode, durationMs: number): void {
+    this.#trackTerminal(
+      PRIMITIVE_FUNNEL_SIDE_EFFECTS.authFailed,
+      eventId,
+      "oauth_required",
+      durationMs,
+      errorCode,
+    );
   }
 
-  installFailed(eventId: string, errorCode: PrimitiveFunnelErrorCode): void {
-    this.#trackTerminal("primitive_install_failed", eventId, errorCode);
+  installStarted(): void {
+    this.#track(PRIMITIVE_FUNNEL_SIDE_EFFECTS.installStarted, {
+      auth_state: "authenticated",
+    });
   }
 
-  previewSucceeded(eventId: string): void {
-    this.#trackTerminal("primitive_preview_succeeded", eventId);
+  installCompleted(eventId: string, durationMs: number): void {
+    this.#trackTerminal(
+      PRIMITIVE_FUNNEL_SIDE_EFFECTS.installCompleted,
+      eventId,
+      "authenticated",
+      durationMs,
+    );
   }
 
-  previewFailed(eventId: string, errorCode: PrimitiveFunnelErrorCode): void {
-    this.#trackTerminal("primitive_preview_failed", eventId, errorCode);
+  installFailed(eventId: string, errorCode: PrimitiveFunnelErrorCode, durationMs: number): void {
+    this.#trackTerminal(
+      PRIMITIVE_FUNNEL_SIDE_EFFECTS.installFailed,
+      eventId,
+      "authenticated",
+      durationMs,
+      errorCode,
+    );
   }
 
-  renderSucceeded(eventId: string): void {
-    this.#trackTerminal("primitive_render_succeeded", eventId);
+  previewSucceeded(eventId: string, durationMs: number): void {
+    this.#trackTerminal(
+      PRIMITIVE_FUNNEL_SIDE_EFFECTS.previewSucceeded,
+      eventId,
+      "authenticated",
+      durationMs,
+    );
   }
 
-  renderFailed(eventId: string, errorCode: PrimitiveFunnelErrorCode): void {
-    this.#trackTerminal("primitive_render_failed", eventId, errorCode);
+  previewFailed(eventId: string, errorCode: PrimitiveFunnelErrorCode, durationMs: number): void {
+    this.#trackTerminal(
+      PRIMITIVE_FUNNEL_SIDE_EFFECTS.previewFailed,
+      eventId,
+      "authenticated",
+      durationMs,
+      errorCode,
+    );
   }
 
-  #track(name: string): void {
+  renderSucceeded(eventId: string, durationMs: number): void {
+    this.#trackTerminal(
+      PRIMITIVE_FUNNEL_SIDE_EFFECTS.renderSucceeded,
+      eventId,
+      "authenticated",
+      durationMs,
+    );
+  }
+
+  renderFailed(eventId: string, errorCode: PrimitiveFunnelErrorCode, durationMs: number): void {
+    this.#trackTerminal(
+      PRIMITIVE_FUNNEL_SIDE_EFFECTS.renderFailed,
+      eventId,
+      "authenticated",
+      durationMs,
+      errorCode,
+    );
+  }
+
+  #track(sideEffect: PrimitiveFunnelSideEffect, properties: Record<string, string | number>): void {
     if (!shouldTrack()) return;
-    trackEvent(name, this.#base);
+    trackEvent(sideEffect.event, {
+      ...this.#base,
+      event_id: `${this.#base.funnel_id}:${sideEffect.suffix}`,
+      funnel_step: sideEffect.step,
+      ...properties,
+    });
   }
 
-  #trackTerminal(name: string, eventId: string, errorCode?: PrimitiveFunnelErrorCode): void {
+  #trackTerminal(
+    sideEffect: PrimitiveFunnelSideEffect,
+    eventId: string,
+    authState: PrimitiveFunnelAuthState,
+    durationMs: number,
+    errorCode?: PrimitiveFunnelErrorCode,
+  ): void {
     if (!shouldTrack() || this.#terminalEventIds.has(eventId)) return;
     this.#terminalEventIds.add(eventId);
-    trackEvent(name, {
+    trackEvent(sideEffect.event, {
       ...this.#base,
       event_id: eventId,
+      funnel_step: sideEffect.step,
+      auth_state: authState,
+      duration_ms: boundedInteger(durationMs, 0, MAX_DURATION_MS),
       ...(errorCode ? { error_code: errorCode } : {}),
     });
   }

--- a/packages/cli/src/telemetry/transport.ts
+++ b/packages/cli/src/telemetry/transport.ts
@@ -94,19 +94,26 @@ function buildPayload(events: readonly QueuedEvent[]): string | null {
  * request that `beforeExit` had just started. Keeping the queue intact until
  * delivery lets the exit-time flushSync() child (which survives the parent)
  * re-send anything unconfirmed; event uuids make that re-send idempotent.
+ *
+ * Returns whether PostHog acknowledged the batch. Almost every caller ignores
+ * this — telemetry is fire-and-forget by design. The exception is the primitive
+ * funnel's terminal events, which consume a durable single-use claim before
+ * emitting: they need to know whether the send actually landed so they can hand
+ * the claim back instead of burning it on an event that never arrived.
  */
-export async function flush(): Promise<void> {
+export async function flush(): Promise<boolean> {
   // Copy, not alias — events queued while the request is in flight must not
   // be swept into the "delivered" set below.
   const snapshot = eventQueue.slice();
   const payload = buildPayload(snapshot);
-  if (payload == null) return;
+  // Nothing queued is not a delivery failure — there was nothing to deliver.
+  if (payload == null) return true;
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FLUSH_TIMEOUT_MS);
 
   try {
-    await fetch(`${POSTHOG_HOST}/batch/`, {
+    const response = await fetch(`${POSTHOG_HOST}/batch/`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Connection: "close" },
       body: payload,
@@ -114,11 +121,15 @@ export async function flush(): Promise<void> {
     });
     // Delivered — forget exactly what was sent (events queued while the
     // request was in flight stay for the next flush).
+    // A rejected batch is dropped too: PostHog will reject the retry the same
+    // way, so re-queueing would just resend it on every later command.
     const sent = new Set(snapshot);
     eventQueue = eventQueue.filter((e) => !sent.has(e));
+    return response.ok;
   } catch {
     // Silently ignore — telemetry must never break the CLI. The events stay
     // queued so the exit-time flushSync() fallback can still deliver them.
+    return false;
   } finally {
     clearTimeout(timeout);
   }

--- a/packages/core/schemas/heygenverse-catalog.json
+++ b/packages/core/schemas/heygenverse-catalog.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hyperframes.heygen.com/schema/heygenverse-catalog.json",
+  "title": "HyperFrames HeyGenVerse Catalog Projection",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "artifactId",
+    "versionId",
+    "canonicalUri",
+    "exportedAt",
+    "records",
+    "catalogDigest"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "artifactId": { "type": "string", "format": "uuid" },
+    "versionId": { "type": "string", "format": "uuid" },
+    "canonicalUri": { "type": "string", "pattern": "^heygenverse://app/" },
+    "exportedAt": { "type": "string", "format": "date-time" },
+    "catalogDigest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "records": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "sourceDigest"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "const": "hyperframes:block" },
+          "sourceDigest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/schemas/registry-item.json
+++ b/packages/core/schemas/registry-item.json
@@ -128,6 +128,18 @@
     "relatedSkill": {
       "type": "string",
       "minLength": 1
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["kind", "artifactId", "versionId", "canonicalUri", "sourceDigest"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "heygenverse-export" },
+        "artifactId": { "type": "string", "format": "uuid" },
+        "versionId": { "type": "string", "format": "uuid" },
+        "canonicalUri": { "type": "string", "pattern": "^heygenverse://app/" },
+        "sourceDigest": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" }
+      }
     }
   },
   "allOf": [

--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -34,6 +34,14 @@ export interface RegistryItemPreview {
   poster?: string;
 }
 
+interface HeyGenVerseExportProvenance {
+  kind: "heygenverse-export";
+  artifactId: string;
+  versionId: string;
+  canonicalUri: string;
+  sourceDigest: string;
+}
+
 /** Fields common to every registry item, regardless of type. */
 interface RegistryItemBase {
   /** JSON Schema URL — `https://hyperframes.heygen.com/schema/registry-item.json`. */
@@ -66,6 +74,8 @@ interface RegistryItemBase {
   preview?: RegistryItemPreview;
   /** Related skill slug (e.g. `hyperframes-captions`) — shown in docs. */
   relatedSkill?: string;
+  /** Read-only identity of a versioned HeyGenVerse export projected into this registry. */
+  provenance?: HeyGenVerseExportProvenance;
 }
 
 /** Full-project example — scaffolded by `hyperframes init --example <name>`. */

--- a/registry/blocks/thread-message-stack/registry-item.json
+++ b/registry/blocks/thread-message-stack/registry-item.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "thread-message-stack",
+  "type": "hyperframes:block",
+  "title": "Thread Message Stack",
+  "description": "A source-owned editable conversation stack with arbitrary incoming and outgoing messages",
+  "tags": ["social", "conversation", "messages"],
+  "dimensions": { "width": 1920, "height": 1080 },
+  "duration": 8,
+  "provenance": {
+    "kind": "heygenverse-export",
+    "artifactId": "21c28523-7487-43e1-927d-43a7fe855859",
+    "versionId": "1aa00c22-b508-4b81-a3a1-4702453d48c2",
+    "canonicalUri": "heygenverse://app/21c28523-7487-43e1-927d-43a7fe855859/version/1aa00c22-b508-4b81-a3a1-4702453d48c2",
+    "sourceDigest": "sha256:5d0c56cbf9dc0af525548acb813a910098de2c902fcc84262fc3100af171f934"
+  },
+  "files": [
+    {
+      "path": "thread-message-stack.html",
+      "target": "compositions/thread-message-stack.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/thread-message-stack/thread-message-stack.html
+++ b/registry/blocks/thread-message-stack/thread-message-stack.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Thread Message Stack</title>
+  </head>
+  <body>
+    <template id="tms-template">
+      <div
+        id="tms-root"
+        data-composition-id="thread-message-stack"
+        data-start="0"
+        data-duration="8"
+        data-width="1920"
+        data-height="1080"
+      >
+        <style>
+          #tms-root,
+          #tms-root * {
+            box-sizing: border-box;
+          }
+
+          #tms-root {
+            position: relative;
+            width: 1920px;
+            height: 1080px;
+            overflow: hidden;
+            container-type: size;
+            isolation: isolate;
+            background: #2e241a;
+            color: #ffffff;
+            font-family: -apple-system, "Helvetica Neue", "Segoe UI", sans-serif;
+            --tms-out-fill: #2d89e1;
+            --tms-out-ink: #ffffff;
+            --tms-in-fill: rgba(240, 240, 245, 0.82);
+            --tms-in-ink: #101216;
+          }
+
+          #tms-roll,
+          #tms-scrim,
+          #tms-view {
+            position: absolute;
+            inset: 0;
+          }
+
+          #tms-roll {
+            overflow: hidden;
+            background:
+              radial-gradient(circle at 18% 20%, #f0d3a6 0, transparent 31%),
+              radial-gradient(circle at 75% 18%, #e8a86a 0, transparent 34%),
+              radial-gradient(circle at 62% 74%, #2e6a8c 0, transparent 32%),
+              radial-gradient(circle at 18% 82%, #6b4a7a 0, transparent 35%), #2e241a;
+            transform: scale(1.12);
+            will-change: transform;
+          }
+
+          #tms-scrim {
+            background:
+              linear-gradient(
+                to bottom,
+                transparent 0,
+                rgba(0, 0, 0, 0.18) 42%,
+                rgba(0, 0, 0, 0.38) 100%
+              ),
+              linear-gradient(to right, rgba(0, 0, 0, 0.32), rgba(0, 0, 0, 0) 78%);
+          }
+
+          #tms-view {
+            overflow: hidden;
+            -webkit-mask-image: linear-gradient(to bottom, transparent 5%, #000 24%, #000 100%);
+            mask-image: linear-gradient(to bottom, transparent 5%, #000 24%, #000 100%);
+          }
+
+          #tms-column {
+            position: absolute;
+            inset: 0;
+          }
+
+          .tms-row {
+            position: absolute;
+            right: 6%;
+            bottom: 10%;
+            left: 6%;
+            display: flex;
+            flex-direction: column;
+            opacity: 0;
+            will-change: transform, opacity;
+          }
+
+          .tms-row[data-side="incoming"] {
+            align-items: flex-start;
+          }
+
+          .tms-row[data-side="outgoing"] {
+            align-items: flex-end;
+          }
+
+          .tms-sender {
+            min-height: 30px;
+            padding: 0 18px 8px;
+            color: #ffffff;
+            font-size: 24px;
+            font-weight: 700;
+            line-height: 1;
+            text-shadow: 0 3px 12px rgba(0, 0, 0, 0.72);
+          }
+
+          .tms-bubble {
+            max-width: min(72%, 920px);
+            padding: 24px 38px;
+            border-radius: 42px;
+            font-size: 42px;
+            font-weight: 500;
+            letter-spacing: -0.015em;
+            line-height: 1.3;
+            overflow-wrap: anywhere;
+            white-space: pre-wrap;
+          }
+
+          .tms-row[data-side="incoming"] .tms-bubble {
+            color: var(--tms-in-ink);
+            background:
+              linear-gradient(180deg, rgba(255, 255, 255, 0.14), rgba(0, 0, 0, 0.05)),
+              var(--tms-in-fill);
+            box-shadow: 0 12px 34px rgba(0, 0, 0, 0.3);
+            transform-origin: 0 100%;
+          }
+
+          .tms-row[data-side="outgoing"] .tms-bubble {
+            color: var(--tms-out-ink);
+            background:
+              linear-gradient(180deg, rgba(255, 255, 255, 0.2), rgba(0, 0, 0, 0.17)),
+              var(--tms-out-fill);
+            box-shadow: 0 12px 38px rgba(0, 0, 0, 0.38);
+            transform-origin: 100% 100%;
+          }
+
+          #tms-driver {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            opacity: 0;
+            pointer-events: none;
+          }
+        </style>
+
+        <div id="tms-roll" data-layout-ignore></div>
+        <div id="tms-scrim" data-layout-ignore></div>
+        <div id="tms-view"><div id="tms-column"></div></div>
+        <div
+          id="tms-driver"
+          class="clip"
+          data-start="0"
+          data-duration="8"
+          data-track-index="0"
+        ></div>
+
+        <div hidden data-hf-primitive-data>
+          {"messages":[{"side":"incoming","text":"wait, that is actually wild","sender":"Northbeam
+          support"},{"side":"outgoing","text":"can you fix it?"},{"side":"incoming","text":"way
+          ahead of you"},{"side":"outgoing","text":"you are unreal"},{"side":"incoming","text":"he
+          owes you dinner for this one"},{"side":"outgoing","text":"already
+          booked"}],"stagger":0.86,"hold":1}
+        </div>
+        <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+        <script>
+          (function () {
+            "use strict";
+            window.__timelines = window.__timelines || {};
+            var root = document.getElementById("tms-root");
+            var column = document.getElementById("tms-column");
+            var roll = document.getElementById("tms-roll");
+            var data = JSON.parse(root.querySelector("[data-hf-primitive-data]").textContent);
+            var messages = data.messages;
+            var duration = Number(root.dataset.duration || 8);
+            var available = Math.max(0.2, duration - Math.max(0, Number(data.hold || 0)) - 0.35);
+            var requestedStagger = Math.max(0, Number(data.stagger == null ? 0.72 : data.stagger));
+            var stagger =
+              messages.length <= 1 ? 0 : Math.min(requestedStagger, available / messages.length);
+            var start = 0.25;
+            var rows = [];
+
+            messages.forEach(function (message, index) {
+              var row = document.createElement("div");
+              row.id = "tms-message-" + index;
+              row.className = "tms-row";
+              row.dataset.side = message.side;
+              if (message.sender !== undefined) {
+                var sender = document.createElement("div");
+                sender.className = "tms-sender";
+                sender.textContent = message.sender;
+                row.appendChild(sender);
+              }
+              var bubble = document.createElement("div");
+              bubble.className = "tms-bubble";
+              bubble.textContent = message.text;
+              row.appendChild(bubble);
+              column.appendChild(row);
+              rows.push(row);
+            });
+
+            var heights = rows.map(function (row) {
+              return Math.max(118, row.offsetHeight || 118) + 22;
+            });
+            var tl = gsap.timeline({ paused: true });
+            tl.fromTo(
+              roll,
+              { x: 0, y: 0, scale: 1.12 },
+              { x: -54, y: -22, scale: 1.18, duration: duration, ease: "sine.inOut" },
+              0,
+            );
+
+            rows.forEach(function (row, index) {
+              var at = start + index * stagger;
+              var direction = row.dataset.side === "incoming" ? -1 : 1;
+              tl.fromTo(
+                row,
+                { x: direction * 34, y: 0, scale: 0.94, opacity: 0 },
+                { x: 0, y: 0, scale: 1, opacity: 1, duration: 0.28, ease: "back.out(1.45)" },
+                at,
+              );
+              var offset = 0;
+              for (var previous = index - 1; previous >= 0; previous -= 1) {
+                offset += heights[previous + 1];
+                tl.to(rows[previous], { y: -offset, duration: 0.24, ease: "power3.out" }, at);
+              }
+            });
+
+            window.__timelines["thread-message-stack"] = tl;
+          })();
+        </script>
+      </div>
+    </template>
+  </body>
+</html>

--- a/registry/heygenverse-catalog.json
+++ b/registry/heygenverse-catalog.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/heygenverse-catalog.json",
+  "schemaVersion": 1,
+  "artifactId": "21c28523-7487-43e1-927d-43a7fe855859",
+  "versionId": "1aa00c22-b508-4b81-a3a1-4702453d48c2",
+  "canonicalUri": "heygenverse://app/21c28523-7487-43e1-927d-43a7fe855859/version/1aa00c22-b508-4b81-a3a1-4702453d48c2",
+  "exportedAt": "2026-08-05T03:56:31Z",
+  "records": [
+    {
+      "name": "thread-message-stack",
+      "type": "hyperframes:block",
+      "sourceDigest": "sha256:5d0c56cbf9dc0af525548acb813a910098de2c902fcc84262fc3100af171f934"
+    }
+  ],
+  "catalogDigest": "sha256:c8c5a26a43564d30f4866b35a0f182820bc6906596afb8bbbf0935d4cef22365"
+}

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -706,6 +706,10 @@
     {
       "name": "beat-freeze-cut",
       "type": "hyperframes:block"
+    },
+    {
+      "name": "thread-message-stack",
+      "type": "hyperframes:block"
     }
   ]
 }

--- a/scripts/catalog-preview-temp.test.ts
+++ b/scripts/catalog-preview-temp.test.ts
@@ -1,0 +1,20 @@
+import { statSync, rmSync } from "node:fs";
+import { basename } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createCatalogPreviewTempDir } from "./catalog-preview-temp.js";
+
+describe("catalog preview temporary directory", () => {
+  it("atomically creates unique owner-only directories", () => {
+    const first = createCatalogPreviewTempDir("thread-message-stack");
+    const second = createCatalogPreviewTempDir("thread-message-stack");
+    try {
+      expect(first).not.toBe(second);
+      expect(basename(first)).toMatch(/^hf-catalog-thread-message-stack-/);
+      expect(statSync(first).mode & 0o777).toBe(0o700);
+      expect(statSync(second).mode & 0o777).toBe(0o700);
+    } finally {
+      rmSync(first, { recursive: true, force: true });
+      rmSync(second, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/catalog-preview-temp.ts
+++ b/scripts/catalog-preview-temp.ts
@@ -1,0 +1,8 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Atomically allocate an owner-only preview directory under the OS temp root. */
+export function createCatalogPreviewTempDir(itemName: string): string {
+  return mkdtempSync(join(tmpdir(), `hf-catalog-${itemName}-`));
+}

--- a/scripts/generate-catalog-previews.test.ts
+++ b/scripts/generate-catalog-previews.test.ts
@@ -1,0 +1,35 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const previewPath = resolve(repoRoot, "docs/images/catalog/blocks/thread-message-stack.png");
+
+afterEach(() => rmSync(previewPath, { force: true }));
+
+describe("catalog preview raw block boundary", () => {
+  it("renders thread-message-stack through the exact Catalog Previews command", () => {
+    rmSync(previewPath, { force: true });
+    const result = spawnSync(
+      "bunx",
+      [
+        "tsx",
+        "scripts/generate-catalog-previews.ts",
+        "--only",
+        "thread-message-stack",
+        "--skip-video",
+      ],
+      { cwd: repoRoot, encoding: "utf8", timeout: 120_000 },
+    );
+    const output = `${result.stdout}${result.stderr}`;
+
+    expect(result.status, output).toBe(0);
+    expect(output).not.toContain("✗ thread-message-stack");
+    expect(output).not.toContain("[Browser:ERROR]");
+    expect(output).not.toContain("timelines not registered");
+    expect(output).not.toContain("sub_timeline_readiness_timeout");
+    expect(output).toContain("✓ thread-message-stack.png");
+    expect(existsSync(previewPath)).toBe(true);
+  }, 125_000);
+});

--- a/scripts/generate-catalog-previews.ts
+++ b/scripts/generate-catalog-previews.ts
@@ -150,6 +150,22 @@ function mirrorRegistryTargets(projectDir: string): void {
   }
 }
 
+/**
+ * Registry primitive payloads are inert text, but HTML formatters may wrap prose
+ * inside JSON strings. Normalize only control-whitespace runs in the temporary
+ * preview copy; the immutable registry source and installed caller payload stay
+ * byte-for-byte untouched.
+ */
+function normalizePrimitiveDataForPreview(content: string): string {
+  return content.replace(
+    /(<div[^>]*data-hf-primitive-data[^>]*>)([\s\S]*?)(<\/div>)/g,
+    (_match, open: string, payload: string, close: string) => {
+      const normalized = payload.replace(/\s*[\r\n]+\s*/g, " ");
+      return `${open}${normalized}${close}`;
+    },
+  );
+}
+
 async function prepareProjectDir(item: CatalogItem): Promise<string> {
   const tmpDir = join(tmpdir(), `hf-catalog-${item.name}-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });
@@ -161,9 +177,13 @@ async function prepareProjectDir(item: CatalogItem): Promise<string> {
   // If the entry file is a standalone HTML (has its own timeline registration),
   // just rename it to index.html. Otherwise create a wrapper.
   if (!existsSync(join(tmpDir, "index.html")) && existsSync(join(tmpDir, item.entryFile))) {
-    const entryContent = readFileSync(join(tmpDir, item.entryFile), "utf-8");
+    const entryPath = join(tmpDir, item.entryFile);
+    const rawEntryContent = readFileSync(entryPath, "utf-8");
+    const entryContent = normalizePrimitiveDataForPreview(rawEntryContent);
+    if (entryContent !== rawEntryContent) writeFileSync(entryPath, entryContent, "utf-8");
     const hasTimeline = entryContent.includes("__timelines");
-    if (hasTimeline) {
+    const isTemplateTransport = /<template(?:\s|>)/i.test(entryContent);
+    if (hasTimeline && !isTemplateTransport) {
       // Standalone block — copy to index.html and render directly.
       // For social overlays with transparent backgrounds, inject a dark bg
       // so the overlay card is visible against something.
@@ -272,6 +292,33 @@ async function generateThumbnail(item: CatalogItem, projectDir: string): Promise
   const framesDir = join(projectDir, "_thumb_frames");
   mkdirSync(framesDir, { recursive: true });
 
+  const { fileServer, session } = await openThumbnailSession(projectDir, framesDir, width, height);
+  try {
+    let duration: number;
+    try {
+      duration = await getCompositionDuration(session);
+    } catch {
+      duration = 5;
+    }
+
+    // Capture after the treatment appears, capped for long compositions.
+    const captureTime = Math.min(3.0, duration * 0.6);
+    const result = await captureFrame(session, 0, captureTime);
+    cpSync(result.path, join(outDir, `${item.name}.png`));
+    console.log(`  ✓ ${item.name}.png (${result.captureTimeMs}ms)`);
+  } finally {
+    await closeCaptureSession(session).catch(() => undefined);
+    fileServer.close();
+    rmSync(framesDir, { recursive: true, force: true });
+  }
+}
+
+async function openThumbnailSession(
+  projectDir: string,
+  framesDir: string,
+  width: number,
+  height: number,
+) {
   const fileServer = await createFileServer({
     projectDir,
     port: 0,
@@ -285,24 +332,10 @@ async function generateThumbnail(item: CatalogItem, projectDir: string): Promise
       format: "png",
     });
     await initializeSession(session);
-
-    let duration: number;
-    try {
-      duration = await getCompositionDuration(session);
-    } catch {
-      duration = 5;
-    }
-
-    // Capture after the treatment appears, capped for long compositions.
-    const captureTime = Math.min(3.0, duration * 0.6);
-    const result = await captureFrame(session, 0, captureTime);
-    cpSync(result.path, join(outDir, `${item.name}.png`));
-    console.log(`  ✓ ${item.name}.png (${result.captureTimeMs}ms)`);
-
-    await closeCaptureSession(session);
-  } finally {
+    return { fileServer, session };
+  } catch (error) {
     fileServer.close();
-    rmSync(framesDir, { recursive: true, force: true });
+    throw error;
   }
 }
 

--- a/scripts/generate-catalog-previews.ts
+++ b/scripts/generate-catalog-previews.ts
@@ -29,7 +29,6 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join, resolve, dirname } from "node:path";
-import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 // Import from source — bun workspace linking doesn't resolve for scripts outside packages/.
 import {
@@ -44,6 +43,7 @@ import {
 } from "../packages/producer/src/index.js";
 import { compileForRender } from "../packages/producer/src/services/htmlCompiler.js";
 import { resolveContainedCopies } from "./registry-target-paths.mjs";
+import { createCatalogPreviewTempDir } from "./catalog-preview-temp.js";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
@@ -167,8 +167,7 @@ function normalizePrimitiveDataForPreview(content: string): string {
 }
 
 async function prepareProjectDir(item: CatalogItem): Promise<string> {
-  const tmpDir = join(tmpdir(), `hf-catalog-${item.name}-${Date.now()}`);
-  mkdirSync(tmpDir, { recursive: true });
+  const tmpDir = createCatalogPreviewTempDir(item.name);
   cpSync(item.sourceDir, tmpDir, { recursive: true });
   mirrorRegistryTargets(tmpDir);
 


### PR DESCRIPTION
## What

Adds the `thread-message-stack` registry block together with the CLI machinery it needs: a bounded caller-payload validator that materializes the block at install time, an OAuth-only install gate, a resumable install intent that survives the browser round-trip, and a privacy-safe funnel that spans catalog, auth, install, preview, and render.

Supersedes the closed mirror attempt in #3035.

## Why

Every existing registry block ships fixed content, so `hyperframes add` only ever had to copy files. This block's content comes from the caller, which opens three holes the current add path cannot cover:

1. No way to prove which upstream catalog artifact and version an installed copy came from.
2. No way to refuse an install that is backed only by an API key, where a real account session is required.
3. No way to finish an install that was interrupted mid-flow while the user completed OAuth in a browser, without either losing the intent or replaying it twice.

The block is the vehicle. The install path is the actual change.

## How

- **Materialization is one function.** `packages/cli/src/registry/threadMessageStack.ts` validates the entire payload before touching a file: at most 100 messages, `text` at most 8192 chars, `sender` at most 256, `side` restricted to `incoming` / `outgoing`, and `stagger` / `hold` finite numbers in 0 to 60. Only then does it rewrite the single `data-hf-primitive-data` island in the block HTML. Validate-then-mutate means a rejected payload can never leave a half-written file behind.
- **Install authorization is its own boundary.** `threadMessageStackAuthorization.ts` requires a persisted OAuth credential and verifies it against the current-user endpoint. Environment and file API keys deliberately do not satisfy it, and the outcome is a closed set (`authorized` / `api-key-only` / `cancelled` / `failed`) so callers cannot treat an ambiguous result as success.
- **Install intent is durable and claimed once.** `commands/catalog-resume.ts` persists a versioned record (item, artifact, version, funnel and install ids, status) through an atomic temp-file plus rename, with an explicit claim, so an install interrupted by the OAuth round-trip resumes exactly once instead of zero or twice.
- **Telemetry has a single side-effect contract.** `telemetry/primitive-funnel*.ts` owns the lifecycle events. Discovery works fully anonymously, and the funnel context is persisted under `.hyperframes/` so preview and render stay stitched to the same funnel after the user authenticates.
- **Provenance rides in the registry item.** The registry-item schemas (`docs/schema/registry-item.json`, `packages/core/schemas/registry-item.json`) gain the upstream artifact and version fields, and the resolver validates the recorded source digest, so an installed copy is traceable to an immutable upstream projection.
- **Preview generation covers the new block.** `scripts/generate-catalog-previews.ts` and `scripts/catalog-preview-temp.ts` extended so the block is rendered by the same pipeline as every other catalog entry.

## Test plan

- 134 focused tests covering validation, authorization, resume, funnel, and the registry item, including a real installer to Studio preview to producer compile chain that produces a deterministic 8-frame MP4.
- Full CLI suite at the reviewed head: 2,498 passed, 2 skipped.
- Catalog preview scripts: 2 passed.
- `npx hyperframes lint` and `npx hyperframes check` on the installed temp project: clean, zero runtime errors.
- CLI and core typechecks, schema sync, changed-file `oxlint` / `oxfmt`, fallow audit, CLI build.
- CI at this head: 61 successful checks, 1 expected Mintlify skip.
- Known and unchanged: aggregate registry lint still reports 38 pre-existing failures across older blocks. The new block passes with 0 warnings.

- [x] Unit tests added/updated
- [ ] Manual testing performed (the end-to-end installer, preview, and render path is exercised in-suite rather than by hand)
- [x] Documentation updated (if applicable) - registry-item schemas
