### PR TITLE
chore: release v0.7.97

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,21 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.97"
+  description="Released - 2026-08-07"
+  tags={["Release", "Studio"]}
+>
+Studio resizes now keep animated elements exactly where they were dropped. The saved GSAP scale and position match the frame shown during the gesture, preventing post-drop jumps.
+
+## Fixes
+
+- **Studio:** Keep first, repeated, rotated, uniform, and per-axis animated resizes pinned to their drop point ([#3076](https://github.com/heygen-com/hyperframes/pull/3076)).
+- **Studio:** Measure stylesheet-sized and legacy elements from their real box instead of a 200px fallback ([#3076](https://github.com/heygen-com/hyperframes/pull/3076)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.96...v0.7.97).
+</Update>
+
+<Update
   label="HyperFrames v0.7.96"
   description="Released - 2026-08-06"
   tags={["Release", "Studio", "Core,cli", "CLI"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.96",
+  "version": "0.7.97",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.97.md
+++ b/releases/v0.7.97.md
@@ -1,0 +1,14 @@
+# HyperFrames v0.7.97
+
+Released on 2026-08-07.
+
+Studio resizes now keep animated elements exactly where they were dropped. The saved GSAP scale and position match the frame shown during the gesture, preventing post-drop jumps.
+
+## Fixes
+
+- **Studio:** Keep first, repeated, rotated, uniform, and per-axis animated resizes pinned to their drop point ([#3076](https://github.com/heygen-com/hyperframes/pull/3076)).
+- **Studio:** Measure stylesheet-sized and legacy elements from their real box instead of a 200px fallback ([#3076](https://github.com/heygen-com/hyperframes/pull/3076)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.96...v0.7.97


### PR DESCRIPTION
## What

Stable release v0.7.97. Bumps all 13 packages and 3 plugin manifests from 0.7.96 to 0.7.97.

This release ships the Studio animated-resize corrections from #3076. Resized elements now persist the same scale and position shown at drop time, including legacy stylesheet-sized elements.

## Validation

- 138/138 release and repository script tests
- Full lint clean
- oxfmt clean across 3,816 files
- All 13 package manifests and 3 plugin manifests verified at 0.7.97

## Release flow

Merge through the normal stable release path. The merged-PR GitHub Actions workflow creates tag v0.7.97 at the exact merge commit, publishes npm latest, and creates the GitHub release.