### PR TITLE
fix(producer): record routing state on the failure path

### DIFF
--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -3264,6 +3264,15 @@ async function executeRenderPipeline(input: {
       usePageSideCompositing: capturePlan.usePageSideCompositing,
       hasHdrContent: capturePlan.hasHdrContent,
       forceScreenshot: capturePlan.forceScreenshot,
+      // Re-recorded here because `syncCapturePlan` above is where routing is
+      // actually decided — including "reverted", which the earlier update
+      // could not know. Without this, capture observability keeps whatever
+      // was true before the plan resolved, so a render that failed while
+      // routed reports no routing state at all: `de_parallel_router` was
+      // present on 95% of render_complete events and 0.8% of render_error.
+      // The failure path is the one the rollout is watching.
+      deWorkerInversion,
+      deParallelRouter,
     });
     observability.checkpoint("capture_strategy", "resolved", {
       plan: capturePlan.kind,

--- a/packages/producer/src/utils/ffprobeArgvContract.test.ts
+++ b/packages/producer/src/utils/ffprobeArgvContract.test.ts
@@ -173,8 +173,18 @@ function discoverCallers(): { found: string[]; unclassified: string[]; shell: st
     for (const entry of readdirSync(dir)) {
       if (SKIP_DIRS.has(entry) || entry.startsWith(".")) continue;
       const abs = join(dir, entry);
-      if (statSync(abs).isDirectory()) walk(abs);
-      else if (isSourceFile(entry)) classify(abs);
+      // Per-entry, because a single unreadable one used to abort the whole
+      // traversal: a dangling symlink under packages/studio/data/projects
+      // threw ENOENT on stat, so every package sorting after `studio` —
+      // including both studio-server callers — silently stopped being
+      // checked. Skipping the entry keeps the sweep complete; the manifest
+      // assertion is what caught the truncation.
+      try {
+        if (statSync(abs).isDirectory()) walk(abs);
+        else if (isSourceFile(entry)) classify(abs);
+      } catch {
+        /* unreadable entry (dangling symlink, permissions) — not a caller */
+      }
     }
   };
   for (const root of SWEEP_ROOTS) {


### PR DESCRIPTION
## The gap

`de_parallel_router` is present on **95.4%** of `render_complete` events and **0.83%** of `render_error`.

That is not "renders fail before capture" — capture context survives failures fine:

| field | `render_complete` | `render_error` |
|---|---|---|
| `capture_mode` | 99.76% | **98.59%** |
| `de_parallel_router` | 95.39% | **0.83%** |

## Cause

`deParallelRouter` is assigned twice in the orchestrator:

- `:2948` — `"routed"`, **before** the capture-observability update
- `:3256` — inside `syncCapturePlan`, where routing is actually resolved, **after** it — and this is the only assignment that can produce `"reverted"`

The update in between recorded whatever was true first. A render that failed while routed reported no routing state at all. The existing comment at the earlier call site says it is recorded there *"so a hard failure while routed/inverted still tells us"* — the intent was right, the value just arrived too late. This adds the fields to the update that already runs immediately after `syncCapturePlan()`.

## Why this blocks the #2840 ramp

The per-install circuit breaker only arms on a **revert**, which requires the render to finish and self-detect. It cannot catch a crash, hang, or OOM — those emit no `render_complete` at all, so the install is never protected and hits it again next render.

Those are precisely the failure modes a percentage ramp exists to bound, on precisely the profiles with no trial coverage (≤4 CPUs at 8.18% of eligible renders, Docker at 3.99%). Ramping while 99.2% of failures carry no routing state means being blind to the thing the ramp is watching for.

Related: among renders that *did* revert, 226 errored vs 175 completed — a revert correlates with outright failure more often than not. Causality is unclear (the render may have been failing anyway), but it argues against treating a revert as a benign "one slow render".

## Also: main is currently red

The ffprobe contract sweep aborted on the first unreadable entry. A dangling symlink at `packages/studio/data/projects/marys-room-companion` throws `ENOENT` on `stat`, killing the whole traversal — so every package sorting after `studio`, including both `studio-server` callers, silently stopped being checked. Now skipped per entry.

The manifest assertion is what caught this, which is exactly what it was added for.

## Verification

Producer suite 598 passing, unit lane exits 0, lint clean. Mutation-tested: removing the per-entry guard reproduces the failure.

**The orchestrator change has no unit seam** — `updateCaptureObservability` is a closure inside the render function, unreachable without a full render. The real verification is the telemetry itself: `de_parallel_router` coverage on `render_error` should rise from 0.83% toward the ~95% seen on completions once this ships. I would treat that as the acceptance check rather than claiming it is proven here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)