### PR TITLE
feat(cli,core): gate the DE parallel router on the canary and ramp to 5%

### DIFF
--- a/packages/cli/src/commands/render.test.ts
+++ b/packages/cli/src/commands/render.test.ts
@@ -47,6 +47,10 @@ const trackingState = vi.hoisted(() => ({
   // `.ts` source under vitest — mocked here so the CLI-trial tests can
   // control it directly instead of inheriting that environment quirk.
   shouldTrack: true,
+  // The rollout slice. The trial only arms for installs the canary enrolled,
+  // so these tests control enrolment directly rather than depending on where
+  // the test machine's bucketSeed happens to land.
+  canaryEnabled: true,
   renderObservations: [] as Array<Record<string, unknown>>,
 }));
 
@@ -170,6 +174,10 @@ vi.mock("../telemetry/config.js", () => ({
 
 vi.mock("../telemetry/client.js", () => ({
   shouldTrack: vi.fn(() => trackingState.shouldTrack),
+}));
+
+vi.mock("../telemetry/canary.js", () => ({
+  isCanaryEnabled: vi.fn(() => trackingState.canaryEnabled),
 }));
 
 vi.mock("../telemetry/events.js", () => ({
@@ -779,6 +787,39 @@ describe("renderLocal — DE parallel-router CLI trial", () => {
       deParallelRouterTrialFired: false,
       telemetryNoticeShown: true,
     };
+    await renderLocal("/tmp/project", "/tmp/out.mp4", baseOptions);
+    expect(process.env.HF_DE_PARALLEL_ROUTER).toBe("true");
+  });
+
+  // The rollout slice. Before this, every eligible install armed the trial —
+  // good for the soak, but an unbounded blast radius the moment the router
+  // regresses. 0.7.60-0.7.64 is the precedent: every unclamped render
+  // reverted for five releases, silently.
+  it("does not arm for an install the canary did not enrol", async () => {
+    trackingState.canaryEnabled = false;
+    configState.disk = {
+      telemetryEnabled: true,
+      deParallelRouterTrialFired: false,
+      telemetryNoticeShown: true,
+    };
+    await renderLocal("/tmp/project", "/tmp/out.mp4", baseOptions);
+    expect(process.env.HF_DE_PARALLEL_ROUTER).toBeUndefined();
+  });
+
+  // Setting the registry percentage to 0 must switch the rollout off for
+  // everyone without needing a code change — that is the revert path.
+  it("arms only when enrolled, so the registry percentage is the kill switch", async () => {
+    configState.disk = {
+      telemetryEnabled: true,
+      deParallelRouterTrialFired: false,
+      telemetryNoticeShown: true,
+    };
+
+    trackingState.canaryEnabled = false;
+    await renderLocal("/tmp/project", "/tmp/out.mp4", baseOptions);
+    expect(process.env.HF_DE_PARALLEL_ROUTER).toBeUndefined();
+
+    trackingState.canaryEnabled = true;
     await renderLocal("/tmp/project", "/tmp/out.mp4", baseOptions);
     expect(process.env.HF_DE_PARALLEL_ROUTER).toBe("true");
   });

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -70,6 +70,7 @@ import {
   type HyperframesConfig,
 } from "../telemetry/config.js";
 import { shouldTrack } from "../telemetry/client.js";
+import { isCanaryEnabled } from "../telemetry/canary.js";
 import { renderJobObservabilityTelemetryPayload } from "../telemetry/renderObservability.js";
 import { bytesToMb } from "../telemetry/system.js";
 import { VERSION } from "../version.js";
@@ -1137,6 +1138,16 @@ function isDeParallelRouterTrialBlocked(config: HyperframesConfig): boolean {
     deParallelRouterTrialFiredThisProcess ||
     Boolean(config.deParallelRouterTrialFired) ||
     overRenderCap ||
+    // The rollout slice. Previously every eligible install armed the trial,
+    // which is what produced the soak — but it is also an unbounded blast
+    // radius the moment the router changes. Ramping through the registry
+    // makes the exposed fraction an explicit, revertible number instead of
+    // all-or-nothing, and the per-install breaker below still bounds each
+    // enrolled install to one bad render.
+    //
+    // Set to 0 in the registry = nobody arms, which is the safe default if
+    // this ever needs to be switched off without a release.
+    !isCanaryEnabled("de-parallel-router") ||
     !config.telemetryEnabled ||
     !shouldTrack() ||
     // cli.ts shows the first-run telemetry disclosure via a fire-and-forget,

--- a/packages/core/src/canary.test.ts
+++ b/packages/core/src/canary.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { canaryBucket, evaluateCanary, parseCanaryOverride, type CanaryInput } from "./canary.js";
 import { CANARIES, canaryEnvVar, findCanary, overdueCanaries } from "./canaryRegistry.js";
 import {
@@ -293,10 +295,24 @@ describe("registry", () => {
 
   // The registry is data, so a ramp is a one-line edit with no code review
   // surface. This canary's own description says "ramp only alongside the
-  // per-install circuit breaker" — without an assertion, bumping it to 5
-  // before that wiring lands would go green.
-  it("keeps de-parallel-router at 0% until the circuit breaker is wired", () => {
-    expect(findCanary("de-parallel-router")?.percentage).toBe(0);
+  // per-install circuit breaker", and the previous version of this test
+  // enforced that by pinning the percentage to 0 — which blocks the ramp
+  // forever and never actually checks the wiring it names.
+  //
+  // Assert the wiring instead: a non-zero percentage is allowed only while
+  // the CLI render path really gates on this canary. Ramping without that
+  // gate would enrol nobody (silently useless) or everybody (unbounded),
+  // depending on which side the mistake fell.
+  it("only ramps de-parallel-router while the CLI render path gates on it", () => {
+    const pct = findCanary("de-parallel-router")?.percentage ?? 0;
+    if (pct === 0) return;
+    const renderSrc = readFileSync(
+      join(import.meta.dirname, "..", "..", "cli", "src", "commands", "render.ts"),
+      "utf8",
+    );
+    expect(renderSrc).toContain('isCanaryEnabled("de-parallel-router")');
+    // And the per-install breaker the description names is still consulted.
+    expect(renderSrc).toContain("deParallelRouterTrialFired");
   });
 
   it("has in-range percentages and a parseable sunset date", () => {

--- a/packages/core/src/canaryRegistry.ts
+++ b/packages/core/src/canaryRegistry.ts
@@ -83,7 +83,17 @@ export const CANARIES: readonly CanaryDefinition[] = [
   // ── Real rollouts ────────────────────────────────────────────────────────
   {
     name: "de-parallel-router",
-    percentage: 0,
+    // Ramp 5 -> 25 -> 100. Calibration validated the bucketer first: accuracy
+    // 9.62%/49.76% against 10%/50% targets at n=13,547, overrides and the CI
+    // population both attributable, and sustained cohort flips at 0.10% —
+    // an order of magnitude under this feature's own ~2.79% revert rate, so
+    // cohort noise cannot corrupt the read.
+    //
+    // At each step, split revert rate by cpu_count and is_docker. Those are
+    // the two segments the opt-in trial never covered (~12% of eligible
+    // renders between them), and worker-count-dependent failure is exactly
+    // how 0.7.60-0.7.64 broke silently for five releases.
+    percentage: 5,
     description:
       "Route auto multi-worker renders to verified parallel drawElement streaming (HF_DE_PARALLEL_ROUTER). Ramp only alongside the per-install circuit breaker.",
     owner: "vance",


### PR DESCRIPTION
## What

Router trial arming is now gated on the `de-parallel-router` canary, and the registry moves **0 → 5%**.

Previously every eligible install armed the trial. That produced the soak — 1,466 installs, with **154 of 155 reverting installs stopping at exactly one** — but it is also an unbounded blast radius the moment the router regresses. The precedent is 0.7.60–0.7.64, where *every* unclamped render reverted for five consecutive releases, silently.

The exposed fraction is now an explicit, revertible number. Setting the percentage back to `0` switches the rollout off for everyone with no code change.

## The bucketer was validated first

Calibration at **n = 13,547** installs:

| check | result |
|---|---|
| `calibration-10` | 9.62% (target 10%) ✓ |
| `calibration-50` | 49.76% (target 50%) ✓ |
| independence | passes |
| `forced_on`/`forced_off` | 0 — overrides ruled out |
| CI population | self-identifying via `excluded` |
| **sustained cohort flips** | **0.10%** |

That 0.10% is an order of magnitude below this feature's own ~2.79% revert rate, so cohort instability cannot meaningfully corrupt the ramp read. It has also held steady across three reads (0.14% → 0.12% → 0.10%), so it is a stable edge rather than something growing.

## Replaces a test that could never pass

`canary.test.ts` pinned the percentage to `0` with the note *"ramp only alongside the per-install circuit breaker"*. But pinning 0 blocks the ramp permanently and never checks the wiring it names.

It now asserts the wiring directly: a non-zero percentage is allowed **only while** the CLI render path gates on this canary and still consults the per-install breaker. Mutation-tested — removing the gate fails it.

## What to watch at each step

Split revert rate by **`cpu_count`** and **`is_docker`**. Those two segments (~12% of eligible renders between them) had near-zero trial coverage, and worker-count-dependent failure is exactly how 0.7.60–0.7.64 broke.

Useful baseline from telemetry: routed renders fail at **2–3.4%**, stable across versions.

## Relationship to #2840

This supersedes #2840's approach. That PR flips to unconditional default-on (`unset = ON`); this ramps through the registry instead, which is the safer shape for the same goal. #2840 can close once this lands, or be reworked to drop the polarity change and keep only its kill-switch parsing fixes.

## Verification

core 1674, cli 2486 passing. Lint clean. Both the gate and the wiring assertion mutation-tested.

One pre-existing failure on main, not from this branch: `audioPadTrim.realmedia` times out at 5s — reproduced on clean `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)