### PR TITLE
chore: regenerate the skills manifest

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -26,7 +26,7 @@
       "files": 121
     },
     "hyperframes-cli": {
-      "hash": "17e2300803951ed7",
+      "hash": "e042fcaaa3f9767f",
       "files": 11
     },
     "hyperframes-core": {


### PR DESCRIPTION
## What

Regenerates `skills-manifest.json` so the `hyperframes-cli` entry matches the skill on disk.

## Why

`hyperframes-cli` gained the search-miss report in #3199 and its content hash moved with it. The manifest is the published freshness fingerprint the CLI reads, so a skill edit that leaves it behind makes the manifest claim a version of the skill that no longer exists. CI caught it on `main`: `skills-manifest.json is out of date - a skill changed without regenerating it.`

It reached `main` because the `Detect changes` gate on #3199 failed on an unrelated deletion check, which left every downstream job in that run skipped, including this one.

## How

`bun packages/cli/scripts/gen-skills-manifest.ts`. One hash changed; no other skill moved.

## Test plan

- `bun packages/cli/scripts/gen-skills-manifest.ts --check` passes locally, which is the exact command the failing job runs.
- Diff is a single line in a generated file, so the CI run on this branch is the verification that matters.

Not covered: nothing else in the manifest was touched, and no skill content changes here.
