### PR TITLE
refactor(sdk): consolidate visual paint heuristics

### DIFF
--- a/docs/packages/sdk.mdx
+++ b/docs/packages/sdk.mdx
@@ -48,6 +48,8 @@ npm install @hyperframes/sdk
 | `@hyperframes/sdk/adapters/memory`   | In-memory persistence adapter for tests, demos, and ephemeral sessions    |
 | `@hyperframes/sdk/adapters/fs`       | Node.js filesystem persistence adapter with version history               |
 | `@hyperframes/sdk/adapters/headless` | No-op preview adapter for agents, CI, and server-side editing             |
+| `@hyperframes/sdk/adapters/iframe`   | Same-origin iframe preview and visual-paint queries                      |
+| `@hyperframes/sdk/visual-paint`      | CSS colour alpha and transparency helpers for browser hosts             |
 
 ## Quick Start
 

--- a/docs/sdk/reference/utilities.mdx
+++ b/docs/sdk/reference/utilities.mdx
@@ -7,6 +7,23 @@ This page covers everything exported from `@hyperframes/sdk` that is not covered
 
 ---
 
+## Visual paint utilities
+
+```typescript
+import { cssColorAlpha, isTransparentColor } from "@hyperframes/sdk/visual-paint";
+```
+
+Use these helpers when a browser host needs the same colour semantics as the iframe preview adapter. `cssColorAlpha()` reads legacy comma syntax and modern slash syntax for RGB and HSL colours, including percentage alpha. Unknown colour syntaxes fail safe as opaque.
+
+```typescript
+cssColorAlpha("rgb(255 255 255 / 25%)"); // 0.25
+isTransparentColor("hsl(0 0% 100% / 0)"); // true
+```
+
+`isTransparentColor()` also treats an empty computed value as transparent, matching the SDK's visual-paint checks.
+
+---
+
 ## History Module
 
 ```typescript

--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -296,11 +296,7 @@
 
   function hasPaint(style) {
     const backgroundColor = style.backgroundColor || "";
-    const hasBackground =
-      backgroundColor !== "" &&
-      backgroundColor !== "transparent" &&
-      !backgroundColor.endsWith(", 0)") &&
-      backgroundColor !== "rgba(0, 0, 0, 0)";
+    const hasBackground = backgroundColor !== "" && colorAlpha(backgroundColor) > 0;
     const hasImage = style.backgroundImage && style.backgroundImage !== "none";
     const hasBorder =
       parsePx(style.borderTopWidth) +
@@ -548,28 +544,10 @@
     return !!element.closest("[data-layout-allow-overlap]");
   }
 
-  function isTransparentColor(color) {
-    return (
-      !color || color === "transparent" || color === "rgba(0, 0, 0, 0)" || color.endsWith(", 0)")
-    );
-  }
-
-  function alphaFromParts(parts, index) {
-    if (parts.length <= index) return 1;
-    const raw = parts[index].trim();
-    return raw.endsWith("%") ? parsePx(raw) / 100 : parsePx(raw);
-  }
-
-  // Alpha of a CSS colour; 1 when no alpha component is present. Handles both
-  // legacy `rgba(r, g, b, a)` and modern `rgb(r g b / a)` syntaxes.
-  function colorAlpha(color) {
-    const match = (color || "").match(/rgba?\(([^)]+)\)/);
-    if (!match) return 1;
-    const body = match[1];
-    return body.includes(",")
-      ? alphaFromParts(body.split(","), 3)
-      : alphaFromParts(body.split("/"), 1);
-  }
+  // Injected from @hyperframes/core/visual-paint by prepareBrowserScript. Keeping the
+  // binding lexical makes the final browser script standalone without installing globals.
+  const colorAlpha = __hyperframesCssColorAlpha;
+  const isTransparentColor = (color) => colorAlpha(color) === 0;
 
   // A text block competes for space only when it is solid: watermark-style text
   // (low colour alpha) is decorative and exempt, as are elements opted out with

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -3,9 +3,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { prepareBrowserScript } from "../utils/browserScript";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const script = readFileSync(join(__dirname, "layout-audit.browser.js"), "utf-8");
+const script = prepareBrowserScript(
+  "layout-audit.browser.js",
+  readFileSync(join(__dirname, "layout-audit.browser.js"), "utf-8"),
+);
 const contrastScript = readFileSync(join(__dirname, "contrast-audit.browser.js"), "utf-8");
 
 interface RectInput {
@@ -1727,6 +1731,14 @@ describe("layout-audit.browser occlusion", () => {
   it("ignores low-opacity overlays such as scrims and grain", () => {
     const issues = auditOcclusionScene({
       overlayStyle: { backgroundColor: "rgb(10, 10, 10)", opacity: "0.3" },
+      topmostId: "overlay",
+    });
+    expect(issues.some((issue) => issue.code === "text_occluded")).toBe(false);
+  });
+
+  it("ignores zero-alpha HSL overlays", () => {
+    const issues = auditOcclusionScene({
+      overlayStyle: { backgroundColor: "hsl(0 0% 100% / 0%)" },
       topmostId: "overlay",
     });
     expect(issues.some((issue) => issue.code === "text_occluded")).toBe(false);

--- a/packages/cli/src/commands/layout.ts
+++ b/packages/cli/src/commands/layout.ts
@@ -8,6 +8,7 @@ import { c } from "../ui/colors.js";
 import { resolveProject } from "../utils/project.js";
 import { resolveDiagnosticNavigationTimeoutMs } from "../utils/renderArgs.js";
 import { normalizeErrorMessage } from "../utils/errorMessage.js";
+import { prepareBrowserScript } from "../utils/browserScript.js";
 import { serveStaticProjectHtml } from "../utils/staticProjectServer.js";
 import { printDeprecationNotice, withMeta } from "../utils/updateCheck.js";
 import {
@@ -288,7 +289,7 @@ async function runLayoutAudit(
 export function loadBrowserScript(name: string): string {
   const candidates = [join(__dirname, name), join(__dirname, "commands", name)];
   for (const candidate of candidates) {
-    if (existsSync(candidate)) return readFileSync(candidate, "utf-8");
+    if (existsSync(candidate)) return prepareBrowserScript(name, readFileSync(candidate, "utf-8"));
   }
   throw new Error(`Missing browser script ${name}`);
 }

--- a/packages/cli/src/utils/browserScript.test.ts
+++ b/packages/cli/src/utils/browserScript.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { loadBrowserScript } from "../commands/layout";
+import { prepareBrowserScript } from "./browserScript";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const layoutAuditSource = readFileSync(join(here, "../commands/layout-audit.browser.js"), "utf-8");
+
+describe("prepareBrowserScript", () => {
+  it("produces an executable standalone audit without leaking the injected helper", () => {
+    const prepared = prepareBrowserScript("layout-audit.browser.js", layoutAuditSource);
+
+    window.eval(prepared);
+
+    expect(Reflect.get(window, "__hyperframesLayoutAudit")).toBeTypeOf("function");
+    expect(Reflect.get(window, "__hyperframesCssColorAlpha")).toBeUndefined();
+  });
+
+  it("leaves unrelated standalone scripts unchanged", () => {
+    expect(prepareBrowserScript("motion-sample.browser.js", "window.example = true;")).toBe(
+      "window.example = true;",
+    );
+  });
+
+  it("is applied by the CLI loader", () => {
+    Reflect.deleteProperty(window, "__hyperframesLayoutAudit");
+    window.eval(loadBrowserScript("layout-audit.browser.js"));
+
+    expect(Reflect.get(window, "__hyperframesLayoutAudit")).toBeTypeOf("function");
+    expect(Reflect.get(window, "__hyperframesCssColorAlpha")).toBeUndefined();
+  });
+});

--- a/packages/cli/src/utils/browserScript.ts
+++ b/packages/cli/src/utils/browserScript.ts
@@ -1,0 +1,14 @@
+import { cssColorAlpha } from "@hyperframes/core/visual-paint";
+
+const LAYOUT_AUDIT_SCRIPT = "layout-audit.browser.js";
+const COLOR_ALPHA_BINDING = "__hyperframesCssColorAlpha";
+
+/**
+ * Inject shared paint primitives into scripts that must execute without module imports.
+ * The outer scope is private and disappears after the audit installs its window hooks.
+ */
+export function prepareBrowserScript(name: string, source: string): string {
+  if (name !== LAYOUT_AUDIT_SCRIPT) return source;
+  const serializedColorAlpha = cssColorAlpha.toString();
+  return `(function () {\nconst ${COLOR_ALPHA_BINDING} = ${serializedColorAlpha};\n${source}\n})();`;
+}

--- a/packages/core/package-subpaths.json
+++ b/packages/core/package-subpaths.json
@@ -92,6 +92,12 @@
       "types": "./dist/colorGrading.d.ts",
       "environments": ["browser", "bun", "node"]
     },
+    "./visual-paint": {
+      "source": "./src/visualPaint.ts",
+      "runtime": "./dist/visualPaint.js",
+      "types": "./dist/visualPaint.d.ts",
+      "environments": ["browser", "bun", "node"]
+    },
     "./color-luts": {
       "source": "./src/colorLuts.ts",
       "runtime": "./dist/colorLuts.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -106,6 +106,12 @@
       "import": "./src/colorGrading.ts",
       "types": "./src/colorGrading.ts"
     },
+    "./visual-paint": {
+      "bun": "./src/visualPaint.ts",
+      "node": "./dist/visualPaint.js",
+      "import": "./src/visualPaint.ts",
+      "types": "./src/visualPaint.ts"
+    },
     "./color-luts": {
       "bun": "./src/colorLuts.ts",
       "node": "./dist/colorLuts.js",
@@ -361,6 +367,10 @@
       "./color-grading": {
         "import": "./dist/colorGrading.js",
         "types": "./dist/colorGrading.d.ts"
+      },
+      "./visual-paint": {
+        "import": "./dist/visualPaint.js",
+        "types": "./dist/visualPaint.d.ts"
       },
       "./color-luts": {
         "import": "./dist/colorLuts.js",

--- a/packages/core/src/visualPaint.test.ts
+++ b/packages/core/src/visualPaint.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { cssColorAlpha, isTransparentColor } from "./visualPaint";
+
+describe("cssColorAlpha", () => {
+  it.each([
+    ["transparent", 0],
+    ["rgba(255, 255, 255, 0)", 0],
+    ["rgb(255 255 255 / 0%)", 0],
+    ["hsl(0 0% 100% / 25%)", 0.25],
+    ["rgb(1, 2, 3)", 1],
+    ["#fff", 1],
+  ])("reads %s as alpha %s", (color, expected) => {
+    expect(cssColorAlpha(color)).toBe(expected);
+  });
+
+  it("treats every zero-alpha functional colour as transparent", () => {
+    expect(isTransparentColor("hsla(120, 50%, 50%, 0)")).toBe(true);
+    expect(isTransparentColor("rgb(255 255 255 / 0.01)")).toBe(false);
+  });
+});

--- a/packages/core/src/visualPaint.ts
+++ b/packages/core/src/visualPaint.ts
@@ -1,0 +1,39 @@
+/**
+ * Return the alpha channel of a CSS functional colour.
+ *
+ * Browsers serialize computed colours as rgb()/rgba(), but accepting hsl()/hsla()
+ * too keeps this helper useful for test doubles and authored values. Unknown colour
+ * syntaxes are treated as opaque because they may still paint.
+ *
+ * Keep this function self-contained: the CLI serializes it into its standalone
+ * browser audit script so that browser-side paint checks share this exact parser.
+ */
+export function cssColorAlpha(value: string): number {
+  if (!value) return 1;
+  if (value.trim().toLowerCase() === "transparent") return 0;
+
+  const match = /^(?:rgba?|hsla?)\(([^)]*)\)$/i.exec(value.trim());
+  if (!match) return 1;
+
+  const body = match[1] ?? "";
+  let rawAlpha: string | undefined;
+  const slash = body.lastIndexOf("/");
+  if (slash >= 0) {
+    rawAlpha = body.slice(slash + 1).trim();
+  } else {
+    const commaParts = body.split(",");
+    if (commaParts.length === 4) rawAlpha = commaParts[3]?.trim();
+  }
+
+  if (!rawAlpha) return 1;
+  const percentage = rawAlpha.endsWith("%");
+  const parsed = Number.parseFloat(rawAlpha);
+  if (!Number.isFinite(parsed)) return 1;
+  const alpha = percentage ? parsed / 100 : parsed;
+  return Math.min(1, Math.max(0, alpha));
+}
+
+/** Whether a CSS colour contributes no painted pixels. */
+export function isTransparentColor(value: string): boolean {
+  return !value || cssColorAlpha(value) === 0;
+}

--- a/packages/sdk/package-subpaths.json
+++ b/packages/sdk/package-subpaths.json
@@ -36,6 +36,12 @@
       "runtime": "./dist/editing/affordances.js",
       "types": "./dist/editing/affordances.d.ts",
       "environments": ["browser", "bun", "node"]
+    },
+    "./visual-paint": {
+      "source": "./src/visualPaint.ts",
+      "runtime": "./dist/visualPaint.js",
+      "types": "./dist/visualPaint.d.ts",
+      "environments": ["browser", "bun", "node"]
     }
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -43,6 +43,11 @@
       "bun": "./src/editing/affordances.ts",
       "import": "./src/editing/affordances.ts",
       "types": "./src/editing/affordances.ts"
+    },
+    "./visual-paint": {
+      "bun": "./src/visualPaint.ts",
+      "import": "./src/visualPaint.ts",
+      "types": "./src/visualPaint.ts"
     }
   },
   "publishConfig": {
@@ -71,6 +76,10 @@
       "./editing": {
         "import": "./dist/editing/affordances.js",
         "types": "./dist/editing/affordances.d.ts"
+      },
+      "./visual-paint": {
+        "import": "./dist/visualPaint.js",
+        "types": "./dist/visualPaint.d.ts"
       }
     },
     "main": "./dist/index.js",

--- a/packages/sdk/src/adapters/iframe.ts
+++ b/packages/sdk/src/adapters/iframe.ts
@@ -52,6 +52,7 @@ import type {
   DraftProps,
   PaintQueryOptions,
 } from "./types.js";
+import { isTransparentColor } from "@hyperframes/core/visual-paint";
 import type { EditOp, Composition } from "../types.js";
 import { applyPatchesToDocument, applyOverrideSet } from "../engine/apply-patches.js";
 
@@ -513,27 +514,6 @@ export const INTRINSIC_PAINT_TAGS: ReadonlySet<string> = new Set([
   "canvas",
   "svg",
 ]);
-
-/**
- * Does this computed colour put down no ink?
- *
- * The `transparent` keyword computes to `rgba(0, 0, 0, 0)`, but ANY colour can carry a zero
- * alpha — `rgba(255, 255, 255, 0)` is exactly as invisible and is what you get from fading a
- * white background out. Matching known spellings misses those, so the alpha is read instead.
- */
-function isTransparentColor(value: string): boolean {
-  if (!value || value === "transparent") return true;
-  // rgb/hsl and their -a forms all carry alpha as the fourth component. Computed
-  // background-color is serialized to rgb() by every engine we target, but matching both
-  // costs one alternation and removes the dependency on that.
-  const inner = /^(?:rgba?|hsla?)\(([^)]*)\)$/.exec(value)?.[1];
-  if (inner === undefined) return false;
-  // Handles both the legacy comma form and the `rgb(r g b / a)` slash form.
-  const parts = inner.split(/[\s,/]+/).filter(Boolean);
-  // An rgb() with no alpha component is fully opaque.
-  const alpha = parts[3];
-  return alpha !== undefined && Number.parseFloat(alpha) === 0;
-}
 
 const BORDER_SIDES = ["top", "right", "bottom", "left"] as const;
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -68,3 +68,4 @@ export type {
 export { createMemoryAdapter } from "./adapters/memory.js";
 export { createHeadlessAdapter } from "./adapters/headless.js";
 export { createIframePreviewAdapter, resolveNearestHfElement } from "./adapters/iframe.js";
+export { cssColorAlpha, isTransparentColor } from "./visualPaint.js";

--- a/packages/sdk/src/visualPaint.ts
+++ b/packages/sdk/src/visualPaint.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared visual-paint primitives for SDK hosts such as Studio.
+ *
+ * The parser itself lives in Core so the CLI can serialize it into its dependency-free
+ * browser audit without depending on the SDK package. SDK remains the public home for
+ * host-facing paint semantics.
+ */
+export { cssColorAlpha, isTransparentColor } from "@hyperframes/core/visual-paint";

--- a/packages/studio/src/captions/parser.test.ts
+++ b/packages/studio/src/captions/parser.test.ts
@@ -1,7 +1,13 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
-import { extractTranscript, buildCaptionModel, TranscriptWord } from "./parser";
+import {
+  extractTranscript,
+  buildCaptionModel,
+  parseCaptionComposition,
+  TranscriptWord,
+} from "./parser";
 import { DEFAULT_STYLE, DEFAULT_CONTAINER, DEFAULT_ANIMATION_SET } from "./types";
+import { Window as HappyWindow } from "happy-dom";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -75,6 +81,31 @@ const NON_CAPTION_SOURCE = `
 `;
 
 const EMPTY_SOURCE = ``;
+
+describe("parseCaptionComposition", () => {
+  it("does not import a zero-alpha non-black group background", () => {
+    const iframeWindow = new HappyWindow();
+    iframeWindow.document.body.innerHTML = `
+      <div class="caption-group" style="background-color: rgba(255, 255, 255, 0)">
+        <span class="word">We</span>
+      </div>
+    `;
+
+    const model = parseCaptionComposition(
+      iframeWindow.document,
+      iframeWindow as unknown as Window,
+      STANDARD_CAPTION_SOURCE,
+      1920,
+      1080,
+      2,
+    );
+    const firstGroupId = model?.groupOrder[0];
+    const group = firstGroupId ? model?.groups.get(firstGroupId) : undefined;
+
+    expect(group?.containerStyle.backgroundColor).toBe("transparent");
+    expect(group?.containerStyle.backgroundOpacity).toBe(0);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/packages/studio/src/captions/parser.ts
+++ b/packages/studio/src/captions/parser.ts
@@ -2,16 +2,15 @@
 // Parses a caption composition's JavaScript source to extract the transcript word array,
 // and builds a CaptionModel from a TranscriptWord array.
 
-import {
+import type {
   CaptionModel,
   CaptionSegment,
   CaptionGroup,
   CaptionStyle,
   CaptionContainerStyle,
-  DEFAULT_STYLE,
-  DEFAULT_CONTAINER,
-  DEFAULT_ANIMATION_SET,
 } from "./types";
+import { DEFAULT_ANIMATION_SET, DEFAULT_CONTAINER, DEFAULT_STYLE } from "./types";
+import { isTransparentColor } from "@hyperframes/sdk/visual-paint";
 
 export interface TranscriptWord {
   id?: string;
@@ -228,7 +227,7 @@ export function parseCaptionComposition(
       const groupComputed = iframeWin.getComputedStyle(firstGroupEl);
       const bgColor = groupComputed.backgroundColor;
       // Only apply if it's not transparent/none
-      if (bgColor && bgColor !== "rgba(0, 0, 0, 0)" && bgColor !== "transparent") {
+      if (!isTransparentColor(bgColor)) {
         containerOverrides.backgroundColor = bgColor;
         containerOverrides.backgroundOpacity = 1;
       }

--- a/packages/studio/src/components/editor/domEditing.test.ts
+++ b/packages/studio/src/components/editor/domEditing.test.ts
@@ -283,6 +283,43 @@ describe("resolveVisualDomEditSelectionTarget", () => {
     ).toBe(visible);
   });
 
+  it("skips zero-alpha backgrounds regardless of their RGB channels", () => {
+    const document = createDocument(`
+      <div id="transparent" style="background-color: rgba(255, 255, 255, 0)"></div>
+      <button id="visible">Visible</button>
+    `);
+    const transparent = document.getElementById("transparent") as HTMLElement;
+    const visible = document.getElementById("visible") as HTMLElement;
+    setElementRect(transparent, { width: 120, height: 32 });
+    setElementRect(visible, { width: 120, height: 32 });
+
+    expect(
+      resolveVisualDomEditSelectionTarget([transparent, visible], {
+        activeCompositionPath: "index.html",
+      }),
+    ).toBe(visible);
+  });
+
+  it("keeps a box-shadow-only element selectable", () => {
+    const document = createDocument(`<div id="shadow" style="box-shadow: 0 4px 20px #000"></div>`);
+    const shadow = document.getElementById("shadow") as HTMLElement;
+    setElementRect(shadow, { width: 120, height: 32 });
+
+    expect(
+      resolveVisualDomEditSelectionTarget([shadow], { activeCompositionPath: "index.html" }),
+    ).toBe(shadow);
+  });
+
+  it("keeps audio elements selectable as Studio visual leaves", () => {
+    const document = createDocument(`<audio id="sound" controls style="display: block"></audio>`);
+    const audio = document.getElementById("sound") as HTMLElement;
+    setElementRect(audio, { width: 300, height: 54 });
+
+    expect(
+      resolveVisualDomEditSelectionTarget([audio], { activeCompositionPath: "index.html" }),
+    ).toBe(audio);
+  });
+
   it("falls back to the nearest stable editable ancestor when a visual child has no target", () => {
     const document = createDocument(`
       <section id="card">

--- a/packages/studio/src/components/editor/domEditingElement.ts
+++ b/packages/studio/src/components/editor/domEditingElement.ts
@@ -9,6 +9,7 @@ import type {
   TimelineElementDomTarget,
   TimelineElementDomTargetOptions,
 } from "./domEditingTypes";
+import { elementPaintsInk } from "@hyperframes/sdk/adapters/iframe";
 import {
   buildStableSelector,
   escapeCssString,
@@ -32,15 +33,8 @@ const VISUAL_LEAF_TAGS = new Set(["img", "video", "canvas", "svg", "audio"]);
 function hasVisualPresence(el: HTMLElement): boolean {
   const win = el.ownerDocument.defaultView;
   if (!win) return false;
+  if (elementPaintsInk(el, win)) return true;
   const cs = win.getComputedStyle(el);
-  if (cs.backgroundImage !== "none") return true;
-  if (
-    cs.backgroundColor &&
-    cs.backgroundColor !== "transparent" &&
-    cs.backgroundColor !== "rgba(0, 0, 0, 0)"
-  )
-    return true;
-  if (cs.borderWidth && parseFloat(cs.borderWidth) > 0 && cs.borderStyle !== "none") return true;
   if (cs.boxShadow && cs.boxShadow !== "none") return true;
   return false;
 }


### PR DESCRIPTION
## What

Consolidates the duplicated visual-paint color parsing used by the SDK, Studio, captions, and the CLI browser audit.

- Adds one pure CSS alpha parser in Core and exposes the host-facing API through the SDK.
- Makes Studio's visual-presence check delegate to SDK paint semantics while preserving Studio-specific `box-shadow` and `audio` policy.
- Reuses the shared transparency check when importing caption backgrounds.
- Injects the exact same alpha function into the CLI's standalone browser audit without leaking a global.

Fixes #3079.

## Why

The existing copies already disagreed. In particular, Studio and captions only recognized a few transparent spellings, so a computed color such as `rgba(255, 255, 255, 0)` could be treated as painted. The CLI also maintained a separate alpha parser.

Keeping the pure parser in Core lets the SDK expose the shared host API while the CLI can bundle the function into its dependency-free browser payload. Caller-specific policy remains local.

## How

- Adds `cssColorAlpha` and `isTransparentColor` under `@hyperframes/core/visual-paint`.
- Re-exports them from `@hyperframes/sdk/visual-paint` and uses the helper in the iframe adapter.
- Replaces Studio's background string matching with SDK delegation.
- Wraps `layout-audit.browser.js` at load time with a lexical, serialized `cssColorAlpha`; the source script remains an internal template and the delivered payload remains standalone.
- Documents the new SDK export.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed — built the production CLI and executed the reconstructed browser payload in a VM; it was standalone and leaked no global
- [x] Documentation updated

Verified:

- Core visual-paint tests: 7 passed
- SDK iframe tests: 97 passed
- Studio DOM editing and captions tests: 78 passed
- CLI loader and layout-audit tests: 85 passed
- Core, SDK, Studio, and CLI typechecks
- Studio and CLI production builds
- package-subpath validation, oxlint, oxfmt, and pre-commit hooks
