### PR TITLE
chore: release v0.7.100

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,40 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.100"
+  description="Released - 2026-08-07"
+  tags={["Release", "Core", "Engine", "Scripts"]}
+>
+Components that another composition mounts now keep their own styles in the live preview. Some of them rendered unstyled before, even though the video they produced was correct.
+Screenshot captures on software rendering no longer accumulate earlier frames, and Studio keeps the preview alive in a tight window.
+
+## Features
+
+- **Producer:** Sniff HTML payload before ffprobe in resolveMediaDuration ([8a11e9776](https://github.com/heygen-com/hyperframes/commit/8a11e9776d3c65c2512c595bbde3dfc5bb194f39)).
+
+## Fixes
+
+- **Engine:** Stop SwiftShader ghosting in software screenshot captures ([b57dc13cb](https://github.com/heygen-com/hyperframes/commit/b57dc13cb6c8752c4f8f9426cfda2faf529136c2), [#3096](https://github.com/heygen-com/hyperframes/pull/3096)).
+- **Studio:** Resize an element whose scale is an instant hold ([a850e97f3](https://github.com/heygen-com/hyperframes/commit/a850e97f3d5a2cfcf183aec2cc2620020e8e1bf4), [#3092](https://github.com/heygen-com/hyperframes/pull/3092)).
+- **Core:** Stop dropping a mounted composition styles, and gate the divergence ([8d9db3df7](https://github.com/heygen-com/hyperframes/commit/8d9db3df731409d5aaed4ba0af70ea1c81ab40e4), [#3094](https://github.com/heygen-com/hyperframes/pull/3094)).
+- **Compiler:** Split font-family only on top-level commas ([172311e95](https://github.com/heygen-com/hyperframes/commit/172311e95e99b04cd2d76d43de9bbadd69c630ab), [#3067](https://github.com/heygen-com/hyperframes/pull/3067)).
+- **Studio:** Keep the preview alive when the window is tight ([d5cc1c9c6](https://github.com/heygen-com/hyperframes/commit/d5cc1c9c6249c27a63269288d8b7771656eb50db), [#3091](https://github.com/heygen-com/hyperframes/pull/3091)).
+- **CLI:** Refresh identity persistence classification ([7640adc5f](https://github.com/heygen-com/hyperframes/commit/7640adc5f2c39bd5d330aca3d0180ea2f67a793d)).
+- **Producer:** Classify JSON error bodies as non-media sources too ([349c066a8](https://github.com/heygen-com/hyperframes/commit/349c066a83c21046f888073776212348c2c5057b)).
+- **Producer:** Scope and harden the markup-payload sniff ([f3689c148](https://github.com/heygen-com/hyperframes/commit/f3689c148190b0c72d1b5296b2a5b740d8dd97d8)).
+
+## Catalog
+
+- **Scripts:** Render template-only blocks in catalog previews ([218eff7d3](https://github.com/heygen-com/hyperframes/commit/218eff7d361487becf7e1d6fc0d85453ac199b5e), [#3098](https://github.com/heygen-com/hyperframes/pull/3098)).
+
+## Internal
+
+- **Core:** Settle the four remaining preview-vs-render divergences ([57ec008cb](https://github.com/heygen-com/hyperframes/commit/57ec008cb295efb0a817840a1eadac53fbbf355e), [#3097](https://github.com/heygen-com/hyperframes/pull/3097)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.99...v0.7.100).
+</Update>
+
+<Update
   label="HyperFrames v0.7.99"
   description="Released - 2026-08-07"
   tags={["Release", "CLI"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.100.md
+++ b/releases/v0.7.100.md
@@ -1,0 +1,33 @@
+# HyperFrames v0.7.100
+
+Released on 2026-08-07.
+
+Components that another composition mounts now keep their own styles in the live preview. Some of them rendered unstyled before, even though the video they produced was correct.
+Screenshot captures on software rendering no longer accumulate earlier frames, and Studio keeps the preview alive in a tight window.
+
+## Features
+
+- **Producer:** Sniff HTML payload before ffprobe in resolveMediaDuration ([8a11e9776](https://github.com/heygen-com/hyperframes/commit/8a11e9776d3c65c2512c595bbde3dfc5bb194f39)).
+
+## Fixes
+
+- **Engine:** Stop SwiftShader ghosting in software screenshot captures ([b57dc13cb](https://github.com/heygen-com/hyperframes/commit/b57dc13cb6c8752c4f8f9426cfda2faf529136c2), [#3096](https://github.com/heygen-com/hyperframes/pull/3096)).
+- **Studio:** Resize an element whose scale is an instant hold ([a850e97f3](https://github.com/heygen-com/hyperframes/commit/a850e97f3d5a2cfcf183aec2cc2620020e8e1bf4), [#3092](https://github.com/heygen-com/hyperframes/pull/3092)).
+- **Core:** Stop dropping a mounted composition styles, and gate the divergence ([8d9db3df7](https://github.com/heygen-com/hyperframes/commit/8d9db3df731409d5aaed4ba0af70ea1c81ab40e4), [#3094](https://github.com/heygen-com/hyperframes/pull/3094)).
+- **Compiler:** Split font-family only on top-level commas ([172311e95](https://github.com/heygen-com/hyperframes/commit/172311e95e99b04cd2d76d43de9bbadd69c630ab), [#3067](https://github.com/heygen-com/hyperframes/pull/3067)).
+- **Studio:** Keep the preview alive when the window is tight ([d5cc1c9c6](https://github.com/heygen-com/hyperframes/commit/d5cc1c9c6249c27a63269288d8b7771656eb50db), [#3091](https://github.com/heygen-com/hyperframes/pull/3091)).
+- **CLI:** Refresh identity persistence classification ([7640adc5f](https://github.com/heygen-com/hyperframes/commit/7640adc5f2c39bd5d330aca3d0180ea2f67a793d)).
+- **Producer:** Classify JSON error bodies as non-media sources too ([349c066a8](https://github.com/heygen-com/hyperframes/commit/349c066a83c21046f888073776212348c2c5057b)).
+- **Producer:** Scope and harden the markup-payload sniff ([f3689c148](https://github.com/heygen-com/hyperframes/commit/f3689c148190b0c72d1b5296b2a5b740d8dd97d8)).
+
+## Catalog
+
+- **Scripts:** Render template-only blocks in catalog previews ([218eff7d3](https://github.com/heygen-com/hyperframes/commit/218eff7d361487becf7e1d6fc0d85453ac199b5e), [#3098](https://github.com/heygen-com/hyperframes/pull/3098)).
+
+## Internal
+
+- **Core:** Settle the four remaining preview-vs-render divergences ([57ec008cb](https://github.com/heygen-com/hyperframes/commit/57ec008cb295efb0a817840a1eadac53fbbf355e), [#3097](https://github.com/heygen-com/hyperframes/pull/3097)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.99...v0.7.100


### PR DESCRIPTION
# HyperFrames v0.7.100

Released on 2026-08-07.

Components that another composition mounts now keep their own styles in the live preview. Some of them rendered unstyled before, even though the video they produced was correct.
Screenshot captures on software rendering no longer accumulate earlier frames, and a render whose media source is really a web page fails with a clear error instead of a confusing FFmpeg one.

## Fixes

- **Core:** A composition mounted inside another keeps its own stylesheet and scripts ([8d9db3df7](https://github.com/heygen-com/hyperframes/commit/8d9db3df731409d5aaed4ba0af70ea1c81ab40e4), [#3094](https://github.com/heygen-com/hyperframes/pull/3094)). When those were authored as siblings of the composition root, the mount dropped them entirely, so three catalog components rendered completely unstyled in the live preview while the video they produced was correct. `oversized-cursor` drew its pointer at 1280px against an authored `7cqw` because the rule was never declared at all. A parity test now assembles the same composition both ways and fails when they disagree.

- **Engine:** Software screenshot captures no longer accumulate earlier frames ([b57dc13cb](https://github.com/heygen-com/hyperframes/commit/b57dc13cb6c8752c4f8f9426cfda2faf529136c2), [#3096](https://github.com/heygen-com/hyperframes/pull/3096)). Raster from previous seeks was never cleared under SwiftShader, so each capture contained the union of everything painted before it and static content read as duplicated one band lower. The software-compositing workaround now applies to every software capture, not only BeginFrame ones.

- **Producer:** A media source that is actually a text document now fails fast with a `NOT_MEDIA_PAYLOAD` error naming the element ([8a11e9776](https://github.com/heygen-com/hyperframes/commit/8a11e9776d3c65c2512c595bbde3dfc5bb194f39), [f3689c148](https://github.com/heygen-com/hyperframes/commit/f3689c148190b0c72d1b5296b2a5b740d8dd97d8), [349c066a8](https://github.com/heygen-com/hyperframes/commit/349c066a83c21046f888073776212348c2c5057b), [#3037](https://github.com/heygen-com/hyperframes/pull/3037)). This catches an HTML page, an XML or SVG document, or a JSON error body served in place of real media. Before, those renders failed deep inside FFmpeg with `moov atom not found`, which pointed at the wrong problem. Images are exempt, because an `<img>` may legitimately be an SVG.

- **Studio:** The preview pane no longer collapses when the window is narrow or short ([d5cc1c9c6](https://github.com/heygen-com/hyperframes/commit/d5cc1c9c6249c27a63269288d8b7771656eb50db), [#3091](https://github.com/heygen-com/hyperframes/pull/3091)). Panel sizes are now reconciled on every resize instead of only at load, and the side panels and timeline give way to a 360 x 200 preview floor. On a half-screen 760 x 760 window the preview went from a 192px strip to 433px wide.

- **Studio:** Resizing an element whose scale is an instant hold now works ([a850e97f3](https://github.com/heygen-com/hyperframes/commit/a850e97f3d5a2cfcf183aec2cc2620020e8e1bf4), [#3092](https://github.com/heygen-com/hyperframes/pull/3092)).

- **Compiler:** `font-family` is split only on top-level commas ([172311e95](https://github.com/heygen-com/hyperframes/commit/172311e95e99b04cd2d76d43de9bbadd69c630ab), [#3067](https://github.com/heygen-com/hyperframes/pull/3067)).

- **CLI:** Telemetry identity classification refreshes when the anonymous ID is replaced after a config deletion or storage recovery ([7640adc5f](https://github.com/heygen-com/hyperframes/commit/7640adc5f2c39bd5d330aca3d0180ea2f67a793d), [#3069](https://github.com/heygen-com/hyperframes/pull/3069)). Event names, distinct IDs, and dashboard semantics are unchanged.

## Catalog

- **Scripts:** Template-only blocks render in catalog previews ([218eff7d3](https://github.com/heygen-com/hyperframes/commit/218eff7d361487becf7e1d6fc0d85453ac199b5e), [#3098](https://github.com/heygen-com/hyperframes/pull/3098)).

## Internal

- **Core:** The four remaining preview-versus-render divergences are settled ([57ec008cb](https://github.com/heygen-com/hyperframes/commit/57ec008cb295efb0a817840a1eadac53fbbf355e), [#3097](https://github.com/heygen-com/hyperframes/pull/3097)). Mounting and rendering now derive their assembly decisions from one module. An inline `<head>` script is no longer discarded on render, a templated composition's stylesheet link is no longer dropped from the video, an anonymous host no longer leaks its composition's CSS unscoped, and scripts keep resolving their own self-referencing queries.

## Note on this PR

Originally cut before #3094, #3096 and #3097 merged. Rebased onto current main so the release contains them; verified that all three commits are ancestors of this branch, that core and player both read 0.7.100, and that the changelog summary is written rather than left as the drafted placeholder.

## Full changelog

https://github.com/heygen-com/hyperframes/compare/v0.7.99...v0.7.100
