### PR TITLE
fix: preserve the composition query and serve the runtime before author scripts

### DIFF
--- a/packages/cli/src/commands/play.test.ts
+++ b/packages/cli/src/commands/play.test.ts
@@ -251,6 +251,31 @@ describe("registerCompositionRoute", () => {
     expect(mocks.resolveProxy).not.toHaveBeenCalled();
   });
 
+  it("serves the runtime script ahead of every author script", async () => {
+    // Compositions read `window.__hyperframes.getVariables()` from an inline
+    // script at init. A runtime injected before </body> loads after that script,
+    // so the documented API is undefined exactly where authors are told to call
+    // it. Pin the ordering at the served-document boundary.
+    const project = tmpProject();
+    writeFileSync(
+      join(project.dir, "index.html"),
+      [
+        '<html><head><script src="https://cdn.example/gsap.js"></script></head>',
+        '<body><div id="root"></div>',
+        "<script>window.__probe = typeof window.__hyperframes;</script>",
+        "</body></html>",
+      ].join(""),
+    );
+    const app = await buildApp(project, false);
+
+    const html = await (await app.request("/composition/index.html")).text();
+
+    const runtimeIndex = html.indexOf('<script src="/runtime.js">');
+    expect(runtimeIndex).toBeGreaterThanOrEqual(0);
+    const firstAuthorScriptIndex = html.search(/<script(?! src="\/runtime\.js")/);
+    expect(firstAuthorScriptIndex).toBeGreaterThan(runtimeIndex);
+  });
+
   it("injects __HF_MEDIA_CODEC_MAP__ into served composition HTML", async () => {
     const project = tmpProject();
     writeFileSync(join(project.dir, "index.html"), "<html><head></head><body></body></html>");

--- a/packages/cli/src/utils/compositionServer.ts
+++ b/packages/cli/src/utils/compositionServer.ts
@@ -6,6 +6,7 @@ import { resolve, dirname } from "node:path";
 import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import { getMimeType } from "@hyperframes/studio-server";
+import { injectTagsAtHeadStart } from "@hyperframes/core/compiler/html-document";
 
 /**
  * `window.__HF_MEDIA_CODEC_MAP__` injection + proxy pre-warm for HTML served
@@ -63,12 +64,17 @@ export function resolveSlideshowPath(): string | null {
   return candidates.find((p) => existsSync(p)) ?? null;
 }
 
-/** Inject the runtime <script> into composition HTML before </body> (or at the end). */
+/**
+ * Inject the runtime <script> at the top of the composition's <head>, ahead of
+ * every author script. Compositions read `window.__hyperframes.getVariables()`
+ * from an inline script at init, so a runtime appended before </body> is not
+ * loaded yet at that point and the documented API is undefined. The compiled
+ * render path hoists the runtime into <head> the same way; this keeps the
+ * served `play` document in parity with it. Placement falls back to before
+ * <body>, then to the top of the document, for fragments without a <head>.
+ */
 export function injectRuntime(html: string): string {
-  const runtimeTag = `<script src="/runtime.js"></script>`;
-  return html.includes("</body>")
-    ? html.replace("</body>", `${runtimeTag}\n</body>`)
-    : html + `\n${runtimeTag}`;
+  return injectTagsAtHeadStart(html, `<script src="/runtime.js"></script>`);
 }
 
 export function assetContentType(filePath: string): string {

--- a/packages/core/src/compiler/htmlDocument.ts
+++ b/packages/core/src/compiler/htmlDocument.ts
@@ -174,16 +174,24 @@ function inlineScriptTags(scripts: readonly string[]): string {
   return scripts.map((source) => `<script>${escapeInlineScriptSource(source)}</script>`).join("\n");
 }
 
-export function injectScriptsAtHeadStart(html: string, scripts: readonly string[]): string {
-  if (scripts.length === 0) return html;
-  const headTags = inlineScriptTags(scripts);
+/**
+ * Insert raw tag markup at the very start of `<head>`, ahead of every author
+ * script (inline or external). Falls back to just before `<body>`, then to the
+ * top of the document, for fragments that carry neither.
+ */
+export function injectTagsAtHeadStart(html: string, tags: string): string {
   if (html.includes("<head")) {
-    return html.replace(/<head\b[^>]*>/i, (match) => `${match}\n${headTags}`);
+    return html.replace(/<head\b[^>]*>/i, (match) => `${match}\n${tags}`);
   }
   if (html.includes("<body")) {
-    return html.replace("<body", () => `${headTags}\n<body`);
+    return html.replace("<body", () => `${tags}\n<body`);
   }
-  return `${headTags}\n${html}`;
+  return `${tags}\n${html}`;
+}
+
+export function injectScriptsAtHeadStart(html: string, scripts: readonly string[]): string {
+  if (scripts.length === 0) return html;
+  return injectTagsAtHeadStart(html, inlineScriptTags(scripts));
 }
 
 export function injectScriptsIntoHtml(

--- a/packages/core/src/compiler/index.ts
+++ b/packages/core/src/compiler/index.ts
@@ -50,6 +50,7 @@ export {
 export {
   RUNTIME_BOOTSTRAP_ATTR,
   injectScriptsAtHeadStart,
+  injectTagsAtHeadStart,
   injectScriptsIntoHtml,
   parseHTMLContent,
   stripEmbeddedRuntimeScripts,

--- a/packages/player/src/shader-options.ts
+++ b/packages/player/src/shader-options.ts
@@ -60,11 +60,25 @@ function normalizeShaderLoadingMode(value: string | null): ShaderLoadingMode {
   return "composition";
 }
 
-function setQueryParam(params: URLSearchParams, key: string, value: string | null): void {
-  if (value === null) params.delete(key);
-  else params.set(key, value);
+/** Drop one of our own keys from raw `a=1&b=2` pairs, matched by name so that
+ *  nothing around it has to be decoded. */
+function withoutParam(pairs: string[], key: string): string[] {
+  return pairs.filter((pair) => pair !== "" && pair.split("=")[0] !== key);
 }
 
+/**
+ * The player's own params, appended to the query the composition author wrote
+ * rather than merged into a re-serialized copy of it.
+ *
+ * `new URLSearchParams(query).toString()` is a form-encoding round trip: it
+ * re-encodes the *whole* query as application/x-www-form-urlencoded, which
+ * writes every space as `+`. A composition reading its own query with
+ * `decodeURIComponent` — percent-decoding, which leaves `+` alone — cannot undo
+ * that, so a value of "Ship it today" arrived on the page as "Ship+it+today".
+ * The two codecs are not inverses, and the player has no business picking one
+ * for a query it is only passing along. The author's bytes now travel through
+ * byte-identical; only our two keys are rewritten.
+ */
 function withShaderQueryParams(
   src: string,
   scale: string | null,
@@ -76,10 +90,13 @@ function withShaderQueryParams(
   const queryIndex = beforeHash.indexOf("?");
   const path = queryIndex >= 0 ? beforeHash.slice(0, queryIndex) : beforeHash;
   const query = queryIndex >= 0 ? beforeHash.slice(queryIndex + 1) : "";
-  const params = new URLSearchParams(query);
-  setQueryParam(params, SHADER_CAPTURE_SCALE_PARAM, scale);
-  setQueryParam(params, SHADER_LOADING_PARAM, loadingMode === "composition" ? null : loadingMode);
-  const nextQuery = params.toString();
+  let pairs = withoutParam(query.split("&"), SHADER_CAPTURE_SCALE_PARAM);
+  pairs = withoutParam(pairs, SHADER_LOADING_PARAM);
+  if (scale !== null) pairs.push(`${SHADER_CAPTURE_SCALE_PARAM}=${encodeURIComponent(scale)}`);
+  if (loadingMode !== "composition") {
+    pairs.push(`${SHADER_LOADING_PARAM}=${encodeURIComponent(loadingMode)}`);
+  }
+  const nextQuery = pairs.join("&");
   return `${path}${nextQuery ? `?${nextQuery}` : ""}${hash}`;
 }
 


### PR DESCRIPTION
## What

Two framework fixes that together unbreak composition variables on the `play` path.

1. **`<hyperframes-player>` hands a composition its query back byte-identical** instead of re-encoding it.
2. **The dev server serves the runtime ahead of every author script**, so `window.__hyperframes` exists when a composition's own inline script runs.

## Why 1: the player was corrupting every query

Every `src` the player set went through `withShaderQueryParams`, which parsed the author's whole query with `URLSearchParams` and re-serialised it with `toString()`. That is a form encoder: it writes a space as `+`. Callers percent-encode and read back with `decodeURIComponent`, which does not turn `+` into a space. The two codecs are not inverses.

It ran **even with nothing to inject**. With no shader attributes both params are deleted, so the round-trip was pure loss, on every `src`, for every consumer.

Symptoms downstream: a headline reading `Ship+it+today`, and SVG path data arriving as `M+92+328+C+178+142...`, which the browser rejects outright so the element renders nothing.

Scope was measured, not assumed: `+`, `&`, `=`, `#`, `%`, `?`, quotes and non-ASCII all survive a `URLSearchParams` round-trip. **Space was the only casualty.** Narrow, but a space in a headline or in path data is the common case.

Deliberately not fixed by replacing `+` with a space on the read side — that corrupts any genuine literal `+`, and the catalog ships `+312%` today.

## Why 2: the runtime arrived too late to be used

`injectRuntime` appended its script before `</body>`, landing after any inline script the composition carried. Served order was gsap at line 6, the composition's init script at line 20, the runtime at line 37. A probe inside the composition's own IIFE recorded `hfTypeAtInit: "undefined"` with no variable keys, and the element rendered its hardcoded fallback rather than the declared value. `window.__hyperframes` only became an object after load.

So the documented API did not exist at the moment authors are told to call it. Two registry blocks had independently worked around it by parsing the authored attribute themselves.

The runtime is *designed* to load early: its entry assigns `__timelines`, installs the authored-opacity capture — whose own comment says it must run while the document is still parsing — and exposes `__hyperframes` synchronously, deferring real work to `DOMContentLoaded`. End-of-body injection defeated all three. Nothing in it needs a parsed DOM, so no `defer` is wanted.

Now injected at head start, reusing the placement cascade `injectScriptsAtHeadStart` already implements rather than adding a fourth copy. Head *start* rather than the closing tag, so the runtime also precedes author scripts inside `<head>`.

## Consumer ledger for the ordering change

`injectRuntime` has exactly one consumer repo-wide: the `play` server's composition route.

| Surface | How it reaches the runtime | Coverage |
| --- | --- | --- |
| `play` composition route | the changed function | **Audited** — served-order diff, browser probe, e2e seek, 14 route tests |
| `play` codec-map injection | runs after, inserts at `</head>` | **Audited** — still lands in head, after the runtime |
| `present` | serves raw by design; injecting would leave the composition paused and blank | Audited by code path |
| `preview` / studio | bundler with a runtime placeholder, already head-injected | Audited by code path, studio not booted |
| `check` browser gate | same bundler | **Audited** — `check` passed exit 0 |
| `snapshot` / `compare` / `layout` / `validate` | pre-bundled HTML, no `injectRuntime` | Audited by code path, **not exercised** |
| `render` / producer | `htmlCompiler` + the same head-start helper | **Audited** — the extraction is behaviour-identical, 49 + 7 tests pass |
| player's client-side rescue injection | fires when `__hf` is absent | Audited — now fires *less* |
| string-matchers on the injected tag | grepped; none existed | **Audited** |

Nothing depended on the runtime booting after DOM parse.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

| Gate | Baseline | After |
| --- | --- | --- |
| `packages/cli` | 2487 passed | **2488 passed** (+1, the new test) |
| `packages/core` | 1700 passed | **1700 passed** |
| `packages/player` | 330 passed | **330 passed** |
| `bun run lint` | — | exit 0 |

Baselines were taken before any edit, and were fully green, so nothing is misattributed.

The ordering test is mutation-checked, not trusted: reverting the fix to the `</body>` form fails exactly one test (`expected 12 to be greater than 159`) and nothing else.

End to end after the fix, same repro: `hfTypeAtInit: "object"`, variable keys present, element renders the declared value. A real example project under `play` exposes the full player API, 5 registered timelines, and 5 distinct screenshot hashes across seeks; two were viewed and show genuinely different composition state.

Reviewer note: a fresh worktree needs `bun run build` before `vitest`, or ~68 files fail to collect on missing workspace build output. That failure looks alarming and reproduces on an unmodified checkout.

## Worth knowing

Fix 1 is latent on `main` and in the published CDN bundle rather than newly broken: no shipped consumer depended on query preservation until compositions began carrying variable payloads.

Separately found and **not** fixed here: several registry blocks declare `data-composition-variables` as an object map, but `readDeclaredDefaults` requires an array and returns `{}` for anything else, so those variables are unreadable even with these fixes. Lint does not catch it. That is an authoring-validation gap with its own PR.
