### PR TITLE
chore: release v0.7.95

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,35 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.95"
+  description="Released - 2026-08-06"
+  tags={["Release", "Studio", "Docs"]}
+>
+Studio now previews rooted timeline media through the correct asset route,
+preventing missing clips in nested project layouts. Thumbnail work is cancelable
+under rapid edits, while refreshed docs make key workflows easier to learn.
+
+## Fixes
+
+- **Studio:** Route rooted timeline media through preview ([88853f170](https://github.com/heygen-com/hyperframes/commit/88853f170f9ab6c7bfa515d59694d1f995ac0e7d), [#3061](https://github.com/heygen-com/hyperframes/pull/3061)).
+
+## Performance
+
+- **Studio Server:** Coordinate cancelable thumbnail generation ([96861cbaf](https://github.com/heygen-com/hyperframes/commit/96861cbafc33e9e7b853b31c56610d50599cb96b), [#2720](https://github.com/heygen-com/hyperframes/pull/2720)).
+
+## Docs & Examples
+
+- Rebuild the docs and catalog with real films, accessible playback, clearer workflow maps, and source-checked SDK guidance ([b793e42ef](https://github.com/heygen-com/hyperframes/commit/b793e42efdf6d674f98da0a63fcc80947ba1751b), [#3010](https://github.com/heygen-com/hyperframes/pull/3010)).
+- Add user interview booking links ([27d113e56](https://github.com/heygen-com/hyperframes/commit/27d113e56c8ebb52a805e73308ffbfe313f8cc32), [#3059](https://github.com/heygen-com/hyperframes/pull/3059)).
+
+## Internal
+
+- **CLI:** Classify identity persistence on every telemetry event ([3b65321a2](https://github.com/heygen-com/hyperframes/commit/3b65321a204383582e3794ac19eca5d6f5eb3474), [#3065](https://github.com/heygen-com/hyperframes/pull/3065)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.94...v0.7.95).
+</Update>
+
+<Update
   label="HyperFrames v0.7.94"
   description="Released - 2026-08-05"
   tags={["Release", "CLI"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.95.md
+++ b/releases/v0.7.95.md
@@ -1,0 +1,28 @@
+# HyperFrames v0.7.95
+
+Released on 2026-08-06.
+
+Studio now previews rooted timeline media through the correct asset route,
+preventing missing clips in nested project layouts. Thumbnail work is cancelable
+under rapid edits, while refreshed docs make key workflows easier to learn.
+
+## Fixes
+
+- **Studio:** Route rooted timeline media through preview ([88853f170](https://github.com/heygen-com/hyperframes/commit/88853f170f9ab6c7bfa515d59694d1f995ac0e7d), [#3061](https://github.com/heygen-com/hyperframes/pull/3061)).
+
+## Performance
+
+- **Studio Server:** Coordinate cancelable thumbnail generation ([96861cbaf](https://github.com/heygen-com/hyperframes/commit/96861cbafc33e9e7b853b31c56610d50599cb96b), [#2720](https://github.com/heygen-com/hyperframes/pull/2720)).
+
+## Docs & Examples
+
+- Rebuild the docs and catalog with real films, accessible playback, clearer workflow maps, and source-checked SDK guidance ([b793e42ef](https://github.com/heygen-com/hyperframes/commit/b793e42efdf6d674f98da0a63fcc80947ba1751b), [#3010](https://github.com/heygen-com/hyperframes/pull/3010)).
+- Add user interview booking links ([27d113e56](https://github.com/heygen-com/hyperframes/commit/27d113e56c8ebb52a805e73308ffbfe313f8cc32), [#3059](https://github.com/heygen-com/hyperframes/pull/3059)).
+
+## Internal
+
+- **CLI:** Classify identity persistence on every telemetry event ([3b65321a2](https://github.com/heygen-com/hyperframes/commit/3b65321a204383582e3794ac19eca5d6f5eb3474), [#3065](https://github.com/heygen-com/hyperframes/pull/3065)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.94...v0.7.95


### PR DESCRIPTION
## Summary

- publish the Studio rooted-timeline preview fix and cancelable thumbnail generation
- publish the rebuilt visual docs and catalog experience
- bump all publishable packages and plugins to 0.7.95
- add reviewed v0.7.95 release notes and docs changelog entry

## Validation

- 138 release and repository script tests passed
- stable release channel validated (latest, release/v0.7.95)
- release artifacts pass oxfmt 0.41.0 across 3,812 files
- all 13 publishable package manifests and 3 plugin manifests report 0.7.95

Do not squash/rebase: stable publication requires a reviewed merged release/v* PR.