### PR TITLE
chore: release v0.7.104

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,21 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.104"
+  description="Released - 2026-08-10"
+  tags={["Release", "Studio"]}
+>
+Selecting and moving elements in Studio's canvas now behaves the way it looks. Multi-selection sticks, a dragged group lands where you dropped it, a resized element keeps its size, and editing no longer flashes the preview.
+
+## Fixes
+
+- **Studio:** Canvas selection, drag and resize correctness ([17ac986bf](https://github.com/heygen-com/hyperframes/commit/17ac986bfe0fffbbc8aac2a68b9e9814f561b562), [#3146](https://github.com/heygen-com/hyperframes/pull/3146)).
+- **Studio:** Stop a Studio edit from reloading the preview ([bea32b8aa](https://github.com/heygen-com/hyperframes/commit/bea32b8aae5bd9008c5fbe453a17a8a4588365ba), [#3137](https://github.com/heygen-com/hyperframes/pull/3137)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.103...v0.7.104).
+</Update>
+
+<Update
   label="HyperFrames v0.7.103"
   description="Released - 2026-08-09"
   tags={["Release", "Core", "Core,cli"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.103",
+  "version": "0.7.104",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.104.md
+++ b/releases/v0.7.104.md
@@ -1,0 +1,14 @@
+# HyperFrames v0.7.104
+
+Released on 2026-08-10.
+
+Selecting and moving elements in Studio's canvas now behaves the way it looks. Multi-selection sticks, a dragged group lands where you dropped it, a resized element keeps its size, and editing no longer flashes the preview.
+
+## Fixes
+
+- **Studio:** Canvas selection, drag and resize correctness ([17ac986bf](https://github.com/heygen-com/hyperframes/commit/17ac986bfe0fffbbc8aac2a68b9e9814f561b562), [#3146](https://github.com/heygen-com/hyperframes/pull/3146)).
+- **Studio:** Stop a Studio edit from reloading the preview ([bea32b8aa](https://github.com/heygen-com/hyperframes/commit/bea32b8aae5bd9008c5fbe453a17a8a4588365ba), [#3137](https://github.com/heygen-com/hyperframes/pull/3137)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.103...v0.7.104


### PR DESCRIPTION
## What

Stable release v0.7.104.

## Why

Ships the Studio canvas correctness work that landed in #3137 and #3146.

## How

`bun run release:prepare 0.7.104` — version bump across the workspace, `releases/v0.7.104.md`, and the changelog entry. Merging this publishes: the workflow tags the merge SHA, publishes npm and cuts the GitHub release.

## Test plan

- Release contents are the two Studio fixes already merged and green on main
- No source changes in this PR beyond version bumps and changelog copy