### PR TITLE
chore: release v0.7.103

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,28 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.103"
+  description="Released - 2026-08-09"
+  tags={["Release", "Core", "Core,cli"]}
+>
+Long renders use the faster parallel capture path again. A gate added in 0.7.101 had switched it off for most installs, making renders slower.
+
+## Features
+
+- **Core,cli:** Ship the DE parallel router fleet-wide — remove the canary gate ([19defeabf](https://github.com/heygen-com/hyperframes/commit/19defeabfe8fa47747d1d8bc087a84d69a09cb59)).
+
+## Fixes
+
+- **Core:** Retry bpm-detective import after transient failure ([b4bd67040](https://github.com/heygen-com/hyperframes/commit/b4bd670402b82f25c1f5e0343336e21455284f80), [#2736](https://github.com/heygen-com/hyperframes/pull/2736)).
+
+## Docs & Examples
+
+- Fix preview port in DOCS_GUIDELINES example ([9ec9e3a71](https://github.com/heygen-com/hyperframes/commit/9ec9e3a711531b3d45c30a1e2c3006df97dbe5cb), [#2903](https://github.com/heygen-com/hyperframes/pull/2903)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.102...v0.7.103).
+</Update>
+
+<Update
   label="HyperFrames v0.7.102"
   description="Released - 2026-08-08"
   tags={["Release", "CLI", "Core"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.103.md
+++ b/releases/v0.7.103.md
@@ -1,0 +1,21 @@
+# HyperFrames v0.7.103
+
+Released on 2026-08-09.
+
+Long renders use the faster parallel capture path again. A gate added in 0.7.101 had switched it off for most installs, making renders slower.
+
+## Features
+
+- **Core,cli:** Ship the DE parallel router fleet-wide — remove the canary gate ([19defeabf](https://github.com/heygen-com/hyperframes/commit/19defeabfe8fa47747d1d8bc087a84d69a09cb59)).
+
+## Fixes
+
+- **Core:** Retry bpm-detective import after transient failure ([b4bd67040](https://github.com/heygen-com/hyperframes/commit/b4bd670402b82f25c1f5e0343336e21455284f80), [#2736](https://github.com/heygen-com/hyperframes/pull/2736)).
+
+## Docs & Examples
+
+- Fix preview port in DOCS_GUIDELINES example ([9ec9e3a71](https://github.com/heygen-com/hyperframes/commit/9ec9e3a711531b3d45c30a1e2c3006df97dbe5cb), [#2903](https://github.com/heygen-com/hyperframes/pull/2903)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.102...v0.7.103


### PR DESCRIPTION
Release v0.7.103.

## Behavioural change for users

**The parallel drawElement router is on for everyone again.** Long renders go
back to the faster parallel capture path.

v0.7.101 shipped that router behind a 5% canary. Measured the next day, the
gate had cut fleet router exposure from 3.13-4.25% of non-CI renders to
**0.13%** — roughly 25x — because out-of-cohort installs are explicitly
disarmed and #2840 deleted the everyone-armed trial in the same change. 2,537
installs lost a feature they already had. #3120 removed the canary entry and
its guard together, restoring the shipped default.

Impact is speed only, never output: a router revert forfeits the speedup, not
the render. The per-install circuit breaker and per-render self-verify are
untouched, and `HF_DE_PARALLEL_ROUTER=false` remains the kill switch.

## Monitoring note

`$feature/canary-de-parallel-router` and `canary_reason_de_parallel_router`
are emitted from the canary registry, so they stop with this release. The
`Ramp —` tiles and the exposure-floor alert on PostHog dashboard 1918875 go
blank once this is adopted. Watch drawElement engagement on 1807532 instead.

Reverting is now a code revert rather than a registry edit — that was the
trade accepted for shipping in one step instead of two.

## Also in this release

- **Core:** retry bpm-detective import after transient failure (#2736)
- **Docs:** fix preview port in DOCS_GUIDELINES example (#2903)

Full changelog: https://github.com/heygen-com/hyperframes/compare/v0.7.102...v0.7.103
