### PR TITLE
fix(compiler): split font-family only on top-level commas

### DIFF
--- a/packages/producer/src/services/deterministicFonts-failClosed.test.ts
+++ b/packages/producer/src/services/deterministicFonts-failClosed.test.ts
@@ -253,6 +253,17 @@ describe("injectDeterministicFontFaces — failClosedFontFetch: true", () => {
     expect(result).toBe(html);
   });
 
+  it("does NOT throw when font-family uses a CSS var() reference with a fallback", async () => {
+    const html = `<!doctype html><html><head><style>
+      .title { font-family: var(--brand-font, inherit); }
+    </style></head><body><h1 class="title">hello</h1></body></html>`;
+    const result = await injectDeterministicFontFaces(html, {
+      failClosedFontFetch: true,
+      fetchImpl: makeFailingFetch(),
+    });
+    expect(result).toBe(html);
+  });
+
   it("resolves simple CSS var() font aliases when injecting deterministic fonts", async () => {
     const html = `<!doctype html><html><head><style>
       :root { --ui-font: "Inter"; --vowel-font: "Montserrat"; }

--- a/packages/producer/src/services/deterministicFonts.ts
+++ b/packages/producer/src/services/deterministicFonts.ts
@@ -54,10 +54,44 @@ export const GENERIC_FAMILIES: ReadonlySet<string> = new Set([
  * Whitespace and surrounding `"…"` / `'…'` quotes are stripped; case is
  * preserved. Pass each name through `normalizeFamilyName` for case-
  * insensitive comparisons.
+ *
+ * Only top-level commas split: a `var(--x, fallback)` expression stays one
+ * token, as does a comma inside a quoted family name.
  */
 export function parseFontFamilyValue(value: string): string[] {
-  return value
-    .split(",")
+  const pieces: string[] = [];
+  let start = 0;
+  let depth = 0;
+  let quote: "'" | '"' | null = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "\\") {
+      index += 1;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === "(") {
+      depth += 1;
+      continue;
+    }
+    if (char === ")") {
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+    if (char !== "," || depth !== 0) continue;
+    pieces.push(value.slice(start, index));
+    start = index + 1;
+  }
+  pieces.push(value.slice(start));
+
+  return pieces
     .map((piece) => piece.trim().replace(/^['"]/, "").replace(/['"]$/, "").trim())
     .filter((piece) => piece.length > 0);
 }

--- a/packages/producer/src/services/render/planValidation.test.ts
+++ b/packages/producer/src/services/render/planValidation.test.ts
@@ -169,6 +169,26 @@ describe("parseFontFamilyValue", () => {
     expect(parseFontFamilyValue(`'My Custom Font', serif`)).toEqual(["My Custom Font", "serif"]);
   });
 
+  it("keeps a comma inside a quoted family name", () => {
+    expect(parseFontFamilyValue(`"Display, Condensed", serif`)).toEqual([
+      "Display, Condensed",
+      "serif",
+    ]);
+  });
+
+  it("keeps a var() fallback in a single token", () => {
+    expect(parseFontFamilyValue(`var(--brand-font, inherit), sans-serif`)).toEqual([
+      "var(--brand-font, inherit)",
+      "sans-serif",
+    ]);
+  });
+
+  it("keeps a nested var() fallback in a single token", () => {
+    expect(
+      parseFontFamilyValue(`var(--brand-font, var(--fallback-font, "Inter")), sans-serif`),
+    ).toEqual([`var(--brand-font, var(--fallback-font, "Inter"))`, "sans-serif"]);
+  });
+
   it("ignores empty entries (trailing commas)", () => {
     expect(parseFontFamilyValue(`Inter,,sans-serif`)).toEqual(["Inter", "sans-serif"]);
   });

--- a/packages/producer/tests/distributed/css-var-fonts/src/index.html
+++ b/packages/producer/tests/distributed/css-var-fonts/src/index.html
@@ -35,7 +35,7 @@
         top: 30%;
         left: 50%;
         transform: translateX(-50%);
-        font-family: var(--display-font), sans-serif;
+        font-family: var(--display-font, "Montserrat"), sans-serif;
         font-size: 48px;
         font-weight: 900;
         color: #e94560;


### PR DESCRIPTION
## What

- Split `font-family` values on **top-level** commas only, so a `var()` expression stays a single token
- Regression coverage: parser unit cases + a fail-closed case using a `var()` fallback, and the distributed `css-var-fonts` fixture now exercises the fallback form

Closes #3066

## Why

`parseFontFamilyValue()` in `packages/producer/src/services/deterministicFonts.ts` split the family stack on every comma with no parenthesis awareness, so:

```css
font-family: var(--brand-font, inherit);
```

parsed to **two** tokens — `var(--brand-font` and `inherit)`.

The guard added in #1655 (for #1654) skips only tokens that start with `var(`, so the orphan fragment `inherit)` survived as a "requested font family". It matches no bundled alias, no Google Fonts family and no system font, so fail-closed distributed renders abort before the first frame:

```
FontFetchError: [Compiler] Unresolved fonts in fail-closed mode: inherit).
Distributed renders require all fonts to be resolvable.
```

Any fallback argument is affected, not just CSS-wide keywords — `var(--brand-font, "Inter")` leaks `Inter")` the same way. #1655 fixed the bare `var(--x)` form and its regression fixture uses no fallback argument, which is why this shape survived.

## How

The splitter now walks the value and only cuts at commas seen at paren depth 0, which keeps `var(--x, fallback)` — and nested `var(--x, var(--y, "Inter"))` — as one token, so the existing `var(` guard and `resolveFontFamilyDeclarationFamilies()` both see the whole expression. No special-casing of `inherit` or any other keyword.

Quotes are tracked in the same pass for two reasons: a parenthesis inside a quoted family name would otherwise skew the depth counter, and a legal quoted comma (`"Display, Condensed"`) no longer splits into two junk names. Trimming, surrounding-quote stripping and empty-entry dropping are unchanged.

Adversarial notes, in case they matter to a reviewer:

- `resolveFontFamilyDeclarationFamilies()` is unaffected in shape — `families[0]` is now the complete `var()` expression it always meant to be, and `families.slice(1)` correctly holds only the *external* fallbacks, not the ones inside the parens.
- A stray unmatched `)` is harmless: depth is clamped at 0.
- Malformed input (unbalanced `(`, unterminated quote) consumes the rest of the value as one token. That is invalid CSS which the browser would also discard, and it fails *closed* toward "skip", not toward "request a bogus family". Left as-is rather than growing the change.
- Not addressed here (pre-existing, and out of scope): when a `var()` primary is undefined, a concrete font in its fallback argument still isn't pre-embedded — it is skipped like any other `var()`. That is #1655's behaviour, unchanged, and strictly better than today's hard failure.

The distributed fixture change (`var(--display-font)` → `var(--display-font, "Montserrat")`) is deliberately render-neutral: `--display-font` is defined as `"Montserrat"` in `:root`, so the computed value and the embedded faces are identical and the existing baseline mp4 stays valid. Reverting the source fix makes that fixture fail resolution again.

## Test plan

- [x] Unit tests added/updated — 3 parser cases in `planValidation.test.ts` (var() fallback, nested var() fallback, quoted comma) and `does NOT throw when font-family uses a CSS var() reference with a fallback` in `deterministicFonts-failClosed.test.ts`
- [x] All 4 new tests verified **failing** with the source change reverted and passing with it
- [x] `bun test` over the touched files: 49 pass / 0 fail
- [x] `bun test` over every `deterministicFonts*` + `planValidation` test file: 84 pass / 0 fail
- [x] `oxfmt --check` and `oxlint` clean on the touched files
- [ ] Distributed regression lane (`css-var-fonts` baseline) — not run locally, no render infrastructure; relying on CI
