### PR TITLE
fix(capture): fall back from networkidle2 to domcontentloaded on nav timeout

### DIFF
--- a/packages/cli/src/capture/index.ts
+++ b/packages/cli/src/capture/index.ts
@@ -42,6 +42,7 @@ import {
 import type { VisionCaptionOutcome } from "./contentExtractor.js";
 import { loadEnvFile, generateProjectScaffold } from "./scaffolding.js";
 import { detectBlockedPage } from "./pageBlockDetection.js";
+import { navigateForCapture } from "./navigateForCapture.js";
 import type { CaptureOptions, CapturePhase, CapturePhaseProgress, CaptureResult } from "./types.js";
 
 export type { CaptureOptions, CaptureResult } from "./types.js";
@@ -238,10 +239,17 @@ export async function captureWebsite(
       }
     });
 
-    // Use networkidle2 (allows 2 ongoing connections) instead of networkidle0 —
-    // modern SPAs often have persistent WebSocket/analytics connections that
-    // prevent networkidle0 from ever resolving.
-    const navigationResponse = await page1.goto(url, { waitUntil: "networkidle2", timeout });
+    const navigation = await navigateForCapture(page1, url, timeout);
+    const navigationResponse = navigation.response;
+    if (navigation.fellBackFromNetworkIdle) {
+      warnings.push(
+        `networkidle2 timed out after ${navigation.networkIdleTimeoutMs}ms; continued with domcontentloaded`,
+      );
+      progress(
+        "warn",
+        `networkidle2 timed out after ${navigation.networkIdleTimeoutMs}ms; continuing with domcontentloaded`,
+      );
+    }
     postNavigationDeadline = Date.now() + budgetMs;
     await new Promise((r) => setTimeout(r, settleTime));
 

--- a/packages/cli/src/capture/navigateForCapture.test.ts
+++ b/packages/cli/src/capture/navigateForCapture.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isNavigationTimeoutError,
+  navigateForCapture,
+  networkIdleAttemptTimeoutMs,
+  NETWORK_IDLE_ATTEMPT_MS,
+} from "./navigateForCapture.js";
+
+describe("networkIdleAttemptTimeoutMs", () => {
+  it("caps at the network-idle attempt budget", () => {
+    expect(networkIdleAttemptTimeoutMs(120_000)).toBe(NETWORK_IDLE_ATTEMPT_MS);
+  });
+
+  it("honors a caller timeout below the attempt budget", () => {
+    expect(networkIdleAttemptTimeoutMs(10_000)).toBe(10_000);
+  });
+});
+
+describe("isNavigationTimeoutError", () => {
+  it("matches Puppeteer navigation timeouts", () => {
+    expect(isNavigationTimeoutError(new Error("Navigation timeout of 30000 ms exceeded"))).toBe(
+      true,
+    );
+  });
+
+  it("ignores unrelated failures", () => {
+    expect(isNavigationTimeoutError(new Error("net::ERR_NAME_NOT_RESOLVED"))).toBe(false);
+  });
+});
+
+describe("navigateForCapture", () => {
+  it("returns after networkidle2 when the page settles", async () => {
+    const response = { status: () => 200 };
+    const goto = vi.fn().mockResolvedValue(response);
+    const result = await navigateForCapture({ goto }, "https://example.com", 120_000);
+
+    expect(result).toEqual({
+      response,
+      waitUntil: "networkidle2",
+      networkIdleTimeoutMs: NETWORK_IDLE_ATTEMPT_MS,
+      fellBackFromNetworkIdle: false,
+    });
+    expect(goto).toHaveBeenCalledTimes(1);
+    expect(goto).toHaveBeenCalledWith("https://example.com", {
+      waitUntil: "networkidle2",
+      timeout: NETWORK_IDLE_ATTEMPT_MS,
+    });
+  });
+
+  it("falls back to domcontentloaded after a networkidle2 navigation timeout", async () => {
+    const response = { status: () => 200 };
+    const goto = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Navigation timeout of 30000 ms exceeded"))
+      .mockResolvedValueOnce(response);
+
+    const result = await navigateForCapture({ goto }, "https://www.yahoo.com/", 120_000);
+
+    expect(result).toEqual({
+      response,
+      waitUntil: "domcontentloaded",
+      networkIdleTimeoutMs: NETWORK_IDLE_ATTEMPT_MS,
+      fellBackFromNetworkIdle: true,
+    });
+    expect(goto).toHaveBeenNthCalledWith(1, "https://www.yahoo.com/", {
+      waitUntil: "networkidle2",
+      timeout: NETWORK_IDLE_ATTEMPT_MS,
+    });
+    expect(goto).toHaveBeenNthCalledWith(2, "https://www.yahoo.com/", {
+      waitUntil: "domcontentloaded",
+      timeout: 90_000,
+    });
+  });
+
+  it("does not fall back for non-timeout navigation errors", async () => {
+    const err = new Error("net::ERR_CONNECTION_REFUSED");
+    const goto = vi.fn().mockRejectedValue(err);
+
+    await expect(navigateForCapture({ goto }, "https://example.com", 120_000)).rejects.toBe(err);
+    expect(goto).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fall back when the caller timeout already equals the idle attempt", async () => {
+    const err = new Error("Navigation timeout of 10000 ms exceeded");
+    const goto = vi.fn().mockRejectedValue(err);
+
+    await expect(navigateForCapture({ goto }, "https://example.com", 10_000)).rejects.toBe(err);
+    expect(goto).toHaveBeenCalledWith("https://example.com", {
+      waitUntil: "networkidle2",
+      timeout: 10_000,
+    });
+  });
+});

--- a/packages/cli/src/capture/navigateForCapture.test.ts
+++ b/packages/cli/src/capture/navigateForCapture.test.ts
@@ -72,6 +72,31 @@ describe("navigateForCapture", () => {
     });
   });
 
+  it.each([
+    { totalTimeoutMs: 31_000, fallbackTimeoutMs: 1_000 },
+    { totalTimeoutMs: 45_000, fallbackTimeoutMs: 15_000 },
+  ])(
+    "uses only the remaining budget for fallback when totalTimeoutMs=$totalTimeoutMs",
+    async ({ totalTimeoutMs, fallbackTimeoutMs }) => {
+      const response = { status: () => 200 };
+      const goto = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Navigation timeout of 30000 ms exceeded"))
+        .mockResolvedValueOnce(response);
+
+      await navigateForCapture({ goto }, "https://www.yahoo.com/", totalTimeoutMs);
+
+      expect(goto).toHaveBeenNthCalledWith(1, "https://www.yahoo.com/", {
+        waitUntil: "networkidle2",
+        timeout: NETWORK_IDLE_ATTEMPT_MS,
+      });
+      expect(goto).toHaveBeenNthCalledWith(2, "https://www.yahoo.com/", {
+        waitUntil: "domcontentloaded",
+        timeout: fallbackTimeoutMs,
+      });
+    },
+  );
+
   it("does not fall back for non-timeout navigation errors", async () => {
     const err = new Error("net::ERR_CONNECTION_REFUSED");
     const goto = vi.fn().mockRejectedValue(err);

--- a/packages/cli/src/capture/navigateForCapture.ts
+++ b/packages/cli/src/capture/navigateForCapture.ts
@@ -50,7 +50,7 @@ export async function navigateForCapture<TResponse>(
     }
   }
 
-  const fallbackTimeoutMs = Math.max(totalTimeoutMs - networkIdleTimeoutMs, networkIdleTimeoutMs);
+  const fallbackTimeoutMs = totalTimeoutMs - networkIdleTimeoutMs;
   const response = await page.goto(url, {
     waitUntil: "domcontentloaded",
     timeout: fallbackTimeoutMs,

--- a/packages/cli/src/capture/navigateForCapture.ts
+++ b/packages/cli/src/capture/navigateForCapture.ts
@@ -1,0 +1,64 @@
+export const NETWORK_IDLE_ATTEMPT_MS = 30_000;
+
+export type CaptureGotoWaitUntil = "networkidle2" | "domcontentloaded";
+
+export interface CaptureGotoOptions {
+  waitUntil: CaptureGotoWaitUntil;
+  timeout: number;
+}
+
+export interface CaptureGotoPage<TResponse = unknown> {
+  goto(url: string, options: CaptureGotoOptions): Promise<TResponse>;
+}
+
+export interface NavigateForCaptureResult<TResponse = unknown> {
+  response: TResponse;
+  waitUntil: CaptureGotoWaitUntil;
+  networkIdleTimeoutMs: number;
+  fellBackFromNetworkIdle: boolean;
+}
+
+export function networkIdleAttemptTimeoutMs(totalTimeoutMs: number): number {
+  return Math.min(NETWORK_IDLE_ATTEMPT_MS, Math.max(0, totalTimeoutMs));
+}
+
+export function isNavigationTimeoutError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /navigation timeout/i.test(msg);
+}
+
+export async function navigateForCapture<TResponse>(
+  page: CaptureGotoPage<TResponse>,
+  url: string,
+  totalTimeoutMs: number,
+): Promise<NavigateForCaptureResult<TResponse>> {
+  const networkIdleTimeoutMs = networkIdleAttemptTimeoutMs(totalTimeoutMs);
+  try {
+    const response = await page.goto(url, {
+      waitUntil: "networkidle2",
+      timeout: networkIdleTimeoutMs,
+    });
+    return {
+      response,
+      waitUntil: "networkidle2",
+      networkIdleTimeoutMs,
+      fellBackFromNetworkIdle: false,
+    };
+  } catch (err) {
+    if (!isNavigationTimeoutError(err) || networkIdleTimeoutMs >= totalTimeoutMs) {
+      throw err;
+    }
+  }
+
+  const fallbackTimeoutMs = Math.max(totalTimeoutMs - networkIdleTimeoutMs, networkIdleTimeoutMs);
+  const response = await page.goto(url, {
+    waitUntil: "domcontentloaded",
+    timeout: fallbackTimeoutMs,
+  });
+  return {
+    response,
+    waitUntil: "domcontentloaded",
+    networkIdleTimeoutMs,
+    fellBackFromNetworkIdle: true,
+  };
+}


### PR DESCRIPTION
## Summary
- Website capture first tries `networkidle2` for up to 30s (or the caller `--timeout` if smaller).
- On a Puppeteer navigation timeout, retry with `domcontentloaded` using the remaining budget, then keep the existing settle/scroll path.
- Non-timeout navigation errors still fail immediately.

Reproduced on yahoo.com: stock 0.7.100 hung 120s on `networkidle2`; with this fallback, capture completes (~1 min) with screenshots/assets.

## Test plan
- [x] `vitest run src/capture/navigateForCapture.test.ts`
- [ ] Manual: `hyperframes capture https://www.yahoo.com/` — should warn about networkidle2 timeout, then succeed
- [ ] Manual: a quiet marketing site — should still finish on the networkidle2 path with no fallback warning


Made with [Cursor](https://cursor.com)