### PR TITLE
fix(skills): remove duplicated media-cleanup block in slideshow

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -70,7 +70,7 @@
       "files": 70
     },
     "slideshow": {
-      "hash": "71368acf61074198",
+      "hash": "6a24a84b0c1a75f9",
       "files": 2
     },
     "talking-head-recut": {

--- a/skills/slideshow/SKILL.md
+++ b/skills/slideshow/SKILL.md
@@ -460,36 +460,6 @@ The same cross-realm rule applies here: global mute must reach iframe `<video>` 
 
 `hyperframes present` serves built bundles from `packages/player/dist`. After changing player or slideshow chrome behavior, run `bun run build` in `packages/player` and restart the present server before testing in a browser.
 
-Presenter notes are editable in the presenter view. Edits are stored in `localStorage` per deck and slide, layered over the manifest notes without rewriting the composition file. Do not add one-off note-editing scripts to decks; rely on the shared slideshow player behavior. If a standalone/custom wrapper truly needs to implement this outside the shared player, use the deterministic storage snippet in `skills/slideshow/references/standalone-harness.md`.
-
-### Media cleanup on slide exit
-
-The slideshow controller owns slide-exit media cleanup. When navigation changes slide or sequence, it calls `hyperframes-player.stopMedia()` before entering the next slide. That command:
-
-- posts `stop-media` to the iframe runtime, which stops WebAudio and pauses native `<video>` / `<audio>` elements;
-- pauses same-origin iframe media directly as a fallback; and
-- pauses parent-frame proxies adopted from iframe media.
-
-Same-slide fragment navigation does **not** stop media. Global/deck-level parent audio, such as a background track wired through `audio-src`, is not treated as slide media.
-
-Do not add per-slide cleanup scripts for normal media players. Keep slide video/audio as normal media in the composition; use `data-has-audio="true"` only when the player should preserve audible native video audio instead of treating it as silent visual media.
-
-When implementing direct iframe fallback cleanup, treat iframe media as cross-realm DOM. Do not test iframe nodes with the parent page's `el instanceof HTMLMediaElement`; that returns false in real browsers. Use `el.ownerDocument.defaultView.HTMLMediaElement` (or an equivalent tag/duck-type guard) before setting `muted` or calling `pause()`.
-
-### Global nav mute
-
-When `<hyperframes-slideshow sound>` renders the nav mute button, that button is the global mute control for the page. It must mute:
-
-- child `<hyperframes-player>` instances, including same-origin iframe media;
-- top-level page `<audio>` / `<video>` elements; and
-- wrapper-owned SFX/global `Audio` objects via the `hf-sound` event.
-
-Do not add a second mute button inside the composition. If a wrapper script creates `new Audio(...)` objects that are not attached to the DOM, it must listen for `hf-sound` and set `clip.muted = detail.muted` on each object, not merely skip future plays.
-
-The same cross-realm rule applies here: global mute must reach iframe `<video>` / `<audio>` elements through the child frame's DOM realm. A passing unit test in a single DOM realm is not enough; verify in a browser that the actual iframe media elements report `muted: true` after clicking the nav mute button.
-
-`hyperframes present` serves built bundles from `packages/player/dist`. After changing player or slideshow chrome behavior, run `bun run build` in `packages/player` and restart the present server before testing in a browser.
-
 ---
 
 ## Running a slideshow standalone (interim)


### PR DESCRIPTION
## What

Deletes a 30-line duplicated block from `skills/slideshow/SKILL.md`. Pure deletion — **+0 −30**, no content added or reworded.

## Why

Lines **431–461** are repeated at **463–491**: the presenter-notes paragraph, then the whole of `### Media cleanup on slide exit` and `### Global nav mute`. Eleven paragraphs, 2,843 bytes — about 7.7% of the file.

**The copies are not identical.** The second is a strict subset that drops exactly one normative paragraph:

> If the source page has custom controls or visualizations attached to media, those controls must listen to the same native element the slideshow player stops and mutes. A pause caused by slide exit, presenter sync, native controls, custom controls, or the global mute button should all update the visible custom UI through media events, not through parallel state.

That matters because of ordering. An agent reading the file top-to-bottom hits the complete version first and the truncated one second — and the natural reading of a repeated section is that the later one supersedes. So the rule most likely to be lost is the one about custom controls syncing through media events, which is exactly the kind of thing that produces a deck where the play button and the actual `<video>` disagree after a slide change.

Everything else in the two copies is verbatim identical, so copy 1 is a strict superset and the later copy can go without merging anything.

## How

Removed lines 463–492 (the duplicate plus its trailing blank), keeping the `---` separator that follows. Nothing else touched — the diff is `+0 −30`.

Verified on the result:

- duplicated paragraphs: **11 → 0**
- the custom-controls rule: present, exactly once
- the presenter-notes paragraph: present, exactly once
- `### Media cleanup on slide exit`, `### Global nav mute`, `## Wrapping component`, `## Running a slideshow standalone`: one heading each
- both `references/standalone-harness.md` pointers retained (the presenter-notes paragraph and the standalone section — two distinct, legitimate mentions)
- code fences still balanced

## One separate observation — no change made

Lines **242–396** are a 154-line, 4.8 KB fenced block: the "Scene HTML (skeleton)" for the 3-slide worked example. It is by far the largest code block in the file; the next largest is under 25 lines.

It could ship as an asset the way `references/standalone-harness.md` already does, which would remove ~13% of the file and give the agent something to copy rather than retype. But an illustrative skeleton is a weaker case for extraction than a complete runnable document, and it may genuinely be more useful inline where the surrounding prose annotates it. Raising it rather than assuming — happy to send it as a follow-up if you want it.

## Test plan

- [ ] Unit tests added/updated — n/a, documentation only
- [x] Manual testing performed — verified against HEAD that the block is duplicated and that the second copy is a strict subset; verified the result has zero duplicated paragraphs, one of each affected heading, and retains the paragraph the duplicate dropped
- [x] Documentation updated (if applicable) — this PR *is* the documentation change

Found while auditing skill files for context-budget cost.
