### PR TITLE
chore: release v0.7.107

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,33 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.107"
+  description="Released - 2026-08-11"
+  tags={["Release", "Skills", "Capture", "Studio"]}
+>
+Studio can now edit and style rich text directly in the preview, including mixed selections and partial character ranges. Feedback prompts now appear after renders, while playback, capture, and editing fixes improve reliability.
+
+## Features
+
+- **Studio:** Show every colour of a mixed selection in the swatch ([896bc336a](https://github.com/heygen-com/hyperframes/commit/896bc336a2eb058fa7cd21e6686b3c6a23879d28), [#3144](https://github.com/heygen-com/hyperframes/pull/3144)).
+- **Studio:** Edit and style text in the preview ([4cc46f5f9](https://github.com/heygen-com/hyperframes/commit/4cc46f5f9f6ba063bcebcc663a9b04c008f119d4), [#3143](https://github.com/heygen-com/hyperframes/pull/3143)).
+- **Studio:** Apply a style to a run of characters ([cb73c8dc2](https://github.com/heygen-com/hyperframes/commit/cb73c8dc2e0d9c6b911044de0e0d7fb5fbb49752), [#3142](https://github.com/heygen-com/hyperframes/pull/3142)).
+- **Core:** Sanitize rich text on the way into a composition ([636dc042a](https://github.com/heygen-com/hyperframes/commit/636dc042a7b773d9038b6bea589b4118051764c5), [#3141](https://github.com/heygen-com/hyperframes/pull/3141)).
+- **Studio:** Ask for feedback when a render ends, not on a session counter ([20d915938](https://github.com/heygen-com/hyperframes/commit/20d915938b33301d78402407d167841f8da3e9a5), [#3205](https://github.com/heygen-com/hyperframes/pull/3205)).
+
+## Fixes
+
+- **Skills:** Stop embedded-captions shipping author-only paths; dedupe slideshow ([d3a4e9037](https://github.com/heygen-com/hyperframes/commit/d3a4e9037096c0234c58b44fcbcc7df87ba8958b), [#3225](https://github.com/heygen-com/hyperframes/pull/3225)).
+- **Capture:** Fall back from networkidle2 to domcontentloaded on nav timeout ([7860d1943](https://github.com/heygen-com/hyperframes/commit/7860d19433e45507c9544f6e6b542e7e572e47c9), [#3224](https://github.com/heygen-com/hyperframes/pull/3224)).
+- **Studio:** Match the write receipt in dev, so an edit stops reloading the preview ([fceb37655](https://github.com/heygen-com/hyperframes/commit/fceb376551093be69e918786532d88eb63a2d07c), [#3206](https://github.com/heygen-com/hyperframes/pull/3206)).
+- **Producer:** Mix audio into a container that can record encoder delay ([dc4383113](https://github.com/heygen-com/hyperframes/commit/dc4383113cfad3677d016b457cce8b4d41ff7b9c), [#3200](https://github.com/heygen-com/hyperframes/pull/3200)).
+- **Core:** Key the preview volume envelope to the clip, not the timeline ([eee9b26fb](https://github.com/heygen-com/hyperframes/commit/eee9b26fb78a6bf3a80e81d6077f7fd93aeca150), [#3198](https://github.com/heygen-com/hyperframes/pull/3198)).
+- **Core:** Stop a graded plate painting through an inactive clip ([91f14958c](https://github.com/heygen-com/hyperframes/commit/91f14958cc449f95a412993373077a6f53fabc1a), [#3196](https://github.com/heygen-com/hyperframes/pull/3196)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.106...v0.7.107).
+</Update>
+
+<Update
   label="HyperFrames v0.7.106"
   description="Released - 2026-08-11"
   tags={["Release", "Catalog", "CLI", "Registry"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.107.md
+++ b/releases/v0.7.107.md
@@ -1,0 +1,26 @@
+# HyperFrames v0.7.107
+
+Released on 2026-08-11.
+
+Studio can now edit and style rich text directly in the preview, including mixed selections and partial character ranges. Feedback prompts now appear after renders, while playback, capture, and editing fixes improve reliability.
+
+## Features
+
+- **Studio:** Show every colour of a mixed selection in the swatch ([896bc336a](https://github.com/heygen-com/hyperframes/commit/896bc336a2eb058fa7cd21e6686b3c6a23879d28), [#3144](https://github.com/heygen-com/hyperframes/pull/3144)).
+- **Studio:** Edit and style text in the preview ([4cc46f5f9](https://github.com/heygen-com/hyperframes/commit/4cc46f5f9f6ba063bcebcc663a9b04c008f119d4), [#3143](https://github.com/heygen-com/hyperframes/pull/3143)).
+- **Studio:** Apply a style to a run of characters ([cb73c8dc2](https://github.com/heygen-com/hyperframes/commit/cb73c8dc2e0d9c6b911044de0e0d7fb5fbb49752), [#3142](https://github.com/heygen-com/hyperframes/pull/3142)).
+- **Core:** Sanitize rich text on the way into a composition ([636dc042a](https://github.com/heygen-com/hyperframes/commit/636dc042a7b773d9038b6bea589b4118051764c5), [#3141](https://github.com/heygen-com/hyperframes/pull/3141)).
+- **Studio:** Ask for feedback when a render ends, not on a session counter ([20d915938](https://github.com/heygen-com/hyperframes/commit/20d915938b33301d78402407d167841f8da3e9a5), [#3205](https://github.com/heygen-com/hyperframes/pull/3205)).
+
+## Fixes
+
+- **Skills:** Stop embedded-captions shipping author-only paths; dedupe slideshow ([d3a4e9037](https://github.com/heygen-com/hyperframes/commit/d3a4e9037096c0234c58b44fcbcc7df87ba8958b), [#3225](https://github.com/heygen-com/hyperframes/pull/3225)).
+- **Capture:** Fall back from networkidle2 to domcontentloaded on nav timeout ([7860d1943](https://github.com/heygen-com/hyperframes/commit/7860d19433e45507c9544f6e6b542e7e572e47c9), [#3224](https://github.com/heygen-com/hyperframes/pull/3224)).
+- **Studio:** Match the write receipt in dev, so an edit stops reloading the preview ([fceb37655](https://github.com/heygen-com/hyperframes/commit/fceb376551093be69e918786532d88eb63a2d07c), [#3206](https://github.com/heygen-com/hyperframes/pull/3206)).
+- **Producer:** Mix audio into a container that can record encoder delay ([dc4383113](https://github.com/heygen-com/hyperframes/commit/dc4383113cfad3677d016b457cce8b4d41ff7b9c), [#3200](https://github.com/heygen-com/hyperframes/pull/3200)).
+- **Core:** Key the preview volume envelope to the clip, not the timeline ([eee9b26fb](https://github.com/heygen-com/hyperframes/commit/eee9b26fb78a6bf3a80e81d6077f7fd93aeca150), [#3198](https://github.com/heygen-com/hyperframes/pull/3198)).
+- **Core:** Stop a graded plate painting through an inactive clip ([91f14958c](https://github.com/heygen-com/hyperframes/commit/91f14958cc449f95a412993373077a6f53fabc1a), [#3196](https://github.com/heygen-com/hyperframes/pull/3196)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.106...v0.7.107


### PR DESCRIPTION
## What

Cuts v0.7.107 from current `main`: version bump across 13 packages and 3 plugin manifests, release notes, and changelog entry.

## Why

The Studio feedback improvement in #3205 merged after v0.7.106. Publishing this release makes feedback prompts appear after render outcomes and exposes the new analytics events in the stable Studio package.

## How

Prepared from `main` at `d3a4e9037` with `bun run release:prepare 0.7.107`. The generated notes cover all 11 commits since v0.7.106, including rich-text editing, feedback timing, and reliability fixes.

## Test plan

- `release:prepare` set 13 packages and 3 plugin manifests to 0.7.107.
- Release notes and changelog cover every merge from v0.7.106 to `d3a4e9037`, checked against `git log`.
- 43 targeted release-script assertions passed locally. The unchanged publish-workflow parser test could not run because the reused local dependency tree lacks `yaml`; CI is the authoritative gate.
- CI on this branch gates merging and publishing.

Not covered locally: publishing itself, which runs from the merge SHA.

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] Documentation updated (if applicable)