### PR TITLE
chore: release v0.7.98

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,23 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.98"
+  description="Released - 2026-08-07"
+  tags={["Release", "Producer"]}
+>
+Failed renders now record whether the parallel drawElement router was active.
+That state was on almost every successful render and almost no failed one, so a
+crash or hang looked the same as a render that never used the router. Nothing
+changes about how renders run.
+
+## Fixes
+
+- **Producer:** Record routing state on the failure path ([a3d13e267](https://github.com/heygen-com/hyperframes/commit/a3d13e2673405dee68643003574d5b260c4d5d18)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.97...v0.7.98).
+</Update>
+
+<Update
   label="HyperFrames v0.7.97"
   description="Released - 2026-08-07"
   tags={["Release", "Studio"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.97",
+  "version": "0.7.98",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.98.md
+++ b/releases/v0.7.98.md
@@ -1,0 +1,16 @@
+# HyperFrames v0.7.98
+
+Released on 2026-08-07.
+
+Failed renders now record whether the parallel drawElement router was active.
+That state was on almost every successful render and almost no failed one, so a
+crash or hang looked the same as a render that never used the router. Nothing
+changes about how renders run.
+
+## Fixes
+
+- **Producer:** Record routing state on the failure path ([a3d13e267](https://github.com/heygen-com/hyperframes/commit/a3d13e2673405dee68643003574d5b260c4d5d18)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.97...v0.7.98


### PR DESCRIPTION
## What

Stable release **v0.7.98**, a single fix: failed renders now record whether the parallel drawElement router was active (#3081).

`de_parallel_router` was on **95.4%** of `render_complete` events and **0.83%** of `render_error`. That was an ordering bug, not renders failing before capture — `capture_mode` survives failures at 98.6%. The routing state was recorded before `syncCapturePlan` resolved it, so the only assignment that can produce `"reverted"` never reached observability.

## Why it matters

This is a prerequisite for ramping #2840. The per-install circuit breaker only arms on a **revert**, which requires the render to finish and self-detect — it cannot catch a crash, hang, or OOM. Those are exactly the failure modes a percentage ramp exists to bound, on exactly the profiles with no trial coverage (≤4 CPUs at 8.18% of eligible renders, Docker at 3.99%). Ramping while 99.2% of failures carried no routing state would have meant being blind to what the ramp is watching for.

## Acceptance check after publish

`de_parallel_router` coverage on `render_error` should climb from 0.83% toward the ~95% seen on completions as installs adopt. The orchestrator change has no unit seam — `updateCaptureObservability` is a closure inside the render function — so that telemetry movement is the real verification, not the test suite.

## Note on numbering

0.7.97 published normally and does **not** contain this fix — #3081 merged after that release commit. This picks up only `a3d13e267`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)