### PR TITLE
fix(feedback): anchor the 0-10 rating everywhere it is asked for

### DIFF
--- a/docs/guides/feedback.mdx
+++ b/docs/guides/feedback.mdx
@@ -19,7 +19,7 @@ From a HyperFrames project, run:
 npx hyperframes feedback --rating 7 --comment "The render finished, but the captions were missing."
 ```
 
-The rating is from 0 to 10. The comment is optional, but a specific example is usually more useful than a score alone.
+The rating is from 0 to 10, where 0 means "not likely to recommend" and 10 means "extremely likely", so a clean run is a 10. The scale was 1 to 5 until mid-2026, which makes 5 the midpoint now rather than the top mark. The comment is optional, but a specific example is usually more useful than a score alone.
 
 ## Report a reproducible bug
 

--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -1037,7 +1037,9 @@ npx hyperframes feedback --rating 7 --comment "render succeeded but GSAP timelin
 npx hyperframes feedback --rating 3 --comment "GSAP timeline froze on seek" --file-issue
 ```
 
-`--rating` is required, 0–10. `--comment` adds free text. `--file-issue`
+`--rating` is required, 0–10, where 0 is "not likely to recommend" and 10 is
+"extremely likely", so a clean run is a 10. The scale was 1–5 until mid-2026,
+which puts 5 at the midpoint instead of the top. `--comment` adds free text. `--file-issue`
 also opens a GitHub issue, `--dir` picks the project published as its repro
 (default: current directory), and `--yes, -y` skips the consent prompt for
 scripts.

--- a/packages/cli/src/commands/feedback.ts
+++ b/packages/cli/src/commands/feedback.ts
@@ -14,7 +14,11 @@ import { submitFeedback } from "../utils/submitFeedback.js";
 import { buildIssueUrl, HYPERFRAMES_REPO_URL } from "../utils/feedbackIssue.js";
 import { VERSION } from "../version.js";
 import { c } from "../ui/colors.js";
-import { parseFeedbackRating } from "../utils/feedbackRating.js";
+import {
+  FEEDBACK_RATING_ANCHOR,
+  FEEDBACK_RATING_SCALE,
+  parseFeedbackRating,
+} from "../utils/feedbackRating.js";
 import { lintFeedbackComment, type FeedbackLintInput } from "../utils/feedbackLint.js";
 
 export const examples: Example[] = [
@@ -155,7 +159,7 @@ export default defineCommand({
   args: {
     rating: {
       type: "string",
-      description: "Likelihood to recommend (0=not likely, 10=extremely likely)",
+      description: `Likelihood to recommend (${FEEDBACK_RATING_ANCHOR}; a clean run is a ${FEEDBACK_RATING_SCALE})`,
       required: true,
     },
     comment: {
@@ -181,7 +185,11 @@ export default defineCommand({
   async run({ args }) {
     const rating = parseFeedbackRating(args.rating);
     if (rating === null) {
-      console.error(c.error("Rating must be an integer between 0 and 10"));
+      console.error(
+        c.error(
+          `Rating must be an integer between 0 and ${FEEDBACK_RATING_SCALE} (${FEEDBACK_RATING_ANCHOR})`,
+        ),
+      );
       failCommand();
     }
 

--- a/packages/cli/src/telemetry/feedback.ts
+++ b/packages/cli/src/telemetry/feedback.ts
@@ -4,7 +4,11 @@ import { shouldTrack } from "./client.js";
 import { trackRenderFeedback } from "./events.js";
 import { detectAgentRuntime } from "./agent_runtime.js";
 import { c } from "../ui/colors.js";
-import { parseFeedbackRating } from "../utils/feedbackRating.js";
+import {
+  FEEDBACK_RATING_ANCHOR,
+  FEEDBACK_RATING_PLACEHOLDER,
+  parseFeedbackRating,
+} from "../utils/feedbackRating.js";
 
 const DEFAULT_FEEDBACK_INTERVAL = 15;
 
@@ -51,7 +55,7 @@ export async function maybePromptRenderFeedback(opts: {
     console.log(
       c.dim("  [hyperframes] ") +
         c.dim("Agent feedback: ") +
-        c.accent('hyperframes feedback --rating <0-10> --comment "..."'),
+        c.accent(`hyperframes feedback --rating ${FEEDBACK_RATING_PLACEHOLDER} --comment "..."`),
     );
     return;
   }
@@ -67,7 +71,7 @@ export async function maybePromptRenderFeedback(opts: {
   writeConfig(config);
 
   const answer = await askQuestion(
-    `  ${c.dim("How likely are you to recommend HyperFrames?")} ${c.accent("[0=not likely 10=extremely likely, enter to skip]")} `,
+    `  ${c.dim("How likely are you to recommend HyperFrames?")} ${c.accent(`[${FEEDBACK_RATING_ANCHOR}, enter to skip]`)} `,
   );
 
   const rating = parseFeedbackRating(answer);

--- a/packages/cli/src/utils/feedbackLint.test.ts
+++ b/packages/cli/src/utils/feedbackLint.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   COMPOSITION_STRUCTURE_RATING_CEILING,
+  UNEXPLAINED_RATING_CEILING,
   VISUAL_DEFECT_KEYWORDS,
   lintFeedbackComment,
   mentionsVisualDefect,
@@ -14,10 +15,26 @@ describe("lintFeedbackComment", () => {
     );
   });
 
-  it("returns no warnings when the comment is missing or blank", () => {
+  it("returns no warnings for a bare above-midpoint vote", () => {
     expect(lintFeedbackComment({ rating: 6, comment: undefined })).toEqual([]);
     expect(lintFeedbackComment({ rating: 6, comment: "" })).toEqual([]);
     expect(lintFeedbackComment({ rating: 6, comment: "   \n  " })).toEqual([]);
+  });
+
+  it.each([undefined, "", "   \n  "])(
+    "warns on a bare bottom-half score (comment %j) and restates the scale",
+    (comment) => {
+      const warnings = lintFeedbackComment({ rating: UNEXPLAINED_RATING_CEILING, comment });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.code).toBe("unexplained-low-rating");
+      // The 1-5 → 0-10 migration is the reason a bare `5` shows up at all.
+      expect(warnings[0]?.message).toContain("1-5");
+      expect(warnings[0]?.message).toContain("--rating 10");
+    },
+  );
+
+  it("does not warn on a bare 10 — a clean run needs no comment", () => {
+    expect(lintFeedbackComment({ rating: 10, comment: undefined })).toEqual([]);
   });
 
   it("warns on non-10 comments missing REPRO COMMAND:", () => {

--- a/packages/cli/src/utils/feedbackLint.ts
+++ b/packages/cli/src/utils/feedbackLint.ts
@@ -32,6 +32,14 @@ export const VISUAL_DEFECT_KEYWORDS: readonly string[] = [
  */
 export const COMPOSITION_STRUCTURE_RATING_CEILING = 7;
 
+/**
+ * Bottom half of the scale. A score at or below the midpoint with no comment
+ * is either an unactionable complaint or — far more often — a caller still
+ * rating on the old 1-5 scale, where `5` meant "perfect" and now lands as a
+ * mediocre 5/10. Both cases deserve the same nudge.
+ */
+export const UNEXPLAINED_RATING_CEILING = Math.floor(FEEDBACK_RATING_SCALE / 2);
+
 const REPRO_MARKER = "REPRO COMMAND:";
 const STRUCTURE_MARKER = "COMPOSITION_STRUCTURE:";
 
@@ -41,8 +49,26 @@ export interface FeedbackLintInput {
 }
 
 export interface FeedbackLintWarning {
-  code: "missing-repro-command" | "missing-composition-structure";
+  code: "missing-repro-command" | "missing-composition-structure" | "unexplained-low-rating";
   message: string;
+}
+
+/**
+ * Bare bottom-half score, no comment. Reminds the caller which end of the
+ * scale is good — the range doubled from 1-5 to 0-10 and `5` survived as a
+ * legal value, so this is what a stale "5 = perfect" habit looks like on the
+ * wire.
+ */
+function unexplainedLowRating(rating: number): FeedbackLintWarning {
+  return {
+    code: "unexplained-low-rating",
+    message: [
+      `${rating}/${FEEDBACK_RATING_SCALE} with no comment is unactionable —`,
+      `ratings run 0-${FEEDBACK_RATING_SCALE} where ${FEEDBACK_RATING_SCALE} is a clean run`,
+      `(the scale used to be 1-5, so ${UNEXPLAINED_RATING_CEILING} is now the midpoint, not the top).`,
+      `Rerun with --comment "<what went wrong>", or --rating ${FEEDBACK_RATING_SCALE} if the run was clean.`,
+    ].join(" "),
+  };
 }
 
 /**
@@ -53,18 +79,21 @@ export interface FeedbackLintWarning {
  *
  * Rules:
  *  1. `rating === 10` — no check. A perfect run doesn't need a repro packet.
- *  2. Comment missing / empty — no check. `feedback --rating 6` with no
- *     comment is a valid quick vote; the maintainer sees rating drift without
- *     the reporter having to synthesize a fake repro.
- *  3. Comment present + rating < 10 + no `REPRO COMMAND:` — warn.
- *  4. Comment present + rating ≤ 7 + visual-defect keyword + no
- *     `COMPOSITION_STRUCTURE:` — warn (in addition to any #3 warning).
+ *  2. Comment missing / empty + rating above the midpoint — no check.
+ *     `feedback --rating 6` with no comment is a valid quick vote; the
+ *     maintainer sees rating drift without a synthesized repro.
+ *  3. Comment missing / empty + rating ≤ 5 — warn. Restate which end of the
+ *     scale is good: an unexplained bottom-half score is usually a caller
+ *     still rating out of 5.
+ *  4. Comment present + rating < 10 + no `REPRO COMMAND:` — warn.
+ *  5. Comment present + rating ≤ 7 + visual-defect keyword + no
+ *     `COMPOSITION_STRUCTURE:` — warn (in addition to any #4 warning).
  */
 export function lintFeedbackComment(input: FeedbackLintInput): FeedbackLintWarning[] {
   const { rating, comment } = input;
   if (rating === FEEDBACK_RATING_SCALE) return [];
   const trimmed = comment?.trim();
-  if (!trimmed) return [];
+  if (!trimmed) return rating <= UNEXPLAINED_RATING_CEILING ? [unexplainedLowRating(rating)] : [];
 
   // Marker checks are case-insensitive to match `mentionsVisualDefect`'s
   // normalization. A reporter who writes `Repro command:` shouldn't get warned

--- a/packages/cli/src/utils/feedbackRating.test.ts
+++ b/packages/cli/src/utils/feedbackRating.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { FEEDBACK_RATING_SCALE, parseFeedbackRating } from "./feedbackRating.js";
+import {
+  FEEDBACK_RATING_ANCHOR,
+  FEEDBACK_RATING_PLACEHOLDER,
+  FEEDBACK_RATING_SCALE,
+  parseFeedbackRating,
+} from "./feedbackRating.js";
 
 describe("parseFeedbackRating", () => {
   it.each(["0", "10"])("accepts the NPS boundary %s", (raw) => {
@@ -14,4 +19,14 @@ describe("parseFeedbackRating", () => {
   it("declares the serialized rating scale", () => {
     expect(FEEDBACK_RATING_SCALE).toBe(10);
   });
+
+  // Both hints must name the top of the scale. A bare "0-10" is what let the
+  // 1-5 era's "5 = perfect" habit keep submitting mediocre scores.
+  it.each([FEEDBACK_RATING_ANCHOR, FEEDBACK_RATING_PLACEHOLDER])(
+    "hint %j carries the top of the scale",
+    (hint) => {
+      expect(hint).toContain(String(FEEDBACK_RATING_SCALE));
+      expect(hint).toMatch(/best|extremely likely/);
+    },
+  );
 });

--- a/packages/cli/src/utils/feedbackRating.ts
+++ b/packages/cli/src/utils/feedbackRating.ts
@@ -1,5 +1,20 @@
 export const FEEDBACK_RATING_SCALE = 10;
 
+/**
+ * Endpoint anchor for the interactive prompt. Never print the bare range:
+ * the scale moved from 1-5 to 0-10 while `5` stayed a legal value, so an
+ * unanchored `0-10` keeps collecting `5`s from callers (agents especially)
+ * that still read 5 as top-of-scale. Both ends always travel with the range.
+ */
+export const FEEDBACK_RATING_ANCHOR = `0=not likely ${FEEDBACK_RATING_SCALE}=extremely likely`;
+
+/**
+ * Argument placeholder for the non-interactive surfaces (agent hint, docs,
+ * skills). Same reason as `FEEDBACK_RATING_ANCHOR`, compressed to fit inline
+ * in a command line.
+ */
+export const FEEDBACK_RATING_PLACEHOLDER = `<0-${FEEDBACK_RATING_SCALE}, ${FEEDBACK_RATING_SCALE}=best>`;
+
 export function parseFeedbackRating(raw: string): number | null {
   const trimmed = raw.trim();
   if (!/^\d+$/.test(trimmed)) return null;

--- a/packages/studio/src/components/StudioFeedbackBar.tsx
+++ b/packages/studio/src/components/StudioFeedbackBar.tsx
@@ -181,6 +181,9 @@ export const StudioFeedbackBar = memo(function StudioFeedbackBar() {
       ) : (
         <>
           <span className="text-neutral-500 flex-shrink-0">Recommend HyperFrames?</span>
+          {/* Endpoint labels: the row is 0-10, and an unlabelled numeric row
+              reads as a 5-star scale to anyone (or any agent) used to one. */}
+          <span className="text-neutral-600 text-[10px] flex-shrink-0">not likely</span>
           <div className="flex items-center gap-0.5">
             {Array.from({ length: 11 }, (_, n) => n).map((n) => (
               <button
@@ -192,6 +195,7 @@ export const StudioFeedbackBar = memo(function StudioFeedbackBar() {
               </button>
             ))}
           </div>
+          <span className="text-neutral-600 text-[10px] flex-shrink-0">extremely likely</span>
           <div className="flex-1" />
           <button
             onClick={handleDismiss}

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -26,7 +26,7 @@
       "files": 121
     },
     "hyperframes-cli": {
-      "hash": "3eab4c5fc1ae8e26",
+      "hash": "4ca462de967d4a5a",
       "files": 11
     },
     "hyperframes-core": {

--- a/skills/hyperframes-cli/SKILL.md
+++ b/skills/hyperframes-cli/SKILL.md
@@ -104,8 +104,10 @@ Use cloud rendering when the user wants hosted rendering without local Chrome, F
 After verifying a successful render, send one feedback report unless telemetry is disabled or the user opted out:
 
 ```bash
-npx hyperframes feedback --rating <0-10> --comment "<specific result or friction>"
+npx hyperframes feedback --rating <0-10, 10=best> --comment "<specific result or friction>"
 ```
+
+**The scale is 0-10, not 0-5.** It was 1-5 until mid-2026, so `5` is now the midpoint, not the top. A clean verified run is a `10`; drop one or two points per real friction you hit. Never send a bare bottom-half score: if it is below 6, say what went wrong in `--comment`.
 
 Keep clean-run feedback concise. For any bug or friction, capture a **reproduction packet** before submitting; do not send only a symptom summary. Include the rerunnable command (relative to the project directory — feedback is submitted to a public channel, so do **not** paste absolute paths, home-directory prefixes, or user/machine identifiers), expected versus actual behavior, exact error (also strip absolute paths from stack traces — keep basename + line, drop the leading directory), whether output completed/fell back/failed, workaround, and repro-project status. For a rating ≤ 7 that describes a visual defect (black frame, flicker, corrupt output, wrong frame, blank output, other visual anomaly), also include a `COMPOSITION_STRUCTURE:` block — a privacy-preserving structural anatomy (element census + attribute presence + timeline shape) so maintainers can pattern-match against known bug families without the composition ZIP. Agents auto-fill this via the composition-census helper; the human user does not fill it by hand. If the issue did not reproduce again, say so and still include the last failing command and logs. Use `--file-issue` only with consent: it publishes a minimal reproduction to a public URL. The required packet format and privacy warning live in `references/preview-render.md`.
 

--- a/skills/hyperframes-cli/references/preview-render.md
+++ b/skills/hyperframes-cli/references/preview-render.md
@@ -153,7 +153,7 @@ npx hyperframes feedback --rating 10                              # clean run, n
 npx hyperframes feedback --rating 6 --comment "bg <video> renders grey in multi-scene; worked around with --format png-sequence"
 ```
 
-`--rating` is an integer from 0-10 (required); `--comment` is free text. Feedback is anonymous and attaches a `doctorSummary` (OS/Node/CPU/mem/ffmpeg) automatically, so don't repeat those fields. A clean run needs only a short result. Before sending any bug, workaround, or confusing behavior, collect this compact reproduction packet:
+`--rating` is an integer from 0-10 (required), where **10 is best and a clean verified run is a 10**. The scale was 1-5 until mid-2026 and `5` stayed legal, so a reflexive `5` now reports a mediocre run: pick the number against the 0-10 endpoints, not against a 5-star habit. A bottom-half score with no `--comment` is unactionable and the CLI warns about it. `--comment` is free text. Feedback is anonymous and attaches a `doctorSummary` (OS/Node/CPU/mem/ffmpeg) automatically, so don't repeat those fields. A clean run needs only a short result. Before sending any bug, workaround, or confusing behavior, collect this compact reproduction packet:
 
 ```text
 REPRO COMMAND: <HF_*/PRODUCER_* env> npx hyperframes <exact command>   # run from the project directory; do NOT paste absolute paths
@@ -173,7 +173,7 @@ COMPOSITION_STRUCTURE:
 
 **Feedback is submitted to a public channel — anonymize before sending.** Redact absolute paths (which leak user home directory + machine identity), any user or project names embedded in paths, secrets, and credentials. Path arguments in the command should stay relative to the project directory (`./renders/out.mp4`, not `/Users/<user>/Documents/…/out.mp4`; `.hf-tmp/`, not `/home/<user>/projects/<real-name>/.hf-tmp/`). Similarly strip absolute paths from `EXACT ERROR:` stack traces and log excerpts — keep the file basename and line number, drop the leading directory. Preserve flags and relevant `HF_*` / `PRODUCER_*` variables verbatim. If the failure no longer reproduces, include the last failing command and log excerpt (redacted the same way). Share a project link only when one is already available and safe to share.
 
-The `hyperframes feedback` command soft-warns when a non-10 `--comment` is missing `REPRO COMMAND:`, and when a rating-≤-7 visual-defect comment is missing `COMPOSITION_STRUCTURE:`. The warnings print above the submission ack and do not block — some legitimate reports (a one-line "cloudrun quota bumped yesterday, fine now") won't fit the mold. Fix the packet and rerun to silence them.
+The `hyperframes feedback` command soft-warns when a non-10 `--comment` is missing `REPRO COMMAND:`, when a rating-≤-7 visual-defect comment is missing `COMPOSITION_STRUCTURE:`, and when a rating of 5 or lower carries no `--comment` at all (the bare-bottom-half report, which is usually a leftover 0-5 reflex). The warnings print above the submission ack and do not block — some legitimate reports (a one-line "cloudrun quota bumped yesterday, fine now") won't fit the mold. Fix the packet and rerun to silence them.
 
 Hit a reproducible bug? Add `--file-issue` (optionally `--dir <project>` and `--yes` for non-interactive shells) to also publish a minimal repro to a public URL and open a pre-filled GitHub `bug` issue draft for a maintainer to file. This publishes the project publicly, so it is opt-in and consent-gated; the issue is never auto-submitted.
 


### PR DESCRIPTION
## What

Every surface that asks for a `hyperframes feedback` rating now states which end of the scale is good, from one shared constant:

- the agent hint after a render: `--rating <0-10, 10=best>` (was a bare `<0-10>`)
- `--rating` help text and the invalid-rating error
- the Studio feedback bar: "not likely" / "extremely likely" labels flanking the 0-10 row
- the `hyperframes-cli` skill, its `preview-render` reference, and both docs pages

Plus a soft warn (never blocks) when a rating of 5 or lower arrives with no `--comment`, restating the scale.

## Why

The scale moved from 1-5 to 0-10, but `5` stayed a legal value and several surfaces kept printing the bare range. A caller habituated to the old top-of-scale still answers `5`, which now records as a mediocre 5/10 instead of the clean run it was meant to report. The interactive prompt already carried `0=not likely 10=extremely likely`; the agent-facing surfaces, which produce most submissions, did not.

The old skill copy is also still installed in user projects, so callers reading `1-5` guidance will keep arriving for a while. The new lint warning is what catches those at submission time.

## How

`FEEDBACK_RATING_ANCHOR` and `FEEDBACK_RATING_PLACEHOLDER` live next to `FEEDBACK_RATING_SCALE` in `feedbackRating.ts`, so a future scale change cannot leave one surface behind. The lint rule reuses the existing soft-warn path in `feedbackLint.ts` and fires only below the midpoint with no comment, so a bare `--rating 6` quick vote is still silent.

No change to what is stored or sent: `rating_scale: 10` and the accepted range are untouched, so existing dashboards are unaffected.

## Test plan

- [x] Unit tests added/updated: bare bottom-half warn (incl. blank-comment variants), bare `10` stays silent, both hints assert they name the top of the scale. `packages/cli` utils + telemetry: 960 passed. `packages/studio` components + telemetry: 1182 passed.
- [x] Manual testing performed: `feedback --help` and the invalid-rating error render the anchor; the composed agent hint reads `hyperframes feedback --rating <0-10, 10=best> --comment "..."`; the Studio bar was rendered headless at 1280px and 720px, still 32px tall with no overflow.
- [x] Documentation updated: `docs/guides/feedback.mdx`, `docs/packages/cli.mdx`, skill + reference, `skills-manifest.json` regenerated.

Not covered: the end-to-end submit path was not exercised against production, to avoid writing junk feedback rows; the warning-print wiring in `feedback.ts` is unchanged and its message is covered by unit tests.
