### PR TITLE
chore: release v0.7.99

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,22 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.99"
+  description="Released - 2026-08-07"
+  tags={["Release", "CLI"]}
+>
+Publishing now retries brief network failures during upload and tells you which step failed when it cannot recover.
+Long timeouts are not retried, and signed upload secrets stay out of error messages.
+
+## Fixes
+
+- **CLI:** Harden publish retry behavior ([dd629697d](https://github.com/heygen-com/hyperframes/commit/dd629697d3356971e50132703b8a897c1a79bfdf)).
+- **CLI:** Recover transient publish failures ([f2d6ce324](https://github.com/heygen-com/hyperframes/commit/f2d6ce32459fc4c6be604a152e8707df03ce96e2)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.98...v0.7.99).
+</Update>
+
+<Update
   label="HyperFrames v0.7.98"
   description="Released - 2026-08-07"
   tags={["Release", "Producer"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.98",
+  "version": "0.7.99",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.99.md
+++ b/releases/v0.7.99.md
@@ -1,0 +1,15 @@
+# HyperFrames v0.7.99
+
+Released on 2026-08-07.
+
+Publishing now retries brief network failures during upload and tells you which step failed when it cannot recover.
+Long timeouts are not retried, and signed upload secrets stay out of error messages.
+
+## Fixes
+
+- **CLI:** Harden publish retry behavior ([dd629697d](https://github.com/heygen-com/hyperframes/commit/dd629697d3356971e50132703b8a897c1a79bfdf)).
+- **CLI:** Recover transient publish failures ([f2d6ce324](https://github.com/heygen-com/hyperframes/commit/f2d6ce32459fc4c6be604a152e8707df03ce96e2)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.98...v0.7.99


### PR DESCRIPTION
## What

Stable release **v0.7.99**, containing the CLI publish recovery fix from #3087.

Publishing now retries one brief transport failure during upload and reports which boundary failed when recovery is exhausted. Long timeouts, direct publish, and completion remain single-shot; signed upload query credentials are redacted from diagnostics.

## Release contents

- Retry transient failures only for staged prepare and the idempotent presigned S3 PUT.
- Add a fixed 200ms retry delay and fresh request bodies/signals per attempt.
- Preserve single-shot semantics for timeout, direct publish, and completion paths.
- Surface stage, cause, code, syscall, errno, and conditional proxy guidance without leaking signed URL queries.
- Publish reviewed `v0.7.99` notes and bump all 13 packages plus 3 plugin manifests.

## Local validation

- `bun run test:scripts` — 138/138 pass.
- `bunx oxfmt --check` — all 18 release files clean.
- Stable release-channel validation — `0.7.99` → `latest`, PR branch accepted.
- `bun run build` — all packages and SDK playground pass.
- `bun run verify:packed-manifests` — 13 packages publish-safe; 108 exports resolved, 103 Node exports executed, clean consumer install and CLI startup verified.

## Publish path

Merge through the normal stable-release workflow. GitHub Actions checks out the exact merge SHA, creates `v0.7.99` there, publishes npm with the `latest` tag, and creates the GitHub release. The local annotated tag was deliberately not pushed.
