### PR TITLE
fix(studio): hold a resized element's size while the timeline is rebuilt

### DIFF
--- a/packages/studio/src/components/editor/manualEditsDom.ts
+++ b/packages/studio/src/components/editor/manualEditsDom.ts
@@ -36,6 +36,7 @@ import { roundRotationAngle } from "./manualEditsParsing";
 import { applyStudioMotionFromDom } from "./studioMotion";
 import { gsapAnimatesProperty } from "./gsapAnimatesProperty";
 import { splitTopLevelWhitespace } from "./manualEditsStyleHelpers";
+import { logResize } from "../../utils/resizeDebug";
 
 /* ── Gesture tracking ─────────────────────────────────────────────── */
 let studioManualEditGestureId = 0;
@@ -454,6 +455,11 @@ export function applyStudioBoxSize(
   element: HTMLElement,
   size: { width: number; height: number },
 ): void {
+  logResize("apply-box-size", {
+    to: `${Math.round(size.width)} x ${Math.round(size.height)}`,
+    from: `${element.style.width || "-"} x ${element.style.height || "-"}`,
+    stack: new Error("apply-box-size").stack?.split("\n").slice(1, 6).join(" < "),
+  });
   promoteInlineForTransform(element);
   applyStudioBoxSizeDimensions(element, size);
 }

--- a/packages/studio/src/components/editor/manualEditsDom.ts
+++ b/packages/studio/src/components/editor/manualEditsDom.ts
@@ -36,7 +36,6 @@ import { roundRotationAngle } from "./manualEditsParsing";
 import { applyStudioMotionFromDom } from "./studioMotion";
 import { gsapAnimatesProperty } from "./gsapAnimatesProperty";
 import { splitTopLevelWhitespace } from "./manualEditsStyleHelpers";
-import { logResize } from "../../utils/resizeDebug";
 
 /* ── Gesture tracking ─────────────────────────────────────────────── */
 let studioManualEditGestureId = 0;
@@ -455,11 +454,6 @@ export function applyStudioBoxSize(
   element: HTMLElement,
   size: { width: number; height: number },
 ): void {
-  logResize("apply-box-size", {
-    to: `${Math.round(size.width)} x ${Math.round(size.height)}`,
-    from: `${element.style.width || "-"} x ${element.style.height || "-"}`,
-    stack: new Error("apply-box-size").stack?.split("\n").slice(1, 6).join(" < "),
-  });
   promoteInlineForTransform(element);
   applyStudioBoxSizeDimensions(element, size);
 }

--- a/packages/studio/src/components/editor/manualEditsDom.ts
+++ b/packages/studio/src/components/editor/manualEditsDom.ts
@@ -561,26 +561,29 @@ function queryStudioElements(doc: Document, attr: string): HTMLElement[] {
 
 function reapplyPathOffsets(doc: Document): void {
   for (const el of queryStudioElements(doc, STUDIO_PATH_OFFSET_ATTR)) {
-    const gsapSkip = gsapAnimatesProperty(el, "x", "y");
+    // Unlike size below, the offset channels COMPOSE — applying both doubles the move.
+    if (gsapAnimatesProperty(el, "x", "y")) continue;
     const x = el.style.getPropertyValue(STUDIO_OFFSET_X_PROP);
     const y = el.style.getPropertyValue(STUDIO_OFFSET_Y_PROP);
-    if (gsapSkip) continue;
-    if (x || y) {
-      applyStudioPathOffset(
-        el,
-        {
-          x: Number.parseFloat(x) || 0,
-          y: Number.parseFloat(y) || 0,
-        },
-        { updateBase: false },
-      );
-    }
+    if (!x && !y) continue;
+    const offset = { x: Number.parseFloat(x) || 0, y: Number.parseFloat(y) || 0 };
+    applyStudioPathOffset(el, offset, { updateBase: false });
   }
 }
 
+/**
+ * Put the studio's committed size back after a seek, GSAP-sized elements included.
+ *
+ * Size does not compose the way the offset above does: both channels write width
+ * and height, so the later write wins and both hold the same number. Standing
+ * aside meant nothing held the size while a soft reload reverted the old timeline
+ * — GSAP hands back each tween's recorded starting width — so until the new one
+ * rendered, the element sat at its stylesheet size. That is the jump after a
+ * resize, and the next gesture then started from a box disagreeing with these
+ * vars and snapped on its first move. Only an element mid-edit carries them.
+ */
 function reapplyBoxSizes(doc: Document): void {
   for (const el of queryStudioElements(doc, STUDIO_BOX_SIZE_ATTR)) {
-    if (gsapAnimatesProperty(el, "width", "height")) continue;
     const w = Number.parseFloat(el.style.getPropertyValue(STUDIO_WIDTH_PROP));
     const h = Number.parseFloat(el.style.getPropertyValue(STUDIO_HEIGHT_PROP));
     if (Number.isFinite(w) && Number.isFinite(h) && w > 0 && h > 0) {

--- a/packages/studio/src/components/editor/manualEditsDom.ts
+++ b/packages/studio/src/components/editor/manualEditsDom.ts
@@ -567,14 +567,11 @@ function reapplyPathOffsets(doc: Document): void {
 
 /**
  * Put the studio's committed size back after a seek, GSAP-sized elements included.
- *
  * Size does not compose the way the offset above does: both channels write width
- * and height, so the later write wins and both hold the same number. Standing
- * aside meant nothing held the size while a soft reload reverted the old timeline
- * — GSAP hands back each tween's recorded starting width — so until the new one
- * rendered, the element sat at its stylesheet size. That is the jump after a
- * resize, and the next gesture then started from a box disagreeing with these
- * vars and snapped on its first move. Only an element mid-edit carries them.
+ * and height, so the later write wins on the same number. Standing aside meant
+ * nothing held the size while a soft reload reverted the old timeline (GSAP hands
+ * back each tween's recorded starting width), so the element sat at its stylesheet
+ * size until the new one rendered — the jump after a resize.
  */
 function reapplyBoxSizes(doc: Document): void {
   for (const el of queryStudioElements(doc, STUDIO_BOX_SIZE_ATTR)) {

--- a/packages/studio/src/components/editor/manualEditsSnapshot.ts
+++ b/packages/studio/src/components/editor/manualEditsSnapshot.ts
@@ -40,7 +40,6 @@ import type {
   StudioRotationSnapshot,
   StudioPathOffsetSnapshot,
 } from "./manualEditsTypes";
-import { logResize } from "../../utils/resizeDebug";
 
 /* ── Capture ──────────────────────────────────────────────────────── */
 export function captureStudioBoxSize(element: HTMLElement): StudioBoxSizeSnapshot {
@@ -115,14 +114,6 @@ function restoreStyleProperty(element: HTMLElement, property: string, value: str
 }
 
 export function restoreStudioBoxSize(element: HTMLElement, previous: StudioBoxSizeSnapshot): void {
-  // Putting the pre-gesture size back is correct on a cancel and wrong after a
-  // successful commit, and the two are indistinguishable from in here — so say
-  // who asked, with the size being restored and the one being replaced.
-  logResize("restore-box-size", {
-    to: `${previous.width || "-"} x ${previous.height || "-"}`,
-    from: `${element.style.width || "-"} x ${element.style.height || "-"}`,
-    stack: new Error("restore-box-size").stack?.split("\n").slice(1, 6).join(" < "),
-  });
   restoreStyleProperty(element, "width", previous.width);
   restoreStyleProperty(element, "height", previous.height);
   restoreStyleProperty(element, "min-width", previous.minWidth);

--- a/packages/studio/src/components/editor/manualEditsSnapshot.ts
+++ b/packages/studio/src/components/editor/manualEditsSnapshot.ts
@@ -40,6 +40,7 @@ import type {
   StudioRotationSnapshot,
   StudioPathOffsetSnapshot,
 } from "./manualEditsTypes";
+import { logResize } from "../../utils/resizeDebug";
 
 /* ── Capture ──────────────────────────────────────────────────────── */
 export function captureStudioBoxSize(element: HTMLElement): StudioBoxSizeSnapshot {
@@ -114,6 +115,14 @@ function restoreStyleProperty(element: HTMLElement, property: string, value: str
 }
 
 export function restoreStudioBoxSize(element: HTMLElement, previous: StudioBoxSizeSnapshot): void {
+  // Putting the pre-gesture size back is correct on a cancel and wrong after a
+  // successful commit, and the two are indistinguishable from in here — so say
+  // who asked, with the size being restored and the one being replaced.
+  logResize("restore-box-size", {
+    to: `${previous.width || "-"} x ${previous.height || "-"}`,
+    from: `${element.style.width || "-"} x ${element.style.height || "-"}`,
+    stack: new Error("restore-box-size").stack?.split("\n").slice(1, 6).join(" < "),
+  });
   restoreStyleProperty(element, "width", previous.width);
   restoreStyleProperty(element, "height", previous.height);
   restoreStyleProperty(element, "min-width", previous.minWidth);

--- a/packages/studio/src/components/editor/reapplyBoxSizeAfterSeek.test.ts
+++ b/packages/studio/src/components/editor/reapplyBoxSizeAfterSeek.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest";
+import { reapplyPositionEditsAfterSeek } from "./manualEditsDom";
+import { STUDIO_BOX_SIZE_ATTR, STUDIO_HEIGHT_PROP, STUDIO_WIDTH_PROP } from "./manualEditsTypes";
+
+/**
+ * A resize commit hands the size to a GSAP tween, and a soft reload reverts the
+ * old timeline before the new one renders — GSAP restores each tween's recorded
+ * starting width on the way out. Nothing else held the size across that window,
+ * so the element sat at its stylesheet size for a few hundred milliseconds: the
+ * jump after a resize. Worse, the next gesture then started from a box that
+ * disagreed with the studio's own vars and snapped on its first move.
+ *
+ * The seek reapply is what closes the window, and it used to stand aside for
+ * exactly the elements that need it — the ones GSAP sizes.
+ */
+describe("box size survives a seek while GSAP owns the size", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    Reflect.deleteProperty(window, "__timelines");
+  });
+
+  function cardSizedByGsap(): HTMLElement {
+    const el = document.createElement("div");
+    el.id = "card";
+    el.setAttribute(STUDIO_BOX_SIZE_ATTR, "true");
+    el.style.setProperty(STUDIO_WIDTH_PROP, "305px");
+    el.style.setProperty(STUDIO_HEIGHT_PROP, "202px");
+    document.body.append(el);
+    // A timeline that animates this element's width/height, as the committed
+    // resize leaves behind.
+    Object.assign(window, {
+      __timelines: {
+        main: {
+          getChildren: () => [{ targets: () => [el], vars: { width: 305, height: 202 } }],
+        },
+      },
+    });
+    return el;
+  }
+
+  it("re-applies the committed size after the timeline gave it back", () => {
+    const el = cardSizedByGsap();
+    // The revert: GSAP puts the tween's recorded starting size back.
+    el.style.width = "395px";
+    el.style.height = "261px";
+
+    reapplyPositionEditsAfterSeek(document);
+
+    expect(el.style.width).toBe("305px");
+    expect(el.style.height).toBe("202px");
+  });
+
+  it("leaves an element alone once its studio size is cleared", () => {
+    const el = cardSizedByGsap();
+    el.style.removeProperty(STUDIO_WIDTH_PROP);
+    el.style.removeProperty(STUDIO_HEIGHT_PROP);
+    el.style.width = "395px";
+
+    reapplyPositionEditsAfterSeek(document);
+
+    expect(el.style.width).toBe("395px");
+  });
+});


### PR DESCRIPTION
## What

A resized element keeps its new size across a seek instead of snapping back to its stylesheet size.

## Why

Size does not compose the way the position offset does: both channels write width and height, so the later write wins. Standing aside meant nothing held the size while a soft reload reverted the old timeline, since GSAP hands back each tween's recorded starting width. The element sat at its stylesheet size until the new timeline rendered — the jump after a resize — and the next gesture then started from a box disagreeing with the committed vars and snapped on its first move.

## How

The size reapply no longer skips GSAP-sized elements. Only an element mid-edit carries the vars, so this cannot affect anything the user is not actively resizing.

## Test plan

- Resize an element, scrub the timeline, and the size holds
- Full suite on the composed stack: 3701 studio, 434 studio-server, 1750 core tests

---

Last of eight stacked PRs re-cutting #3077. The tip of this branch reproduces #3077 exactly: of the 86 files that branch changed, none differ.