### PR TITLE
chore: release v0.7.101

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,35 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.101"
+  description="Released - 2026-08-08"
+  tags={["Release", "Studio", "CLI", "Cli,core"]}
+>
+Faster drawElement capture starts rolling out to a small slice of installs. Five in
+a hundred now use the parallel capture path for long renders. If a render ever has
+to fall back, that install turns it off and keeps it off.
+
+Set HF_DE_PARALLEL_ROUTER=false to opt out, or =true to opt in early. Studio also
+stops three editor crashes.
+
+## Features
+
+- **Cli,core:** Ramp the default-on router through the canary ([4a2514232](https://github.com/heygen-com/hyperframes/commit/4a2514232b9f20ea4baa94510e79a42bae85e92f)).
+- **Producer:** Enable the parallel-DE router by default, behind a per-install circuit breaker ([c6df112ac](https://github.com/heygen-com/hyperframes/commit/c6df112ac1843e228a9d40bbcb6bad1752f53de5)).
+
+## Fixes
+
+- **Studio:** Stop three crash-boundary trips in the editor ([d8a91fc34](https://github.com/heygen-com/hyperframes/commit/d8a91fc347df4def4a957609d1847ca3306eb867), [#3102](https://github.com/heygen-com/hyperframes/pull/3102)).
+- **CLI:** Keep a set-but-empty router env var breaker-managed (review) ([af535080a](https://github.com/heygen-com/hyperframes/commit/af535080a250bb150c0a6448517a075cd8076818)).
+
+## Docs & Examples
+
+- **CLI:** Stop calling the router trial an opt-in in risk prose ([1033d0327](https://github.com/heygen-com/hyperframes/commit/1033d03271fb381be51fbc1103063cd8147a626b)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.100...v0.7.101).
+</Update>
+
+<Update
   label="HyperFrames v0.7.100"
   description="Released - 2026-08-07"
   tags={["Release", "Core", "Engine", "Scripts"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.101.md
+++ b/releases/v0.7.101.md
@@ -1,0 +1,28 @@
+# HyperFrames v0.7.101
+
+Released on 2026-08-08.
+
+Faster drawElement capture starts rolling out to a small slice of installs. Five in
+a hundred now use the parallel capture path for long renders. If a render ever has
+to fall back, that install turns it off and keeps it off.
+
+Set HF_DE_PARALLEL_ROUTER=false to opt out, or =true to opt in early. Studio also
+stops three editor crashes.
+
+## Features
+
+- **Cli,core:** Ramp the default-on router through the canary ([4a2514232](https://github.com/heygen-com/hyperframes/commit/4a2514232b9f20ea4baa94510e79a42bae85e92f)).
+- **Producer:** Enable the parallel-DE router by default, behind a per-install circuit breaker ([c6df112ac](https://github.com/heygen-com/hyperframes/commit/c6df112ac1843e228a9d40bbcb6bad1752f53de5)).
+
+## Fixes
+
+- **Studio:** Stop three crash-boundary trips in the editor ([d8a91fc34](https://github.com/heygen-com/hyperframes/commit/d8a91fc347df4def4a957609d1847ca3306eb867), [#3102](https://github.com/heygen-com/hyperframes/pull/3102)).
+- **CLI:** Keep a set-but-empty router env var breaker-managed (review) ([af535080a](https://github.com/heygen-com/hyperframes/commit/af535080a250bb150c0a6448517a075cd8076818)).
+
+## Docs & Examples
+
+- **CLI:** Stop calling the router trial an opt-in in risk prose ([1033d0327](https://github.com/heygen-com/hyperframes/commit/1033d03271fb381be51fbc1103063cd8147a626b)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.100...v0.7.101


### PR DESCRIPTION
## What

Stable release **v0.7.101**, covering the 5 commits since v0.7.100.

**This is the release that starts the parallel drawElement router rollout.** #2840 merged after v0.7.100 was cut, so the ramp has not reached anyone yet — publishing this is what activates it.

## Behavioural change worth reading before merging

On publish, **5% of installs** begin using the parallel capture path by default on eligible renders (drawElement-capable, ≥700 frames, auto multi-worker). Everyone else is unaffected.

Safety properties that ship with it:

- **Per-render self-verify** stays in front of output. In the last 14 days it caught 149 bad renders, 128 of them PSNR damage — that is what protects correctness, and it runs regardless of the ramp.
- **Per-install circuit breaker** stays. 154 of 155 reverting installs stop at exactly one revert.
- **`percentage: 0` in `canaryRegistry.ts` is a full fleet-wide revert** with no release needed.
- `HF_DE_PARALLEL_ROUTER=false` opts a user out, `=true` opts in early. Explicit choice wins in both directions.

## Ramp discipline after this ships

**Hold at 5% until PRINFRA-372 resolves.** `--workers auto` crashes every worker ("detached Frame" / "Target closed") on macOS arm64 while `--workers 1` is clean, and the router forces 3 workers. PRINFRA-339 (indefinite stalls) and PRINFRA-354 (silent hang) are also open. None of those emit `render_complete`, so **neither the self-verify nor the breaker catches them** — a repro harness is attached to PRINFRA-372 and needs a ≤16 GB darwin/arm64 host.

At each step split revert rate by `cpu_count` and `is_docker` — the two segments with near-zero coverage in today's trial population. Baseline: routed renders fail at 2–3.4%, stable across versions.

## Also in this release

- Studio: three editor crash-boundary trips fixed (#3102)
- CLI: a set-but-empty `HF_DE_PARALLEL_ROUTER` stays breaker-managed rather than exempting the install from its own breaker

## Note on numbering

0.7.99 and 0.7.100 published normally and do **not** contain the router work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
