### PR TITLE
chore: release v0.7.102

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,24 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.102"
+  description="Released - 2026-08-08"
+  tags={["Release", "CLI", "Core"]}
+>
+Text with spaces in it now reaches your composition intact. Before, a space could arrive as a plus sign, which garbled headlines and left some shapes drawing nothing at all.
+Compositions can also read their own variables the moment they start, because the runtime now loads before your scripts do.
+
+## Fixes
+
+- Preserve the composition query and serve the runtime before author scripts ([b6ff3ab74](https://github.com/heygen-com/hyperframes/commit/b6ff3ab74556b844dd87b067cf850badc000bba7), [#3114](https://github.com/heygen-com/hyperframes/pull/3114)).
+- **CLI:** Stop skills update deleting skills the manifest never covered ([ed3ff98ce](https://github.com/heygen-com/hyperframes/commit/ed3ff98ce0443a232fc740a5821c601e67fd09cc), [#3118](https://github.com/heygen-com/hyperframes/pull/3118)).
+- **Core:** Draw the dim baseline only from tweens the guess still applies to ([cef0dde5f](https://github.com/heygen-com/hyperframes/commit/cef0dde5f2e9028349be0eef31e6ba2622405fe2)).
+- **Core:** Let a composition declare its caption colour states ([1e7799bfb](https://github.com/heygen-com/hyperframes/commit/1e7799bfbb08c30a55b01a262653f40a2bbeda8a)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.101...v0.7.102).
+</Update>
+
+<Update
   label="HyperFrames v0.7.101"
   description="Released - 2026-08-08"
   tags={["Release", "Studio", "CLI", "Cli,core"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.102.md
+++ b/releases/v0.7.102.md
@@ -1,0 +1,17 @@
+# HyperFrames v0.7.102
+
+Released on 2026-08-08.
+
+Text with spaces in it now reaches your composition intact. Before, a space could arrive as a plus sign, which garbled headlines and left some shapes drawing nothing at all.
+Compositions can also read their own variables the moment they start, because the runtime now loads before your scripts do.
+
+## Fixes
+
+- Preserve the composition query and serve the runtime before author scripts ([b6ff3ab74](https://github.com/heygen-com/hyperframes/commit/b6ff3ab74556b844dd87b067cf850badc000bba7), [#3114](https://github.com/heygen-com/hyperframes/pull/3114)).
+- **CLI:** Stop skills update deleting skills the manifest never covered ([ed3ff98ce](https://github.com/heygen-com/hyperframes/commit/ed3ff98ce0443a232fc740a5821c601e67fd09cc), [#3118](https://github.com/heygen-com/hyperframes/pull/3118)).
+- **Core:** Draw the dim baseline only from tweens the guess still applies to ([cef0dde5f](https://github.com/heygen-com/hyperframes/commit/cef0dde5f2e9028349be0eef31e6ba2622405fe2)).
+- **Core:** Let a composition declare its caption colour states ([1e7799bfb](https://github.com/heygen-com/hyperframes/commit/1e7799bfbb08c30a55b01a262653f40a2bbeda8a)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.101...v0.7.102


### PR DESCRIPTION
# HyperFrames v0.7.102

Text with spaces in it now reaches your composition intact. Before, a space could arrive as a plus sign, which garbled headlines and left some shapes drawing nothing at all.

Compositions can also read their own variables the moment they start, because the runtime now loads before your scripts do.

## Fixes

- **Player and CLI:** Preserve the composition query, and serve the runtime before author scripts ([#3114](https://github.com/heygen-com/hyperframes/pull/3114)).

  Two defects on the same path. The player re-serialised every query it touched with a form encoder, which writes a space as `+`, while callers percent-encode and read back with `decodeURIComponent`. Those are not inverses, so any space in any query value arrived corrupted. It ran even when the player had nothing to inject. Separately, the dev server appended the runtime before `</body>`, so it landed after a composition's own inline script and `window.__hyperframes` did not exist at the moment authors are told to call it.

  Measured rather than assumed: space was the only corrupted character. `+`, `&`, `=`, `#`, `%`, `?`, quotes and non-ASCII all survived. It is a narrow bug with a wide blast radius, because a space in a headline or in SVG path data is the common case, and invalid path data renders nothing at all.

- **CLI:** Stop `skills update` deleting skills the manifest never covered ([#3118](https://github.com/heygen-com/hyperframes/pull/3118)).

- **Core:** Draw the dim baseline only from tweens the guess still applies to ([cef0dde5f](https://github.com/heygen-com/hyperframes/commit/cef0dde5f2e9028349be0eef31e6ba2622405fe2)).

- **Core:** Let a composition declare its caption colour states ([1e7799bfb](https://github.com/heygen-com/hyperframes/commit/1e7799bfbb08c30a55b01a262653f40a2bbeda8a)).

## Why this one matters for the catalog

The query fix is the root cause behind a large share of catalog previews rendering wrong. Path-data variables were arriving invalid, so several primitives drew an empty box while their own composition file was fine. That divergence is what made it hard to find.

## Full changelog

https://github.com/heygen-com/hyperframes/compare/v0.7.101...v0.7.102
