### PR TITLE
fix(engine): disable GPU compositing on SwiftShader for all capture modes

### DIFF
--- a/packages/engine/src/services/browserManager.test.ts
+++ b/packages/engine/src/services/browserManager.test.ts
@@ -132,7 +132,7 @@ describe("buildChromeArgs browser GPU mode", () => {
     expect(args).not.toContain("--enable-gpu-rasterization");
   });
 
-  it("disables GPU compositing only for software BeginFrame capture", () => {
+  it("disables GPU compositing for all software capture modes (#2550, #3049)", () => {
     const softwareBeginFrame = buildChromeArgs(
       { ...base, captureMode: "beginframe" },
       { browserGpuMode: "software" },
@@ -145,10 +145,27 @@ describe("buildChromeArgs browser GPU mode", () => {
       { ...base, captureMode: "beginframe", platform: "linux" },
       { browserGpuMode: "hardware" },
     );
+    const hardwareScreenshot = buildChromeArgs(
+      { ...base, captureMode: "screenshot", platform: "linux" },
+      { browserGpuMode: "hardware" },
+    );
 
     expect(softwareBeginFrame).toContain("--disable-gpu-compositing");
-    expect(softwareScreenshot).not.toContain("--disable-gpu-compositing");
+    expect(softwareScreenshot).toContain("--disable-gpu-compositing");
     expect(hardwareBeginFrame).not.toContain("--disable-gpu-compositing");
+    expect(hardwareScreenshot).not.toContain("--disable-gpu-compositing");
+  });
+
+  it("appends PRODUCER_EXTRA_CHROME_ARGS when set", () => {
+    process.env.PRODUCER_EXTRA_CHROME_ARGS =
+      "--disable-partial-raster --force-gpu-mem-available-mb=4096";
+    try {
+      const args = buildChromeArgs(base);
+      expect(args).toContain("--disable-partial-raster");
+      expect(args).toContain("--force-gpu-mem-available-mb=4096");
+    } finally {
+      delete process.env.PRODUCER_EXTRA_CHROME_ARGS;
+    }
   });
 
   it("uses Metal-backed ANGLE for hardware browser GPU mode on macOS", () => {

--- a/packages/engine/src/services/browserManager.ts
+++ b/packages/engine/src/services/browserManager.ts
@@ -910,20 +910,21 @@ export function buildChromeArgs(
     chromeArgs.push(WEBGPU_FLAG);
   }
 
+  // SwiftShader's GPU compositor can retain a transformed layer across frames,
+  // producing phantom duplicate content at regular vertical offsets (HF#2550,
+  // HF#3049). The artefact appears in BOTH BeginFrame and Page.captureScreenshot
+  // capture modes: a band of page content is duplicated at exactly
+  // renderHeight/4 in the alpha channel, and static DOM elements (SVG lines,
+  // rects) are affected equally. Routing compositing through Chrome's software
+  // path eliminates the stale-layer retention. Hardware-GPU captures keep their
+  // existing compositor path. Remove this workaround once the pinned
+  // chrome-headless-shell includes https://issues.chromium.org/issues/535256667.
+  if (browserGpuMode === "software") {
+    chromeArgs.push("--disable-gpu-compositing");
+  }
+
   // BeginFrame flags — only when using chrome-headless-shell on Linux
   if (options.captureMode !== "screenshot") {
-    // SwiftShader's GPU compositor can retain a transformed layer for several
-    // sequential frames after a GSAP yoyo/reversal. The DOM and timeline are
-    // already at the requested time, but both BeginFrame and
-    // Page.captureScreenshot read the stale surface (the duplicate is present
-    // in the raw JPEG before encoding). Keep deterministic BeginFrame capture,
-    // but route compositing through Chrome's software path when the browser is
-    // already in software-GPU mode. Hardware-GPU and screenshot captures keep
-    // their existing compositor paths. Remove this workaround once the pinned
-    // chrome-headless-shell includes https://issues.chromium.org/issues/535256667.
-    if (browserGpuMode === "software") {
-      chromeArgs.push("--disable-gpu-compositing");
-    }
     chromeArgs.push(
       "--deterministic-mode",
       "--enable-begin-frame-control",
@@ -940,6 +941,12 @@ export function buildChromeArgs(
   if (gpuDisabled) {
     chromeArgs.push("--disable-gpu");
   }
+
+  const extraArgs = process.env.PRODUCER_EXTRA_CHROME_ARGS;
+  if (extraArgs) {
+    chromeArgs.push(...extraArgs.split(/\s+/).filter(Boolean));
+  }
+
   return chromeArgs;
 }
 


### PR DESCRIPTION
## Summary

- Move `--disable-gpu-compositing` from the BeginFrame-only block to all capture modes when `browserGpuMode === "software"`
- Add `PRODUCER_EXTRA_CHROME_ARGS` env var for passing additional Chrome flags during debugging

## Problem

SwiftShader's GPU compositor retains stale transformed layers across frames, producing phantom duplicate content at exactly `renderHeight/4` vertical offsets. The artefact appears in both BeginFrame and `Page.captureScreenshot` capture modes — the existing comment documents this ("both BeginFrame and Page.captureScreenshot read the stale surface"), but the `--disable-gpu-compositing` workaround was gated to BeginFrame mode only.

Software-GPU renders are clamped to screenshot mode by the `forceScreenshot` invariant (`applyConcreteGpuScreenshotClamp`), so the workaround never applied to the most common SwiftShader capture path.

## Root cause

`buildChromeArgs` placed `--disable-gpu-compositing` inside the `if (options.captureMode !== "screenshot")` block (line 914–926). This was originally scoped to BeginFrame because BeginFrame drives the compositor step-by-step (where stale retention is deterministic), while screenshot mode was considered "good enough" because the compositor runs freely. Issue #3049 proves that SwiftShader's compositor also retains stale layers in screenshot mode, with a different pattern: band duplication at `renderHeight/4` rather than sequential-frame yoyo persistence.

## Fix

Hoist `--disable-gpu-compositing` out of the BeginFrame block so it fires for any `browserGpuMode === "software"` session, regardless of capture mode. Hardware-GPU captures are unaffected.

The `PRODUCER_EXTRA_CHROME_ARGS` escape hatch (space-separated env var) lets users inject Chrome flags without wrapping the binary — the original issue reporter specifically called this out as needed for debugging.

## Validation

- `npx vitest run packages/engine/src/services/browserManager.test.ts` — 42/42 passing (8 `resolveHeadlessShellPath` tests require `bun`, pre-existing skip in this env)
- Test updated: "disables GPU compositing for all software capture modes (#2550, #3049)" now asserts `--disable-gpu-compositing` present for BOTH `softwareBeginFrame` and `softwareScreenshot`
- New test: "appends PRODUCER_EXTRA_CHROME_ARGS when set"
- `bunx oxlint packages/engine/src/services/browserManager.ts` — 0 warnings, 0 errors
- `bunx oxfmt --check` — clean

Closes #3049