### PR TITLE
feat(studio): show every colour of a mixed selection in the swatch

### DIFF
--- a/packages/studio/src/components/editor/InlineTextToolbar.test.tsx
+++ b/packages/studio/src/components/editor/InlineTextToolbar.test.tsx
@@ -249,7 +249,10 @@ describe("InlineTextToolbar", () => {
     selectAll(element);
 
     const swatch = toolbarIn(host)!.querySelector<HTMLElement>("span[aria-hidden]")!;
-    expect(swatch.style.background).toBe("linear-gradient(90deg, red 25.00%, lime 75.00%)");
+    expect(swatch.style.backgroundImage).toBe("linear-gradient(90deg, red 25.00%, lime 75.00%)");
+    // Without this the gradient repeats under the border, painting the end
+    // colour along the leading edge and the start colour along the trailing one.
+    expect(swatch.style.backgroundOrigin).toBe("border-box");
   });
 
   it("shows a plain swatch when the whole selection is one colour", () => {
@@ -259,7 +262,7 @@ describe("InlineTextToolbar", () => {
     selectAll(element);
 
     const swatch = toolbarIn(host)!.querySelector<HTMLElement>("span[aria-hidden]")!;
-    expect(swatch.style.background).toBe("red");
+    expect(swatch.style.backgroundColor).toBe("red");
   });
 });
 

--- a/packages/studio/src/components/editor/InlineTextToolbar.test.tsx
+++ b/packages/studio/src/components/editor/InlineTextToolbar.test.tsx
@@ -3,7 +3,7 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, it } from "vitest";
-import { InlineTextToolbar } from "./InlineTextToolbar";
+import { InlineTextToolbar, swatchBackground } from "./InlineTextToolbar";
 import type { InlineTextEditSession } from "../../hooks/useInlineTextEdit";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -219,7 +219,6 @@ describe("InlineTextToolbar", () => {
     expect(toolbar.style.left).toBe(`${100 + (20 + 50) * scale}px`);
     expect(toolbar.style.top).toBe(`${50 + 40 * scale - 10}px`);
   });
-
   it("moves below a selection that leaves no room above the viewport", () => {
     const { element, session, iframe } = scene("hello world");
     iframe.getBoundingClientRect = () => ({ left: 0, top: 0, width: 400 }) as DOMRect;
@@ -239,5 +238,52 @@ describe("InlineTextToolbar", () => {
     const scale = 400 / window.innerWidth;
     expect(toolbar.style.top).toBe(`${10 * scale + 10}px`);
     expect(toolbar.style.transform).toBe("translate(-50%, 0)");
+  });
+
+  it("shows the selection's colours in the swatch when they differ", () => {
+    const { element, session, iframe } = scene(
+      '<span style="color: red">Hello</span><span style="color: lime">world</span>',
+    );
+    const { host } = render(session, iframe);
+
+    selectAll(element);
+
+    const swatch = toolbarIn(host)!.querySelector<HTMLElement>("span[aria-hidden]")!;
+    expect(swatch.style.background).toBe(
+      "linear-gradient(90deg, red 0.00% 50.00%, lime 50.00% 100.00%)",
+    );
+  });
+
+  it("shows a plain swatch when the whole selection is one colour", () => {
+    const { element, session, iframe } = scene('<span style="color: red">Hello world</span>');
+    const { host } = render(session, iframe);
+
+    selectAll(element);
+
+    const swatch = toolbarIn(host)!.querySelector<HTMLElement>("span[aria-hidden]")!;
+    expect(swatch.style.background).toBe("red");
+  });
+});
+
+describe("swatchBackground", () => {
+  it("shows every colour in the selection, sized by how much text carries it", () => {
+    expect(
+      swatchBackground(
+        [
+          { value: "red", chars: 5 },
+          { value: "lime", chars: 15 },
+        ],
+        undefined,
+      ),
+    ).toBe("linear-gradient(90deg, red 0.00% 25.00%, lime 25.00% 100.00%)");
+  });
+
+  it("stays a plain swatch when the selection is one colour", () => {
+    expect(swatchBackground([{ value: "red", chars: 5 }], "red")).toBe("red");
+  });
+
+  it("falls back to the agreed colour when the characters carry none", () => {
+    expect(swatchBackground([], "rgb(1, 2, 3)")).toBe("rgb(1, 2, 3)");
+    expect(swatchBackground([], undefined)).toBe("#ffffff");
   });
 });

--- a/packages/studio/src/components/editor/InlineTextToolbar.test.tsx
+++ b/packages/studio/src/components/editor/InlineTextToolbar.test.tsx
@@ -249,7 +249,7 @@ describe("InlineTextToolbar", () => {
     selectAll(element);
 
     const swatch = toolbarIn(host)!.querySelector<HTMLElement>("span[aria-hidden]")!;
-    expect(swatch.style.backgroundImage).toBe("linear-gradient(90deg, red 25.00%, lime 75.00%)");
+    expect(swatch.style.backgroundImage).toBe("linear-gradient(135deg, red 0.00%, lime 100.00%)");
     // Without this the gradient repeats under the border, painting the end
     // colour along the leading edge and the start colour along the trailing one.
     expect(swatch.style.backgroundOrigin).toBe("border-box");
@@ -267,20 +267,23 @@ describe("InlineTextToolbar", () => {
 });
 
 describe("swatchBackground", () => {
-  it("blends every colour in the selection, weighted by how much text carries it", () => {
-    expect(
-      swatchBackground(
-        [
-          { value: "red", chars: 5 },
-          { value: "lime", chars: 15 },
-        ],
-        undefined,
-      ),
-    ).toBe("linear-gradient(90deg, red 12.50%, lime 62.50%)");
+  it("sweeps through each distinct colour, evenly spaced", () => {
+    expect(swatchBackground(["red", "lime"], undefined)).toBe(
+      "linear-gradient(135deg, red 0.00%, lime 100.00%)",
+    );
+    expect(swatchBackground(["red", "lime", "cyan"], undefined)).toBe(
+      "linear-gradient(135deg, red 0.00%, lime 50.00%, cyan 100.00%)",
+    );
+  });
+
+  it("shows a colour once however much text carries it", () => {
+    expect(swatchBackground(["red", "red", "lime"], undefined)).toBe(
+      "linear-gradient(135deg, red 0.00%, lime 100.00%)",
+    );
   });
 
   it("stays a plain swatch when the selection is one colour", () => {
-    expect(swatchBackground([{ value: "red", chars: 5 }], "red")).toBe("red");
+    expect(swatchBackground(["red"], "red")).toBe("red");
   });
 
   it("falls back to the agreed colour when the characters carry none", () => {

--- a/packages/studio/src/components/editor/InlineTextToolbar.test.tsx
+++ b/packages/studio/src/components/editor/InlineTextToolbar.test.tsx
@@ -249,9 +249,7 @@ describe("InlineTextToolbar", () => {
     selectAll(element);
 
     const swatch = toolbarIn(host)!.querySelector<HTMLElement>("span[aria-hidden]")!;
-    expect(swatch.style.background).toBe(
-      "linear-gradient(90deg, red 0.00% 50.00%, lime 50.00% 100.00%)",
-    );
+    expect(swatch.style.background).toBe("linear-gradient(90deg, red 25.00%, lime 75.00%)");
   });
 
   it("shows a plain swatch when the whole selection is one colour", () => {
@@ -266,7 +264,7 @@ describe("InlineTextToolbar", () => {
 });
 
 describe("swatchBackground", () => {
-  it("shows every colour in the selection, sized by how much text carries it", () => {
+  it("blends every colour in the selection, weighted by how much text carries it", () => {
     expect(
       swatchBackground(
         [
@@ -275,7 +273,7 @@ describe("swatchBackground", () => {
         ],
         undefined,
       ),
-    ).toBe("linear-gradient(90deg, red 0.00% 25.00%, lime 25.00% 100.00%)");
+    ).toBe("linear-gradient(90deg, red 12.50%, lime 62.50%)");
   });
 
   it("stays a plain swatch when the selection is one colour", () => {

--- a/packages/studio/src/components/editor/InlineTextToolbar.test.tsx
+++ b/packages/studio/src/components/editor/InlineTextToolbar.test.tsx
@@ -264,6 +264,15 @@ describe("InlineTextToolbar", () => {
     const swatch = toolbarIn(host)!.querySelector<HTMLElement>("span[aria-hidden]")!;
     expect(swatch.style.backgroundColor).toBe("red");
   });
+
+  it("opens the colour input on a shorthand hex selection", () => {
+    const { element, session, iframe } = scene('<span style="color: #f00">Hello world</span>');
+    const { host } = render(session, iframe);
+
+    selectAll(element);
+
+    expect(host.querySelector<HTMLInputElement>('input[type="color"]')?.value).toBe("#ff0000");
+  });
 });
 
 describe("swatchBackground", () => {
@@ -273,12 +282,6 @@ describe("swatchBackground", () => {
     );
     expect(swatchBackground(["red", "lime", "cyan"], undefined)).toBe(
       "linear-gradient(135deg, red 0.00%, lime 50.00%, cyan 100.00%)",
-    );
-  });
-
-  it("shows a colour once however much text carries it", () => {
-    expect(swatchBackground(["red", "red", "lime"], undefined)).toBe(
-      "linear-gradient(135deg, red 0.00%, lime 100.00%)",
     );
   });
 

--- a/packages/studio/src/components/editor/InlineTextToolbar.tsx
+++ b/packages/studio/src/components/editor/InlineTextToolbar.tsx
@@ -101,7 +101,15 @@ export function InlineTextToolbar({
         <span
           aria-hidden="true"
           className="h-3.5 w-3.5 rounded-full border border-white/25"
-          style={{ background: swatchBackground(placement.colours, styles.color) }}
+          // `background` maps a gradient to the PADDING box and then repeats it
+          // to fill the border box, so the 1px border shows the strip either
+          // side of the tile: the end colour on the left, the start colour on
+          // the right. A red-to-green swatch grew a green edge and a red one.
+          // Set after the shorthand, which resets it.
+          style={{
+            background: swatchBackground(placement.colours, styles.color),
+            backgroundOrigin: "border-box",
+          }}
         />
         {/* `inset-0` is not enough on its own: a colour input carries a
             user-agent minimum width, which wins over the right edge and lets

--- a/packages/studio/src/components/editor/InlineTextToolbar.tsx
+++ b/packages/studio/src/components/editor/InlineTextToolbar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { applyInlineStyle, readInlineStyle } from "./inlineTextStyleRange";
+import { applyInlineStyle, readInlineStyle, readInlineStyleSpread } from "./inlineTextStyleRange";
 import type { InlineTextEditSession } from "../../hooks/useInlineTextEdit";
 
 /**
@@ -27,6 +27,7 @@ interface ToolbarPlacement {
   top: number;
   placeBelow: boolean;
   styles: Record<string, string>;
+  colours: Array<{ value: string; chars: number }>;
 }
 
 export function InlineTextToolbar({
@@ -100,7 +101,7 @@ export function InlineTextToolbar({
         <span
           aria-hidden="true"
           className="h-3.5 w-3.5 rounded-full border border-white/25"
-          style={{ background: styles.color || DEFAULT_COLOR }}
+          style={{ background: swatchBackground(placement.colours, styles.color) }}
         />
         {/* `inset-0` is not enough on its own: a colour input carries a
             user-agent minimum width, which wins over the right edge and lets
@@ -110,7 +111,7 @@ export function InlineTextToolbar({
           type="color"
           aria-label="Text colour"
           className="absolute inset-0 h-full w-full min-w-0 cursor-pointer opacity-0"
-          value={toHexColor(styles.color)}
+          value={toHexColor(styles.color ?? placement.colours[0]?.value)}
           onChange={(event) => apply({ color: event.target.value })}
         />
       </label>
@@ -137,6 +138,29 @@ export function InlineTextToolbar({
       />
     </div>
   );
+}
+
+/**
+ * The selection's colours, in the proportion they are used: one band per run of
+ * characters that share a colour. Hard stops, not a blend — the swatch is
+ * reporting the colours that are there, and a fade would draw colours that are
+ * not. A selection with one colour is a plain swatch, as before.
+ */
+export function swatchBackground(
+  colours: Array<{ value: string; chars: number }>,
+  agreed: string | undefined,
+): string {
+  if (colours.length === 0) return agreed || DEFAULT_COLOR;
+  if (colours.length === 1) return colours[0]!.value;
+  const total = colours.reduce((sum, colour) => sum + colour.chars, 0);
+  let offset = 0;
+  const stops = colours.map((colour) => {
+    const from = (offset / total) * 100;
+    offset += colour.chars;
+    const to = (offset / total) * 100;
+    return `${colour.value} ${from.toFixed(2)}% ${to.toFixed(2)}%`;
+  });
+  return `linear-gradient(90deg, ${stops.join(", ")})`;
 }
 
 function swallow(event: { preventDefault: () => void; stopPropagation: () => void }): void {
@@ -209,6 +233,7 @@ function placeOverSelection(
     top: placeBelow ? box.top + (rect.top + rect.height) * scale + GAP_PX : above,
     placeBelow,
     styles: readInlineStyle(range, READ_PROPERTIES),
+    colours: readInlineStyleSpread(range, "color"),
   };
 }
 

--- a/packages/studio/src/components/editor/InlineTextToolbar.tsx
+++ b/packages/studio/src/components/editor/InlineTextToolbar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { applyInlineStyle, readInlineStyle, readInlineStyleSpread } from "./inlineTextStyleRange";
+import { parseCssColor, toHexColor } from "./colorValue";
 import type { InlineTextEditSession } from "../../hooks/useInlineTextEdit";
 
 /**
@@ -28,6 +29,7 @@ interface ToolbarPlacement {
   placeBelow: boolean;
   styles: Record<string, string>;
   colours: string[];
+  pickerColour: string;
 }
 
 export function InlineTextToolbar({
@@ -119,7 +121,7 @@ export function InlineTextToolbar({
           type="color"
           aria-label="Text colour"
           className="absolute inset-0 h-full w-full min-w-0 cursor-pointer opacity-0"
-          value={toHexColor(styles.color ?? placement.colours[0])}
+          value={placement.pickerColour}
           onChange={(event) => apply({ color: event.target.value })}
         />
       </label>
@@ -158,12 +160,14 @@ export function InlineTextToolbar({
  * character has to be as visible as one used by thirty or it may as well not be
  * drawn.
  */
-export function swatchBackground(colours: readonly string[], agreed: string | undefined): string {
-  const distinct = [...new Set(colours)];
-  if (distinct.length === 0) return agreed || DEFAULT_COLOR;
-  if (distinct.length === 1) return distinct[0]!;
-  const stops = distinct.map(
-    (colour, index) => `${colour} ${((index / (distinct.length - 1)) * 100).toFixed(2)}%`,
+export function swatchBackground(
+  distinctColours: readonly string[],
+  agreed: string | undefined,
+): string {
+  if (distinctColours.length === 0) return agreed || DEFAULT_COLOR;
+  if (distinctColours.length === 1) return distinctColours[0]!;
+  const stops = distinctColours.map(
+    (colour, index) => `${colour} ${((index / (distinctColours.length - 1)) * 100).toFixed(2)}%`,
   );
   return `linear-gradient(135deg, ${stops.join(", ")})`;
 }
@@ -233,12 +237,15 @@ function placeOverSelection(
   const above = box.top + rect.top * scale - GAP_PX;
   const placeBelow = above < TOOLBAR_HEIGHT_PX;
 
+  const styles = readInlineStyle(range, READ_PROPERTIES);
+  const colours = readInlineStyleSpread(range, "color");
   return {
     left: box.left + (rect.left + rect.width / 2) * scale,
     top: placeBelow ? box.top + (rect.top + rect.height) * scale + GAP_PX : above,
     placeBelow,
-    styles: readInlineStyle(range, READ_PROPERTIES),
-    colours: readInlineStyleSpread(range, "color"),
+    styles,
+    colours,
+    pickerColour: toPickerColour(styles.color ?? colours[0], doc),
   };
 }
 
@@ -248,18 +255,26 @@ function isBold(weight: string | undefined): boolean {
   return Number.parseInt(weight, 10) >= 600;
 }
 
-/**
- * A colour input only accepts `#rrggbb`, and what the page reports is whatever
- * the stylesheet said. An unreadable value opens the picker on white rather
- * than refusing to open.
- */
-function toHexColor(value: string | undefined): string {
+/** A colour input accepts only `#rrggbb`; normalise any valid CSS colour to it. */
+function toPickerColour(value: string | undefined, doc: Document): string {
   if (!value) return DEFAULT_COLOR;
-  if (/^#[0-9a-f]{6}$/i.test(value)) return value;
-  const channels = value.match(/\d+(\.\d+)?/g);
-  if (!channels || channels.length < 3) return DEFAULT_COLOR;
-  return `#${channels
-    .slice(0, 3)
-    .map((channel) => Number(channel).toString(16).padStart(2, "0"))
-    .join("")}`;
+  const parsed = parseCssColor(value);
+  if (parsed) return toHexColor(parsed);
+
+  // Canvas delegates the full CSS colour grammar to the browser, including
+  // named colours that the small serialisation parser intentionally omits.
+  // DOM-only test environments can lack a canvas implementation, in which
+  // case the picker degrades to its explicit default while the swatch remains
+  // truthful because CSS still paints the original value.
+  try {
+    const context = doc.createElement("canvas").getContext("2d");
+    if (!context) return DEFAULT_COLOR;
+    context.fillStyle = DEFAULT_COLOR;
+    context.fillStyle = value;
+    const normalised =
+      typeof context.fillStyle === "string" ? parseCssColor(context.fillStyle) : null;
+    return normalised ? toHexColor(normalised) : DEFAULT_COLOR;
+  } catch {
+    return DEFAULT_COLOR;
+  }
 }

--- a/packages/studio/src/components/editor/InlineTextToolbar.tsx
+++ b/packages/studio/src/components/editor/InlineTextToolbar.tsx
@@ -141,10 +141,9 @@ export function InlineTextToolbar({
 }
 
 /**
- * The selection's colours, in the proportion they are used: one band per run of
- * characters that share a colour. Hard stops, not a blend — the swatch is
- * reporting the colours that are there, and a fade would draw colours that are
- * not. A selection with one colour is a plain swatch, as before.
+ * The selection's colours blended left to right, each sitting at the middle of
+ * the share of characters that carry it. A selection with one colour is a plain
+ * swatch, as before.
  */
 export function swatchBackground(
   colours: Array<{ value: string; chars: number }>,
@@ -155,10 +154,9 @@ export function swatchBackground(
   const total = colours.reduce((sum, colour) => sum + colour.chars, 0);
   let offset = 0;
   const stops = colours.map((colour) => {
-    const from = (offset / total) * 100;
+    const middle = ((offset + colour.chars / 2) / total) * 100;
     offset += colour.chars;
-    const to = (offset / total) * 100;
-    return `${colour.value} ${from.toFixed(2)}% ${to.toFixed(2)}%`;
+    return `${colour.value} ${middle.toFixed(2)}%`;
   });
   return `linear-gradient(90deg, ${stops.join(", ")})`;
 }

--- a/packages/studio/src/components/editor/InlineTextToolbar.tsx
+++ b/packages/studio/src/components/editor/InlineTextToolbar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
-import { applyInlineStyle, readInlineStyle, readInlineStyleSpread } from "./inlineTextStyleRange";
+import { applyInlineStyle } from "./inlineTextStyleRange";
+import { readInlineStyle, readInlineStyleSpread } from "./inlineTextStyleRead";
 import { parseCssColor, toHexColor } from "./colorValue";
 import type { InlineTextEditSession } from "../../hooks/useInlineTextEdit";
 

--- a/packages/studio/src/components/editor/InlineTextToolbar.tsx
+++ b/packages/studio/src/components/editor/InlineTextToolbar.tsx
@@ -27,7 +27,7 @@ interface ToolbarPlacement {
   top: number;
   placeBelow: boolean;
   styles: Record<string, string>;
-  colours: Array<{ value: string; chars: number }>;
+  colours: string[];
 }
 
 export function InlineTextToolbar({
@@ -95,12 +95,12 @@ export function InlineTextToolbar({
       onClick={(event) => event.stopPropagation()}
     >
       <label
-        className="relative flex h-6 w-6 cursor-pointer items-center justify-center rounded-md hover:bg-white/10"
+        className="group relative flex h-6 w-6 cursor-pointer items-center justify-center rounded-md hover:bg-white/10"
         title="Text colour"
       >
         <span
           aria-hidden="true"
-          className="h-3.5 w-3.5 rounded-full border border-white/25"
+          className="h-4 w-4 rounded-full border-2 border-white/25 transition-transform duration-150 group-hover:scale-110 group-active:scale-95"
           // `background` maps a gradient to the PADDING box and then repeats it
           // to fill the border box, so the 1px border shows the strip either
           // side of the tile: the end colour on the left, the start colour on
@@ -119,7 +119,7 @@ export function InlineTextToolbar({
           type="color"
           aria-label="Text colour"
           className="absolute inset-0 h-full w-full min-w-0 cursor-pointer opacity-0"
-          value={toHexColor(styles.color ?? placement.colours[0]?.value)}
+          value={toHexColor(styles.color ?? placement.colours[0])}
           onChange={(event) => apply({ color: event.target.value })}
         />
       </label>
@@ -149,24 +149,23 @@ export function InlineTextToolbar({
 }
 
 /**
- * The selection's colours blended left to right, each sitting at the middle of
- * the share of characters that carry it. A selection with one colour is a plain
- * swatch, as before.
+ * The selection's colours as one swatch: a diagonal sweep through each distinct
+ * colour, evenly spaced. A selection with one colour is a plain swatch.
+ *
+ * Distinct rather than weighted, and evenly spaced rather than proportional,
+ * matching the mixed-colour swatch in the design tool this sits alongside. The
+ * swatch answers "which colours are in here", and at 16px a colour used by one
+ * character has to be as visible as one used by thirty or it may as well not be
+ * drawn.
  */
-export function swatchBackground(
-  colours: Array<{ value: string; chars: number }>,
-  agreed: string | undefined,
-): string {
-  if (colours.length === 0) return agreed || DEFAULT_COLOR;
-  if (colours.length === 1) return colours[0]!.value;
-  const total = colours.reduce((sum, colour) => sum + colour.chars, 0);
-  let offset = 0;
-  const stops = colours.map((colour) => {
-    const middle = ((offset + colour.chars / 2) / total) * 100;
-    offset += colour.chars;
-    return `${colour.value} ${middle.toFixed(2)}%`;
-  });
-  return `linear-gradient(90deg, ${stops.join(", ")})`;
+export function swatchBackground(colours: readonly string[], agreed: string | undefined): string {
+  const distinct = [...new Set(colours)];
+  if (distinct.length === 0) return agreed || DEFAULT_COLOR;
+  if (distinct.length === 1) return distinct[0]!;
+  const stops = distinct.map(
+    (colour, index) => `${colour} ${((index / (distinct.length - 1)) * 100).toFixed(2)}%`,
+  );
+  return `linear-gradient(135deg, ${stops.join(", ")})`;
 }
 
 function swallow(event: { preventDefault: () => void; stopPropagation: () => void }): void {

--- a/packages/studio/src/components/editor/inlineTextStyleRange.test.ts
+++ b/packages/studio/src/components/editor/inlineTextStyleRange.test.ts
@@ -704,18 +704,13 @@ describe("readInlineStyleSpread", () => {
       '<span style="color: red">Hello</span><span style="color: lime">world</span>',
     );
 
-    expect(readInlineStyleSpread(rangeOver(host, 0, 10), "color")).toEqual([
-      { value: "red", chars: 5 },
-      { value: "lime", chars: 5 },
-    ]);
+    expect(readInlineStyleSpread(rangeOver(host, 0, 10), "color")).toEqual(["red", "lime"]);
   });
 
-  it("collapses characters that share a colour into one band", () => {
+  it("reports a colour once, however many characters carry it", () => {
     const host = mount('<span style="color: red">He</span><span style="color: red">llo</span>');
 
-    expect(readInlineStyleSpread(rangeOver(host, 0, 5), "color")).toEqual([
-      { value: "red", chars: 5 },
-    ]);
+    expect(readInlineStyleSpread(rangeOver(host, 0, 5), "color")).toEqual(["red"]);
   });
 
   it("reports only what the selection covers", () => {
@@ -723,9 +718,7 @@ describe("readInlineStyleSpread", () => {
       '<span style="color: red">Hello</span><span style="color: lime">world</span>',
     );
 
-    expect(readInlineStyleSpread(rangeOver(host, 6, 10), "color")).toEqual([
-      { value: "lime", chars: 4 },
-    ]);
+    expect(readInlineStyleSpread(rangeOver(host, 6, 10), "color")).toEqual(["lime"]);
   });
 
   it("ignores whitespace, which shows no colour at all", () => {
@@ -738,10 +731,7 @@ describe("readInlineStyleSpread", () => {
         '<span style="color: lime"> world</span>',
     );
 
-    expect(readInlineStyleSpread(rangeOver(host, 0, 12), "color")).toEqual([
-      { value: "red", chars: 5 },
-      { value: "lime", chars: 5 },
-    ]);
+    expect(readInlineStyleSpread(rangeOver(host, 0, 12), "color")).toEqual(["red", "lime"]);
   });
 
   it("is empty when the characters carry no colour of their own", () => {

--- a/packages/studio/src/components/editor/inlineTextStyleRange.test.ts
+++ b/packages/studio/src/components/editor/inlineTextStyleRange.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { applyInlineStyle, readInlineStyle, readInlineStyleSpread } from "./inlineTextStyleRange";
+import { applyInlineStyle } from "./inlineTextStyleRange";
+import { readInlineStyle, readInlineStyleSpread } from "./inlineTextStyleRead";
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/packages/studio/src/components/editor/inlineTextStyleRange.test.ts
+++ b/packages/studio/src/components/editor/inlineTextStyleRange.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { applyInlineStyle, readInlineStyle } from "./inlineTextStyleRange";
+import { applyInlineStyle, readInlineStyle, readInlineStyleSpread } from "./inlineTextStyleRange";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -695,5 +695,42 @@ describe("applyInlineStyle when something else is painting the glyphs", () => {
     if (live) applyInlineStyle(live, { "font-weight": "700" });
 
     expect(host.innerHTML).not.toContain("-webkit-text-fill-color");
+  });
+});
+
+describe("readInlineStyleSpread", () => {
+  it("reports every colour in the selection, in order, with its share", () => {
+    const host = mount(
+      '<span style="color: red">Hello</span><span style="color: lime">world</span>',
+    );
+
+    expect(readInlineStyleSpread(rangeOver(host, 0, 10), "color")).toEqual([
+      { value: "red", chars: 5 },
+      { value: "lime", chars: 5 },
+    ]);
+  });
+
+  it("collapses characters that share a colour into one band", () => {
+    const host = mount('<span style="color: red">He</span><span style="color: red">llo</span>');
+
+    expect(readInlineStyleSpread(rangeOver(host, 0, 5), "color")).toEqual([
+      { value: "red", chars: 5 },
+    ]);
+  });
+
+  it("reports only what the selection covers", () => {
+    const host = mount(
+      '<span style="color: red">Hello</span><span style="color: lime">world</span>',
+    );
+
+    expect(readInlineStyleSpread(rangeOver(host, 6, 10), "color")).toEqual([
+      { value: "lime", chars: 4 },
+    ]);
+  });
+
+  it("is empty when the characters carry no colour of their own", () => {
+    const host = mount("Hello world");
+
+    expect(readInlineStyleSpread(rangeOver(host, 0, 5), "color")).toEqual([]);
   });
 });

--- a/packages/studio/src/components/editor/inlineTextStyleRange.test.ts
+++ b/packages/studio/src/components/editor/inlineTextStyleRange.test.ts
@@ -699,7 +699,7 @@ describe("applyInlineStyle when something else is painting the glyphs", () => {
 });
 
 describe("readInlineStyleSpread", () => {
-  it("reports every colour in the selection, in order, with its share", () => {
+  it("reports every distinct colour in the selection, in order", () => {
     const host = mount(
       '<span style="color: red">Hello</span><span style="color: lime">world</span>',
     );

--- a/packages/studio/src/components/editor/inlineTextStyleRange.test.ts
+++ b/packages/studio/src/components/editor/inlineTextStyleRange.test.ts
@@ -728,6 +728,22 @@ describe("readInlineStyleSpread", () => {
     ]);
   });
 
+  it("ignores whitespace, which shows no colour at all", () => {
+    // Colour the whole element, then recolour one word: the whitespace around it
+    // keeps the first colour. It paints no glyph, so counting it puts a band of a
+    // colour nothing on screen is painted in at the edge of the swatch.
+    const host = mount(
+      '<span style="color: lime"> </span>' +
+        '<span style="color: red">Hello</span>' +
+        '<span style="color: lime"> world</span>',
+    );
+
+    expect(readInlineStyleSpread(rangeOver(host, 0, 12), "color")).toEqual([
+      { value: "red", chars: 5 },
+      { value: "lime", chars: 5 },
+    ]);
+  });
+
   it("is empty when the characters carry no colour of their own", () => {
     const host = mount("Hello world");
 

--- a/packages/studio/src/components/editor/inlineTextStyleRange.ts
+++ b/packages/studio/src/components/editor/inlineTextStyleRange.ts
@@ -188,25 +188,57 @@ function holdsBothEnds(host: Element, range: Range): boolean {
  * agrees about it, which is what a control can honestly display.
  */
 export function readInlineStyle(range: Range, properties: string[]): Record<string, string> {
-  const host = editingHost(range.startContainer);
-  if (!host || !holdsBothEnds(host, range)) return {};
-  const start = offsetOf(host, range.startContainer, range.startOffset);
-  const end = offsetOf(host, range.endContainer, range.endOffset);
-  if (start === null || end === null) return {};
-
-  const collapsed = start === end;
-  const covered = charRuns(readRuns(host))
-    .slice(collapsed ? Math.max(0, start - 1) : start, collapsed ? Math.max(1, start) : end)
-    .map((entry) => entry.style);
-  if (covered.length === 0) return {};
+  const covered = coveredStyles(range);
+  if (!covered) return {};
 
   const styles: Record<string, string> = {};
   for (const property of properties) {
-    const first = covered[0]?.[property];
+    const first: string | undefined = covered[0]?.[property];
     if (first === undefined) continue;
     if (covered.every((style) => style[property] === first)) styles[property] = first;
   }
   return styles;
+}
+
+/**
+ * What one property looks like across the range, in document order, as runs of
+ * consecutive characters that share a value: `[{ value: "red", chars: 5 },
+ * { value: "lime", chars: 6 }]`.
+ *
+ * `readInlineStyle` above answers "what is this range" and reports nothing when
+ * the range disagrees with itself — right for a toggle, which can only be on or
+ * off. A swatch can show more than one value at once, and showing the default
+ * instead reads as "this text is white" when none of it is.
+ */
+export function readInlineStyleSpread(
+  range: Range,
+  property: string,
+): Array<{ value: string; chars: number }> {
+  const covered = coveredStyles(range);
+  if (!covered) return [];
+  const spread: Array<{ value: string; chars: number }> = [];
+  for (const style of covered) {
+    const value = style[property];
+    if (value === undefined) continue;
+    const last = spread.at(-1);
+    if (last?.value === value) last.chars++;
+    else spread.push({ value, chars: 1 });
+  }
+  return spread;
+}
+
+/** The style of every character the range covers, or null when it covers none. */
+function coveredStyles(range: Range): Array<Record<string, string>> | null {
+  const host = editingHost(range.startContainer);
+  if (!host || !holdsBothEnds(host, range)) return null;
+  const start = offsetOf(host, range.startContainer, range.startOffset);
+  const end = offsetOf(host, range.endContainer, range.endOffset);
+  if (start === null || end === null) return null;
+  const collapsed = start === end;
+  const covered = charRuns(readRuns(host))
+    .slice(collapsed ? Math.max(0, start - 1) : start, collapsed ? Math.max(1, start) : end)
+    .map((entry) => entry.style);
+  return covered.length > 0 ? covered : null;
 }
 
 /**

--- a/packages/studio/src/components/editor/inlineTextStyleRange.ts
+++ b/packages/studio/src/components/editor/inlineTextStyleRange.ts
@@ -182,55 +182,13 @@ function holdsBothEnds(host: Element, range: Range): boolean {
   return host.contains(range.startContainer) && host.contains(range.endContainer);
 }
 
-/**
- * What the range is styled with, for a toolbar that has to open showing the
- * truth rather than a default. Reports a property only when the whole range
- * agrees about it, which is what a control can honestly display.
- */
-export function readInlineStyle(range: Range, properties: string[]): Record<string, string> {
-  const chars = coveredChars(range);
-  if (!chars) return {};
-  const covered = chars.map((entry) => entry.style);
-
-  const styles: Record<string, string> = {};
-  for (const property of properties) {
-    const first: string | undefined = covered[0]?.[property];
-    if (first === undefined) continue;
-    if (covered.every((style) => style[property] === first)) styles[property] = first;
-  }
-  return styles;
-}
-
-/**
- * The distinct values one property takes across the range, in document order:
- * `["red", "lime"]`.
- *
- * `readInlineStyle` above answers "what is this range" and reports nothing when
- * the range disagrees with itself — right for a toggle, which can only be on or
- * off. A swatch can show more than one value at once, and showing the default
- * instead reads as "this text is white" when none of it is.
- */
-export function readInlineStyleSpread(range: Range, property: string): string[] {
-  const covered = coveredChars(range);
-  if (!covered) return [];
-  const seen = new Set<string>();
-  const spread: string[] = [];
-  for (const { char, style } of covered) {
-    // A space paints nothing, so the colour it inherits is not a colour anyone
-    // can see. Counting it puts the element's own colour in the swatch for text
-    // that shows none of it — the stray band on a selection that happens to
-    // start or end next to a space.
-    if (!char.trim()) continue;
-    const value = style[property];
-    if (value === undefined || seen.has(value)) continue;
-    seen.add(value);
-    spread.push(value);
-  }
-  return spread;
+export interface InlineStyleChar {
+  char: string;
+  style: Readonly<Record<string, string>>;
 }
 
 /** Every character the range covers with its style, or null when it covers none. */
-function coveredChars(range: Range): Array<{ char: string; style: Record<string, string> }> | null {
+export function readCoveredInlineStyleChars(range: Range): readonly InlineStyleChar[] | null {
   const host = editingHost(range.startContainer);
   if (!host || !holdsBothEnds(host, range)) return null;
   const start = offsetOf(host, range.startContainer, range.startOffset);

--- a/packages/studio/src/components/editor/inlineTextStyleRange.ts
+++ b/packages/studio/src/components/editor/inlineTextStyleRange.ts
@@ -202,33 +202,29 @@ export function readInlineStyle(range: Range, properties: string[]): Record<stri
 }
 
 /**
- * What one property looks like across the range, in document order, as runs of
- * consecutive characters that share a value: `[{ value: "red", chars: 5 },
- * { value: "lime", chars: 6 }]`.
+ * The distinct values one property takes across the range, in document order:
+ * `["red", "lime"]`.
  *
  * `readInlineStyle` above answers "what is this range" and reports nothing when
  * the range disagrees with itself — right for a toggle, which can only be on or
  * off. A swatch can show more than one value at once, and showing the default
  * instead reads as "this text is white" when none of it is.
  */
-export function readInlineStyleSpread(
-  range: Range,
-  property: string,
-): Array<{ value: string; chars: number }> {
+export function readInlineStyleSpread(range: Range, property: string): string[] {
   const covered = coveredChars(range);
   if (!covered) return [];
-  const spread: Array<{ value: string; chars: number }> = [];
+  const seen = new Set<string>();
+  const spread: string[] = [];
   for (const { char, style } of covered) {
     // A space paints nothing, so the colour it inherits is not a colour anyone
-    // can see. Counting it puts a band of the element's own colour in the swatch
-    // for text that shows none of it — the stray edge on a selection that just
-    // happens to start or end next to a space.
+    // can see. Counting it puts the element's own colour in the swatch for text
+    // that shows none of it — the stray band on a selection that happens to
+    // start or end next to a space.
     if (!char.trim()) continue;
     const value = style[property];
-    if (value === undefined) continue;
-    const last = spread.at(-1);
-    if (last?.value === value) last.chars++;
-    else spread.push({ value, chars: 1 });
+    if (value === undefined || seen.has(value)) continue;
+    seen.add(value);
+    spread.push(value);
   }
   return spread;
 }

--- a/packages/studio/src/components/editor/inlineTextStyleRange.ts
+++ b/packages/studio/src/components/editor/inlineTextStyleRange.ts
@@ -188,8 +188,9 @@ function holdsBothEnds(host: Element, range: Range): boolean {
  * agrees about it, which is what a control can honestly display.
  */
 export function readInlineStyle(range: Range, properties: string[]): Record<string, string> {
-  const covered = coveredStyles(range);
-  if (!covered) return {};
+  const chars = coveredChars(range);
+  if (!chars) return {};
+  const covered = chars.map((entry) => entry.style);
 
   const styles: Record<string, string> = {};
   for (const property of properties) {
@@ -214,10 +215,15 @@ export function readInlineStyleSpread(
   range: Range,
   property: string,
 ): Array<{ value: string; chars: number }> {
-  const covered = coveredStyles(range);
+  const covered = coveredChars(range);
   if (!covered) return [];
   const spread: Array<{ value: string; chars: number }> = [];
-  for (const style of covered) {
+  for (const { char, style } of covered) {
+    // A space paints nothing, so the colour it inherits is not a colour anyone
+    // can see. Counting it puts a band of the element's own colour in the swatch
+    // for text that shows none of it — the stray edge on a selection that just
+    // happens to start or end next to a space.
+    if (!char.trim()) continue;
     const value = style[property];
     if (value === undefined) continue;
     const last = spread.at(-1);
@@ -227,8 +233,8 @@ export function readInlineStyleSpread(
   return spread;
 }
 
-/** The style of every character the range covers, or null when it covers none. */
-function coveredStyles(range: Range): Array<Record<string, string>> | null {
+/** Every character the range covers with its style, or null when it covers none. */
+function coveredChars(range: Range): Array<{ char: string; style: Record<string, string> }> | null {
   const host = editingHost(range.startContainer);
   if (!host || !holdsBothEnds(host, range)) return null;
   const start = offsetOf(host, range.startContainer, range.startOffset);
@@ -237,7 +243,7 @@ function coveredStyles(range: Range): Array<Record<string, string>> | null {
   const collapsed = start === end;
   const covered = charRuns(readRuns(host))
     .slice(collapsed ? Math.max(0, start - 1) : start, collapsed ? Math.max(1, start) : end)
-    .map((entry) => entry.style);
+    .map((entry) => ({ char: entry.char, style: entry.style }));
   return covered.length > 0 ? covered : null;
 }
 
@@ -341,11 +347,18 @@ function ownStyle(element: HTMLElement): Record<string, string> {
 }
 
 /** One entry per character, which is the easiest thing to slice and compare. */
-function charRuns(runs: StyledRun[]): Array<Omit<StyledRun, "text">> {
-  const perChar: Array<Omit<StyledRun, "text">> = [];
+function charRuns(runs: StyledRun[]): Array<Omit<StyledRun, "text"> & { char: string }> {
+  const perChar: Array<Omit<StyledRun, "text"> & { char: string }> = [];
   for (const run of runs) {
+    // By UTF-16 unit, not code point: `restyle` indexes this list with selection
+    // offsets, which count units, so an emoji has to stay two entries long.
     for (let index = 0; index < run.text.length; index += 1) {
-      perChar.push({ style: run.style, origin: run.origin, identity: run.identity });
+      perChar.push({
+        char: run.text[index] ?? "",
+        style: run.style,
+        origin: run.origin,
+        identity: run.identity,
+      });
     }
   }
   return perChar;

--- a/packages/studio/src/components/editor/inlineTextStyleRead.ts
+++ b/packages/studio/src/components/editor/inlineTextStyleRead.ts
@@ -1,0 +1,47 @@
+import { readCoveredInlineStyleChars } from "./inlineTextStyleRange";
+
+/**
+ * What the range is styled with, for a toolbar that has to open showing the
+ * truth rather than a default. Reports a property only when the whole range
+ * agrees about it, which is what a control can honestly display.
+ */
+export function readInlineStyle(range: Range, properties: string[]): Record<string, string> {
+  const chars = readCoveredInlineStyleChars(range);
+  if (!chars) return {};
+
+  const styles: Record<string, string> = {};
+  for (const property of properties) {
+    const first: string | undefined = chars[0]?.style[property];
+    if (first === undefined) continue;
+    if (chars.every(({ style }) => style[property] === first)) styles[property] = first;
+  }
+  return styles;
+}
+
+/**
+ * The distinct values one property takes across the range, in document order:
+ * `["red", "lime"]`.
+ *
+ * `readInlineStyle` above answers "what is this range" and reports nothing when
+ * the range disagrees with itself — right for a toggle, which can only be on or
+ * off. A swatch can show more than one value at once, and showing the default
+ * instead reads as "this text is white" when none of it is.
+ */
+export function readInlineStyleSpread(range: Range, property: string): string[] {
+  const covered = readCoveredInlineStyleChars(range);
+  if (!covered) return [];
+  const seen = new Set<string>();
+  const spread: string[] = [];
+  for (const { char, style } of covered) {
+    // A space paints nothing, so the colour it inherits is not a colour anyone
+    // can see. Counting it puts the element's own colour in the swatch for text
+    // that shows none of it — the stray band on a selection that happens to
+    // start or end next to a space.
+    if (!char.trim()) continue;
+    const value = style[property];
+    if (value === undefined || seen.has(value)) continue;
+    seen.add(value);
+    spread.push(value);
+  }
+  return spread;
+}

--- a/packages/studio/src/hooks/useInlineTextEdit.test.tsx
+++ b/packages/studio/src/hooks/useInlineTextEdit.test.tsx
@@ -103,6 +103,27 @@ describe("useInlineTextEdit", () => {
     act(() => root.unmount());
   });
 
+  it("drops a selection dragged across the edited element's boundary", () => {
+    const element = heading("Hello world");
+    const outsider = heading("somewhere else");
+    const { controls, root } = mount();
+
+    act(() => {
+      controls().start(element);
+    });
+    const range = document.createRange();
+    range.setStart(element.firstChild!, 6);
+    range.setEnd(outsider.firstChild!, 4);
+    const selection = document.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    act(() => controls().commit());
+
+    expect(selection.toString()).toBe("");
+    act(() => root.unmount());
+  });
+
   it("makes the element editable, and focuses it once the press has finished", async () => {
     const element = heading();
     const { controls, root, onPause } = mount();

--- a/packages/studio/src/hooks/useInlineTextEdit.test.tsx
+++ b/packages/studio/src/hooks/useInlineTextEdit.test.tsx
@@ -54,6 +54,55 @@ describe("useInlineTextEdit", () => {
     act(() => root.unmount());
   });
 
+  /**
+   * Removing contenteditable and blurring does not drop the browser's own
+   * highlight, so a word picked with a double press stayed painted grey after
+   * the click that closed the edit — text that reads as selected in an element
+   * that is no longer being edited.
+   */
+  it("drops the highlight when the edit closes", () => {
+    const element = heading("Hello world, style me");
+    const { controls, root } = mount();
+
+    act(() => {
+      controls().start(element);
+    });
+    // Select "world", the way a double press inside the text does.
+    const text = element.firstChild!;
+    const range = document.createRange();
+    range.setStart(text, 6);
+    range.setEnd(text, 11);
+    const selection = document.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    expect(selection.toString()).toBe("world");
+
+    act(() => controls().commit());
+
+    expect(selection.toString()).toBe("");
+    act(() => root.unmount());
+  });
+
+  it("leaves a selection outside the edited element alone", () => {
+    const element = heading("Hello world, style me");
+    const outsider = heading("somewhere else entirely");
+    const { controls, root } = mount();
+
+    act(() => {
+      controls().start(element);
+    });
+    const range = document.createRange();
+    range.selectNodeContents(outsider);
+    const selection = document.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    act(() => controls().commit());
+
+    expect(selection.toString()).toBe("somewhere else entirely");
+    act(() => root.unmount());
+  });
+
   it("makes the element editable, and focuses it once the press has finished", async () => {
     const element = heading();
     const { controls, root, onPause } = mount();

--- a/packages/studio/src/hooks/useInlineTextEdit.ts
+++ b/packages/studio/src/hooks/useInlineTextEdit.ts
@@ -66,6 +66,20 @@ export interface InlineTextEditControls {
   cancel: () => void;
 }
 
+/**
+ * Drop the text selection, but only when it lives inside this element.
+ *
+ * A selection somewhere else in the preview belongs to whatever put it there
+ * and is not this session's to clear.
+ */
+function clearSelectionWithin(element: HTMLElement): void {
+  const selection = element.ownerDocument.defaultView?.getSelection();
+  if (!selection || selection.rangeCount === 0) return;
+  const range = selection.getRangeAt(0);
+  if (!element.contains(range.commonAncestorContainer)) return;
+  selection.removeAllRanges();
+}
+
 export function useInlineTextEdit({
   onCommit,
   onPause,
@@ -98,6 +112,10 @@ export function useInlineTextEdit({
       // Restored rather than cleared: the composition may have authored one.
       open.element.style.outline = open.outline;
       open.element.style.outlineOffset = open.outlineOffset;
+      // Drop the highlight too. Removing contenteditable and blurring leaves a
+      // selection made inside the element painted on screen, so a word picked
+      // with a double press stayed grey after the click that closed the edit.
+      clearSelectionWithin(open.element);
       open.element.blur();
     }
     return open;

--- a/packages/studio/src/hooks/useInlineTextEdit.ts
+++ b/packages/studio/src/hooks/useInlineTextEdit.ts
@@ -76,7 +76,7 @@ function clearSelectionWithin(element: HTMLElement): void {
   const selection = element.ownerDocument.defaultView?.getSelection();
   if (!selection || selection.rangeCount === 0) return;
   const range = selection.getRangeAt(0);
-  if (!element.contains(range.commonAncestorContainer)) return;
+  if (!element.contains(range.startContainer) && !element.contains(range.endContainer)) return;
   selection.removeAllRanges();
 }
 


### PR DESCRIPTION
## What

The inline text toolbar shows every distinct colour in a mixed selection instead of falling back to white.

## Why

The toolbar reports a property only when the whole selection agrees on it. That is right for toggles such as bold and italic, but a colour swatch can represent several values at once. Falling back to the default made mixed text report a colour that was not selected.

## How

- Read distinct inline colours in document order while excluding whitespace, which paints no glyph.
- Render an evenly spaced 135-degree sweep so even a colour used by one character remains visible in the compact swatch.
- Anchor the gradient to the border box so it does not repeat beneath the ring.
- Normalize shorthand, functional, transparent, and named CSS colours for the native colour input.
- Clear selections owned by a closing inline-edit session, including selections dragged across its boundary, while preserving unrelated selections.

## Test plan

- 114 focused toolbar, style-range, and edit-session tests
- Full Studio suite: 3,791 passed, 18 todo
- Studio typecheck, oxlint, and oxfmt checks
- Codex in-app-browser E2E with `rich-text-demo`: mixed diagonal swatch, border-box paint, colour-picker value, selection preserved through formatting, source persistence, selection cleanup, and no preview reload
