### PR TITLE
docs: add user interview booking links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Talk with the HyperFrames team
+    url: https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ2cSpKoDgmcmRrgekrnrgqmvPT8W6F2Zg6e7MY7IJqaZKwpn_I0NdTHkN390iguMepE_NVg8ezb?gv=true
+    about: Share what you are building and help us improve the developer experience in a casual 30-minute conversation.

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ HyperFrames is used in production at [HeyGen](https://www.heygen.com), with comm
 
 - Questions and ideas: [Discord](https://discord.gg/EbK98HBPdk)
 - Bugs and feature requests: [GitHub Issues](https://github.com/heygen-com/hyperframes/issues)
+- User research: [Book a casual 30-minute conversation with the HyperFrames team](https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ2cSpKoDgmcmRrgekrnrgqmvPT8W6F2Zg6e7MY7IJqaZKwpn_I0NdTHkN390iguMepE_NVg8ezb?gv=true) — no preparation or sales pitch
 - Security reports: [SECURITY.md](SECURITY.md)
 - Contributions: [CONTRIBUTING.md](CONTRIBUTING.md)
 

--- a/docs/guides/feedback.mdx
+++ b/docs/guides/feedback.mdx
@@ -5,6 +5,12 @@ description: "Report a problem or tell the HyperFrames team what would make the 
 
 Useful feedback explains the outcome you wanted and what stopped you from reaching it.
 
+## Talk with the HyperFrames team
+
+Building something with HyperFrames? We would love to understand what you are creating, where you got stuck, and what feels harder than it should.
+
+[Book a casual 30-minute conversation with the HyperFrames team](https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ2cSpKoDgmcmRrgekrnrgqmvPT8W6F2Zg6e7MY7IJqaZKwpn_I0NdTHkN390iguMepE_NVg8ezb?gv=true). No preparation is required, and this is product research—not a sales call.
+
 ## Send feedback from the command line
 
 From a HyperFrames project, run:


### PR DESCRIPTION
## Summary

- add a user interview booking link to the README community section
- add a dedicated conversation invitation to the existing feedback guide
- surface the interview link in GitHub's new-issue chooser

## Why

Make it easy for open-source users to proactively share feedback about the HyperFrames developer experience, especially when they are already looking for help or community resources.

## User impact

HyperFrames users can book a casual 30-minute research conversation from the README, documentation, or issue flow. The invitation makes clear that no preparation is required and that the call is product research, not a sales conversation.

## Validation

- `git diff --check`
- `bunx oxfmt --check README.md docs/guides/feedback.mdx .github/ISSUE_TEMPLATE/config.yml`
- parsed `.github/ISSUE_TEMPLATE/config.yml` with Ruby YAML and verified the contact link
