### PR TITLE
style(studio): format AGENTS.md

### DIFF
--- a/packages/studio/AGENTS.md
+++ b/packages/studio/AGENTS.md
@@ -17,7 +17,7 @@ Two consequences you will meet immediately:
 - Reaching a preview element from a driver or a test means going through the
   iframe: `iframe.contentDocument.getElementById(...)`. Studio's own panels may
   be inside shadow roots, so a plain `document.querySelector` finds neither.
-- Every overlay box is a *measurement* of an element, not the element. When
+- Every overlay box is a _measurement_ of an element, not the element. When
   chrome disagrees with the pixels underneath it, the bug is almost always in
   the measurement, in `components/editor/domEditOverlayGeometry.ts`.
 


### PR DESCRIPTION
## What

Runs `packages/studio/AGENTS.md` through oxfmt. One character: `*measurement*` becomes `_measurement_`.

## Why

oxfmt formats markdown as well as source, and the file I added in #3165 was not formatted. `main` has been red on Format since that merge, and because CI checks the merge with main, every open PR inherits the failure.

## Test plan

- `bun run format:check` — the exact CI command — passes on this branch and fails without it