### PR TITLE
docs(skills): fix zoom-through total and drop redundant keyword bracket in cut-the-curve

### DIFF
--- a/.agents/skills/cut-the-curve/SKILL.md
+++ b/.agents/skills/cut-the-curve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cut-the-curve
-description: "The technique catalog: five velocity-matched SEAMS (zoom-through, INVERSE zoom-through, cut-the-curve, waterfall cut, rack-focus blur-cut) plus the two in-scene techniques — waterfall ENTRY (staggered arrival cascades for title cards / segment openers) and the nudge curve (slow-fast-slow three-phase group slides). Covers partial-travel (~12% of frame) velocity matching via mirrored power4 eases, the Z scale-sign rule, size-scaled blur (10px text / 18-20px full-frame), word-by-word staggered cuts, cascade pacing by element weight, and the 10/65/25 slide ratio. Read before authoring any transition, text-beat handoff, kinetic text entry, or group reposition. [depth, zoom, inverse-zoom, scale-sign, mirrored-zoom, rack-focus, pacing, velocity, cut-the-curve, waterfall, stagger, cascade, kinetic-text, title-card, segment-opener, nudge, slide, easing, group-motion, z-depth, motion-graphics, cinematic, transition, blur, directional-continuity]"
+description: "The technique catalog: five velocity-matched SEAMS (zoom-through, INVERSE zoom-through, cut-the-curve, waterfall cut, rack-focus blur-cut) plus the two in-scene techniques — waterfall ENTRY (staggered arrival cascades for title cards / segment openers) and the nudge curve (slow-fast-slow three-phase group slides). Covers partial-travel (~12% of frame) velocity matching via mirrored power4 eases, the Z scale-sign rule, size-scaled blur (10px text / 18-20px full-frame), word-by-word staggered cuts, cascade pacing by element weight, and the 10/65/25 slide ratio. Read before authoring any transition, text-beat handoff, kinetic text entry, or group reposition."
 ---
 
 # Cut the Curve — the technique catalog
@@ -53,7 +53,7 @@ Same peak blur on both sides at the swap frame. Blur the WRAPPER, never children
 
 Z-axis velocity-matched cut; **never both texts visible.** Everything GROWS: the outgoing
 text accelerates toward camera, a hard swap hides at peak blur, the incoming text keeps
-growing into the focal plane. Headlines and short phrases only. Total ≈ 0.4s.
+growing into the focal plane. Headlines and short phrases only. Total ≈ 0.7s.
 
 | Phase          | Scale    | Blur     | Opacity           | Ease                                       | Duration |
 | -------------- | -------- | -------- | ----------------- | ------------------------------------------ | -------- |

--- a/.claude/skills/cut-the-curve/SKILL.md
+++ b/.claude/skills/cut-the-curve/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cut-the-curve
-description: "The technique catalog: five velocity-matched SEAMS (zoom-through, INVERSE zoom-through, cut-the-curve, waterfall cut, rack-focus blur-cut) plus the two in-scene techniques — waterfall ENTRY (staggered arrival cascades for title cards / segment openers) and the nudge curve (slow-fast-slow three-phase group slides). Covers partial-travel (~12% of frame) velocity matching via mirrored power4 eases, the Z scale-sign rule, size-scaled blur (10px text / 18-20px full-frame), word-by-word staggered cuts, cascade pacing by element weight, and the 10/65/25 slide ratio. Read before authoring any transition, text-beat handoff, kinetic text entry, or group reposition. [depth, zoom, inverse-zoom, scale-sign, mirrored-zoom, rack-focus, pacing, velocity, cut-the-curve, waterfall, stagger, cascade, kinetic-text, title-card, segment-opener, nudge, slide, easing, group-motion, z-depth, motion-graphics, cinematic, transition, blur, directional-continuity]"
+description: "The technique catalog: five velocity-matched SEAMS (zoom-through, INVERSE zoom-through, cut-the-curve, waterfall cut, rack-focus blur-cut) plus the two in-scene techniques — waterfall ENTRY (staggered arrival cascades for title cards / segment openers) and the nudge curve (slow-fast-slow three-phase group slides). Covers partial-travel (~12% of frame) velocity matching via mirrored power4 eases, the Z scale-sign rule, size-scaled blur (10px text / 18-20px full-frame), word-by-word staggered cuts, cascade pacing by element weight, and the 10/65/25 slide ratio. Read before authoring any transition, text-beat handoff, kinetic text entry, or group reposition."
 ---
 
 # Cut the Curve — the technique catalog
@@ -53,7 +53,7 @@ Same peak blur on both sides at the swap frame. Blur the WRAPPER, never children
 
 Z-axis velocity-matched cut; **never both texts visible.** Everything GROWS: the outgoing
 text accelerates toward camera, a hard swap hides at peak blur, the incoming text keeps
-growing into the focal plane. Headlines and short phrases only. Total ≈ 0.4s.
+growing into the focal plane. Headlines and short phrases only. Total ≈ 0.7s.
 
 | Phase          | Scale    | Blur     | Opacity           | Ease                                       | Duration |
 | -------------- | -------- | -------- | ----------------- | ------------------------------------------ | -------- |


### PR DESCRIPTION
## What

Two documentation fixes to the `cut-the-curve` skill, applied to both mirrored copies (`.agents/skills/` and `.claude/skills/`, byte-identical at HEAD):

1. §1 Zoom-Through: `Total ≈ 0.4s` → `Total ≈ 0.7s`
2. Frontmatter `description`: dropped the trailing 25-tag keyword bracket (949 → 663 chars)

Plus one question in "Open question" below that I did **not** change, because I can't tell which number is intended.

No behavioural or render changes.

## Why

### 1. §1's stated total contradicts its own table

§1 says `Total ≈ 0.4s`, but the table directly beneath gives Exit `0.2s` and Entry `0.5s`. Those phases are sequential — the hard swap sits between them — so the total is `0.7s`.

§2 Inverse Zoom-Through carries the same durations (`~0.2s` exit, `~0.5s` entry) and states it correctly: `Total ≈ 0.7s (30% exit / 70% entry)`. `0.2/0.7 ≈ 29%`, `0.5/0.7 ≈ 71%` — §2's arithmetic checks out, §1's does not.

If `0.4s` was the intended budget then the table's durations are what need changing instead; happy to flip the fix.

### 2. The keyword bracket costs 285 chars and adds ~nothing

```
[depth, zoom, inverse-zoom, scale-sign, mirrored-zoom, rack-focus, pacing, velocity,
cut-the-curve, waterfall, stagger, cascade, kinetic-text, title-card, segment-opener,
nudge, slide, easing, group-motion, z-depth, motion-graphics, cinematic, transition,
blur, directional-continuity]
```

285 of the description's 949 characters. Checking every tag against the skill text:

- **17 of 25** already appear verbatim in the description prose above it — `zoom`, `inverse-zoom`, `scale-sign`, `rack-focus`, `pacing`, `velocity`, `cut-the-curve`, `waterfall`, `stagger`, `cascade`, `kinetic-text`, `title-card`, `segment-opener`, `nudge`, `slide`, `transition`, `blur`
- **1** — `easing` — is present as "mirrored power4 **eases**"
- **7** — `depth`, `mirrored-zoom`, `group-motion`, `z-depth`, `motion-graphics`, `cinematic`, `directional-continuity` — appear **nowhere in the skill**, neither in the description nor anywhere in the body

So the bracket restates terms already present, plus seven the skill never uses.

### Why the 285 chars are worth reclaiming

Claude Code's skill listing is **hard-capped at ~30,000 characters**. Measured across 127 recorded listings in my own session transcripts: at 52 skills the listing is 7,986 chars, but every listing from 67 skills upward pins between 29,934 and 30,050 — 67, 85, 120, 142, 171 and 186 skills all land at ~30k. Past the cap Claude Code keeps each skill's *name* and drops *descriptions* from the tail wholesale.

That makes description length zero-sum across a user's entire skill set, not just a per-skill cost. In my install `cut-the-curve`'s 949-char description is the 3rd largest of 85 skills, and 31 skills are already reduced to bare names with no description at all — including `seam-craft` and `oversized-cursor`, two of `cut-the-curve`'s own siblings in the motion-doctrine router graph. A sibling stripped to a bare name can't be matched on intent, which is the failure mode the tags were presumably added to prevent.

## How

Two single-line edits per file, applied identically to both copies so they stay in sync. Nothing else touched — no table values, no mechanics, no code templates.

## Open question — "25–30% of travel" doesn't reconcile with the stated fade durations

Left unchanged; I don't know which number is authoritative.

§3 (The fade trick):
> exit opacity completes at ~25–30% of its travel (fade ≈ 0.18–0.3s vs motion 0.3–0.34s)

§4 (Waterfall Cut table): exit `0.34s power4.in`, exit fade `0.18s`, "word gone by ~25–30% of travel".

Reading "travel" as **distance**: under `power4.in` the distance fraction is `(t/T)^4`. With `t = 0.18s`, `T = 0.34s` → `(0.529)^4 ≈ 0.08`. The word is ~8% along, not 25–30%. To be gone by 25% of distance the fade would need `t = T · 0.25^0.25 ≈ 0.24s` (~`0.25s` for 30%).

Reading "travel" as **elapsed time**: `0.18 / 0.34 ≈ 53%` — also not 25–30%.

§3's own ranges straddle the same gap: fade `0.18–0.3s` against motion `0.3–0.34s` is 53–100% of the time, i.e. ~8–100% of the distance.

So either the fade durations want lengthening toward ~0.24s, or the "25–30%" figure wants restating, or "travel" means something specific worth spelling out. Glad to send that fix once I know which.

## Test plan

- [ ] Unit tests added/updated — n/a, documentation only
- [x] Manual testing performed — verified both files on the branch are byte-identical to the intended content; diff against `main` is 2 files, +4 −4, confined to the two lines described
- [x] Documentation updated (if applicable) — this PR *is* the documentation change

Found while auditing skill descriptions for listing-budget cost.
