### PR TITLE
fix(skills): define .video-wrapper.pip-pill in talking-head-recut template

### DIFF
--- a/skills/talking-head-recut/SKILL.md
+++ b/skills/talking-head-recut/SKILL.md
@@ -913,6 +913,17 @@ ffmpeg -y -i "$VIDEO_PATH" -c:v libx264 -crf 18 -g 30 -keyint_min 30 \
         border-radius: 16px;
         box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
       }
+
+      /* Pip chrome: `.framed` plus a white ring, so a pip reads as a distinct
+         inset against a busy background. The ring is a box-shadow spread rather
+         than a border, so it adds no layout box and the pixel-exact pip targets
+         in the GSAP lookup table stay correct. */
+      .video-wrapper.pip-pill {
+        border-radius: 16px;
+        box-shadow:
+          0 0 0 3px rgba(255, 255, 255, 0.9),
+          0 12px 40px rgba(0, 0, 0, 0.35);
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## What

Defines `.video-wrapper.pip-pill` in the `talking-head-recut` composition template. The class is referenced three times and defined zero times, so every pip that follows the GSAP lookup table currently renders with no chrome at all.

Three larger findings from the same read are written up under "Further findings" — no changes made for those, they need a maintainer call first.

## Why

`pip-pill` is used in three places:

| Line | Use |
|---|---|
| 1115 | GSAP lookup table, `pip` (bottom-right) → `pip-pill` (border-radius + ring + shadow) |
| 1116 | GSAP lookup table, `pip` (top-left) → `pip-pill` |
| 1125 | `tl.set("#video-wrap", { className: "video-wrapper pip-pill" }, T)` |

and described at line 1120 as "border-radius + white ring + drop shadow". There is no CSS rule for it anywhere in the file. Because line 1125 sets `className` wholesale, applying it *removes* whatever chrome was there and replaces it with a class that does nothing — a pip ends up with square corners and no shadow.

This is not a misspelling of `.framed`. `.video-wrapper.framed` (line 912) is `border-radius: 16px` + drop shadow; `pip-pill` is documented as that **plus a white ring**. So it is a distinct intended style that was never implemented, and renaming the references to `.framed` would silently drop the ring. The fix defines what the docs already promise.

The ring is a `box-shadow` spread rather than a `border` on purpose: the pip targets in both tables are pixel-exact (`{ left: 1480, top: 760, width: 400, height: 300 }`), and a border would add to the layout box and shift them.

## How

Eleven lines added to the `<style>` block in the composition template, directly after the `.framed` rule it builds on. Values mirror `.framed` so the two stay visually consistent. Nothing else touched.

## Further findings — no changes made, these need a decision

### 1. The `#video-wrap` GSAP target table exists twice, and the copies disagree

Lines **577–582** ("4 composition layouts") and lines **1111–1118** ("GSAP target lookup table") both map composition layout → `#video-wrap` target.

They are not the same table. The second adds a `pip` top-left row, a "hide video" row, and an "extra css class" column; the first adds portrait values and a "when to use" column. So each is incomplete on its own, and an agent reading only one gets a partial picture.

They also **contradict each other on pip chrome**: line 581 says `pip` gets `.framed`, line 1115 says `pip` gets `pip-pill`. This PR makes both classes valid, so either instruction now produces working output — but the disagreement about which chrome a pip should have is still there, and only you can say which is intended.

Suggested: one merged table (all three ratios, both extra columns), defined once near the layout section and referenced from Step 9.

### 2. The `zone` bounds table also exists twice

Lines **182–188** (Step 6) and **591–597** (Step 7), near-identical, with wording that has already drifted — `whiteboard-area` reads "inset 40px margin (or 45% of portrait height)" in the first and "inset 40px margin (landscape) or bottom 45% (portrait)" in the second. The second phrasing is the clearer one.

Suggested: keep the Step 6 copy (where `zone` is introduced), have Step 7 point at it.

### 3. The composition template could ship as an asset instead of prose

Lines **799–1065** — 267 lines, ~19KB — are a complete, self-contained `<!doctype html>` … `</html>` document: font-face block, `:root` theme vars, stage/video-wrapper/card-host CSS, the `#stage` element with its `data-*` timing attributes, an example card-host pair, and the full GSAP scaffold. Today the agent retypes all of it from markdown.

The skill already ships and stages an `assets/` tree, so the mechanism exists:

```bash
cp -n "$SKILL_DIR/assets/fonts/"*                  "$WORK_DIR/public/fonts/"
cp -n "$SKILL_DIR/assets/vendor/gsap.min.js"       "$WORK_DIR/public/vendor/"
cp -n "$SKILL_DIR/assets/composition-template.html" "$WORK_DIR/public/index.html"
```

Step 9 would then reduce to filling in `data-duration` / `data-fps` / `data-width` / `data-height`, swapping the `:root` palette for the chosen `themeId`, emitting one `card-host clip` div per card, and appending the compiled GSAP statements.

The argument for it: a copied file cannot drift from the documented contract, and retyping is exactly where the lint violations the doc warns about (`timed_element_missing_clip_class`, `font_family_without_font_face`) get introduced — both are hard-coded correctly in the template. It would also take SKILL.md from ~65KB to ~46KB on its own.

If that lands and you want to go further, these blocks are each needed at exactly one step and nowhere else, and the skill already has a healthy `references/` tree to follow:

| Block | Lines | Size |
|---|---|---|
| "Confirm Visual Direction with User" — both question channels, reply parsing, resolution tables | 256–466 | ~15KB |
| Card HTML contract, portrait sizing table, `data-anim` kinds | 659–777 | ~7KB |
| GSAP statement cheat sheet, video framing reference, QA rules | 1067–1163 | ~8KB |
| Storyboard schema, zone table, card-count pacing tables | 121–253, 602–652 | ~9KB |

Happy to send any of these as follow-up PRs — I held off because (1) and (3) in particular are your call on intent, not mechanical fixes.

## Test plan

- [ ] Unit tests added/updated — n/a, CSS in a documentation template
- [x] Manual testing performed — verified against HEAD that `pip-pill` has 3 usages and 0 definitions, that `.video-wrapper.framed` is defined at line 912 with different properties, and that the diff is confined to the 11 added lines
- [x] Documentation updated (if applicable) — the template *is* the documentation

Found while auditing skill files for context-budget cost.
