### PR TITLE
chore(cli): bump pinned Chromium to 152.0.7977.30

### DIFF
--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -20,7 +20,22 @@ async function loadPuppeteerBrowsers(): Promise<PuppeteerBrowsers> {
   }
 }
 
-const CHROME_VERSION = "152.0.7928.2";
+// Bumped from 152.0.7928.2 on 2026-08-10 to pick up crbug 522872457's fix
+// (CL 8032671, "Force-merge PendingLayer for canvas child descendant", merged
+// 2026-07-07 — after the 152.0.7935.0 canary cut, so the old pin predated it).
+//
+// Measured on the shipping headless-shell binary, drawElementImage vs a CDP
+// screenshot of the identical state:
+//   sibling content dropped from 3D captures  — FIXED
+//   background lost from 3D captures          — FIXED
+//   backface-visibility:hidden ignored        — STILL BROKEN (1.4 dB -> 14.8 dB;
+//                                               better, still far under the
+//                                               32 dB floor)
+// So the 3D compile gate must stay. See PRINFRA-486.
+//
+// Deliberately Beta, not Canary. 153.0.8000.0 measured identical to this build
+// on every probe variant, so crossing a major buys nothing measurable.
+const CHROME_VERSION = "152.0.7977.30";
 const CACHE_ROOT_DIR = join(homedir(), ".cache", "hyperframes");
 const CACHE_DIR = join(homedir(), ".cache", "hyperframes", "chrome");
 // Puppeteer's managed cache — where `@puppeteer/browsers install
@@ -332,7 +347,7 @@ async function findFromCache(): Promise<CacheLookupResult> {
   // this is the non-`preferManagedChrome` path, which exists so a user who
   // installed chrome-headless-shell separately (via `@puppeteer/browsers
   // install`) keeps using that binary instead of being silently switched to
-  // the HF-pinned one. Note `CHROME_VERSION` (above) is a Dev-channel pin
+  // the HF-pinned one. Note `CHROME_VERSION` (above) is a pre-Stable pin
   // that may be NEWER than a user's puppeteer-cache Stable build — this is
   // about respecting an explicit prior choice, not "newest wins".
   const fromPuppeteer = findFromPuppeteerCache();


### PR DESCRIPTION
**Stack 1/3** — base of the drawElement fixes that follow.

Bumps the pinned Chromium to pick up crbug 522872457's fix (CL 8032671), which landed after the 152.0.7935.0 canary cut and so post-dated the old 152.0.7928.2 pin.

Beta rather than Canary deliberately: 153.0.8000.0 measured identical to this build on every probe variant, so crossing a major buys nothing measurable. Verified `chrome-headless-shell` ships for mac-x64, mac-arm64, win32, win64 and linux64 at this version, so the bump cannot brick downloads on a platform not tested here.

### What the new build fixes, and what it does not

Re-probed every 3D signal the compile gate matches, `drawElementImage` vs a CDP screenshot of the identical state, on the shipping headless-shell binary:

| variant | old pin | new pin | |
|---|---|---|---|
| sibling content dropped from 3D captures | broken | **fixed** | |
| background lost from 3D captures | broken | **fixed** | |
| `backface-visibility: hidden` ignored | 1.4 dB | 14.8 dB | still under the 32 dB floor |

The upstream fix repaired the collateral damage only. That is recorded in the comment above `CHROME_VERSION` so the next person does not re-run the probe.

Stack:
1. **this PR** — the pin
2. #3232 — inverted depth sign in 3D projection
3. #3172 — per-frame deadline so a wedged renderer falls back instead of failing the render

🤖 Generated with [Claude Code](https://claude.com/claude-code)