### PR TITLE
docs(core): fix broken links in core.md

### DIFF
--- a/packages/core/docs/core.md
+++ b/packages/core/docs/core.md
@@ -4,7 +4,7 @@ Reference for generating and editing HyperFrames HTML compositions. This is your
 
 **New to HyperFrames?** Start with the [quickstart template](./quickstart-template.html) — a copy-paste composition with inline comments explaining every required piece. See [common mistakes](./common-mistakes.md) for pitfalls that break compositions.
 
-For Frame adapters and deterministic frame rendering direction, see [`../../FRAME.md`](../../FRAME.md) and [`../adapters/README.md`](../adapters/README.md).
+For Frame adapters and deterministic frame rendering direction, see the [Frame Adapters section in `CLAUDE.md`](../../../CLAUDE.md#key-conventions) and [`../src/adapters/index.ts`](../src/adapters/index.ts).
 
 Producer-canonical parity note:
 


### PR DESCRIPTION
## Summary
- `packages/core/docs/core.md` linked to `../../FRAME.md` and `../adapters/README.md` — neither file exists (verified with `git log`, dead since the initial commit).
- Points the sentence to real, existing docs instead: the Frame Adapters section in `CLAUDE.md` and the actual `packages/core/src/adapters/index.ts` source.

## Test plan
- [x] Verified both new link targets exist (`CLAUDE.md`, `packages/core/src/adapters/index.ts`)
- [x] Verified old targets never existed anywhere in repo history
- Docs-only change, no code/build/test impact