### PR TITLE
chore: release v0.7.96

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,118 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.96"
+  description="Released - 2026-08-06"
+  tags={["Release", "Studio", "Core,cli", "CLI"]}
+>
+Canary rollouts now record why each install landed in or out of a cohort, on both
+the CLI and Studio. Before this, a forced override and an ordinary cohort roll
+looked identical, so cohort changes could not be explained. Telemetry events also
+say whether an install's anonymous id will survive to the next run.
+
+For everyday use the visible changes are a Studio fix for rooted timeline media in
+preview, cancelable thumbnail generation, and a large pass over the docs examples.
+
+## Features
+
+- **Studio:** Emit the canary reason on Studio events too ([b3990ac78](https://github.com/heygen-com/hyperframes/commit/b3990ac789a40242b38eb740475811a03e701b2b)).
+- **Core,cli:** Emit the canary decision reason alongside the assignment ([076657a63](https://github.com/heygen-com/hyperframes/commit/076657a63994a911deba65cd4d54131d5997e1d1)).
+- **CLI:** Classify identity persistence on every telemetry event ([3b65321a2](https://github.com/heygen-com/hyperframes/commit/3b65321a204383582e3794ac19eca5d6f5eb3474), [#3065](https://github.com/heygen-com/hyperframes/pull/3065)).
+
+## Fixes
+
+- **Studio:** Route rooted timeline media through preview ([88853f170](https://github.com/heygen-com/hyperframes/commit/88853f170f9ab6c7bfa515d59694d1f995ac0e7d), [#3061](https://github.com/heygen-com/hyperframes/pull/3061)).
+- **Scripts:** Import the changelog style note instead of duplicating it ([8cadefa5d](https://github.com/heygen-com/hyperframes/commit/8cadefa5d8d0f558863e35327b6059aeef76523c)).
+- **Scripts:** Restore the texture instruction phrase a core test pins ([ddbd547fa](https://github.com/heygen-com/hyperframes/commit/ddbd547fad33042c10172b4e3607ed0b12fd7a06)).
+- **Scripts:** The repo already knew which items have no poster ([74ba97b7e](https://github.com/heygen-com/hyperframes/commit/74ba97b7edcc6ed2166fe00ee280c8c05ff718fc)).
+- **Scripts:** Actually commit the delivery encode ([4f1ace9f4](https://github.com/heygen-com/hyperframes/commit/4f1ace9f476fe10e9b6da2a9e9bae0332f5ead1a)).
+- **Docs:** Stop claiming a poster image that was never generated ([a6217f5ed](https://github.com/heygen-com/hyperframes/commit/a6217f5ed145b28e80ecfb5744fd7d3537f1335e)).
+
+## Performance
+
+- **Studio Server:** Coordinate cancelable thumbnail generation ([96861cbaf](https://github.com/heygen-com/hyperframes/commit/96861cbafc33e9e7b853b31c56610d50599cb96b), [#2720](https://github.com/heygen-com/hyperframes/pull/2720)).
+
+## Docs & Examples
+
+- Add user interview booking links ([27d113e56](https://github.com/heygen-com/hyperframes/commit/27d113e56c8ebb52a805e73308ffbfe313f8cc32), [#3059](https://github.com/heygen-com/hyperframes/pull/3059)).
+- Correct composition offset rationale; pin nav fix; label-in-name ([fed2baf27](https://github.com/heygen-com/hyperframes/commit/fed2baf27882cda0e19ae0e972f7335a162c36eb)).
+- **Examples:** Stop the sound control from following the card's link ([83db94e75](https://github.com/heygen-com/hyperframes/commit/83db94e75e87271c86f8823e636b729c500cbac9)).
+- **Examples:** Reset control state on offscreen release; precise a11y labels ([f3d1d531d](https://github.com/heygen-com/hyperframes/commit/f3d1d531d138d69e7d347391e5f7a4b35fb599a3)).
+- Complete the media-start layer map + fix the third page ([c49fea2e0](https://github.com/heygen-com/hyperframes/commit/c49fea2e0c4caaa7c4329493cdd5112581addc06)).
+- **Examples:** Reduced-motion play starts both films; precise media-start layers ([630c8900f](https://github.com/heygen-com/hyperframes/commit/630c8900f5866d5cd51eb3da96293981e41fc971)).
+- **Studio:** Note the third arrow-key meaning after merging Timeline navigation ([b541245f1](https://github.com/heygen-com/hyperframes/commit/b541245f1a49b1c784797050c7ae81040115d946)).
+- **Examples:** Allow voluntary playback under reduced motion; a11y parity ([c9fd7465c](https://github.com/heygen-com/hyperframes/commit/c9fd7465c9b9d516b53241fee1f8ca78d18ba905)).
+- **Sdk:** Fix dispatch/can contract, second stale GSAP site, media-start layers ([8e658bd6c](https://github.com/heygen-com/hyperframes/commit/8e658bd6c932ee1b8c65f247f9767d75fbd56275)).
+- **Examples:** Intersection-gate the recreate pair too ([aa077e000](https://github.com/heygen-com/hyperframes/commit/aa077e000df94db2348fa6d744909a67706b09e1)).
+- **Examples:** Make hover-audio accessible, lazy-loaded, and guard-complete ([0467bc812](https://github.com/heygen-com/hyperframes/commit/0467bc812916259a53a3f08eb30fb8a35586ee19)).
+- Correct three source-contradiction findings from review ([0f6259d46](https://github.com/heygen-com/hyperframes/commit/0f6259d461cfb678d60ae7926d343fbe44aee925)).
+- **Theme:** Brand the Playground CTA + align the navbar logo ([b62c3fd65](https://github.com/heygen-com/hyperframes/commit/b62c3fd65617cb1d89c828e1f7460893d34a3216)).
+- **Nav:** Lift 30 Days above the update feeds in Explore ([c53c7efd1](https://github.com/heygen-com/hyperframes/commit/c53c7efd1ec1070251ecf1a25643f96d5b96e7a7)).
+- **Examples:** Fix silent recreate references (stale keys -\> new audio keys) ([4b1a526fa](https://github.com/heygen-com/hyperframes/commit/4b1a526facb128b98a33a2c8878761320bfea529)).
+- **Examples:** K3 promo now hover-to-hear with its audio version from X ([821189586](https://github.com/heygen-com/hyperframes/commit/821189586f19da6a67472ddfb952a63f0f1afc85)).
+- **Examples:** Replace two padded launch films + wire figma audio ([630c6c880](https://github.com/heygen-com/hyperframes/commit/630c6c880ddf164ca3dbad0a6979b0d943ec2691)).
+- **Examples:** More hover-audio + a 'Where HyperFrames plugs in' strip ([59a2ee31c](https://github.com/heygen-com/hyperframes/commit/59a2ee31c93818ce06c8575af4043948f0404a34)).
+- **Examples:** Hover-audio on six more grid films from the X launch archive ([e6bc8f139](https://github.com/heygen-com/hyperframes/commit/e6bc8f139c032d202d94fe2b4837b2e1b0f45ff8)).
+- **Examples:** Hover-to-hear on the four launch films that have audio masters ([fb6a82c50](https://github.com/heygen-com/hyperframes/commit/fb6a82c5052d5c801ecd6ec52d1ceadf4757e6a9)).
+- **30 Days:** Hover a card to hear the film's audio ([5361b9e10](https://github.com/heygen-com/hyperframes/commit/5361b9e10c80c787527ffa25a0db01002ddebbf0)).
+- **Examples:** Drop three dead source links (no such launch folder) ([8298bd439](https://github.com/heygen-com/hyperframes/commit/8298bd439092f67badef626987f385bb020a61dc)).
+- **Examples:** Bind reference video muted to state so unmute sticks ([407a5fd51](https://github.com/heygen-com/hyperframes/commit/407a5fd5139cda1dc10aae21aa52f6bc69c1e502)).
+- **Examples:** Sync the recreate pairs with a tap-to-unmute button ([bde03484a](https://github.com/heygen-com/hyperframes/commit/bde03484ae46345d4f10051a6db7155073e1eb76)).
+- **Examples:** Add 1:1 recreate-any-video comparison block ([98ae45e06](https://github.com/heygen-com/hyperframes/commit/98ae45e0661f120cedb8bda2d6002224db146924)).
+- 30 Days shows all thirty films, the real ones ([a46bc9d56](https://github.com/heygen-com/hyperframes/commit/a46bc9d565de76ad6e6dc5d35c6a9ff7d1e5cf76)).
+- Remove the Reference Project — nobody wants to be sent to GitHub ([b5509602f](https://github.com/heygen-com/hyperframes/commit/b5509602fa9f8ad9944c79b9f73f3a440357ecbf)).
+- 30 Days keeps its structure but borrows no videos ([06d2d6f24](https://github.com/heygen-com/hyperframes/commit/06d2d6f24c31b094198e4cd630d1f34c5df5dd2e)).
+- Examples shows 19 launch films grouped by what they prove, and 30 Days moves into Explore ([8483b51d4](https://github.com/heygen-com/hyperframes/commit/8483b51d4b7111710b8ac98befbd3c9ca07432cd)).
+- Light-theme videos on nine guides, plus two rewritten pages ([ad4c6a9b6](https://github.com/heygen-com/hyperframes/commit/ad4c6a9b6e0781e4253507ec4a179b83b3faee9b)).
+- Put the ten workflows in one place, and connect the two tracks ([f742084fa](https://github.com/heygen-com/hyperframes/commit/f742084fa85c1e2be1c0711c4467c48d4cd6f214)).
+- Name the two workflows the captions page covers ([c66961637](https://github.com/heygen-com/hyperframes/commit/c669616370db90f63ef4828e53db8a34e760406b)).
+- The examples gallery now tells you what it is ([18c0b8319](https://github.com/heygen-com/hyperframes/commit/18c0b8319d657d6b7578c6a34b8c183b5ff1865e)).
+- E_NO_GSAP_TIMELINE is not a missing feature ([d3331aad2](https://github.com/heygen-com/hyperframes/commit/d3331aad28ccb1f3ace49227e06d844e0c4ee58d)).
+- An Inspector map that matches the Inspector, and an example that can run ([9a659053d](https://github.com/heygen-com/hyperframes/commit/9a659053db3a3da95a4eece58f15e871ce9dc9d8)).
+- Four more the source contradicts, one of them mine ([af5ebf09c](https://github.com/heygen-com/hyperframes/commit/af5ebf09ce8bd15991da51bf83a9fe852e8dca29)).
+- Three things the source contradicts, found by reading the pages ([d01253771](https://github.com/heygen-com/hyperframes/commit/d01253771fa7f3eac4fa9126c7bedb9911e0be30)).
+- A compare example that works, and prose instead of a semicolon list ([1a22d6542](https://github.com/heygen-com/hyperframes/commit/1a22d6542a9a1492882cd11943b68e4a29522407)).
+- Three Studio shortcuts the page never mentioned ([f28b6d2bf](https://github.com/heygen-com/hyperframes/commit/f28b6d2bf73490cae7dd0403682064169951af5a)).
+- Write down the house narrator, and stop the videos sounding like two products ([bb7b0c899](https://github.com/heygen-com/hyperframes/commit/bb7b0c899f91bcfd1b4f36378bc750aa74e95976)).
+- Put the slideshow demo on the slideshow page ([199885b85](https://github.com/heygen-com/hyperframes/commit/199885b85edea981a3ce132fd09e3bcaac7ff316)).
+- Six pages get a real film instead of a six-second clip ([b4648e0e5](https://github.com/heygen-com/hyperframes/commit/b4648e0e5a45734970e3e905efcac4cf76d51057)).
+- Make the ten hardest-reading prompting pages readable ([8dba394d4](https://github.com/heygen-com/hyperframes/commit/8dba394d4dd52678cd49b68a3ec8fd8a921a1d6d)).
+- Stop serving render masters as if they were deliverables ([158d0fea1](https://github.com/heygen-com/hyperframes/commit/158d0fea1fa8e267f9e77aafc1f359ae37781beb)).
+- Draw the project model instead of describing it twice ([31366d724](https://github.com/heygen-com/hyperframes/commit/31366d724d83ff855c1a02edb2c37ff441a3648c)).
+- The last five blind guides now show the thing ([f595a7d68](https://github.com/heygen-com/hyperframes/commit/f595a7d68388c2e8842d3b8f5346273d0f9450b7)).
+- Move 19 anchor links onto the headings that now exist ([d16f6e69d](https://github.com/heygen-com/hyperframes/commit/d16f6e69d72c8582fac9577f57aaad158596b1e1)).
+- Make the two hardest-reading pages readable, and draw the two core concepts ([eb199bd15](https://github.com/heygen-com/hyperframes/commit/eb199bd1595f7774a16fb7baea12510a8d8a02d6)).
+- Four more guides show the thing instead of describing it ([8762887a5](https://github.com/heygen-com/hyperframes/commit/8762887a5b3773f460fa61e017d870f68f5d540a)).
+- Point two prompting links at headings that exist ([951c6ea45](https://github.com/heygen-com/hyperframes/commit/951c6ea45c1eddc377a40542a84acd40d1f472ef)).
+- Give every click-to-play video an audio track ([60f09dfcf](https://github.com/heygen-com/hyperframes/commit/60f09dfcfd3f8b18ac51e9d26f34e614969477e8)).
+- Keep the audio on the Huly launch film ([61cd3f1da](https://github.com/heygen-com/hyperframes/commit/61cd3f1da2afd8b59ee1a729c6653513a70e73bf)).
+- Show GSAP keyframes moving, and drop the weakest video on Examples ([ef9980948](https://github.com/heygen-com/hyperframes/commit/ef9980948206fa6c13f7c0c55e00f3f906c42a9f)).
+- Rewrite four pages that told instead of showed ([72d4016f5](https://github.com/heygen-com/hyperframes/commit/72d4016f5f25fb71c856f0d6fd9e52e91686c83a)).
+- Show the work on Media effects, Product launch, and Examples ([84b5160b6](https://github.com/heygen-com/hyperframes/commit/84b5160b663c8bf758c4134fdffceba4982ae374)).
+
+## Catalog
+
+- **Catalog:** Explicit section ownership, no body-sniffing heuristic ([d373c3f4a](https://github.com/heygen-com/hyperframes/commit/d373c3f4a09f59b349586c0885be47388844a658)).
+- **Catalog:** Restore the required Related topics section on generated pages ([6ff6601dd](https://github.com/heygen-com/hyperframes/commit/6ff6601dd03026f55be3d974222ac5c4ff890a8e)).
+- Quiet fallow complexity on the catalog generator's grown functions ([b33974cf7](https://github.com/heygen-com/hyperframes/commit/b33974cf72270fded5b9caf2244f26acf6b3c7e6)).
+- **Scripts:** Drop the catalog poster instead of guarding it, and cut the encode pass down ([592301248](https://github.com/heygen-com/hyperframes/commit/592301248ea93336189aa723b0b24971f7173ae0)).
+- **Docs:** The poster guard again, for the catalog index this time ([663f3e832](https://github.com/heygen-com/hyperframes/commit/663f3e8325c192324520113fa1819b3e1fcdd07a)).
+- Rebuild the catalog generator, and show what background removal and HDR do ([2a7d9bd0a](https://github.com/heygen-com/hyperframes/commit/2a7d9bd0ad114a7aadf65f1f65b8556f8da6d61d)).
+
+## Internal
+
+- Regenerate skills manifest after the media-use voice rule ([00a4f454e](https://github.com/heygen-com/hyperframes/commit/00a4f454ee75d4c434ee034f6dc62e5e924783fb)).
+
+## Other Changes
+
+- **Scripts:** Oxfmt the nav-suppression assertion ([aa928f399](https://github.com/heygen-com/hyperframes/commit/aa928f399a571fa9b61c67a931db4a97dfb1875d)).
+- Format the house-narrator note in tts.md, resync manifest ([08fadcef4](https://github.com/heygen-com/hyperframes/commit/08fadcef41d1128ed2493978ea665874306f60c6)).
+- Format changelog-weekly.ts ([fffc56c33](https://github.com/heygen-com/hyperframes/commit/fffc56c33b96c0fa9e3db15cb0f4799d0cbd6e5b)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.94...v0.7.96).
+</Update>
+
+<Update
   label="HyperFrames v0.7.95"
   description="Released - 2026-08-06"
   tags={["Release", "Studio", "Docs"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.96.md
+++ b/releases/v0.7.96.md
@@ -1,0 +1,111 @@
+# HyperFrames v0.7.96
+
+Released on 2026-08-06.
+
+Canary rollouts now record why each install landed in or out of a cohort, on both
+the CLI and Studio. Before this, a forced override and an ordinary cohort roll
+looked identical, so cohort changes could not be explained. Telemetry events also
+say whether an install's anonymous id will survive to the next run.
+
+For everyday use the visible changes are a Studio fix for rooted timeline media in
+preview, cancelable thumbnail generation, and a large pass over the docs examples.
+
+## Features
+
+- **Studio:** Emit the canary reason on Studio events too ([b3990ac78](https://github.com/heygen-com/hyperframes/commit/b3990ac789a40242b38eb740475811a03e701b2b)).
+- **Core,cli:** Emit the canary decision reason alongside the assignment ([076657a63](https://github.com/heygen-com/hyperframes/commit/076657a63994a911deba65cd4d54131d5997e1d1)).
+- **CLI:** Classify identity persistence on every telemetry event ([3b65321a2](https://github.com/heygen-com/hyperframes/commit/3b65321a204383582e3794ac19eca5d6f5eb3474), [#3065](https://github.com/heygen-com/hyperframes/pull/3065)).
+
+## Fixes
+
+- **Studio:** Route rooted timeline media through preview ([88853f170](https://github.com/heygen-com/hyperframes/commit/88853f170f9ab6c7bfa515d59694d1f995ac0e7d), [#3061](https://github.com/heygen-com/hyperframes/pull/3061)).
+- **Scripts:** Import the changelog style note instead of duplicating it ([8cadefa5d](https://github.com/heygen-com/hyperframes/commit/8cadefa5d8d0f558863e35327b6059aeef76523c)).
+- **Scripts:** Restore the texture instruction phrase a core test pins ([ddbd547fa](https://github.com/heygen-com/hyperframes/commit/ddbd547fad33042c10172b4e3607ed0b12fd7a06)).
+- **Scripts:** The repo already knew which items have no poster ([74ba97b7e](https://github.com/heygen-com/hyperframes/commit/74ba97b7edcc6ed2166fe00ee280c8c05ff718fc)).
+- **Scripts:** Actually commit the delivery encode ([4f1ace9f4](https://github.com/heygen-com/hyperframes/commit/4f1ace9f476fe10e9b6da2a9e9bae0332f5ead1a)).
+- **Docs:** Stop claiming a poster image that was never generated ([a6217f5ed](https://github.com/heygen-com/hyperframes/commit/a6217f5ed145b28e80ecfb5744fd7d3537f1335e)).
+
+## Performance
+
+- **Studio Server:** Coordinate cancelable thumbnail generation ([96861cbaf](https://github.com/heygen-com/hyperframes/commit/96861cbafc33e9e7b853b31c56610d50599cb96b), [#2720](https://github.com/heygen-com/hyperframes/pull/2720)).
+
+## Docs & Examples
+
+- Add user interview booking links ([27d113e56](https://github.com/heygen-com/hyperframes/commit/27d113e56c8ebb52a805e73308ffbfe313f8cc32), [#3059](https://github.com/heygen-com/hyperframes/pull/3059)).
+- Correct composition offset rationale; pin nav fix; label-in-name ([fed2baf27](https://github.com/heygen-com/hyperframes/commit/fed2baf27882cda0e19ae0e972f7335a162c36eb)).
+- **Examples:** Stop the sound control from following the card's link ([83db94e75](https://github.com/heygen-com/hyperframes/commit/83db94e75e87271c86f8823e636b729c500cbac9)).
+- **Examples:** Reset control state on offscreen release; precise a11y labels ([f3d1d531d](https://github.com/heygen-com/hyperframes/commit/f3d1d531d138d69e7d347391e5f7a4b35fb599a3)).
+- Complete the media-start layer map + fix the third page ([c49fea2e0](https://github.com/heygen-com/hyperframes/commit/c49fea2e0c4caaa7c4329493cdd5112581addc06)).
+- **Examples:** Reduced-motion play starts both films; precise media-start layers ([630c8900f](https://github.com/heygen-com/hyperframes/commit/630c8900f5866d5cd51eb3da96293981e41fc971)).
+- **Studio:** Note the third arrow-key meaning after merging Timeline navigation ([b541245f1](https://github.com/heygen-com/hyperframes/commit/b541245f1a49b1c784797050c7ae81040115d946)).
+- **Examples:** Allow voluntary playback under reduced motion; a11y parity ([c9fd7465c](https://github.com/heygen-com/hyperframes/commit/c9fd7465c9b9d516b53241fee1f8ca78d18ba905)).
+- **Sdk:** Fix dispatch/can contract, second stale GSAP site, media-start layers ([8e658bd6c](https://github.com/heygen-com/hyperframes/commit/8e658bd6c932ee1b8c65f247f9767d75fbd56275)).
+- **Examples:** Intersection-gate the recreate pair too ([aa077e000](https://github.com/heygen-com/hyperframes/commit/aa077e000df94db2348fa6d744909a67706b09e1)).
+- **Examples:** Make hover-audio accessible, lazy-loaded, and guard-complete ([0467bc812](https://github.com/heygen-com/hyperframes/commit/0467bc812916259a53a3f08eb30fb8a35586ee19)).
+- Correct three source-contradiction findings from review ([0f6259d46](https://github.com/heygen-com/hyperframes/commit/0f6259d461cfb678d60ae7926d343fbe44aee925)).
+- **Theme:** Brand the Playground CTA + align the navbar logo ([b62c3fd65](https://github.com/heygen-com/hyperframes/commit/b62c3fd65617cb1d89c828e1f7460893d34a3216)).
+- **Nav:** Lift 30 Days above the update feeds in Explore ([c53c7efd1](https://github.com/heygen-com/hyperframes/commit/c53c7efd1ec1070251ecf1a25643f96d5b96e7a7)).
+- **Examples:** Fix silent recreate references (stale keys -> new audio keys) ([4b1a526fa](https://github.com/heygen-com/hyperframes/commit/4b1a526facb128b98a33a2c8878761320bfea529)).
+- **Examples:** K3 promo now hover-to-hear with its audio version from X ([821189586](https://github.com/heygen-com/hyperframes/commit/821189586f19da6a67472ddfb952a63f0f1afc85)).
+- **Examples:** Replace two padded launch films + wire figma audio ([630c6c880](https://github.com/heygen-com/hyperframes/commit/630c6c880ddf164ca3dbad0a6979b0d943ec2691)).
+- **Examples:** More hover-audio + a 'Where HyperFrames plugs in' strip ([59a2ee31c](https://github.com/heygen-com/hyperframes/commit/59a2ee31c93818ce06c8575af4043948f0404a34)).
+- **Examples:** Hover-audio on six more grid films from the X launch archive ([e6bc8f139](https://github.com/heygen-com/hyperframes/commit/e6bc8f139c032d202d94fe2b4837b2e1b0f45ff8)).
+- **Examples:** Hover-to-hear on the four launch films that have audio masters ([fb6a82c50](https://github.com/heygen-com/hyperframes/commit/fb6a82c5052d5c801ecd6ec52d1ceadf4757e6a9)).
+- **30 Days:** Hover a card to hear the film's audio ([5361b9e10](https://github.com/heygen-com/hyperframes/commit/5361b9e10c80c787527ffa25a0db01002ddebbf0)).
+- **Examples:** Drop three dead source links (no such launch folder) ([8298bd439](https://github.com/heygen-com/hyperframes/commit/8298bd439092f67badef626987f385bb020a61dc)).
+- **Examples:** Bind reference video muted to state so unmute sticks ([407a5fd51](https://github.com/heygen-com/hyperframes/commit/407a5fd5139cda1dc10aae21aa52f6bc69c1e502)).
+- **Examples:** Sync the recreate pairs with a tap-to-unmute button ([bde03484a](https://github.com/heygen-com/hyperframes/commit/bde03484ae46345d4f10051a6db7155073e1eb76)).
+- **Examples:** Add 1:1 recreate-any-video comparison block ([98ae45e06](https://github.com/heygen-com/hyperframes/commit/98ae45e0661f120cedb8bda2d6002224db146924)).
+- 30 Days shows all thirty films, the real ones ([a46bc9d56](https://github.com/heygen-com/hyperframes/commit/a46bc9d565de76ad6e6dc5d35c6a9ff7d1e5cf76)).
+- Remove the Reference Project — nobody wants to be sent to GitHub ([b5509602f](https://github.com/heygen-com/hyperframes/commit/b5509602fa9f8ad9944c79b9f73f3a440357ecbf)).
+- 30 Days keeps its structure but borrows no videos ([06d2d6f24](https://github.com/heygen-com/hyperframes/commit/06d2d6f24c31b094198e4cd630d1f34c5df5dd2e)).
+- Examples shows 19 launch films grouped by what they prove, and 30 Days moves into Explore ([8483b51d4](https://github.com/heygen-com/hyperframes/commit/8483b51d4b7111710b8ac98befbd3c9ca07432cd)).
+- Light-theme videos on nine guides, plus two rewritten pages ([ad4c6a9b6](https://github.com/heygen-com/hyperframes/commit/ad4c6a9b6e0781e4253507ec4a179b83b3faee9b)).
+- Put the ten workflows in one place, and connect the two tracks ([f742084fa](https://github.com/heygen-com/hyperframes/commit/f742084fa85c1e2be1c0711c4467c48d4cd6f214)).
+- Name the two workflows the captions page covers ([c66961637](https://github.com/heygen-com/hyperframes/commit/c669616370db90f63ef4828e53db8a34e760406b)).
+- The examples gallery now tells you what it is ([18c0b8319](https://github.com/heygen-com/hyperframes/commit/18c0b8319d657d6b7578c6a34b8c183b5ff1865e)).
+- E_NO_GSAP_TIMELINE is not a missing feature ([d3331aad2](https://github.com/heygen-com/hyperframes/commit/d3331aad28ccb1f3ace49227e06d844e0c4ee58d)).
+- An Inspector map that matches the Inspector, and an example that can run ([9a659053d](https://github.com/heygen-com/hyperframes/commit/9a659053db3a3da95a4eece58f15e871ce9dc9d8)).
+- Four more the source contradicts, one of them mine ([af5ebf09c](https://github.com/heygen-com/hyperframes/commit/af5ebf09ce8bd15991da51bf83a9fe852e8dca29)).
+- Three things the source contradicts, found by reading the pages ([d01253771](https://github.com/heygen-com/hyperframes/commit/d01253771fa7f3eac4fa9126c7bedb9911e0be30)).
+- A compare example that works, and prose instead of a semicolon list ([1a22d6542](https://github.com/heygen-com/hyperframes/commit/1a22d6542a9a1492882cd11943b68e4a29522407)).
+- Three Studio shortcuts the page never mentioned ([f28b6d2bf](https://github.com/heygen-com/hyperframes/commit/f28b6d2bf73490cae7dd0403682064169951af5a)).
+- Write down the house narrator, and stop the videos sounding like two products ([bb7b0c899](https://github.com/heygen-com/hyperframes/commit/bb7b0c899f91bcfd1b4f36378bc750aa74e95976)).
+- Put the slideshow demo on the slideshow page ([199885b85](https://github.com/heygen-com/hyperframes/commit/199885b85edea981a3ce132fd09e3bcaac7ff316)).
+- Six pages get a real film instead of a six-second clip ([b4648e0e5](https://github.com/heygen-com/hyperframes/commit/b4648e0e5a45734970e3e905efcac4cf76d51057)).
+- Make the ten hardest-reading prompting pages readable ([8dba394d4](https://github.com/heygen-com/hyperframes/commit/8dba394d4dd52678cd49b68a3ec8fd8a921a1d6d)).
+- Stop serving render masters as if they were deliverables ([158d0fea1](https://github.com/heygen-com/hyperframes/commit/158d0fea1fa8e267f9e77aafc1f359ae37781beb)).
+- Draw the project model instead of describing it twice ([31366d724](https://github.com/heygen-com/hyperframes/commit/31366d724d83ff855c1a02edb2c37ff441a3648c)).
+- The last five blind guides now show the thing ([f595a7d68](https://github.com/heygen-com/hyperframes/commit/f595a7d68388c2e8842d3b8f5346273d0f9450b7)).
+- Move 19 anchor links onto the headings that now exist ([d16f6e69d](https://github.com/heygen-com/hyperframes/commit/d16f6e69d72c8582fac9577f57aaad158596b1e1)).
+- Make the two hardest-reading pages readable, and draw the two core concepts ([eb199bd15](https://github.com/heygen-com/hyperframes/commit/eb199bd1595f7774a16fb7baea12510a8d8a02d6)).
+- Four more guides show the thing instead of describing it ([8762887a5](https://github.com/heygen-com/hyperframes/commit/8762887a5b3773f460fa61e017d870f68f5d540a)).
+- Point two prompting links at headings that exist ([951c6ea45](https://github.com/heygen-com/hyperframes/commit/951c6ea45c1eddc377a40542a84acd40d1f472ef)).
+- Give every click-to-play video an audio track ([60f09dfcf](https://github.com/heygen-com/hyperframes/commit/60f09dfcfd3f8b18ac51e9d26f34e614969477e8)).
+- Keep the audio on the Huly launch film ([61cd3f1da](https://github.com/heygen-com/hyperframes/commit/61cd3f1da2afd8b59ee1a729c6653513a70e73bf)).
+- Show GSAP keyframes moving, and drop the weakest video on Examples ([ef9980948](https://github.com/heygen-com/hyperframes/commit/ef9980948206fa6c13f7c0c55e00f3f906c42a9f)).
+- Rewrite four pages that told instead of showed ([72d4016f5](https://github.com/heygen-com/hyperframes/commit/72d4016f5f25fb71c856f0d6fd9e52e91686c83a)).
+- Show the work on Media effects, Product launch, and Examples ([84b5160b6](https://github.com/heygen-com/hyperframes/commit/84b5160b663c8bf758c4134fdffceba4982ae374)).
+
+## Catalog
+
+- **Catalog:** Explicit section ownership, no body-sniffing heuristic ([d373c3f4a](https://github.com/heygen-com/hyperframes/commit/d373c3f4a09f59b349586c0885be47388844a658)).
+- **Catalog:** Restore the required Related topics section on generated pages ([6ff6601dd](https://github.com/heygen-com/hyperframes/commit/6ff6601dd03026f55be3d974222ac5c4ff890a8e)).
+- Quiet fallow complexity on the catalog generator's grown functions ([b33974cf7](https://github.com/heygen-com/hyperframes/commit/b33974cf72270fded5b9caf2244f26acf6b3c7e6)).
+- **Scripts:** Drop the catalog poster instead of guarding it, and cut the encode pass down ([592301248](https://github.com/heygen-com/hyperframes/commit/592301248ea93336189aa723b0b24971f7173ae0)).
+- **Docs:** The poster guard again, for the catalog index this time ([663f3e832](https://github.com/heygen-com/hyperframes/commit/663f3e8325c192324520113fa1819b3e1fcdd07a)).
+- Rebuild the catalog generator, and show what background removal and HDR do ([2a7d9bd0a](https://github.com/heygen-com/hyperframes/commit/2a7d9bd0ad114a7aadf65f1f65b8556f8da6d61d)).
+
+## Internal
+
+- Regenerate skills manifest after the media-use voice rule ([00a4f454e](https://github.com/heygen-com/hyperframes/commit/00a4f454ee75d4c434ee034f6dc62e5e924783fb)).
+
+## Other Changes
+
+- **Scripts:** Oxfmt the nav-suppression assertion ([aa928f399](https://github.com/heygen-com/hyperframes/commit/aa928f399a571fa9b61c67a931db4a97dfb1875d)).
+- Format the house-narrator note in tts.md, resync manifest ([08fadcef4](https://github.com/heygen-com/hyperframes/commit/08fadcef41d1128ed2493978ea665874306f60c6)).
+- Format changelog-weekly.ts ([fffc56c33](https://github.com/heygen-com/hyperframes/commit/fffc56c33b96c0fa9e3db15cb0f4799d0cbd6e5b)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.94...v0.7.96


### PR DESCRIPTION
## What

Stable release **v0.7.96**, covering everything since **v0.7.94** — the last version actually on npm.

Headline is canary attribution: rollouts now record *why* each install landed in or out of a cohort, on both the CLI and Studio (#3074). Before this a forced `HF_CANARY_*` override and an ordinary cohort roll produced an identical assignment, so cohort changes could not be explained. Also ships identity-persistence classification on every telemetry event (#3065), a Studio fix for rooted timeline media in preview (#3061), and cancelable thumbnail generation (#2720).

## Why this is 0.7.96 and not 0.7.95

**v0.7.95 was never published.** Its release PR (#3068) merged correctly at 17:12 UTC and the publish workflow fired — but that run has been stuck `in_progress` for hours and produced no tag and no npm artifact. npm `latest` is still `0.7.94`, while main's `package.json` reads `0.7.95`.

The cause is the ongoing GitHub incident: **Actions is in `major_outage`** (started 15:22 UTC, still unresolved). Webhook triggers are throttled, so pushes and PRs are not scheduling runs, and runners are being assigned jobs that no longer exist.

Because `v0.7.95` has no tag, the generated notes correctly span `v0.7.94...v0.7.96`, so nothing from 0.7.95 is lost — its changelog entry is also already on main from #3068.

## ⚠️ Merge ordering matters

**Do not merge this until v0.7.95 is settled.** The publish workflow sets the npm `latest` dist-tag. If 0.7.96 publishes and the stuck 0.7.95 run later resumes, `latest` would move **backwards** to 0.7.95.

Suggested order once Actions recovers:
1. Let the 0.7.95 run finish, or re-run its merged-PR event (the documented recovery path), or cancel it if it is unrecoverable.
2. Confirm CI is green on `main` — **#3074 merged with no matrix coverage at all** (only `WIP` plus a skipped Mintlify), because of the same outage.
3. Then merge this.

## Verification

Local suites on the merged content: core 1674, cli 2475, studio 3480, studio-server 416. Lint clean. The canary-reason change was mutation-tested at all three layers — core helper, CLI binding, Studio binding.

This PR itself will show no checks until Actions recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
