### PR TITLE
fix(core): preserve native audio fallback

### DIFF
--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { initSandboxRuntimeModular } from "./init";
 import { TYPEGPU_PRESENT_HEARTBEAT_MS } from "./adapters/typegpu";
 import type { RuntimeTimelineLike } from "./types";
+import { WebAudioTransport } from "./webAudioTransport";
 
 function createMockTimeline(duration: number): RuntimeTimelineLike {
   const state = { time: 0, paused: true, duration };
@@ -2436,6 +2437,55 @@ describe("initSandboxRuntimeModular", () => {
 
     expect(video.muted).toBe(true);
     expect(audio.muted).toBe(false);
+  });
+
+  it("keeps an unowned native audio fallback audible while WebAudio owns another track", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "root");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    const owned = document.createElement("audio");
+    owned.id = "webaudio-owned";
+    owned.setAttribute("data-start", "0");
+    owned.setAttribute("data-duration", "10");
+    owned.setAttribute("src", "music.mp3");
+    root.appendChild(owned);
+
+    const nativeFallback = document.createElement("audio");
+    nativeFallback.id = "native-fallback";
+    nativeFallback.setAttribute("data-start", "0");
+    nativeFallback.setAttribute("data-duration", "10");
+    nativeFallback.setAttribute("src", "voiceover.mp3");
+    root.appendChild(nativeFallback);
+
+    vi.spyOn(WebAudioTransport.prototype, "isActive").mockReturnValue(true);
+    vi.spyOn(WebAudioTransport.prototype, "ownsElement").mockImplementation(
+      (element) => element === owned,
+    );
+
+    window.__timelines = { root: createMockTimeline(10) };
+    initSandboxRuntimeModular();
+    window.__player?.renderSeek(0);
+
+    expect(owned.muted).toBe(true);
+    expect(nativeFallback.muted).toBe(false);
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          source: "hf-parent",
+          type: "control",
+          action: "set-media-output-muted",
+          muted: true,
+        },
+      }),
+    );
+
+    expect(owned.muted).toBe(true);
+    expect(nativeFallback.muted).toBe(true);
   });
 
   it("native media sync opt-out leaves user-started media playing while timeline is paused", () => {

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -2033,9 +2033,7 @@ export function initSandboxRuntimeModular(): void {
         timeSeconds: state.currentTime,
         playing: state.isPlaying,
         playbackRate: state.playbackRate,
-        outputMuted:
-          state.mediaOutputMuted ||
-          (!state.webAudioMediaDisabled && !state.nativeMediaSyncDisabled && webAudio.isActive()),
+        outputMuted: state.mediaOutputMuted,
         userMuted: state.bridgeMuted,
         userVolume: state.bridgeVolume,
         forceSync,


### PR DESCRIPTION
## Summary

- use the global output mute only for parent-proxy ownership
- keep WebAudio muting scoped to each element actually owned by WebAudio
- cover mixed WebAudio/native fallback plus parent force-mute behavior in the runtime integration test

## Root cause

The runtime supports mixed ownership on a per-element basis:

- a track that decodes successfully may be played by WebAudio
- another track in the same composition may fail WebAudio fetch/decode and continue through its native `HTMLMediaElement`
- video soundtracks may likewise remain native while separate audio tracks use WebAudio

Before this change, one active WebAudio source made `webAudio.isActive()` true and passed `outputMuted: true` to `syncRuntimeMedia`. Because `outputMuted` means “force-mute every media element,” one WebAudio-owned track globally muted unrelated native fallback tracks. In the reported mixed-CORS case, background music entered WebAudio while narration could not; the narration continued advancing natively but was silent.

## Ownership invariant

The intended rule is:

```ts
muteThisElement =
  parentOwnsAllAudio ||
  userMuted ||
  webAudio.ownsElement(thisElement);
```

`syncRuntimeMedia` already implements that split:

- `outputMuted || userMuted` force-mutes all elements
- `isWebAudioOwned(el)` mutes only the element duplicated through WebAudio
- an unowned element remains audible through the native fallback

This PR therefore passes only `state.mediaOutputMuted` as the global output mute and retains `isWebAudioOwned: (el) => webAudio.ownsElement(el)` for per-element ownership.

## Why the removed clauses are not lost safeguards

### `nativeMediaSyncDisabled`

The call to `syncRuntimeMedia` is already inside `if (!state.nativeMediaSyncDisabled)`. Rechecking the same flag inside the `outputMuted` expression was redundant. When native media sync is disabled, this call is skipped entirely.

### `webAudioMediaDisabled`

Disabling WebAudio prevents new WebAudio scheduling and stops active sources. With no active source, `webAudio.ownsElement(el)` is false and native media is the intended output. This flag should choose the transport, not globally silence native media.

### `webAudio.isActive()`

This reports whether *any* WebAudio source is active; it does not report whether WebAudio owns a particular element. Using it as a global mute conflated composition-level activity with per-element ownership and defeated the existing `ownsElement(el)` contract.

## Safety behavior that remains unchanged

- Parent-proxy ownership still sets `state.mediaOutputMuted`, immediately mutes the WebAudio master and every DOM media element, and is reasserted on subsequent ticks.
- The user's mute preference remains independently enforced through `state.bridgeMuted` / `userMuted`.
- A WebAudio source mutes its corresponding DOM element when scheduled, and `ownsElement(el)` continues to prevent double audio.
- Stopping WebAudio restores the element's prior mute state.
- Native autoplay rejection still reports `media-autoplay-blocked`, allowing the player to promote audio ownership to parent proxies.

## Regression coverage

The new runtime test creates two simultaneous tracks while WebAudio is globally active:

1. a WebAudio-owned track remains muted in the DOM
2. an unowned native fallback remains unmuted
3. after parent ownership sends `set-media-output-muted: true`, both tracks are muted

Existing media and transport tests additionally cover owned/unowned separation, global parent/user mute, exact-element ownership, and ownership cleanup.

## Verification

- core typecheck
- 1,498/1,498 core tests
- formatter and linter
- exact mixed-CORS Chrome canary: native narration remained unmuted and advanced while background music remained WebAudio-owned at its authored gain
- parent force-mute behavior verified after mixed ownership was established

## Draft status and remaining validation

This PR intentionally remains a draft while stronger end-to-end coverage is added or reviewed. Useful follow-ups before marking it ready:

- real asynchronous mixed decode success/failure rather than mocked ownership
- WebAudio music plus a native video soundtrack
- native `NotAllowedError` promotion to parent-proxy ownership
- enabling/disabling WebAudio and native synchronization during playback

Those gaps do not change the ownership reasoning above, but documenting and exercising them reduces regression risk before merge.
