### PR TITLE
fix(core): stop a graded plate painting through an inactive clip

### DIFF
--- a/packages/core/src/runtime/colorGrading.test.ts
+++ b/packages/core/src/runtime/colorGrading.test.ts
@@ -770,6 +770,35 @@ describe("createColorGradingRuntime", () => {
     expect(canvas.style.opacity).toBe("0.75");
   });
 
+  it("hides the canvas when an ancestor clip goes out of its visibility window", () => {
+    // A graded <img> inside a timed sub-composition carries no data-start of its
+    // own, so nothing tells grading the clip left the screen — the canvas has to
+    // notice from the source's inherited visibility. Before the fix, grading's own
+    // opacity hide short-circuited that read and the canvas kept an explicit
+    // `visibility: visible`, painting the treated plate over the active scene.
+    const scene = document.createElement("div");
+    const image = makeDrawableImage();
+    scene.appendChild(image);
+    document.body.appendChild(scene);
+
+    runtime = createColorGradingRuntime();
+    const canvas = document.querySelector<HTMLCanvasElement>("[data-hf-color-grading-canvas]");
+    if (!canvas) throw new Error("Expected color grading canvas");
+    expect(canvas.style.visibility).toBe("visible");
+
+    scene.style.visibility = "hidden";
+    runtime.redraw();
+
+    expect(canvas.style.visibility).toBe("hidden");
+
+    scene.style.visibility = "visible";
+    runtime.redraw();
+
+    expect(canvas.style.visibility).toBe("visible");
+    // Grading still owns the source's opacity hide, so the canvas keeps full opacity.
+    expect(canvas.style.opacity).toBe("1");
+  });
+
   it("allows a drawable producer render frame to initialize hidden source grading", () => {
     const video = makeDrawableVideo();
     video.style.display = "none";

--- a/packages/core/src/runtime/colorGrading.ts
+++ b/packages/core/src/runtime/colorGrading.ts
@@ -3065,12 +3065,19 @@ function drawEntry(entry: ColorGradingEntry): boolean {
   const sourceVisibility = entry.element.style.getPropertyValue("visibility");
   const injectedFrameSource = isRenderFrameImage(source);
   if (injectedFrameSource) keepCanvasAboveSource(entry, source);
+  const computed = window.getComputedStyle(injectedFrameSource ? source : entry.element);
+  // `hideSourceElement` owns the source's inline opacity while grading is active
+  // (opacity:0 !important), so reading it back would mirror grading's own hide
+  // onto the canvas and blank it. That gate is about opacity ONLY: grading never
+  // writes `visibility`, so the source's computed visibility always tracks the
+  // clip window and has to be re-read every frame. Leaving it stale let the
+  // canvas keep an explicit `visibility: visible` and paint straight through an
+  // inactive ancestor clip's inherited `visibility: hidden`.
   if (injectedFrameSource || !hiddenByColorGrading) {
-    const computed = window.getComputedStyle(injectedFrameSource ? source : entry.element);
     entry.sourceOpacityForCanvas = computed.opacity || "1";
-    entry.sourceVisibleForCanvas =
-      (injectedFrameSource || sourceVisibility !== "hidden") && computed.visibility !== "hidden";
   }
+  entry.sourceVisibleForCanvas =
+    (injectedFrameSource || sourceVisibility !== "hidden") && computed.visibility !== "hidden";
   const layout = updateCanvasLayout(entry, styleSource);
   if (!layout) return false;
 


### PR DESCRIPTION
## What

A color-graded `<img>` or `<video>` inside a timed sub-composition keeps painting after its clip window closes, compositing the treated plate over whichever scene is actually on screen. This makes the grading canvas respect its clip's visibility window.

## Why

Reproduced on macOS with a two-scene composition: scene A (0-3s, ungraded test chart) and scene B (3-6s, same chart with `data-color-grading`). At t=1.5s, a second and a half before scene B starts, scene B's treatment is composited over scene A.

The runtime hides the sub-composition wrapper correctly with `visibility: hidden`. The grading canvas, however, carries an explicit inline `visibility: visible`, and an explicit value on a descendant escapes an ancestor's inherited `hidden`. `syncTimedElementVisibility` already carries a comment warning about exactly this leak class, but its guard only covers timed descendants, and a graded image inside a sub-composition has no `data-start` of its own.

Preview and render agree here: the snapshot still and the rendered frame at the same timestamp are byte-identical. Both are wrong the same way, so this is a real defect rather than a preview-vs-render divergence.

## How

`drawEntry` only refreshed its cached view of the source's visibility inside `if (injectedFrameSource || !hiddenByColorGrading)`. That gate exists for **opacity**: `hideSourceElement` sets `opacity: 0 !important` on the source while grading is active, so mirroring the source's computed opacity onto the canvas would blank it. Visibility got swept into the same gate by accident, and since every graded source is hidden-by-grading, the visibility mirror could never self-heal once it went stale.

The two mirrors are now split. Opacity stays gated; visibility is re-read from computed style every frame. Grading never writes `visibility`, so the source's computed visibility always tracks the clip window.

Deriving the canvas's visibility from the source, rather than from a notification, is the reason this is a root fix: any way of hiding a clip now works, including ones that do not exist yet. The alternative — teaching `syncTimedElementVisibility` to also notify grading for untimed descendants — would leave the next hiding mechanism broken again.

Not covered here: the `~20 ms` offset between an audio clip's authored `data-start` and where it lands in the rendered mix, and the preview volume-envelope time base. Both are separate findings from the same investigation and are filed separately.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

New regression test in `colorGrading.test.ts`: a graded image inside a wrapper that goes `visibility: hidden` must hide its canvas, and show it again when the wrapper comes back. Verified it fails on `main` with exactly the reported symptom (`visible` where `hidden` was expected) and passes with the fix.

- `packages/core` suite: 1912 passed, 100 files.
- End-to-end on the original repro: the rendered frame at t=1.5s is now byte-identical to the same composition with the grading attribute removed (`8c61b9d2…`), where before the fix it differed (`f036db6c…`). Scene B still grades correctly in its own window.
- `oxlint` and `oxfmt --check` clean on both changed files.
