### PR TITLE
chore: release v0.7.106

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,46 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.106"
+  description="Released - 2026-08-11"
+  tags={["Release", "Catalog", "CLI", "Registry"]}
+>
+Catalog pages now play the real composition in the player instead of a recorded video. The sidebar groups 358 items under eight sections you can open.
+
+Every item with variables gets a panel you can change. The preview rebuilds with your values, a link keeps them, and the install command copies with them attached. Reinstalling an item no longer overwrites your edits.
+
+## Fixes
+
+- **Studio:** Read the rotate property when measuring an element's angle ([3e5be0e8c](https://github.com/heygen-com/hyperframes/commit/3e5be0e8c30812e45d302f24dc5aecd3d135ef04), [#3163](https://github.com/heygen-com/hyperframes/pull/3163)).
+
+## Docs & Examples
+
+- **Changelog:** Weekly digest 2026-08-03–2026-08-10 ([945988d61](https://github.com/heygen-com/hyperframes/commit/945988d61facb36ae1a7e27519db2acb3c84fced), [#3154](https://github.com/heygen-com/hyperframes/pull/3154)).
+- **Studio:** Write down what Studio does not tell you about itself ([604f02b31](https://github.com/heygen-com/hyperframes/commit/604f02b31a4e5950262066cf39adbc01d65bbade), [#3165](https://github.com/heygen-com/hyperframes/pull/3165)).
+
+## Catalog
+
+- **Catalog:** Put the variables panel back, on payloads ([1ae2067b8](https://github.com/heygen-com/hyperframes/commit/1ae2067b8da54555889f09f05b826fc791c5ec4c), [#3199](https://github.com/heygen-com/hyperframes/pull/3199)).
+- **Catalog:** Group the sidebar by what you came to make ([ce18acf07](https://github.com/heygen-com/hyperframes/commit/ce18acf075d56e44ebe6382edffc8f3baa96c2c8), [#3194](https://github.com/heygen-com/hyperframes/pull/3194)).
+- **CLI:** Keep your edits when you reinstall a catalog item ([0c33b2dc7](https://github.com/heygen-com/hyperframes/commit/0c33b2dc7ab711ebd9c124ce44535d36d47da748), [#3193](https://github.com/heygen-com/hyperframes/pull/3193)).
+- **Registry:** Bring back the video-primitive moves ([9734578e6](https://github.com/heygen-com/hyperframes/commit/9734578e6065d6dec8993c4e30a978263c3eaa8b), [#3169](https://github.com/heygen-com/hyperframes/pull/3169)).
+- **Catalog:** Keep the recorded video for canvas drawElement previews ([0f7630519](https://github.com/heygen-com/hyperframes/commit/0f763051910f9b38ada67a0f3699a0a75f00b22a), [#3171](https://github.com/heygen-com/hyperframes/pull/3171)).
+- **Catalog:** Resolve assets a script loads by name ([470f802d9](https://github.com/heygen-com/hyperframes/commit/470f802d9f387b0a6e77e25d0b199bf9c16e68f0), [#3170](https://github.com/heygen-com/hyperframes/pull/3170)).
+- **Catalog:** Play the real composition on catalog pages ([536165b6e](https://github.com/heygen-com/hyperframes/commit/536165b6ef1ad2fbd5d799a4a43fe0f31495852f), [#3168](https://github.com/heygen-com/hyperframes/pull/3168)).
+- **Media Use:** Derive provider cost tier from the registry ([6de29f5be](https://github.com/heygen-com/hyperframes/commit/6de29f5beabf29545c1c70e97530d4cf24542c5b), [#3155](https://github.com/heygen-com/hyperframes/pull/3155)).
+
+## Internal
+
+- Regenerate the skills manifest ([0156b5688](https://github.com/heygen-com/hyperframes/commit/0156b5688da70690770ec8dd5253482d0b82c7df), [#3203](https://github.com/heygen-com/hyperframes/pull/3203)).
+
+## Other Changes
+
+- **Studio:** Format AGENTS.md ([a58ebf610](https://github.com/heygen-com/hyperframes/commit/a58ebf610bc56dcced7505c706e031cc8fd36d3c), [#3167](https://github.com/heygen-com/hyperframes/pull/3167)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.105...v0.7.106).
+</Update>
+
+<Update
   label="HyperFrames v0.7.105"
   description="Released - 2026-08-10"
   tags={["Release", "Producer,engine", "CLI", "Scripts"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.105",
+  "version": "0.7.106",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.106.md
+++ b/releases/v0.7.106.md
@@ -1,0 +1,39 @@
+# HyperFrames v0.7.106
+
+Released on 2026-08-11.
+
+Catalog pages now play the real composition in the player instead of a recorded video. The sidebar groups 358 items under eight sections you can open.
+
+Every item with variables gets a panel you can change. The preview rebuilds with your values, a link keeps them, and the install command copies with them attached. Reinstalling an item no longer overwrites your edits.
+
+## Fixes
+
+- **Studio:** Read the rotate property when measuring an element's angle ([3e5be0e8c](https://github.com/heygen-com/hyperframes/commit/3e5be0e8c30812e45d302f24dc5aecd3d135ef04), [#3163](https://github.com/heygen-com/hyperframes/pull/3163)).
+
+## Docs & Examples
+
+- **Changelog:** Weekly digest 2026-08-03–2026-08-10 ([945988d61](https://github.com/heygen-com/hyperframes/commit/945988d61facb36ae1a7e27519db2acb3c84fced), [#3154](https://github.com/heygen-com/hyperframes/pull/3154)).
+- **Studio:** Write down what Studio does not tell you about itself ([604f02b31](https://github.com/heygen-com/hyperframes/commit/604f02b31a4e5950262066cf39adbc01d65bbade), [#3165](https://github.com/heygen-com/hyperframes/pull/3165)).
+
+## Catalog
+
+- **Catalog:** Put the variables panel back, on payloads ([1ae2067b8](https://github.com/heygen-com/hyperframes/commit/1ae2067b8da54555889f09f05b826fc791c5ec4c), [#3199](https://github.com/heygen-com/hyperframes/pull/3199)).
+- **Catalog:** Group the sidebar by what you came to make ([ce18acf07](https://github.com/heygen-com/hyperframes/commit/ce18acf075d56e44ebe6382edffc8f3baa96c2c8), [#3194](https://github.com/heygen-com/hyperframes/pull/3194)).
+- **CLI:** Keep your edits when you reinstall a catalog item ([0c33b2dc7](https://github.com/heygen-com/hyperframes/commit/0c33b2dc7ab711ebd9c124ce44535d36d47da748), [#3193](https://github.com/heygen-com/hyperframes/pull/3193)).
+- **Registry:** Bring back the video-primitive moves ([9734578e6](https://github.com/heygen-com/hyperframes/commit/9734578e6065d6dec8993c4e30a978263c3eaa8b), [#3169](https://github.com/heygen-com/hyperframes/pull/3169)).
+- **Catalog:** Keep the recorded video for canvas drawElement previews ([0f7630519](https://github.com/heygen-com/hyperframes/commit/0f763051910f9b38ada67a0f3699a0a75f00b22a), [#3171](https://github.com/heygen-com/hyperframes/pull/3171)).
+- **Catalog:** Resolve assets a script loads by name ([470f802d9](https://github.com/heygen-com/hyperframes/commit/470f802d9f387b0a6e77e25d0b199bf9c16e68f0), [#3170](https://github.com/heygen-com/hyperframes/pull/3170)).
+- **Catalog:** Play the real composition on catalog pages ([536165b6e](https://github.com/heygen-com/hyperframes/commit/536165b6ef1ad2fbd5d799a4a43fe0f31495852f), [#3168](https://github.com/heygen-com/hyperframes/pull/3168)).
+- **Media Use:** Derive provider cost tier from the registry ([6de29f5be](https://github.com/heygen-com/hyperframes/commit/6de29f5beabf29545c1c70e97530d4cf24542c5b), [#3155](https://github.com/heygen-com/hyperframes/pull/3155)).
+
+## Internal
+
+- Regenerate the skills manifest ([0156b5688](https://github.com/heygen-com/hyperframes/commit/0156b5688da70690770ec8dd5253482d0b82c7df), [#3203](https://github.com/heygen-com/hyperframes/pull/3203)).
+
+## Other Changes
+
+- **Studio:** Format AGENTS.md ([a58ebf610](https://github.com/heygen-com/hyperframes/commit/a58ebf610bc56dcced7505c706e031cc8fd36d3c), [#3167](https://github.com/heygen-com/hyperframes/pull/3167)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.105...v0.7.106


### PR DESCRIPTION
## What

Cuts v0.7.106 from current `main`: version bump across 13 packages and 3 plugin manifests, release notes, changelog entry.

## Why

0.7.105 is what `npx hyperframes` installs today, and it predates the catalog work. The `--vars` flag the catalog's install command now copies does not exist in the published CLI, so a reader who copies that line gets an unknown-option error until this ships.

## How

Re-cut from `main` at `0156b5688` with `release-prepare`. The previous cut stopped at #3194 because a local `v0.7.106` tag pinned the commit range to the earlier cut, so everything merged after it was invisible to the drafter. Deleted the tag and redrafted against `HEAD`, which picked up #3199 and #3203.

Two pairs are left out of the notes deliberately, because each nets to nothing for a reader: #3090 with its revert #3162 (superseded by #3169, which is listed), and #3201 with its revert #3202.

## Test plan

- `release-prepare` reports 13 packages and 3 plugin manifests set to 0.7.106, matching the file list in the diff.
- Release notes and changelog entry cover every merge from v0.7.105 to `0156b5688`, checked against `git log`.
- CI on this branch is the gate for the rest.

Not covered: publishing itself, which happens on merge, and no code changes are in this PR.
