### PR TITLE
fix(hyperframes-animation): correct the iOS system default spring register label

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -22,7 +22,7 @@
       "files": 17
     },
     "hyperframes-animation": {
-      "hash": "a5be218c0b0fe377",
+      "hash": "7c0cbe89d5339b47",
       "files": 121
     },
     "hyperframes-audio": {

--- a/skills/hyperframes-animation/adapters/gsap-easing-and-stagger.md
+++ b/skills/hyperframes-animation/adapters/gsap-easing-and-stagger.md
@@ -65,8 +65,9 @@ Why not a real-time spring library: an interactive spring is a stateful integrat
 ```javascript
 // springEase — a damped spring's exact position curve as a GSAP ease.
 // response         ≈ seconds one oscillation would take (0.3–0.6 for entrances)
-// dampingFraction  1.0       = critically damped — smooth settle, NO overshoot (house default)
-//                  0.80–0.85 ≈ the iOS system register — ~1–1.5% overshoot, felt not seen
+// dampingFraction  1.0       = critically damped — smooth settle, NO overshoot (house default;
+//                              also the iOS system default — Animation.default is response 0.55, dampingFraction 1.0)
+//                  0.80–0.85 ≈ SwiftUI's "snappy" preset — ~1–1.5% overshoot, felt not seen
 //                  0.60–0.70 = explicitly playful — ~5–10% overshoot (rare; replaces back.out)
 function springEase({ response = 0.5, dampingFraction = 1 } = {}) {
   const w = (2 * Math.PI) / response; // undamped natural frequency
@@ -116,12 +117,12 @@ tl.fromTo(
 );
 ```
 
-| dampingFraction   | overshoot       | register                                                                                                                                           |
-| ----------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **1.0 (default)** | none (monotone) | The house settle — the exact curve `power3.out` approximates. Product / enterprise / serious tone.                                                 |
-| 0.80–0.85         | ~1–1.5%         | "Alive, not bouncy" — the iOS system default register. The overshoot is felt, not seen.                                                            |
-| 0.60–0.70         | ~5–10%          | Explicitly-playful ONLY (same rule as `back.out`, which this replaces — a spring's second-order settle reads physical where `back` reads cartoon). |
-| < 0.55            | > 12%           | Don't. Cartoon-wobble territory.                                                                                                                   |
+| dampingFraction   | overshoot       | register                                                                                                                                                                                         |
+| ----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **1.0 (default)** | none (monotone) | The house settle — the exact curve `power3.out` approximates; also the iOS system default (`Animation.default`: a response 0.55 spring, critically damped). Product / enterprise / serious tone. |
+| 0.80–0.85         | ~1–1.5%         | "Alive, not bouncy" — ≈ SwiftUI's `snappy` preset, an optional livelier register. The overshoot is felt, not seen.                                                                               |
+| 0.60–0.70         | ~5–10%          | Explicitly-playful ONLY (same rule as `back.out`, which this replaces — a spring's second-order settle reads physical where `back` reads cartoon).                                               |
+| < 0.55            | > 12%           | Don't. Cartoon-wobble territory.                                                                                                                                                                 |
 
 | response  | duration (ζ=1) | feel                                                         |
 | --------- | -------------- | ------------------------------------------------------------ |


### PR DESCRIPTION
Small factual correction in `skills/hyperframes-animation/adapters/gsap-easing-and-stagger.md`.

The file labels dampingFraction **0.80–0.85** as "the iOS system register" (springEase
comment) and "the iOS system default register" (dampingFraction table). Per Apple, the
iOS system default — [`Animation.default`](https://developer.apple.com/documentation/swiftui/animation/default),
since iOS 17 — is a spring with **response 0.55, dampingFraction 1.0**: critically
damped, no bounce. 0.80–0.85 corresponds to SwiftUI's `snappy` preset
([`Spring`](https://developer.apple.com/documentation/swiftui/spring) — "a small amount
of bounce"), an optional livelier register rather than the platform default.

## Changes

- springEase comment: the "iOS system default" fact moves to the `1.0` line
  (`Animation.default` = response 0.55, dampingFraction 1.0); `0.80–0.85` is relabeled
  ≈ SwiftUI's `snappy` preset.
- dampingFraction table: same relabel on the `0.80–0.85` row; the `1.0` row gains the
  true-default note.

No behavioral change — `springEase` itself is untouched, and the file's surrounding
doctrine ("Well-made system animations are critically damped or close to it", default
ζ=1) already agrees with the corrected labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
