### PR TITLE
fix(studio): read the rotate property when measuring an element's angle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/aws-lambda": {
       "name": "@hyperframes/aws-lambda",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/client-sfn": "^3.700.0",
@@ -57,7 +57,7 @@
     },
     "packages/cli": {
       "name": "@hyperframes/cli",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "bin": {
         "hyperframes": "./bin/hyperframes.mjs",
       },
@@ -107,7 +107,7 @@
     },
     "packages/core": {
       "name": "@hyperframes/core",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "dependencies": {
         "@chenglou/pretext": "^0.0.5",
         "@hyperframes/lint": "workspace:*",
@@ -132,7 +132,7 @@
     },
     "packages/engine": {
       "name": "@hyperframes/engine",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "dependencies": {
         "@hono/node-server": "^2.0.5",
         "@hyperframes/core": "workspace:^",
@@ -151,7 +151,7 @@
     },
     "packages/gcp-cloud-run": {
       "name": "@hyperframes/gcp-cloud-run",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "dependencies": {
         "@google-cloud/storage": "^7.14.0",
         "@google-cloud/workflows": "^4.2.0",
@@ -172,7 +172,7 @@
     },
     "packages/lint": {
       "name": "@hyperframes/lint",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "dependencies": {
         "@hyperframes/parsers": "workspace:*",
         "htmlparser2": "^10.1.0",
@@ -190,7 +190,7 @@
     },
     "packages/parsers": {
       "name": "@hyperframes/parsers",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "dependencies": {
         "@babel/parser": "^7.27.0",
         "acorn": "^8.17.0",
@@ -210,7 +210,7 @@
     },
     "packages/player": {
       "name": "@hyperframes/player",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
       },
@@ -225,7 +225,7 @@
     },
     "packages/producer": {
       "name": "@hyperframes/producer",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "dependencies": {
         "@fontsource/archivo-black": "^5.2.8",
         "@fontsource/eb-garamond": "^5.2.7",
@@ -270,7 +270,7 @@
     },
     "packages/sdk": {
       "name": "@hyperframes/sdk",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "@hyperframes/parsers": "workspace:*",
@@ -300,7 +300,7 @@
     },
     "packages/shader-transitions": {
       "name": "@hyperframes/shader-transitions",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "dependencies": {
         "html2canvas": "^1.4.1",
       },
@@ -312,7 +312,7 @@
     },
     "packages/studio": {
       "name": "@hyperframes/studio",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.3",
@@ -344,6 +344,7 @@
         "@types/react-dom": "19",
         "@vitejs/plugin-react": "^4.0.0",
         "autoprefixer": "^10.4.0",
+        "chokidar": "^4.0.3",
         "fake-indexeddb": "^6.2.5",
         "postcss": "^8.4.0",
         "puppeteer-core": "^25.2.1",
@@ -362,7 +363,7 @@
     },
     "packages/studio-server": {
       "name": "@hyperframes/studio-server",
-      "version": "0.7.78",
+      "version": "0.7.105",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "@hyperframes/parsers": "workspace:*",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -85,6 +85,7 @@
     "@types/react-dom": "19",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.0",
+    "chokidar": "^4.0.3",
     "fake-indexeddb": "^6.2.5",
     "postcss": "^8.4.0",
     "puppeteer-core": "^25.2.1",

--- a/packages/studio/src/components/editor/DomEditSelectionChrome.test.tsx
+++ b/packages/studio/src/components/editor/DomEditSelectionChrome.test.tsx
@@ -69,10 +69,15 @@ describe("DomEditSelectionChrome crop composition", () => {
       offsetHeight: { value: 100 },
     });
     document.body.append(element);
-    vi.spyOn(window, "getComputedStyle").mockReturnValue({
-      clipPath: "inset(10px)",
-      transform: "matrix(0.8660254, 0.5, -0.5, 0.8660254, 0, 0)",
-    } as CSSStyleDeclaration);
+    // Per element, not blanket: the crop frame composes the element's transform
+    // with its ancestors', so answering "rotated 30deg" for every node in the
+    // document would have the frame read the same turn several times over.
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      ((node: Element) =>
+        (node === element
+          ? { clipPath: "inset(10px)", transform: "matrix(0.8660254, 0.5, -0.5, 0.8660254, 0, 0)" }
+          : { clipPath: "none", transform: "none" }) as CSSStyleDeclaration) as never,
+    );
     const selection = {
       element,
       id: "clip",

--- a/packages/studio/src/components/editor/DomEditSelectionChrome.test.tsx
+++ b/packages/studio/src/components/editor/DomEditSelectionChrome.test.tsx
@@ -8,6 +8,29 @@ import { DomEditSelectionChrome } from "./DomEditSelectionChrome";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
+/** A selection whose capabilities are all on or all off, plus a host to render into. */
+function selectionFixture(
+  element: HTMLElement,
+  selector: string,
+  enabled: boolean,
+  extra: Record<string, unknown> = {},
+) {
+  const selection = {
+    element,
+    selector,
+    ...extra,
+    capabilities: {
+      canCrop: enabled,
+      canApplyManualOffset: enabled,
+      canApplyManualSize: enabled,
+      canApplyManualRotation: enabled,
+    },
+  } as unknown as DomEditSelection;
+  const host = document.createElement("div");
+  document.body.append(host);
+  return { selection, host, root: createRoot(host) };
+}
+
 describe("DomEditSelectionChrome crop composition", () => {
   it("renders overlay-only transparent chrome at headline geometry without changing composition bytes", () => {
     const composition = document.implementation.createHTMLDocument();
@@ -18,19 +41,7 @@ describe("DomEditSelectionChrome crop composition", () => {
     `;
     const headline = composition.querySelector<HTMLElement>(".hl-text")!;
     const before = composition.documentElement.outerHTML;
-    const selection = {
-      element: headline,
-      selector: ".hl-text",
-      capabilities: {
-        canCrop: false,
-        canApplyManualOffset: false,
-        canApplyManualSize: false,
-        canApplyManualRotation: false,
-      },
-    } as unknown as DomEditSelection;
-    const host = document.createElement("div");
-    document.body.append(host);
-    const root = createRoot(host);
+    const { selection, host, root } = selectionFixture(headline, ".hl-text", false);
     act(() => {
       root.render(
         <DomEditSelectionChrome
@@ -78,20 +89,7 @@ describe("DomEditSelectionChrome crop composition", () => {
           ? { clipPath: "inset(10px)", transform: "matrix(0.8660254, 0.5, -0.5, 0.8660254, 0, 0)" }
           : { clipPath: "none", transform: "none" }) as CSSStyleDeclaration) as never,
     );
-    const selection = {
-      element,
-      id: "clip",
-      selector: "#clip",
-      capabilities: {
-        canCrop: true,
-        canApplyManualOffset: true,
-        canApplyManualSize: true,
-        canApplyManualRotation: true,
-      },
-    } as unknown as DomEditSelection;
-    const host = document.createElement("div");
-    document.body.append(host);
-    const root = createRoot(host);
+    const { selection, host, root } = selectionFixture(element, "#clip", true, { id: "clip" });
     act(() => {
       root.render(
         <DomEditSelectionChrome

--- a/packages/studio/src/components/editor/domEditOverlayCrop.test.ts
+++ b/packages/studio/src/components/editor/domEditOverlayCrop.test.ts
@@ -206,9 +206,44 @@ describe("readElementCropFrame", () => {
     expect(frame.height).toBeCloseTo(200, 3);
   });
 
-  it("3D transform falls back to the axis-aligned frame", () => {
+  /**
+   * A 3D matrix is not automatically unmeasurable. GSAP writes one for an
+   * ordinary 2D move or spin (force3D), so refusing every `matrix3d` drew the
+   * crop outline square on elements the rest of the chrome drew rotated.
+   * The identity here is a 2D transform written the long way.
+   */
+  it("reads a planar matrix3d rather than giving up on it", () => {
     const frame = readElementCropFrame(
       fakeEl("matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)"),
+      overlayRect,
+    );
+    expect(frame.angleDeg).toBe(0);
+    // The element's own box, centred on the overlay rect, not the rect itself.
+    expect(frame.width).toBeCloseTo(200, 6);
+    expect(frame.height).toBeCloseTo(100, 6);
+  });
+
+  it("reads a 2D rotation written as matrix3d", () => {
+    const frame = readElementCropFrame(
+      fakeEl("matrix3d(0.866025,0.5,0,0,-0.5,0.866025,0,0,0,0,1,0,0,0,0,1)"),
+      overlayRect,
+    );
+    expect(frame.angleDeg).toBeCloseTo(30, 3);
+  });
+
+  it("reads a flipped element, which still has a real size", () => {
+    // Negative z scale — a composition that mirrors an element writes this.
+    const frame = readElementCropFrame(
+      fakeEl("matrix3d(-0.866025,-0.5,0,0,-0.5,0.866025,0,0,0,0,-1,0,0,0,0,1)"),
+      overlayRect,
+    );
+    expect(frame.width).toBeGreaterThan(0);
+    expect(frame.height).toBeGreaterThan(0);
+  });
+
+  it("still falls back on a perspective transform, which no single angle describes", () => {
+    const frame = readElementCropFrame(
+      fakeEl("matrix3d(1,0,0,0.002,0,1,0,0,0,0,1,0,0,0,0,1)"),
       overlayRect,
     );
     expect(frame).toEqual({

--- a/packages/studio/src/components/editor/domEditOverlayCrop.test.ts
+++ b/packages/studio/src/components/editor/domEditOverlayCrop.test.ts
@@ -213,14 +213,13 @@ describe("readElementCropFrame", () => {
    * The identity here is a 2D transform written the long way.
    */
   it("reads a planar matrix3d rather than giving up on it", () => {
+    // scale(1.5, 2) written the long way — planar, and not the identity.
     const frame = readElementCropFrame(
-      fakeEl("matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)"),
+      fakeEl("matrix3d(1.5,0,0,0,0,2,0,0,0,0,1,0,0,0,0,1)"),
       overlayRect,
     );
-    expect(frame.angleDeg).toBe(0);
-    // The element's own box, centred on the overlay rect, not the rect itself.
-    expect(frame.width).toBeCloseTo(200, 6);
-    expect(frame.height).toBeCloseTo(100, 6);
+    expect(frame.scaleX).toBeCloseTo(1.5, 3);
+    expect(frame.scaleY).toBeCloseTo(2, 3);
   });
 
   it("reads a 2D rotation written as matrix3d", () => {

--- a/packages/studio/src/components/editor/domEditOverlayCrop.test.ts
+++ b/packages/studio/src/components/editor/domEditOverlayCrop.test.ts
@@ -7,8 +7,8 @@ import {
   resolveCropInsetFromEdgeDrag,
   resolveCropInsetFromMoveDrag,
   rotateDeltaIntoFrame,
-  individualRotateDegrees,
 } from "./domEditOverlayCrop";
+import { individualRotateDegrees } from "./domEditOverlayTransform";
 
 describe("resolveCropInsetFromEdgeDrag", () => {
   const startInsets = { top: 10, right: 20, bottom: 30, left: 40 };
@@ -161,10 +161,15 @@ describe("readElementCropInsets tri-state", () => {
 describe("readElementCropFrame", () => {
   const overlayRect = { left: 100, top: 50, width: 220, height: 130, editScaleX: 1, editScaleY: 1 };
 
+  // Models an element well enough for the ancestor walk: it reports its own
+  // transform, claims no composition-root attribute, and has no parent, so the
+  // walk composes exactly one node.
   const fakeEl = (transform: string, offsetWidth = 200, offsetHeight = 100) =>
     ({
       offsetWidth,
       offsetHeight,
+      parentElement: null,
+      hasAttribute: () => false,
       ownerDocument: { defaultView: { getComputedStyle: () => ({ transform }) } },
     }) as unknown as HTMLElement;
 
@@ -306,5 +311,67 @@ describe("individualRotateDegrees", () => {
     expect(individualRotateDegrees(undefined)).toBe(0);
     expect(individualRotateDegrees("")).toBe(0);
     expect(individualRotateDegrees("12")).toBe(0);
+  });
+});
+
+describe("readElementCropFrame — the composed walk", () => {
+  /**
+   * The case the crop outline got wrong: a text layer inside a rotated card.
+   * The layer carries its own spin and its parent turns it again, so the box
+   * belongs at the combination. Reading the element alone drew it across the
+   * text at roughly a right angle.
+   */
+  const nested = (childTransform: string, parentTransform: string) => {
+    const style = (transform: string) => ({ transform }) as CSSStyleDeclaration;
+    const parent = {
+      offsetWidth: 400,
+      offsetHeight: 300,
+      parentElement: null,
+      hasAttribute: (name: string) => name === "data-composition-id",
+      ownerDocument: { defaultView: { getComputedStyle: () => style(parentTransform) } },
+    };
+    return {
+      offsetWidth: 200,
+      offsetHeight: 100,
+      parentElement: parent,
+      hasAttribute: () => false,
+      ownerDocument: {
+        defaultView: {
+          getComputedStyle: (node: unknown) =>
+            node === parent ? style(parentTransform) : style(childTransform),
+        },
+      },
+    } as unknown as HTMLElement;
+  };
+
+  const overlayRect = { left: 100, top: 50, width: 220, height: 130, editScaleX: 1, editScaleY: 1 };
+
+  it("adds the parent's rotation to the child's", () => {
+    // child 30deg inside a parent turned 60deg → the layer paints at 90.
+    const frame = readElementCropFrame(
+      nested(
+        "matrix(0.8660254, 0.5, -0.5, 0.8660254, 0, 0)",
+        "matrix(0.5, 0.8660254, -0.8660254, 0.5, 0, 0)",
+      ),
+      overlayRect,
+    );
+    expect(frame.angleDeg).toBeCloseTo(90, 3);
+  });
+
+  it("takes the parent's rotation when the child has none of its own", () => {
+    const frame = readElementCropFrame(
+      nested("none", "matrix(0.8660254, 0.5, -0.5, 0.8660254, 0, 0)"),
+      overlayRect,
+    );
+    expect(frame.angleDeg).toBeCloseTo(30, 3);
+  });
+
+  it("stops at the composition root rather than walking the whole document", () => {
+    // The root itself is marked, so its own transform is the last one counted.
+    const frame = readElementCropFrame(
+      nested("none", "matrix(0.8660254, 0.5, -0.5, 0.8660254, 0, 0)"),
+      overlayRect,
+    );
+    expect(frame.angleDeg).toBeCloseTo(30, 3);
   });
 });

--- a/packages/studio/src/components/editor/domEditOverlayCrop.test.ts
+++ b/packages/studio/src/components/editor/domEditOverlayCrop.test.ts
@@ -7,6 +7,7 @@ import {
   resolveCropInsetFromEdgeDrag,
   resolveCropInsetFromMoveDrag,
   rotateDeltaIntoFrame,
+  individualRotateDegrees,
 } from "./domEditOverlayCrop";
 
 describe("resolveCropInsetFromEdgeDrag", () => {
@@ -239,5 +240,37 @@ describe("rotateDeltaIntoFrame", () => {
     const back = rotateDeltaIntoFrame(local.deltaX, local.deltaY, -30);
     expect(back.deltaX).toBeCloseTo(7, 6);
     expect(back.deltaY).toBeCloseTo(-3, 6);
+  });
+});
+
+describe("individualRotateDegrees", () => {
+  /**
+   * Studio's rotate handle writes the CSS `rotate` property, not `transform`.
+   * Everything that measured an element's angle read `transform` alone, so a
+   * turned element reported upright and the selection box, crop outline and
+   * child outlines all drew square across it.
+   */
+  it("reads a plain angle", () => {
+    expect(individualRotateDegrees("-22deg")).toBeCloseTo(-22, 6);
+    expect(individualRotateDegrees("45deg")).toBeCloseTo(45, 6);
+  });
+
+  it("reads an explicit z-axis rotation, honouring the axis sign", () => {
+    expect(individualRotateDegrees("0 0 1 30deg")).toBeCloseTo(30, 6);
+    expect(individualRotateDegrees("0 0 -1 30deg")).toBeCloseTo(-30, 6);
+  });
+
+  it("reports nothing for a rotation that leaves the overlay's plane", () => {
+    // A 3D turn has no single in-plane angle. Reporting one would draw the
+    // chrome at a plausible-looking wrong angle instead of falling back square.
+    expect(individualRotateDegrees("1 0 0 45deg")).toBe(0);
+    expect(individualRotateDegrees("0 1 0 45deg")).toBe(0);
+  });
+
+  it("reports nothing when the property is absent or unparseable", () => {
+    expect(individualRotateDegrees("none")).toBe(0);
+    expect(individualRotateDegrees(undefined)).toBe(0);
+    expect(individualRotateDegrees("")).toBe(0);
+    expect(individualRotateDegrees("12")).toBe(0);
   });
 });

--- a/packages/studio/src/components/editor/domEditOverlayCrop.ts
+++ b/packages/studio/src/components/editor/domEditOverlayCrop.ts
@@ -183,15 +183,36 @@ export interface CropFrame {
  * rotation, or a 3D/unparseable matrix. The caller falls back to the
  * axis-aligned box rather than guessing an angle.
  */
-/** The 2D matrix components of a `matrix(...)` transform, or null if it is 3D or unparseable. */
+/** Perspective terms this far from zero mean the mapping is not affine. */
+const PERSPECTIVE_EPSILON = 1e-6;
+
+/**
+ * The 2D components of a computed transform, or null when it cannot be used.
+ *
+ * Accepts `matrix3d` as well as `matrix`, taking the same 2D projection the
+ * rest of the overlay reads through DOMMatrix. GSAP writes a 3D matrix for an
+ * ordinary 2D move or spin (force3D), and a composition that flips an element
+ * writes one with a negative z scale — treating either as unmeasurable left the
+ * crop outline square on an element every other piece of chrome drew rotated.
+ *
+ * Only a perspective term rules the matrix out, because that is where the
+ * mapping stops being affine and a single angle stops describing it.
+ */
 function parseMatrixComponents(
   transform: string,
 ): { a: number; b: number; c: number; d: number } | null {
-  const m = /^matrix\(([^)]+)\)$/.exec(transform);
-  if (!m) return null;
-  const [a, b, c, d] = m[1]!.split(",").map((v) => Number.parseFloat(v));
-  if (![a, b, c, d].every(Number.isFinite)) return null;
-  return { a: a!, b: b!, c: c!, d: d! };
+  const flat = /^matrix\(([^)]+)\)$/.exec(transform);
+  if (flat) {
+    const [a, b, c, d] = flat[1]!.split(",").map((v) => Number.parseFloat(v));
+    return [a, b, c, d].every(Number.isFinite) ? { a: a!, b: b!, c: c!, d: d! } : null;
+  }
+  const spatial = /^matrix3d\(([^)]+)\)$/.exec(transform);
+  if (!spatial) return null;
+  const m = spatial[1]!.split(",").map((v) => Number.parseFloat(v));
+  if (m.length !== 16 || !m.every(Number.isFinite)) return null;
+  const affine = [m[3], m[7], m[11]].every((v) => Math.abs(v!) < PERSPECTIVE_EPSILON);
+  if (!affine) return null;
+  return { a: m[0]!, b: m[1]!, c: m[4]!, d: m[5]! };
 }
 
 /** The element's own `transform` and `rotate`, read together in one pass. */
@@ -236,7 +257,8 @@ export function readElementCropFrame(
   const { a, b, c, d, spin } = planar;
   const elScaleX = Math.hypot(a, b);
   const det = a * d - b * c;
-  const elScaleY = elScaleX !== 0 ? det / elScaleX : 1;
+  // |det| : a flipped element (negative determinant) still has a real size.
+  const elScaleY = elScaleX !== 0 ? Math.abs(det) / elScaleX : 1;
   if (elScaleX <= 0 || elScaleY <= 0) return aabb;
   const angleDeg = (Math.atan2(b, a) * 180) / Math.PI + spin;
   const scaleX = elScaleX * editX;

--- a/packages/studio/src/components/editor/domEditOverlayCrop.ts
+++ b/packages/studio/src/components/editor/domEditOverlayCrop.ts
@@ -225,16 +225,83 @@ function readTransformAndSpin(element: HTMLElement): { transform: string; spin: 
   }
 }
 
+const IDENTITY = { a: 1, b: 0, c: 0, d: 1 };
+
+/** `outer` applied around `inner`, as an ancestor composes over a child. */
+function composeMatrices(
+  outer: { a: number; b: number; c: number; d: number },
+  inner: { a: number; b: number; c: number; d: number },
+): { a: number; b: number; c: number; d: number } {
+  return {
+    a: outer.a * inner.a + outer.c * inner.b,
+    b: outer.b * inner.a + outer.d * inner.b,
+    c: outer.a * inner.c + outer.c * inner.d,
+    d: outer.b * inner.c + outer.d * inner.d,
+  };
+}
+
+/** The `rotate` property's angle as a 2D matrix. */
+function spinMatrix(degrees: number): { a: number; b: number; c: number; d: number } {
+  const rad = (degrees * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  return { a: cos, b: sin, c: -sin, d: cos };
+}
+
+/**
+ * The transform the element actually paints under: its own, composed with every
+ * ancestor's up to the composition root.
+ *
+ * Reading the element alone drew the crop outline at the wrong angle for
+ * anything nested — a text layer inside a rotated card carries its own spin,
+ * and the box has to be drawn at the sum of the two, which is what the user
+ * sees. Within each level, CSS applies the individual `rotate` property before
+ * `transform`, and an ancestor applies outside its child.
+ */
+/** One node's own contribution: its `rotate` property applied before its `transform`. */
+function ownPlanarMatrix(node: HTMLElement): { a: number; b: number; c: number; d: number } | null {
+  const read = readTransformAndSpin(node);
+  if (!read) return null;
+  const hasTransform = Boolean(read.transform) && read.transform !== "none";
+  const base = hasTransform ? parseMatrixComponents(read.transform) : IDENTITY;
+  if (!base) return null;
+  return read.spin === 0 ? base : composeMatrices(spinMatrix(read.spin), base);
+}
+
+/** Whether the matrix leaves the box exactly as it found it. */
+function isIdentity(m: { a: number; b: number; c: number; d: number }): boolean {
+  return (
+    Math.abs(m.a - 1) < PERSPECTIVE_EPSILON &&
+    Math.abs(m.b) < PERSPECTIVE_EPSILON &&
+    Math.abs(m.c) < PERSPECTIVE_EPSILON &&
+    Math.abs(m.d - 1) < PERSPECTIVE_EPSILON
+  );
+}
+
+/**
+ * The transform the element actually paints under: its own, composed with every
+ * ancestor's up to the composition root.
+ *
+ * Reading the element alone drew the crop outline at the wrong angle for
+ * anything nested — a text layer inside a rotated card carries its own spin,
+ * and the box has to be drawn at the combination of the two, which is what the
+ * user sees. An ancestor applies outside its child.
+ *
+ * Null when nothing up the chain transforms the element: the caller's
+ * axis-aligned rect already describes it, and that comes from real layout
+ * rather than the element's untransformed box.
+ */
 function readPlanarTransform(
   element: HTMLElement,
-): { a: number; b: number; c: number; d: number; spin: number } | null {
-  const read = readTransformAndSpin(element);
-  if (!read) return null;
-  const { transform, spin } = read;
-  const hasTransform = Boolean(transform) && transform !== "none";
-  if (!hasTransform) return spin === 0 ? null : { a: 1, b: 0, c: 0, d: 1, spin };
-  const parts = parseMatrixComponents(transform);
-  return parts ? { ...parts, spin } : null;
+): { a: number; b: number; c: number; d: number } | null {
+  let acc = IDENTITY;
+  for (let node: HTMLElement | null = element; node; node = node.parentElement) {
+    const own = ownPlanarMatrix(node);
+    if (!own) return null;
+    acc = composeMatrices(own, acc);
+    if (node.hasAttribute?.("data-composition-id")) break;
+  }
+  return isIdentity(acc) ? null : acc;
 }
 
 export function readElementCropFrame(
@@ -254,13 +321,13 @@ export function readElementCropFrame(
   };
   const planar = readPlanarTransform(element);
   if (!planar) return aabb;
-  const { a, b, c, d, spin } = planar;
+  const { a, b, c, d } = planar;
   const elScaleX = Math.hypot(a, b);
   const det = a * d - b * c;
   // |det| : a flipped element (negative determinant) still has a real size.
   const elScaleY = elScaleX !== 0 ? Math.abs(det) / elScaleX : 1;
   if (elScaleX <= 0 || elScaleY <= 0) return aabb;
-  const angleDeg = (Math.atan2(b, a) * 180) / Math.PI + spin;
+  const angleDeg = (Math.atan2(b, a) * 180) / Math.PI;
   const scaleX = elScaleX * editX;
   const scaleY = elScaleY * editY;
   const width = element.offsetWidth * scaleX;

--- a/packages/studio/src/components/editor/domEditOverlayCrop.ts
+++ b/packages/studio/src/components/editor/domEditOverlayCrop.ts
@@ -1,3 +1,4 @@
+import { composeElementTransform, type PlanarTransformOps } from "./domEditOverlayTransform";
 import { parseInsetClipPathSides, type ClipPathInsetSides } from "./clipPathHelpers";
 
 export type CropEdge = "top" | "right" | "bottom" | "left";
@@ -112,30 +113,6 @@ export function resolveCropInsetFromMoveDrag(input: {
 
 /** Display-only hug: shrink a projected rect by the element's inset crop.
  *  For rects nothing writes back to (e.g. the hover ring). */
-/**
- * The planar rotation in the CSS `rotate` property, in degrees.
- *
- * Computes to `none`, an angle (`-22deg`), or an axis plus an angle
- * (`0 0 1 -22deg`). Only a rotation about z stays in the overlay's plane; any
- * other axis is 3D and reports 0, which leaves the caller on its axis-aligned
- * fallback rather than drawing a box at a plausible-looking wrong angle.
- */
-export function individualRotateDegrees(value: string | undefined): number {
-  if (!value || value === "none") return 0;
-  const parts = value.trim().split(/\s+/);
-  const angle = parts.at(-1);
-  if (!angle?.endsWith("deg")) return 0;
-  if (parts.length === 4) {
-    const [x, y, z] = parts;
-    if (Number(x) !== 0 || Number(y) !== 0 || Math.abs(Number(z)) !== 1) return 0;
-    const deg = Number.parseFloat(angle);
-    return Number.isFinite(deg) ? deg * Math.sign(Number(z)) : 0;
-  }
-  if (parts.length !== 1) return 0;
-  const deg = Number.parseFloat(angle);
-  return Number.isFinite(deg) ? deg : 0;
-}
-
 export function hugRectForElement(
   rect: CropScreenRect & { editScaleX: number; editScaleY: number },
   element: HTMLElement,
@@ -183,8 +160,12 @@ export interface CropFrame {
  * rotation, or a 3D/unparseable matrix. The caller falls back to the
  * axis-aligned box rather than guessing an angle.
  */
+const IDENTITY = { a: 1, b: 0, c: 0, d: 1 };
+
 /** Perspective terms this far from zero mean the mapping is not affine. */
 const PERSPECTIVE_EPSILON = 1e-6;
+
+type Planar2D = { a: number; b: number; c: number; d: number };
 
 /**
  * The 2D components of a computed transform, or null when it cannot be used.
@@ -198,9 +179,7 @@ const PERSPECTIVE_EPSILON = 1e-6;
  * Only a perspective term rules the matrix out, because that is where the
  * mapping stops being affine and a single angle stops describing it.
  */
-function parseMatrixComponents(
-  transform: string,
-): { a: number; b: number; c: number; d: number } | null {
+function parseMatrixComponents(transform: string): Planar2D | null {
   const flat = /^matrix\(([^)]+)\)$/.exec(transform);
   if (flat) {
     const [a, b, c, d] = flat[1]!.split(",").map((v) => Number.parseFloat(v));
@@ -215,61 +194,24 @@ function parseMatrixComponents(
   return { a: m[0]!, b: m[1]!, c: m[4]!, d: m[5]! };
 }
 
-/** The element's own `transform` and `rotate`, read together in one pass. */
-function readTransformAndSpin(element: HTMLElement): { transform: string; spin: number } | null {
-  try {
-    const style = element.ownerDocument.defaultView?.getComputedStyle(element);
-    return { transform: style?.transform ?? "", spin: individualRotateDegrees(style?.rotate) };
-  } catch {
-    return null;
-  }
-}
-
-const IDENTITY = { a: 1, b: 0, c: 0, d: 1 };
-
-/** `outer` applied around `inner`, as an ancestor composes over a child. */
-function composeMatrices(
-  outer: { a: number; b: number; c: number; d: number },
-  inner: { a: number; b: number; c: number; d: number },
-): { a: number; b: number; c: number; d: number } {
-  return {
+/** The crop frame only needs an angle and a scale, so it composes plain 2D components. */
+const PLANAR_2D_OPS: PlanarTransformOps<Planar2D> = {
+  identity: () => IDENTITY,
+  fromTransform: parseMatrixComponents,
+  fromRotate: (degrees) => {
+    const rad = (degrees * Math.PI) / 180;
+    return { a: Math.cos(rad), b: Math.sin(rad), c: -Math.sin(rad), d: Math.cos(rad) };
+  },
+  compose: (outer, inner) => ({
     a: outer.a * inner.a + outer.c * inner.b,
     b: outer.b * inner.a + outer.d * inner.b,
     c: outer.a * inner.c + outer.c * inner.d,
     d: outer.b * inner.c + outer.d * inner.d,
-  };
-}
-
-/** The `rotate` property's angle as a 2D matrix. */
-function spinMatrix(degrees: number): { a: number; b: number; c: number; d: number } {
-  const rad = (degrees * Math.PI) / 180;
-  const cos = Math.cos(rad);
-  const sin = Math.sin(rad);
-  return { a: cos, b: sin, c: -sin, d: cos };
-}
-
-/**
- * The transform the element actually paints under: its own, composed with every
- * ancestor's up to the composition root.
- *
- * Reading the element alone drew the crop outline at the wrong angle for
- * anything nested — a text layer inside a rotated card carries its own spin,
- * and the box has to be drawn at the sum of the two, which is what the user
- * sees. Within each level, CSS applies the individual `rotate` property before
- * `transform`, and an ancestor applies outside its child.
- */
-/** One node's own contribution: its `rotate` property applied before its `transform`. */
-function ownPlanarMatrix(node: HTMLElement): { a: number; b: number; c: number; d: number } | null {
-  const read = readTransformAndSpin(node);
-  if (!read) return null;
-  const hasTransform = Boolean(read.transform) && read.transform !== "none";
-  const base = hasTransform ? parseMatrixComponents(read.transform) : IDENTITY;
-  if (!base) return null;
-  return read.spin === 0 ? base : composeMatrices(spinMatrix(read.spin), base);
-}
+  }),
+};
 
 /** Whether the matrix leaves the box exactly as it found it. */
-function isIdentity(m: { a: number; b: number; c: number; d: number }): boolean {
+function isIdentity(m: Planar2D): boolean {
   return (
     Math.abs(m.a - 1) < PERSPECTIVE_EPSILON &&
     Math.abs(m.b) < PERSPECTIVE_EPSILON &&
@@ -279,29 +221,21 @@ function isIdentity(m: { a: number; b: number; c: number; d: number }): boolean 
 }
 
 /**
- * The transform the element actually paints under: its own, composed with every
- * ancestor's up to the composition root.
+ * The transform the element paints under, in 2D components.
  *
- * Reading the element alone drew the crop outline at the wrong angle for
- * anything nested — a text layer inside a rotated card carries its own spin,
- * and the box has to be drawn at the combination of the two, which is what the
- * user sees. An ancestor applies outside its child.
- *
- * Null when nothing up the chain transforms the element: the caller's
- * axis-aligned rect already describes it, and that comes from real layout
- * rather than the element's untransformed box.
+ * Null when nothing up the chain transforms it: the caller's axis-aligned rect
+ * already describes it, and that comes from real layout rather than the
+ * element's untransformed box.
  */
-function readPlanarTransform(
-  element: HTMLElement,
-): { a: number; b: number; c: number; d: number } | null {
-  let acc = IDENTITY;
-  for (let node: HTMLElement | null = element; node; node = node.parentElement) {
-    const own = ownPlanarMatrix(node);
-    if (!own) return null;
-    acc = composeMatrices(own, acc);
-    if (node.hasAttribute?.("data-composition-id")) break;
-  }
-  return isIdentity(acc) ? null : acc;
+function readPlanarTransform(element: HTMLElement): Planar2D | null {
+  const acc = composeElementTransform(element, PLANAR_2D_OPS, (node) => {
+    try {
+      return node.ownerDocument.defaultView?.getComputedStyle(node) ?? null;
+    } catch {
+      return null;
+    }
+  });
+  return acc && !isIdentity(acc) ? acc : null;
 }
 
 export function readElementCropFrame(

--- a/packages/studio/src/components/editor/domEditOverlayCrop.ts
+++ b/packages/studio/src/components/editor/domEditOverlayCrop.ts
@@ -112,6 +112,30 @@ export function resolveCropInsetFromMoveDrag(input: {
 
 /** Display-only hug: shrink a projected rect by the element's inset crop.
  *  For rects nothing writes back to (e.g. the hover ring). */
+/**
+ * The planar rotation in the CSS `rotate` property, in degrees.
+ *
+ * Computes to `none`, an angle (`-22deg`), or an axis plus an angle
+ * (`0 0 1 -22deg`). Only a rotation about z stays in the overlay's plane; any
+ * other axis is 3D and reports 0, which leaves the caller on its axis-aligned
+ * fallback rather than drawing a box at a plausible-looking wrong angle.
+ */
+export function individualRotateDegrees(value: string | undefined): number {
+  if (!value || value === "none") return 0;
+  const parts = value.trim().split(/\s+/);
+  const angle = parts.at(-1);
+  if (!angle?.endsWith("deg")) return 0;
+  if (parts.length === 4) {
+    const [x, y, z] = parts;
+    if (Number(x) !== 0 || Number(y) !== 0 || Math.abs(Number(z)) !== 1) return 0;
+    const deg = Number.parseFloat(angle);
+    return Number.isFinite(deg) ? deg * Math.sign(Number(z)) : 0;
+  }
+  if (parts.length !== 1) return 0;
+  const deg = Number.parseFloat(angle);
+  return Number.isFinite(deg) ? deg : 0;
+}
+
 export function hugRectForElement(
   rect: CropScreenRect & { editScaleX: number; editScaleY: number },
   element: HTMLElement,
@@ -147,6 +171,51 @@ export interface CropFrame {
   scaleY: number;
 }
 
+/**
+ * The element's own 2D transform as matrix components, plus the `rotate`
+ * property's angle.
+ *
+ * `rotate` is a separate CSS property, not part of `transform`, and it is the
+ * one Studio's rotate handle writes — reading `transform` alone reported a
+ * turned element as upright, so the crop outline drew square across it.
+ *
+ * Null means there is nothing planar to draw against: no transform and no
+ * rotation, or a 3D/unparseable matrix. The caller falls back to the
+ * axis-aligned box rather than guessing an angle.
+ */
+/** The 2D matrix components of a `matrix(...)` transform, or null if it is 3D or unparseable. */
+function parseMatrixComponents(
+  transform: string,
+): { a: number; b: number; c: number; d: number } | null {
+  const m = /^matrix\(([^)]+)\)$/.exec(transform);
+  if (!m) return null;
+  const [a, b, c, d] = m[1]!.split(",").map((v) => Number.parseFloat(v));
+  if (![a, b, c, d].every(Number.isFinite)) return null;
+  return { a: a!, b: b!, c: c!, d: d! };
+}
+
+/** The element's own `transform` and `rotate`, read together in one pass. */
+function readTransformAndSpin(element: HTMLElement): { transform: string; spin: number } | null {
+  try {
+    const style = element.ownerDocument.defaultView?.getComputedStyle(element);
+    return { transform: style?.transform ?? "", spin: individualRotateDegrees(style?.rotate) };
+  } catch {
+    return null;
+  }
+}
+
+function readPlanarTransform(
+  element: HTMLElement,
+): { a: number; b: number; c: number; d: number; spin: number } | null {
+  const read = readTransformAndSpin(element);
+  if (!read) return null;
+  const { transform, spin } = read;
+  const hasTransform = Boolean(transform) && transform !== "none";
+  if (!hasTransform) return spin === 0 ? null : { a: 1, b: 0, c: 0, d: 1, spin };
+  const parts = parseMatrixComponents(transform);
+  return parts ? { ...parts, spin } : null;
+}
+
 export function readElementCropFrame(
   element: HTMLElement,
   overlayRect: CropScreenRect & { editScaleX: number; editScaleY: number },
@@ -162,22 +231,14 @@ export function readElementCropFrame(
     scaleX: editX,
     scaleY: editY,
   };
-  let transform = "";
-  try {
-    transform = element.ownerDocument.defaultView?.getComputedStyle(element).transform ?? "";
-  } catch {
-    return aabb;
-  }
-  if (!transform || transform === "none") return aabb;
-  const m = /^matrix\(([^)]+)\)$/.exec(transform);
-  if (!m) return aabb; // matrix3d or unparseable → axis-aligned fallback
-  const [a, b, c, d] = m[1]!.split(",").map((v) => Number.parseFloat(v));
-  if (![a, b, c, d].every(Number.isFinite)) return aabb;
-  const elScaleX = Math.hypot(a!, b!);
-  const det = a! * d! - b! * c!;
+  const planar = readPlanarTransform(element);
+  if (!planar) return aabb;
+  const { a, b, c, d, spin } = planar;
+  const elScaleX = Math.hypot(a, b);
+  const det = a * d - b * c;
   const elScaleY = elScaleX !== 0 ? det / elScaleX : 1;
   if (elScaleX <= 0 || elScaleY <= 0) return aabb;
-  const angleDeg = (Math.atan2(b!, a!) * 180) / Math.PI;
+  const angleDeg = (Math.atan2(b, a) * 180) / Math.PI + spin;
   const scaleX = elScaleX * editX;
   const scaleY = elScaleY * editY;
   const width = element.offsetWidth * scaleX;

--- a/packages/studio/src/components/editor/domEditOverlayGeometry.test.ts
+++ b/packages/studio/src/components/editor/domEditOverlayGeometry.test.ts
@@ -165,6 +165,19 @@ describe("orientedOverlayRect — rotation gate (perf fix, V15 18a/18b)", () => 
    * a text layer inside a rotated card got an upright dashed box sitting across
    * the rotated glyphs — the parent's chrome rotated and its children's did not.
    */
+  /**
+   * The selection box and the crop outline compose the same ancestor walk, so
+   * this asserts the geometry side of the case the crop test covers: a child
+   * inside a rotated parent reports the angle it paints at, not its own.
+   */
+  it("composes the parent's rotation into the child's angle", () => {
+    const { overlayEl, iframe, el } = buildHarness();
+    el.parentElement!.style.transform = ROTATE_30DEG_MATRIX;
+    const rect = orientedOverlayRect(overlayEl, iframe, el);
+    expect(rect).not.toBeNull();
+    expect(rect!.angle).toBeCloseTo(30, 3);
+  });
+
   it("child outlines carry the element's angle, so they can co-rotate with it", () => {
     const { overlayEl, iframe, el } = buildHarness();
     el.style.transform = ROTATE_30DEG_MATRIX;

--- a/packages/studio/src/components/editor/domEditOverlayGeometry.ts
+++ b/packages/studio/src/components/editor/domEditOverlayGeometry.ts
@@ -1,6 +1,6 @@
 import { type DomEditSelection, findElementForSelection } from "./domEditing";
 import { isElementVisibleThroughAncestors } from "./domEditingDom";
-import { hugRectForElement } from "./domEditOverlayCrop";
+import { hugRectForElement, individualRotateDegrees } from "./domEditOverlayCrop";
 
 export interface OverlayRect {
   left: number;
@@ -149,11 +149,20 @@ function readElementTransformSnapshot(
   try {
     let matrix = new DOMMatrixCtor();
     for (let node: HTMLElement | null = element; node; node = node.parentElement) {
-      const transform = node === element ? cs.transform : win.getComputedStyle(node).transform;
-      if (transform && transform !== "none") {
-        // An ancestor applies outside, so it multiplies on the left.
-        matrix = new DOMMatrixCtor(transform).multiply(matrix);
-      }
+      const style = node === element ? cs : win.getComputedStyle(node);
+      const transform = style.transform;
+      let own =
+        transform && transform !== "none" ? new DOMMatrixCtor(transform) : new DOMMatrixCtor();
+      // `rotate` is its own CSS property, not part of `transform`, and it is what
+      // Studio's own rotate handle writes. Reading `transform` alone reported a
+      // rotated element as upright, so every piece of chrome measured from this
+      // matrix — the selection box, the crop outline, the child outlines — drew
+      // square across a rotated element. CSS applies the individual properties
+      // before `transform`, so it composes on the left.
+      const spin = individualRotateDegrees(style.rotate);
+      if (spin !== 0) own = new DOMMatrixCtor().rotateSelf(spin).multiply(own);
+      // An ancestor applies outside, so it multiplies on the left.
+      matrix = own.multiply(matrix);
       if (node.hasAttribute("data-composition-id")) break;
     }
     return { matrix, cs };

--- a/packages/studio/src/components/editor/domEditOverlayGeometry.ts
+++ b/packages/studio/src/components/editor/domEditOverlayGeometry.ts
@@ -1,6 +1,7 @@
 import { type DomEditSelection, findElementForSelection } from "./domEditing";
 import { isElementVisibleThroughAncestors } from "./domEditingDom";
-import { hugRectForElement, individualRotateDegrees } from "./domEditOverlayCrop";
+import { hugRectForElement } from "./domEditOverlayCrop";
+import { composeElementTransform, type PlanarTransformOps } from "./domEditOverlayTransform";
 
 export interface OverlayRect {
   left: number;
@@ -146,26 +147,19 @@ function readElementTransformSnapshot(
   const DOMMatrixCtor = (win as Window & typeof globalThis).DOMMatrix;
   if (!DOMMatrixCtor) return null;
   const cs = win.getComputedStyle(element);
+  // The corner math transforms points, so this algebra keeps the full matrix,
+  // translation included, where the crop frame's keeps only 2D components.
+  const ops: PlanarTransformOps<DOMMatrix> = {
+    identity: () => new DOMMatrixCtor(),
+    fromTransform: (value) => new DOMMatrixCtor(value),
+    fromRotate: (degrees) => new DOMMatrixCtor().rotateSelf(degrees),
+    compose: (outer, inner) => outer.multiply(inner),
+  };
   try {
-    let matrix = new DOMMatrixCtor();
-    for (let node: HTMLElement | null = element; node; node = node.parentElement) {
-      const style = node === element ? cs : win.getComputedStyle(node);
-      const transform = style.transform;
-      let own =
-        transform && transform !== "none" ? new DOMMatrixCtor(transform) : new DOMMatrixCtor();
-      // `rotate` is its own CSS property, not part of `transform`, and it is what
-      // Studio's own rotate handle writes. Reading `transform` alone reported a
-      // rotated element as upright, so every piece of chrome measured from this
-      // matrix — the selection box, the crop outline, the child outlines — drew
-      // square across a rotated element. CSS applies the individual properties
-      // before `transform`, so it composes on the left.
-      const spin = individualRotateDegrees(style.rotate);
-      if (spin !== 0) own = new DOMMatrixCtor().rotateSelf(spin).multiply(own);
-      // An ancestor applies outside, so it multiplies on the left.
-      matrix = own.multiply(matrix);
-      if (node.hasAttribute("data-composition-id")) break;
-    }
-    return { matrix, cs };
+    const matrix = composeElementTransform(element, ops, (node) =>
+      node === element ? cs : win.getComputedStyle(node),
+    );
+    return matrix ? { matrix, cs } : null;
   } catch {
     return null;
   }

--- a/packages/studio/src/components/editor/domEditOverlayTransform.ts
+++ b/packages/studio/src/components/editor/domEditOverlayTransform.ts
@@ -77,8 +77,7 @@ export function composeElementTransform<M>(
     const style = getStyle(node);
     if (!style) return null;
     const transform = style.transform;
-    let own =
-      transform && transform !== "none" ? ops.fromTransform(transform) : ops.identity();
+    let own = transform && transform !== "none" ? ops.fromTransform(transform) : ops.identity();
     if (!own) return null;
     const spin = individualRotateDegrees(style.rotate);
     if (spin !== 0) own = ops.compose(ops.fromRotate(spin), own);

--- a/packages/studio/src/components/editor/domEditOverlayTransform.ts
+++ b/packages/studio/src/components/editor/domEditOverlayTransform.ts
@@ -1,0 +1,89 @@
+/**
+ * One walk from an element up to its composition root, composing the transform
+ * it actually paints under.
+ *
+ * The overlay measures an element's angle in two places — the selection box and
+ * the crop frame — and they need different arithmetic: one works in DOMMatrix
+ * because it goes on to transform corner points, the other in plain 2D
+ * components because it only needs an angle and a scale. What they must never
+ * differ on is *which* transforms count and in what order, because when they
+ * disagree the chrome disagrees with itself: the selection box drawn at one
+ * angle and the crop outline at another, on the same element.
+ *
+ * So the walk lives here once and takes the arithmetic as a parameter. Adding
+ * an individual property CSS grew later — `translate`, `scale` — means adding
+ * one step here and one method to each algebra, rather than finding both walks
+ * and hoping.
+ */
+
+/** The composition's own root; the walk stops there rather than at the document. */
+const COMPOSITION_ROOT_ATTR = "data-composition-id";
+
+/**
+ * The arithmetic the walk needs, whatever the caller's matrix type is.
+ *
+ * `fromTransform` returns null for a transform the caller cannot use — a
+ * perspective matrix, say — which aborts the walk rather than composing a
+ * matrix that describes something other than what is painted.
+ */
+export interface PlanarTransformOps<M> {
+  identity(): M;
+  fromTransform(value: string): M | null;
+  fromRotate(degrees: number): M;
+  /** `outer` applied around `inner`, as an ancestor composes over a child. */
+  compose(outer: M, inner: M): M;
+}
+
+/**
+ * The planar rotation in the CSS `rotate` property, in degrees.
+ *
+ * Computes to `none`, an angle (`-22deg`), or an axis plus an angle
+ * (`0 0 1 -22deg`). Only a rotation about z stays in the overlay's plane; any
+ * other axis is 3D and reports 0, which leaves the caller on its axis-aligned
+ * fallback rather than drawing a box at a plausible-looking wrong angle.
+ */
+export function individualRotateDegrees(value: string | undefined): number {
+  if (!value || value === "none") return 0;
+  const parts = value.trim().split(/\s+/);
+  const angle = parts.at(-1);
+  if (!angle?.endsWith("deg")) return 0;
+  if (parts.length === 4) {
+    const [x, y, z] = parts;
+    if (Number(x) !== 0 || Number(y) !== 0 || Math.abs(Number(z)) !== 1) return 0;
+    const deg = Number.parseFloat(angle);
+    return Number.isFinite(deg) ? deg * Math.sign(Number(z)) : 0;
+  }
+  if (parts.length !== 1) return 0;
+  const deg = Number.parseFloat(angle);
+  return Number.isFinite(deg) ? deg : 0;
+}
+
+/**
+ * The element's transform composed with every ancestor's, up to the composition
+ * root.
+ *
+ * Within a node, CSS applies the individual properties before `transform`, so
+ * `rotate` composes on the left of it. Between nodes, an ancestor applies
+ * outside its child. Null means some node's transform was unusable and the
+ * caller should fall back rather than guess.
+ */
+export function composeElementTransform<M>(
+  element: HTMLElement,
+  ops: PlanarTransformOps<M>,
+  getStyle: (node: HTMLElement) => CSSStyleDeclaration | null,
+): M | null {
+  let acc = ops.identity();
+  for (let node: HTMLElement | null = element; node; node = node.parentElement) {
+    const style = getStyle(node);
+    if (!style) return null;
+    const transform = style.transform;
+    let own =
+      transform && transform !== "none" ? ops.fromTransform(transform) : ops.identity();
+    if (!own) return null;
+    const spin = individualRotateDegrees(style.rotate);
+    if (spin !== 0) own = ops.compose(ops.fromRotate(spin), own);
+    acc = ops.compose(own, acc);
+    if (node.hasAttribute(COMPOSITION_ROOT_ATTR)) break;
+  }
+  return acc;
+}

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -3,7 +3,8 @@ import react from "@vitejs/plugin-react";
 import { readFileSync, readdirSync, existsSync, lstatSync, realpathSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { readNodeRequestBody } from "./vite.request-body.js";
-import { createViteAdapter, isPathWithin } from "./vite.adapter";
+import { watch } from "chokidar";
+import { createViteAdapter } from "./vite.adapter";
 
 async function loadRuntimeSourceForDev(
   server: import("vite").ViteDevServer,
@@ -143,15 +144,16 @@ function devProjectApi(): Plugin {
         }
       });
 
-      // Watch project directories for file changes → HMR
+      // Watch project directories on a watcher of our own. Vite's is told to
+      // ignore them (see `server.watch.ignored`), because it answers an html
+      // change with a full page reload; this one only announces the change and
+      // lets Studio decide what to do with it.
       const realProjectPaths: string[] = [];
       try {
         for (const entry of readdirSync(dataDir, { withFileTypes: true })) {
           const full = join(dataDir, entry.name);
           try {
-            const real = lstatSync(full).isSymbolicLink() ? realpathSync(full) : full;
-            realProjectPaths.push(real);
-            server.watcher.add(real);
+            realProjectPaths.push(lstatSync(full).isSymbolicLink() ? realpathSync(full) : full);
           } catch {
             /* skip broken symlinks */
           }
@@ -160,24 +162,29 @@ function devProjectApi(): Plugin {
         /* dataDir doesn't exist yet */
       }
 
-      server.watcher.on("change", (filePath: string) => {
-        const isProjectFile = realProjectPaths.some((p) => isPathWithin(p, filePath));
-        if (
-          isProjectFile &&
-          (filePath.endsWith(".html") ||
-            filePath.endsWith(".css") ||
-            filePath.endsWith(".js") ||
-            filePath.endsWith(".json"))
-        ) {
-          console.log(`[Studio] File changed: ${filePath}`);
-          const receipt = _studioServerModule?.consumeFileWriteReceipt?.(filePath) ?? null;
-          server.ws.send({
-            type: "custom",
-            event: "hf:file-change",
-            data: receipt ?? { path: filePath },
-          });
-        }
+      const projectWatcher = watch(realProjectPaths, {
+        ignoreInitial: true,
+        // A project write is a whole-file replace; wait for it to settle so a
+        // half-written composition is never announced.
+        awaitWriteFinish: { stabilityThreshold: 40, pollInterval: 10 },
       });
+      projectWatcher.on("change", (filePath: string) => {
+        if (
+          !filePath.endsWith(".html") &&
+          !filePath.endsWith(".css") &&
+          !filePath.endsWith(".js") &&
+          !filePath.endsWith(".json")
+        )
+          return;
+        console.log(`[Studio] File changed: ${filePath}`);
+        const receipt = _studioServerModule?.consumeFileWriteReceipt?.(filePath) ?? null;
+        server.ws.send({
+          type: "custom",
+          event: "hf:file-change",
+          data: receipt ?? { path: filePath },
+        });
+      });
+      server.httpServer?.on("close", () => void projectWatcher.close());
     },
   };
 }
@@ -205,6 +212,15 @@ export default defineConfig({
   },
   server: {
     port: 5190,
+    watch: {
+      // A composition lives under this package's root, so Vite's HMR sees a
+      // write to one as an html page dependency changing and full-reloads the
+      // browser. That reload is the flash after every edit in the canvas, and
+      // it is not Studio's to make: the app already decides whether a write of
+      // its own needs the preview refreshed, and the plugin below announces
+      // project writes as `hf:file-change` off its own watcher.
+      ignored: ["**/data/projects/**"],
+    },
   },
   ssr: {
     // recast / @babel/parser are CommonJS and call `require("fs")`. They are


### PR DESCRIPTION
## What

Overlay chrome now follows an element turned with Studio's rotate handle. Before, the selection box, crop outline and child outlines all drew square across a visibly rotated element.

## Before / after

Same composition, same element. `main` on the left, this branch on the right.

Selecting the card — the dashed crop outline sat square across a rotated element:

<img width="1468" height="682" alt="rotated card, before and after" src="https://github.com/user-attachments/assets/0de7b3a3-790e-49f9-905a-7acbcffa2b0e" />

Selecting the text layer inside it — the outline has to follow the angle the layer paints under, which is its own spin composed with its parent's:

<img width="1468" height="682" alt="nested text layer, before and after" src="https://github.com/user-attachments/assets/af1dacbc-a23e-4d15-9738-dbc920b1d843" />

## Why

The rotate handle writes the CSS `rotate` property. That is an individual transform property, not part of `transform`, so `getComputedStyle(el).transform` reports nothing for it. Both places that measure an element's angle read only `transform`, so a rotated element measured as upright and every box derived from that measurement drew axis-aligned.

Two more refusals sat behind it. The crop outline accepted only `matrix(...)`, and GSAP writes `matrix3d(...)` for an ordinary 2D move or spin (force3D); a composition that mirrors an element writes one with a negative determinant, which was refused too. And it read the element's own transform rather than the one it paints under, so a layer inside a rotated card was drawn at its own angle instead of the combination.

## How

The overlay geometry and the crop frame both read `rotate` alongside `transform` and compose them the way CSS does — individual properties before `transform`, an ancestor outside its child. The crop frame walks to the composition root instead of reading the element alone, and takes the same 2D projection the rest of the chrome reads through DOMMatrix. Only a perspective term still falls back to axis-aligned, because that is where the mapping stops being affine and no single angle describes it.

## Test plan

- Measured in a browser on a card carrying `rotate: -22deg`. Before: selection box 0, crop outline 0, both child outlines 0. After: all four report -22. Reverting the one-line read puts them back to 0.
- - On the nested case above, selection box, crop outline and child outline all report 49 and the same rect
- - Unit tests for the angle parser (plain angle, explicit z-axis including sign, 3D axes rejected, absent or unparseable) and for the transforms the crop frame must not refuse (planar `matrix3d`, a flipped element, perspective still falling back)
- - Two existing tests asserted the old behaviour and were updated: one used the identity written as `matrix3d` as its "3D means give up" fixture, and one stubbed `getComputedStyle` to answer "rotated 30deg" for every node in the document, which made composing read the same turn once per ancestor
- - Full studio suite (3607), lint, format, fallow and the size cap green