### PR TITLE
fix(core): key the preview volume envelope to the clip, not the timeline

### DIFF
--- a/packages/core/src/runtime/media.ts
+++ b/packages/core/src/runtime/media.ts
@@ -273,7 +273,13 @@ export function syncRuntimeMedia(params: {
       if (clip.volumeKeyframes && clip.volumeKeyframes.length > 0) {
         // Keyframes probed from the GSAP timeline — same source as the renderer.
         // Use the interpolated envelope value directly; no need to track GSAP changes.
-        authorVolume = clampVolume(interpolateVolumeGain(clip.volumeKeyframes, relTime));
+        // Index by elapsed time on the TIMELINE since the clip began, which is what
+        // a normalised envelope is keyed by (and what the renderer's PCM baker uses).
+        // `relTime` is a position inside the media SOURCE — it carries `mediaStart`
+        // and the playback rate — so it only coincides with the envelope's time base
+        // for an untrimmed clip playing at 1x from t=0.
+        const elapsedInClip = params.timeSeconds - clip.start;
+        authorVolume = clampVolume(interpolateVolumeGain(clip.volumeKeyframes, elapsedInClip));
       } else if (previousRuntimeVolume === undefined) {
         // First tick this clip is active. The transport has already seeked GSAP
         // to the current time (seekTimelineAndAdapters runs before syncRuntimeMedia),

--- a/packages/core/src/runtime/mediaVolumeEnvelope.test.ts
+++ b/packages/core/src/runtime/mediaVolumeEnvelope.test.ts
@@ -1,6 +1,10 @@
 /** @vitest-environment jsdom */
 import { describe, expect, it } from "vitest";
-import { probeAndCacheElementVolume, probeElementVolumeKeyframes } from "./mediaVolumeEnvelope";
+import {
+  interpolateVolumeGain,
+  probeAndCacheElementVolume,
+  probeElementVolumeKeyframes,
+} from "./mediaVolumeEnvelope";
 
 describe("probeElementVolumeKeyframes", () => {
   it("retains the last plateau sample before a short volume change", () => {
@@ -142,5 +146,41 @@ describe("probeAndCacheElementVolume", () => {
     expect(cache.get(audio)).toEqual(
       expect.arrayContaining([expect.objectContaining({ volume: 0 })]),
     );
+  });
+
+  it("caches a track-relative envelope for a clip that starts after t=0", () => {
+    // The probe stamps timeline seek times. A clip starting at 2s therefore
+    // yields keyframes at 2.0+, and reading them with track-relative time landed
+    // before the first keyframe and clamped to its volume — 0 for a fade-in, so
+    // the preview stayed silent for the whole clip while the render was correct.
+    const audio = document.createElement("audio");
+    audio.dataset.start = "2";
+    audio.dataset.duration = "1";
+    audio.dataset.volume = "1";
+    document.body.append(audio);
+
+    const timeline = {
+      totalTime(next?: number) {
+        if (next !== undefined) {
+          // 0.05s linear fade-in at the clip's start (timeline t=2).
+          audio.volume = Math.max(0, Math.min(1, (next - 2) / 0.05));
+        }
+        return 0;
+      },
+    };
+    const cache = new WeakMap<HTMLMediaElement, { time: number; volume: number }[]>();
+
+    probeAndCacheElementVolume(audio, timeline, 3, cache);
+
+    const envelope = cache.get(audio);
+    if (!envelope) throw new Error("Expected a cached envelope");
+    expect(envelope[0]).toEqual({ time: 0, volume: 0 });
+    expect(envelope.at(-1)?.time).toBeCloseTo(1, 5);
+
+    // Silent at the clip's start, full once the fade is done, and it stays there.
+    expect(interpolateVolumeGain(envelope, 0)).toBeCloseTo(0, 5);
+    expect(interpolateVolumeGain(envelope, 0.05)).toBeCloseTo(1, 5);
+    expect(interpolateVolumeGain(envelope, 0.5)).toBeCloseTo(1, 5);
+    expect(interpolateVolumeGain(envelope, 1)).toBeCloseTo(1, 5);
   });
 });

--- a/packages/core/src/runtime/mediaVolumeEnvelope.ts
+++ b/packages/core/src/runtime/mediaVolumeEnvelope.ts
@@ -179,8 +179,15 @@ export interface VolumeProbeOptions {
 }
 
 /**
- * Probe a media element and, if volume automation is detected, store the
- * keyframes in `cache`. Safe to call with a null timeline — returns early.
+ * Probe a media element and, if volume automation is detected, store a
+ * NORMALISED envelope in `cache`. Safe to call with a null timeline — returns
+ * early.
+ *
+ * `probeElementVolumeKeyframes` stamps each keyframe with the timeline seek
+ * time it was sampled at. Everything downstream of this cache — like the
+ * renderer's PCM baker — indexes an envelope by track-relative seconds, so the
+ * rebase belongs here, at the one point that fills the cache, rather than at
+ * each read.
  */
 export function probeAndCacheElementVolume(
   mediaEl: HTMLMediaElement,
@@ -217,6 +224,8 @@ export function probeAndCacheElementVolume(
   const keyframes = probeElementVolumeKeyframes(mediaEl, seekFn, compositionDuration, 60);
   if (Number.isFinite(originalTime)) seekFn(originalTime);
   if (keyframes) {
-    cache.set(mediaEl, keyframes);
+    const { start, staticVolume } = resolveVolumeProbeWindow(mediaEl, compositionDuration);
+    const envelope = normaliseEnvelope(keyframes, start, staticVolume);
+    if (envelope.length > 0) cache.set(mediaEl, envelope);
   }
 }


### PR DESCRIPTION
## What

A GSAP volume fade on an audio clip that starts after `t=0` leaves the preview silent for the clip's entire length, while the encoded render is correct. This puts the preview back on the same envelope the renderer uses.

## Why

Reproduced on macOS with one `<audio data-start="2" data-duration="3" data-volume="1">` and a 0.05s `fromTo` volume fade at the clip's start. Probing `el.volume` through the preview:

| timeline t | before | expected |
| --- | --- | --- |
| 2.00 | 0 | 0 |
| 2.05 (mid-fade) | 0.667 | 0.667 |
| 2.10 | **0** | 1 |
| 3.00 | **0** | 1 |
| 5.50 | **0** | 1 |

The encoded render was already right: full volume reached just after the fade and held to the clip's end. So the same composition sounded silent while authoring and correct once rendered, which is the worst version of this to debug.

`mediaVolumeEnvelope` exists to keep preview and render on one envelope — its own header comment says so — and its contract is "normalise, then read with track-relative seconds". The preview skipped both halves:

- `probeElementVolumeKeyframes` stamps each keyframe with the **timeline** seek time it sampled at.
- `normaliseEnvelope`, which rebases those onto the track, had exactly one caller: the renderer's PCM baker in `audioVolumeEnvelope.ts`.
- The preview passed the raw keyframes to `interpolateVolumeGain` along with `relTime`.

For a clip at `t=2`, every preview lookup landed two seconds before the first keyframe and clamped to its volume — 0 for a fade-in. Two controls confirm the mechanism: the same clip with no fade previews at a steady 1, and the same fade at `data-start="0"` previews correctly, because there timeline time and track time coincide.

## How

Rebase once, at the single point that fills the cache, so the cached envelope has one documented time base instead of one per reader.

Read it with elapsed-time-in-clip instead of `relTime`. `relTime` is a position inside the media **source**: it carries `mediaStart` and the playback rate, so it only coincides with the envelope's time base for an untrimmed clip playing at 1x from zero. That second half also fixes a latent sibling — a trimmed clip (`data-playback-start`) read the wrong envelope point even when it started at 0.

The renderer's path is untouched; it already normalised.

Not covered here: audio clips land about 20 ms after their authored `data-start` in the rendered mix. That reproduces with and without volume automation, is not encoder priming (two codecs agree, and a hand-built reference through the same ffmpeg lands exactly on time), and is a separate defect in the assemble stage rather than in this envelope. Filed separately.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

New regression test in `mediaVolumeEnvelope.test.ts`: a clip starting at `t=2` with a 0.05s fade must cache an envelope whose first keyframe is at `time: 0`, and reading it must give 0 at the clip's start, 1 once the fade completes, and 1 held to the end. Verified it fails on `main` with `{ time: 2 }` where `{ time: 0 }` was expected, and passes with the fix.

- `packages/core` suite: 1912 passed, 100 files. `packages/engine` audio mixer and volume-envelope suites: 30 passed.
- End-to-end on the original repro, preview now reads 0 → 0.667 → 1 → 1 → 1 across the fade, matching the authored tween and the encoded audio.
- Re-rendered the same project and measured the encoded envelope: onset, 50%, 95% and tail are byte-for-byte the same numbers as before the change, so the render path is unaffected.
- `oxlint` and `oxfmt` clean on all three changed files.
