### PR TITLE
feat(core,cli): emit the canary decision reason alongside the assignment

### DIFF
--- a/packages/cli/src/telemetry/canary.test.ts
+++ b/packages/cli/src/telemetry/canary.test.ts
@@ -267,6 +267,14 @@ describe("reason reaches the event properties", () => {
     expect(canaryEventProperties()["canary_reason_test_gamma"]).toBe("excluded");
   });
 
+  // The PR body advertises no_unit_id as one of two values that pay for
+  // themselves; the resolver exercises it but the emission layer did not.
+  it("reports no_unit_id at the emission layer when the install has no id", () => {
+    configState.anonymousId = "";
+    configState.bucketSeed = undefined;
+    expect(canaryEventProperties()["canary_reason_test_gamma"]).toBe("no_unit_id");
+  });
+
   it("reports telemetry_opt_out when the preference is off", () => {
     configState.telemetryEnabled = false;
     // Emitted for completeness; by construction such an install sends nothing,

--- a/packages/cli/src/telemetry/canary.test.ts
+++ b/packages/cli/src/telemetry/canary.test.ts
@@ -142,6 +142,9 @@ describe("telemetry opt-out is canary opt-out", () => {
       "$feature/canary-test-alpha": "false",
       "$feature/canary-test-gamma": "false",
       "$feature/canary-test-beta": "false",
+      canary_reason_test_alpha: "telemetry_opt_out",
+      canary_reason_test_gamma: "telemetry_opt_out",
+      canary_reason_test_beta: "telemetry_opt_out",
     });
   });
 });
@@ -228,10 +231,46 @@ describe("CLI canary binding", () => {
       "$feature/canary-test-alpha": "true",
       "$feature/canary-test-gamma": expect.stringMatching(/^(true|false)$/),
       "$feature/canary-test-beta": "false",
+      canary_reason_test_alpha: "in_cohort",
+      canary_reason_test_gamma: expect.stringMatching(/^(in_cohort|out_of_cohort)$/),
+      canary_reason_test_beta: "out_of_cohort",
     });
 
     __resetCanaryCacheForTests();
     process.env.HF_CANARY_TEST_ALPHA = "off";
     expect(canaryEventProperties()["$feature/canary-test-alpha"]).toBe("false");
+  });
+});
+
+// End of the wire: the CLI binding computes the reason and used to drop it.
+describe("reason reaches the event properties", () => {
+  it("pairs every canary's assignment with its reason", () => {
+    const props = canaryEventProperties();
+    expect(props["$feature/canary-test-alpha"]).toBe("true");
+    expect(props["canary_reason_test_alpha"]).toBe("in_cohort");
+    expect(props["canary_reason_test_beta"]).toBe("out_of_cohort");
+  });
+
+  it("reports an explicit override as forced, not as a cohort roll", () => {
+    process.env.HF_CANARY_TEST_BETA = "on";
+    const props = canaryEventProperties();
+    expect(props["$feature/canary-test-beta"]).toBe("true");
+    // Same assignment a real enrolment would produce — the reason is the only
+    // thing that distinguishes them, which is the point.
+    expect(props["canary_reason_test_beta"]).toBe("forced_on");
+  });
+
+  it("reports CI as excluded rather than out_of_cohort", () => {
+    systemState.is_ci = true;
+    // Both are enabled:false, but `excluded` was never bucketed. Conflating
+    // them is what biased the first fleet accuracy read low.
+    expect(canaryEventProperties()["canary_reason_test_gamma"]).toBe("excluded");
+  });
+
+  it("reports telemetry_opt_out when the preference is off", () => {
+    configState.telemetryEnabled = false;
+    // Emitted for completeness; by construction such an install sends nothing,
+    // so this value should never actually be observed in the warehouse.
+    expect(canaryEventProperties()["canary_reason_test_alpha"]).toBe("telemetry_opt_out");
   });
 });

--- a/packages/cli/src/telemetry/canary.ts
+++ b/packages/cli/src/telemetry/canary.ts
@@ -180,13 +180,22 @@ export function canaryDecisionsForStudio(): Record<string, CliCanaryDecision> {
 
 /**
  * Canary assignments as PostHog flag properties — `$feature/canary-<name>`
- * set to `"true"` / `"false"` for every registered canary. Spread onto every
- * event so any metric can be broken down by cohort using PostHog's native
- * flag tooling, with nothing configured server-side. See
- * `canaryFeatureProperties` for why non-enrolled canaries are emitted too.
+ * set to `"true"` / `"false"` for every registered canary, each paired with a
+ * `canary_reason_<name>`. Spread onto every event so any metric can be broken
+ * down by cohort using PostHog's native flag tooling, with nothing configured
+ * server-side. See `canaryFeatureProperties` for why non-enrolled canaries are
+ * emitted too, and why the reason has to ride along.
+ *
+ * The reason is what makes a cohort flip attributable. `resolveCanary` has
+ * computed it all along and this function used to drop it, so an install
+ * reporting both values looked identical whether a developer had toggled
+ * `HF_CANARY_*` or the bucketer had genuinely disagreed with itself.
  */
 export function canaryEventProperties(): Record<string, string> {
   return canaryFeatureProperties(
-    CANARIES.map((c) => ({ name: c.name, enabled: resolveCanary(c.name).enabled })),
+    CANARIES.map((c) => {
+      const { enabled, reason } = resolveCanary(c.name);
+      return { name: c.name, enabled, reason };
+    }),
   );
 }

--- a/packages/core/src/canary.test.ts
+++ b/packages/core/src/canary.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { canaryBucket, evaluateCanary, parseCanaryOverride, type CanaryInput } from "./canary.js";
 import { CANARIES, canaryEnvVar, findCanary, overdueCanaries } from "./canaryRegistry.js";
-import { CANARY_FEATURE_PREFIX, canaryFeatureKey, canaryFeatureProperties } from "./canary.js";
+import {
+  CANARY_FEATURE_PREFIX,
+  canaryFeatureKey,
+  canaryFeatureProperties,
+  canaryReasonKey,
+} from "./canary.js";
 
 const base = (over: Partial<CanaryInput> = {}): CanaryInput => ({
   feature: "test-feature",
@@ -369,5 +374,58 @@ describe("PostHog flag-shaped properties", () => {
 
   it("is empty when nothing is registered", () => {
     expect(canaryFeatureProperties([])).toEqual({});
+  });
+});
+
+// The attribution property. Without it, an install reporting both "true" and
+// "false" for a canary whose percentage never moved is indistinguishable from
+// a developer toggling HF_CANARY_*. The first calibration read hit exactly
+// that: 304 installs reported both values and the anomalous ones could not be
+// separated from deliberate overrides.
+describe("canary reason property", () => {
+  it("rides alongside the assignment, outside the $feature namespace", () => {
+    const props = canaryFeatureProperties([
+      { name: "de-parallel-router", enabled: true, reason: "in_cohort" },
+    ]);
+    expect(props["$feature/canary-de-parallel-router"]).toBe("true");
+    expect(props["canary_reason_de_parallel_router"]).toBe("in_cohort");
+  });
+
+  // A non-boolean under `$feature/` would corrupt the flag's own breakdowns,
+  // which is the whole reason the reason gets its own key.
+  it("never puts a reason inside the flag namespace", () => {
+    const props = canaryFeatureProperties([{ name: "x", enabled: false, reason: "forced_off" }]);
+    for (const [key, value] of Object.entries(props)) {
+      if (key.startsWith(CANARY_FEATURE_PREFIX)) {
+        expect(value).toMatch(/^(true|false)$/);
+      }
+    }
+  });
+
+  it("separates a forced override from a genuine cohort roll at the same value", () => {
+    const forced = canaryFeatureProperties([{ name: "f", enabled: true, reason: "forced_on" }]);
+    const rolled = canaryFeatureProperties([{ name: "f", enabled: true, reason: "in_cohort" }]);
+    // Identical assignment — only the reason tells them apart. This is the
+    // distinction the calibration read could not make.
+    expect(forced["$feature/canary-f"]).toBe(rolled["$feature/canary-f"]);
+    expect(forced["canary_reason_f"]).not.toBe(rolled["canary_reason_f"]);
+  });
+
+  it("emits `excluded` for CI, which replaces joining on is_ci", () => {
+    const props = canaryFeatureProperties([{ name: "c", enabled: false, reason: "excluded" }]);
+    // `excluded` and `out_of_cohort` are both enabled:false but mean different
+    // things — CI was never bucketed, the other lost the roll. Counting them
+    // together is what biased the first accuracy read low.
+    expect(props["canary_reason_c"]).toBe("excluded");
+  });
+
+  it("omits the reason key when no reason is supplied", () => {
+    const props = canaryFeatureProperties([{ name: "n", enabled: true }]);
+    expect(props["$feature/canary-n"]).toBe("true");
+    expect(props).not.toHaveProperty("canary_reason_n");
+  });
+
+  it("sanitizes the name into a property-safe key", () => {
+    expect(canaryReasonKey("de-parallel-router")).toBe("canary_reason_de_parallel_router");
   });
 });

--- a/packages/core/src/canary.ts
+++ b/packages/core/src/canary.ts
@@ -176,6 +176,19 @@ export function canaryFeatureKey(name: string): string {
 }
 
 /**
+ * Companion key carrying WHY a canary resolved as it did.
+ *
+ * Deliberately outside the `$feature/` namespace: PostHog treats those as flag
+ * values and a non-boolean there would corrupt the flag's own breakdowns. This
+ * is an ordinary property that sits alongside.
+ *
+ * `de-parallel-router` → `canary_reason_de_parallel_router`.
+ */
+export function canaryReasonKey(name: string): string {
+  return `canary_reason_${name.replace(/[^A-Za-z0-9]+/g, "_")}`;
+}
+
+/**
  * Build the telemetry properties for a set of resolved canaries.
  *
  * Emits EVERY registered canary, not just the enrolled ones, because absent
@@ -186,13 +199,26 @@ export function canaryFeatureKey(name: string): string {
  *
  * Values are the strings `"true"` / `"false"` to match how PostHog records
  * boolean flag values, so the property is directly comparable to a real flag.
+ *
+ * **The reason rides alongside when supplied**, under `canary_reason_<name>`.
+ * Without it the assignment alone is ambiguous in the one case that matters:
+ * an install reporting both `"true"` and `"false"` for a canary whose
+ * percentage never moved is indistinguishable from a developer toggling
+ * `HF_CANARY_*`. The first calibration read hit exactly that wall — 304
+ * installs reported both values and the genuinely anomalous ones could not be
+ * separated from deliberate overrides. The registry doc deferred this until
+ * the stability check came back dirty; it did.
+ *
+ * `reason` is optional so existing callers keep working; a caller that has the
+ * full decision should pass it.
  */
 export function canaryFeatureProperties(
-  entries: ReadonlyArray<{ name: string; enabled: boolean }>,
+  entries: ReadonlyArray<{ name: string; enabled: boolean; reason?: CanaryReason }>,
 ): Record<string, string> {
   const props: Record<string, string> = {};
   for (const entry of entries) {
     props[canaryFeatureKey(entry.name)] = entry.enabled ? "true" : "false";
+    if (entry.reason !== undefined) props[canaryReasonKey(entry.name)] = entry.reason;
   }
   return props;
 }

--- a/packages/studio/src/telemetry/canary.test.ts
+++ b/packages/studio/src/telemetry/canary.test.ts
@@ -194,6 +194,8 @@ describe("telemetry", () => {
     expect(canaryEventProperties()).toEqual({
       "$feature/canary-on-everywhere": "true",
       "$feature/canary-off-everywhere": "false",
+      canary_reason_on_everywhere: "in_cohort",
+      canary_reason_off_everywhere: "out_of_cohort",
     });
 
     __resetStudioCanaryCacheForTests();
@@ -235,6 +237,8 @@ describe("telemetry opt-out is canary opt-out", () => {
     expect(canaryEventProperties()).toEqual({
       "$feature/canary-on-everywhere": "false",
       "$feature/canary-off-everywhere": "false",
+      canary_reason_on_everywhere: "telemetry_opt_out",
+      canary_reason_off_everywhere: "telemetry_opt_out",
     });
   });
 });
@@ -321,5 +325,26 @@ describe("CLI-launched Studio adopts the CLI's decisions", () => {
     it("still refuses cohort enrolment with no CLI decision at all", () => {
       expect(resolveCanary("on-everywhere").reason).toBe("telemetry_opt_out");
     });
+  });
+});
+
+// A CLI-launched Studio shares the CLI's bucket seed, so a cohort flip can
+// surface on either surface. Attribution on only one of them makes the two
+// flip counts irreconcilable — which is why this is not a CLI-only property.
+describe("Studio attribution matches the CLI", () => {
+  it("distinguishes a local URL override from a cohort roll at the same value", () => {
+    setSearch("?hf_canary_off_everywhere=on");
+    const props = canaryEventProperties();
+    expect(props["$feature/canary-off-everywhere"]).toBe("true");
+    expect(props["canary_reason_off_everywhere"]).toBe("forced_on");
+    // Same assignment `on-everywhere` reaches by an ordinary roll.
+    expect(props["$feature/canary-on-everywhere"]).toBe("true");
+    expect(props["canary_reason_on_everywhere"]).toBe("in_cohort");
+  });
+
+  it("never puts a reason inside the $feature namespace", () => {
+    for (const [key, value] of Object.entries(canaryEventProperties())) {
+      if (key.startsWith("$feature/")) expect(value).toMatch(/^(true|false)$/);
+    }
   });
 });

--- a/packages/studio/src/telemetry/canary.ts
+++ b/packages/studio/src/telemetry/canary.ts
@@ -257,12 +257,22 @@ export function isCanaryEnabled(name: string): boolean {
 }
 
 /**
- * Canary assignments as PostHog flag properties (`$feature/canary-<name>`),
- * attached to every Studio event so any metric can be split by cohort —
- * identical shape to the CLI, so a rollout spanning both reads as one flag.
+ * Canary assignments as PostHog flag properties (`$feature/canary-<name>`)
+ * plus their `canary_reason_<name>`, attached to every Studio event so any
+ * metric can be split by cohort — identical shape to the CLI, so a rollout
+ * spanning both reads as one flag.
+ *
+ * The reason has to be here too, not just CLI-side. A CLI-launched Studio
+ * adopts the CLI's decisions and shares its bucket seed, so a cohort flip can
+ * surface on either surface; emitting attribution on only one of them makes
+ * the two flip counts irreconcilable and leaves Studio-observed flips
+ * unattributable — the exact ambiguity this property exists to remove.
  */
 export function canaryEventProperties(): Record<string, string> {
   return canaryFeatureProperties(
-    CANARIES.map((c) => ({ name: c.name, enabled: resolveCanary(c.name).enabled })),
+    CANARIES.map((c) => {
+      const { enabled, reason } = resolveCanary(c.name);
+      return { name: c.name, enabled, reason };
+    }),
   );
 }


### PR DESCRIPTION
## Why now

The calibration contract deferred this deliberately: *"Emitting a reason property is skipped — add it only if this check comes back dirty."*

It came back dirty. The first fleet read (n = 27,226 non-CI installs on `v0.7.92`+) found **304 installs (1.08%) reporting both values** for a canary whose percentage never moved. The genuinely anomalous ones could not be separated from a developer toggling `HF_CANARY_*`, because **the assignment is identical in both cases** — `"true"` is `"true"` whether it came from a cohort roll or a forced override.

`resolveCanary` has computed the reason all along; `canaryEventProperties` dropped it on the floor.

## What changes

Every canary now emits `canary_reason_<name>` beside its `$feature/canary-<name>` assignment.

**Deliberately outside the `$feature/` namespace.** PostHog treats those as flag values, and a non-boolean there would corrupt the flag's own breakdowns — the exact analysis surface the assignment property exists to feed.

## Two values pay for themselves immediately

Beyond override attribution, of the six wire values (`telemetry_opt_out` never emits by construction):

- **`excluded`** — CI installs. These are excluded from percentage enrolment but still emit `"false"`, so today they must be dropped by joining on `is_ci`. Conflating them with `out_of_cohort` is what made the first accuracy read look like a **significant failure** — 9.22% against a 10% target, z = −2.56 — when the non-CI population was on target at 9.49%. This kills that whole class of error.
- **`no_unit_id`** — the fails-closed corner when `bucketSeed` is missing.

## Verification

Mutation-tested at both layers: dropping the reason in the CLI binding fails 6 tests, dropping it in the core helper fails 3.

New coverage pins the case this exists for — that a forced override and a genuine cohort roll produce an **identical assignment** and are told apart only by the reason — plus that CI reports `excluded` rather than `out_of_cohort`, and that no reason ever lands inside the `$feature/` namespace.

Two existing exact-shape assertions updated rather than loosened.

Suites: core 1674, cli 2474, studio 3478, studio-server 416. Lint clean.

## What this does not do

It will **not** settle the shared-identity question behind the residual **38** unexplained installs — it reports `in_cohort`/`out_of_cohort` on *both* sides of a flip, i.e. what was decided, not why the seeds diverged. That needs `bucket_seed_origin` or the already-merged `identity_persistence` reaching a release. This removes the larger, cheaper ambiguity first.

**Where 38 comes from** (it is not in #3030 — flagged in review, reconciling here): #3030's table reports **70** installs in the >1h post-settled bucket. A later root-cause pass split those 70 by whether the assignment tracks the CI flag within each install:

| | installs |
|---|---|
| `false` events are exactly the CI ones → the documented `exclude: is_ci` rule meeting a shared `distinct_id` | 32 |
| mixed | 1 |
| **never CI → genuinely unexplained** | **38** |

So 70 is the pre-attribution count and 38 is what survives removing the CI artifact. That pass also **falsified** the Docker/container hypothesis — flipped installs are *less* containerized than baseline (4.23% vs 12.98%), while CI is enriched 15.6×. Neither number is in #3030 because that PR was withdrawn to an empty diff; the record lives in the repo's internal `plans/` handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
