### PR TITLE
chore: release v0.7.105

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,30 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.105"
+  description="Released - 2026-08-10"
+  tags={["Release", "Producer,engine", "CLI", "Scripts"]}
+>
+Catalog search now understands meaning, not just keywords, and runs entirely on your machine. Finding the right block no longer depends on guessing its name.
+
+## Features
+
+- **Scripts:** Fail a branch that deletes files main still ships ([f28bc80a1](https://github.com/heygen-com/hyperframes/commit/f28bc80a1d9c238ecaf36d8a5fee13933a3824fb), [#3150](https://github.com/heygen-com/hyperframes/pull/3150)).
+- **Scripts:** Typecheck the scripts directory ([79dff2051](https://github.com/heygen-com/hyperframes/commit/79dff2051699c9bae28088eb795c4cbebff6dde1), [#3149](https://github.com/heygen-com/hyperframes/pull/3149)).
+
+## Fixes
+
+- **Producer,engine:** Stop mislabelling capture mode, and name the silent drawElement refusals ([33ac86fd3](https://github.com/heygen-com/hyperframes/commit/33ac86fd3842f5f40cc66033fd8ad06d0c495c44), [#3151](https://github.com/heygen-com/hyperframes/pull/3151)).
+- **CLI:** Follow every redirect a host may answer with ([db3de4c1b](https://github.com/heygen-com/hyperframes/commit/db3de4c1bf2fa8e093aeb26c67f79e352ef5af89), [#3148](https://github.com/heygen-com/hyperframes/pull/3148)).
+
+## Catalog
+
+- **CLI:** Search the catalog by meaning, on this machine ([68205dbbc](https://github.com/heygen-com/hyperframes/commit/68205dbbc159412209663ede7732629b4f50bcf1), [#3089](https://github.com/heygen-com/hyperframes/pull/3089)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.104...v0.7.105).
+</Update>
+
+<Update
   label="HyperFrames v0.7.104"
   description="Released - 2026-08-10"
   tags={["Release", "Studio"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.104",
+  "version": "0.7.105",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.105.md
+++ b/releases/v0.7.105.md
@@ -1,0 +1,23 @@
+# HyperFrames v0.7.105
+
+Released on 2026-08-10.
+
+Catalog search now understands meaning, not just keywords, and runs entirely on your machine. Finding the right block no longer depends on guessing its name.
+
+## Features
+
+- **Scripts:** Fail a branch that deletes files main still ships ([f28bc80a1](https://github.com/heygen-com/hyperframes/commit/f28bc80a1d9c238ecaf36d8a5fee13933a3824fb), [#3150](https://github.com/heygen-com/hyperframes/pull/3150)).
+- **Scripts:** Typecheck the scripts directory ([79dff2051](https://github.com/heygen-com/hyperframes/commit/79dff2051699c9bae28088eb795c4cbebff6dde1), [#3149](https://github.com/heygen-com/hyperframes/pull/3149)).
+
+## Fixes
+
+- **Producer,engine:** Stop mislabelling capture mode, and name the silent drawElement refusals ([33ac86fd3](https://github.com/heygen-com/hyperframes/commit/33ac86fd3842f5f40cc66033fd8ad06d0c495c44), [#3151](https://github.com/heygen-com/hyperframes/pull/3151)).
+- **CLI:** Follow every redirect a host may answer with ([db3de4c1b](https://github.com/heygen-com/hyperframes/commit/db3de4c1bf2fa8e093aeb26c67f79e352ef5af89), [#3148](https://github.com/heygen-com/hyperframes/pull/3148)).
+
+## Catalog
+
+- **CLI:** Search the catalog by meaning, on this machine ([68205dbbc](https://github.com/heygen-com/hyperframes/commit/68205dbbc159412209663ede7732629b4f50bcf1), [#3089](https://github.com/heygen-com/hyperframes/pull/3089)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.104...v0.7.105


### PR DESCRIPTION
Release v0.7.105.

## User-facing change

**Catalog search now understands meaning, not just keywords, and runs entirely on your machine** (#3089). Finding the right block no longer depends on guessing its name.

Also: downloads follow every redirect a host may answer with (#3148), so fetches that previously died on a redirect chain now complete.

## Observability correction (no behaviour change)

#3151 fixes two telemetry defects found while auditing the fast-capture dashboard. Neither changes how anything renders — only what renders report about themselves — but both were corrupting the data the drawElement roadmap is being planned from:

- **`captureMode` reported `beginframe` on hosts that cannot run it.** BeginFrame is Linux-only, enforced in both real entry points, but the observability field derived the mode from `forceScreenshot` alone. That mislabelled **30,625 Windows renders over 14 days** — about a fifth of the dashboard's capture-mode data — as BeginFrame when they were really screenshot.
- **Renders that never became drawElement candidates carried no reason at all.** Every `resolveDefaultDrawElement` branch returned a bare `false`, and the orchestrator's clamp only fires while `useDrawElement` is still true, so a config-time refusal could never acquire a reason by construction. **56,507 renders over 14 days** sat in the "Why not drawElement" chart's unnamed bucket. They now report `unsupported_platform`, `software_gpu`, `worker_encode_off` or `disabled`.

Worth knowing for anyone reading the fast-capture dashboard: the capture-mode field is now correct on non-Linux, but on Linux it remains an upper bound — the platform test is the only condition modelled, while real BeginFrame also needs a headless-shell binary, no supersampling, no transparent drawElement route and `--enable-begin-frame-control`. Deriving the field from the session's own `launchCaptureMode` is the tracked follow-up.

## Also in this release

- **Scripts:** fail a branch that deletes files main still ships (#3150)
- **Scripts:** typecheck the scripts directory (#3149)

Full changelog: https://github.com/heygen-com/hyperframes/compare/v0.7.104...v0.7.105
