### PR TITLE
fix(engine): correct the inverted depth sign in 3D projection

### DIFF
--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -20,7 +20,22 @@ async function loadPuppeteerBrowsers(): Promise<PuppeteerBrowsers> {
   }
 }
 
-const CHROME_VERSION = "152.0.7928.2";
+// Bumped from 152.0.7928.2 on 2026-08-10 to pick up crbug 522872457's fix
+// (CL 8032671, "Force-merge PendingLayer for canvas child descendant", merged
+// 2026-07-07 — after the 152.0.7935.0 canary cut, so the old pin predated it).
+//
+// Measured on the shipping headless-shell binary, drawElementImage vs a CDP
+// screenshot of the identical state:
+//   sibling content dropped from 3D captures  — FIXED
+//   background lost from 3D captures          — FIXED
+//   backface-visibility:hidden ignored        — STILL BROKEN (1.4 dB -> 14.8 dB;
+//                                               better, still far under the
+//                                               32 dB floor)
+// So the 3D compile gate must stay. See PRINFRA-486.
+//
+// Deliberately Beta, not Canary. 153.0.8000.0 measured identical to this build
+// on every probe variant, so crossing a major buys nothing measurable.
+const CHROME_VERSION = "152.0.7977.30";
 const CACHE_ROOT_DIR = join(homedir(), ".cache", "hyperframes");
 const CACHE_DIR = join(homedir(), ".cache", "hyperframes", "chrome");
 // Puppeteer's managed cache — where `@puppeteer/browsers install
@@ -332,7 +347,7 @@ async function findFromCache(): Promise<CacheLookupResult> {
   // this is the non-`preferManagedChrome` path, which exists so a user who
   // installed chrome-headless-shell separately (via `@puppeteer/browsers
   // install`) keeps using that binary instead of being silently switched to
-  // the HF-pinned one. Note `CHROME_VERSION` (above) is a Dev-channel pin
+  // the HF-pinned one. Note `CHROME_VERSION` (above) is a pre-Stable pin
   // that may be NEWER than a user's puppeteer-cache Stable build — this is
   // about respecting an explicit prior choice, not "newest wins".
   const fromPuppeteer = findFromPuppeteerCache();

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1514,6 +1514,7 @@ function trackRenderMetrics(
     deBlankRecaptures: perf?.drawElement?.blankRecaptures,
     deBoundaryFrames: perf?.drawElement?.boundaryFrames,
     deNcprFallbacks: perf?.drawElement?.ncprFallbacks,
+    deFrameTimeouts: perf?.drawElement?.frameTimeouts,
     compositionDurationMs,
     compositionWidth: perf?.resolution.width,
     compositionHeight: perf?.resolution.height,

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -235,6 +235,7 @@ export function trackRenderComplete(
     deBlankRecaptures?: number;
     deBoundaryFrames?: number;
     deNcprFallbacks?: number;
+    deFrameTimeouts?: number;
     // "cli" when triggered by `hyperframes render` (default), "studio" when
     // triggered by a studio preview-server render (POST /api/projects/:id/render).
     source?: "cli" | "studio";
@@ -336,6 +337,7 @@ export function trackRenderComplete(
       de_blank_recaptures: props.deBlankRecaptures,
       de_boundary_frames: props.deBoundaryFrames,
       de_ncpr_fallbacks: props.deNcprFallbacks,
+      de_frame_timeouts: props.deFrameTimeouts,
       ...powerStateFields(),
       source: props.source ?? "cli",
       composition_duration_ms: props.compositionDurationMs,

--- a/packages/engine/src/services/frameCapture-frameDeadline.test.ts
+++ b/packages/engine/src/services/frameCapture-frameDeadline.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for the per-frame drawElement deadline (`withFrameDeadline`, PRINFRA-488).
+ *
+ * The deadline races the capture round-trip from OUTSIDE `captureFrameCore`,
+ * because puppeteer cannot abort an in-flight `page.evaluate`. That is exactly
+ * why the stall counter has to live in the `onTimeout` hook: a wedged renderer
+ * never returns, so no catch block inside the work promise ever runs. The first
+ * shipped version incremented `session.deFrameTimeouts` in that unreachable
+ * catch, so the counter — and the `CapturePerfSummary` field it feeds — read 0
+ * on every stalled render.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { withFrameDeadline } from "./frameCapture.js";
+
+describe("withFrameDeadline", () => {
+  it("rejects with DeFrameTimeoutError and fires onTimeout when work outlives the deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      // Never settles — the wedged-renderer shape.
+      const raced = withFrameDeadline(new Promise<string>(() => {}), "frame 7", 15_000, onTimeout);
+      const assertion = expect(raced).rejects.toThrow(/frame 7 exceeded 15000ms/);
+      await vi.advanceTimersByTimeAsync(15_000);
+      await assertion;
+      expect(onTimeout).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("passes the value through and leaves onTimeout alone when work wins", async () => {
+    vi.useFakeTimers();
+    try {
+      const onTimeout = vi.fn();
+      const raced = withFrameDeadline(Promise.resolve("buffer"), "frame 7", 15_000, onTimeout);
+      await expect(raced).resolves.toBe("buffer");
+      // Past the deadline: the cleared timer must not fire late.
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(onTimeout).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/engine/src/services/frameCapture-frameDeadline.test.ts
+++ b/packages/engine/src/services/frameCapture-frameDeadline.test.ts
@@ -10,6 +10,7 @@
  * on every stalled render.
  */
 
+import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import { withFrameDeadline } from "./frameCapture.js";
 
@@ -41,5 +42,40 @@ describe("withFrameDeadline", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// The three drawElement capture entry points are only reachable with a real
+// Chrome page, so the wiring is pinned at the source level instead. The first
+// shipped deadline bounded ONLY the streaming path, leaving the disk and
+// worker-encode paths to hit the 60 s render-level watchdog on the same wedged
+// renderer — a coverage gap invisible to any unit test of the deadline itself.
+describe("drawElement capture entry points", () => {
+  const source = readFileSync(new URL("./frameCapture.ts", import.meta.url), "utf8");
+
+  const bodyOf = (name: string): string => {
+    const start = source.indexOf(`export async function ${name}(`);
+    expect(start).toBeGreaterThan(-1);
+    // Up to the next top-level declaration — enough to cover the function body.
+    const next = source.indexOf("\nexport ", start + 1);
+    return source.slice(start, next === -1 ? undefined : next);
+  };
+
+  it.each(["captureFrameToBuffer", "captureFrame", "captureFrameToBufferPipelined"])(
+    "%s bounds its drawElement round-trip",
+    (entryPoint) => {
+      expect(bodyOf(entryPoint)).toContain("withDeFrameDeadline(");
+    },
+  );
+
+  // Diagnostics screenshot and evaluate against the page that just stopped
+  // scheduling, so running them on a stall spends the whole budget the deadline
+  // saved. The pipelined catch must bail before reaching them.
+  it("skips per-frame diagnostics when the pipelined path times out", () => {
+    const body = bodyOf("captureFrameToBufferPipelined");
+    const bail = body.indexOf("if (isDeFrameTimeoutError(captureError)) throw captureError;");
+    const diagnostics = body.indexOf("captureFrameErrorDiagnostics(");
+    expect(bail).toBeGreaterThan(-1);
+    expect(diagnostics).toBeGreaterThan(bail);
   });
 });

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -3202,6 +3202,42 @@ export async function withFrameDeadline<T>(
   }
 }
 
+function isDeFrameTimeoutError(err: unknown): boolean {
+  return err instanceof DeFrameTimeoutError;
+}
+
+/**
+ * Bound a drawElement round-trip, counting and logging the stall if the
+ * deadline wins. Every drawElement capture entry point goes through this —
+ * streaming (`captureFrameToBuffer`), disk (`captureFrame`) and worker-encode
+ * (`captureFrameToBufferPipelined`). Bounding only one of them left the other
+ * two hitting the 60 s render-level watchdog on the same wedged renderer,
+ * which is the whole failure this deadline exists to replace.
+ */
+function withDeFrameDeadline<T>(
+  session: CaptureSession,
+  frameIndex: number,
+  work: Promise<T>,
+): Promise<T> {
+  if (session.captureMode !== "drawelement") return work;
+  return withFrameDeadline(work, `frame ${frameIndex}`, DE_FRAME_TIMEOUT_MS, () => {
+    // Deliberately NO per-frame screenshot fallback. When the renderer stops
+    // scheduling it is wedged for EVERY subsequent round-trip on that page —
+    // measured: the screenshot fallback blew the same deadline. Fail fast and
+    // let the producer re-render the whole comp on a fresh page via the
+    // screenshot path, the only recovery that works. Counted here rather than
+    // in a capture catch: the deadline rejects from OUTSIDE the work promise,
+    // so no catch inside it ever runs.
+    session.deFrameTimeouts = (session.deFrameTimeouts ?? 0) + 1;
+    console.log(
+      `[engine] fast capture: frame ${frameIndex} — capture exceeded ` +
+        `${DE_FRAME_TIMEOUT_MS}ms; renderer stalled after drawElementImage ` +
+        `(PRINFRA-488). Failing the drawElement attempt so the whole render ` +
+        `retries via screenshot.`,
+    );
+  });
+}
+
 async function captureFrameCore(
   session: CaptureSession,
   frameIndex: number,
@@ -3376,10 +3412,10 @@ export async function captureFrame(
   frameIndex: number,
   time: number,
 ): Promise<CaptureResult> {
-  const { buffer, quantizedTime, captureTimeMs } = await captureFrameCore(
+  const { buffer, quantizedTime, captureTimeMs } = await withDeFrameDeadline(
     session,
     frameIndex,
-    time,
+    captureFrameCore(session, frameIndex, time),
   );
   const framePath = writeCapturedFrame(session, frameIndex, buffer);
   return { frameIndex, time: quantizedTime, path: framePath, captureTimeMs };
@@ -3413,30 +3449,11 @@ export async function captureFrameToBuffer(
   frameIndex: number,
   time: number,
 ): Promise<CaptureBufferResult> {
-  const { buffer, captureTimeMs } =
-    session.captureMode === "drawelement"
-      ? await withFrameDeadline(
-          captureFrameCore(session, frameIndex, time),
-          `frame ${frameIndex}`,
-          DE_FRAME_TIMEOUT_MS,
-          () => {
-            // Deliberately NO per-frame screenshot fallback. When the renderer
-            // stops scheduling it is wedged for EVERY subsequent round-trip on
-            // that page — measured: the screenshot fallback blew the same
-            // deadline. Fail fast and let the producer re-render the whole comp
-            // on a fresh page via the screenshot path, the only recovery that
-            // works. Counted here rather than in captureFrameCore's catch: the
-            // deadline rejects from outside it, so that catch never runs.
-            session.deFrameTimeouts = (session.deFrameTimeouts ?? 0) + 1;
-            console.log(
-              `[engine] fast capture: frame ${frameIndex} — capture exceeded ` +
-                `${DE_FRAME_TIMEOUT_MS}ms; renderer stalled after drawElementImage ` +
-                `(PRINFRA-488). Failing the drawElement attempt so the whole render ` +
-                `retries via screenshot.`,
-            );
-          },
-        )
-      : await captureFrameCore(session, frameIndex, time);
+  const { buffer, captureTimeMs } = await withDeFrameDeadline(
+    session,
+    frameIndex,
+    captureFrameCore(session, frameIndex, time),
+  );
 
   return { buffer, captureTimeMs };
 }
@@ -3535,12 +3552,10 @@ export async function captureFrameToBufferPipelined(
     // syncToPaintEvent = true); see initDrawElementOrTransparentBackground. The
     // BeginFrame branch present in the synchronous captureFrameCore is therefore
     // unreachable here and intentionally omitted.
-    const { encodeResult } = await produceDrawElementFrame(
-      page,
-      options.width,
-      options.height,
-      options.quality ?? 80,
-      true,
+    const { encodeResult } = await withDeFrameDeadline(
+      session,
+      frameIndex,
+      produceDrawElementFrame(page, options.width, options.height, options.quality ?? 80, true),
     );
 
     const captureTimeMs = Date.now() - startTime;
@@ -3574,6 +3589,11 @@ export async function captureFrameToBufferPipelined(
       const buffer = await pageScreenshotCapture(page, options);
       return { encodeResult: Promise.resolve(buffer), captureTimeMs: Date.now() - startTime };
     }
+    // A blown deadline means the renderer is not draining its task queue, so
+    // the diagnostics below — which screenshot and evaluate against that same
+    // page — would block until the render-level watchdog fires, spending the
+    // whole budget the deadline just saved.
+    if (isDeFrameTimeoutError(captureError)) throw captureError;
     // Mirror captureFrameCore: capture per-frame diagnostics (frame-error
     // PNG/HTML/JSON + console tail) before rethrowing so pipelined-path
     // failures are debuggable like the serial path.

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -213,6 +213,13 @@ export interface CaptureSession {
   /** Count of per-frame "No cached paint record" screenshot fallbacks (telemetry). */
   deNcprFallbacks?: number;
   /**
+   * Count of drawElement frame captures that blew `HF_DE_FRAME_TIMEOUT_MS`
+   * because the renderer stopped scheduling after drawElementImage returned
+   * (PRINFRA-488). Each one aborts the drawElement attempt so the whole render
+   * retries via screenshot.
+   */
+  deFrameTimeouts?: number;
+  /**
    * drawElement init passed every gate but stopped before verification +
    * canvas injection: the session has no video-frame injector yet (probe
    * sessions initialize before extraction) and the comp has <video> elements,
@@ -3133,6 +3140,68 @@ function isNoCachedPaintRecordError(err: unknown): boolean {
   return msg.includes("No cached paint record");
 }
 
+/**
+ * Per-frame deadline for the drawElement capture round-trip.
+ *
+ * drawElementImage can return normally and then leave the renderer not draining
+ * its task queue: the `setTimeout(…, 0)` that drawAndEncode schedules to run
+ * `toDataURL` never fires, so the capture `page.evaluate` never settles.
+ * Reproduced deterministically on Chromium 152.0.7977.30, one comp, always the
+ * same frame (PRINFRA-488). Nothing below the render-level watchdog bounded
+ * this, so a single bad frame failed the ENTIRE render after a 60 s stall.
+ *
+ * This bounds the round-trip so the frame can take the same per-frame screenshot
+ * fallback the `No cached paint record` case already takes — one slow frame
+ * instead of a dead render. Tune with `HF_DE_FRAME_TIMEOUT_MS`; 0 disables.
+ */
+const DE_FRAME_TIMEOUT_MS = Number(process.env.HF_DE_FRAME_TIMEOUT_MS ?? "15000");
+
+class DeFrameTimeoutError extends Error {
+  constructor(label: string, ms: number) {
+    super(`drawElement ${label} exceeded ${ms}ms (renderer stopped scheduling; see PRINFRA-488)`);
+    this.name = "DeFrameTimeoutError";
+  }
+}
+
+/**
+ * Race `work` against a deadline. The losing promise is NOT cancellable —
+ * puppeteer cannot abort an in-flight `page.evaluate` — so its rejection is
+ * swallowed to avoid an unhandled rejection when it eventually settles (or
+ * never does). The orphaned round-trip keeps running in its Chrome worker;
+ * that worker is reclaimed by the outer retry rebuilding the page
+ * (`closeOrphanedProbeForRetry`), not by anything here.
+ *
+ * `onTimeout` fires exactly when the deadline wins, and is the ONLY place the
+ * stall is observable: because the deadline races `work` from outside, nothing
+ * inside `work` — including its own catch blocks — ever sees this error.
+ *
+ * Exported for the deadline unit test; `captureFrameToBuffer` is the only
+ * production caller.
+ */
+export async function withFrameDeadline<T>(
+  work: Promise<T>,
+  label: string,
+  ms: number,
+  onTimeout?: () => void,
+): Promise<T> {
+  if (!(ms > 0)) return work;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const guard = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      onTimeout?.();
+      reject(new DeFrameTimeoutError(label, ms));
+    }, ms);
+  });
+  try {
+    return await Promise.race([work, guard]);
+  } finally {
+    if (timer) clearTimeout(timer);
+    void work.catch(() => {
+      /* orphaned round-trip — see doc above */
+    });
+  }
+}
+
 async function captureFrameCore(
   session: CaptureSession,
   frameIndex: number,
@@ -3344,7 +3413,30 @@ export async function captureFrameToBuffer(
   frameIndex: number,
   time: number,
 ): Promise<CaptureBufferResult> {
-  const { buffer, captureTimeMs } = await captureFrameCore(session, frameIndex, time);
+  const { buffer, captureTimeMs } =
+    session.captureMode === "drawelement"
+      ? await withFrameDeadline(
+          captureFrameCore(session, frameIndex, time),
+          `frame ${frameIndex}`,
+          DE_FRAME_TIMEOUT_MS,
+          () => {
+            // Deliberately NO per-frame screenshot fallback. When the renderer
+            // stops scheduling it is wedged for EVERY subsequent round-trip on
+            // that page — measured: the screenshot fallback blew the same
+            // deadline. Fail fast and let the producer re-render the whole comp
+            // on a fresh page via the screenshot path, the only recovery that
+            // works. Counted here rather than in captureFrameCore's catch: the
+            // deadline rejects from outside it, so that catch never runs.
+            session.deFrameTimeouts = (session.deFrameTimeouts ?? 0) + 1;
+            console.log(
+              `[engine] fast capture: frame ${frameIndex} — capture exceeded ` +
+                `${DE_FRAME_TIMEOUT_MS}ms; renderer stalled after drawElementImage ` +
+                `(PRINFRA-488). Failing the drawElement attempt so the whole render ` +
+                `retries via screenshot.`,
+            );
+          },
+        )
+      : await captureFrameCore(session, frameIndex, time);
 
   return { buffer, captureTimeMs };
 }
@@ -3951,5 +4043,6 @@ export function getCapturePerfSummary(session: CaptureSession): CapturePerfSumma
     deVerifyInitMs: session.deVerifyInitMs ?? 0,
     deBoundaryFrames: session.clipBoundaryFrames?.size ?? 0,
     deNcprFallbacks: session.deNcprFallbacks ?? 0,
+    deFrameTimeouts: session.deFrameTimeouts ?? 0,
   };
 }

--- a/packages/engine/src/services/threeDProjection.ts
+++ b/packages/engine/src/services/threeDProjection.ts
@@ -816,7 +816,11 @@ export async function initThreeDProjectionInPage(): Promise<ThreeDProjectionResu
       // rendering a two-plane preserve-3d comp on both capture paths and
       // comparing; the self-verify net CANNOT catch a regression here, because
       // it captures ground truth after this rewrite and would compare wrong
-      // geometry against wrong geometry.
+      // geometry against wrong geometry (measured: a 65 dB "pass" over a
+      // truly-broken 18.8 dB render). The only backstop that can see this class
+      // of regression is a render-parity comp in a regression shard, which
+      // needs harness plumbing rather than a fixture drop — PRINFRA-570 carries
+      // the scope. Until it lands, THIS SIGN IS UNCOVERED BY CI.
       const ndc: Mat4 = [
         2 / canvasW,
         0,

--- a/packages/engine/src/services/threeDProjection.ts
+++ b/packages/engine/src/services/threeDProjection.ts
@@ -786,7 +786,37 @@ export async function initThreeDProjectionInPage(): Promise<ThreeDProjectionResu
       gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
       gl.useProgram(prog);
 
-      // canvas px → clip space, y flipped, z scaled into the clip volume
+      // canvas px → clip space, y flipped, z scaled into the clip volume AND
+      // NEGATED.
+      //
+      // The negation is load-bearing. CSS puts +z toward the viewer (see the
+      // convention note on the matrix helpers above); GL's depth buffer treats
+      // LARGER ndc z as FARTHER, and this context clears depth to 1 and tests
+      // LEQUAL. Passing CSS z through with a positive scale therefore inverted
+      // every depth comparison: the nearest quad got the largest depth, lost
+      // the test, and was occluded by the quad behind it.
+      //
+      // The y-flip on the row above changes handedness, which was already
+      // compensated for winding (frontFace(gl.CW) at group setup) but never
+      // for depth — so the bug only showed up once two quads in one context
+      // could be visible at the same time. A single-quad context has nothing to
+      // lose a depth test against, which is why it went unnoticed.
+      //
+      // Measured on a comp with two planes at ±45° in one preserve-3d context,
+      // drawElement render vs a screenshot render of the same comp:
+      // 18.8 dB (near plane painted behind the far one, labels and colours
+      // swapped) → 51.2 dB, visually identical to the screenshot arm. The
+      // single-quad cases are unchanged by the negation: backface flip card at
+      // rest 54.5 dB, perspective+rotationX 51.1 dB, matrix3d 49.5 dB.
+      //
+      // NOTE: this cannot be covered by a unit test — the whole enclosing
+      // function is contractually self-contained (no outer-scope references,
+      // it is shipped into the page via page.evaluate), so the matrix is not
+      // reachable from a test without breaking that contract. Verify it by
+      // rendering a two-plane preserve-3d comp on both capture paths and
+      // comparing; the self-verify net CANNOT catch a regression here, because
+      // it captures ground truth after this rewrite and would compare wrong
+      // geometry against wrong geometry.
       const ndc: Mat4 = [
         2 / canvasW,
         0,
@@ -798,7 +828,7 @@ export async function initThreeDProjectionInPage(): Promise<ThreeDProjectionResu
         1,
         0,
         0,
-        Z_SCALE,
+        -Z_SCALE,
         0,
         0,
         0,

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -345,6 +345,14 @@ export interface CapturePerfSummary {
   deBoundaryFrames: number;
   /** Per-frame "No cached paint record" screenshot fallbacks during capture. */
   deNcprFallbacks: number;
+  /**
+   * Per-frame drawElement captures that blew the `HF_DE_FRAME_TIMEOUT_MS`
+   * deadline and took the screenshot fallback (renderer stopped scheduling
+   * after drawElementImage returned — PRINFRA-488). Non-zero means the render
+   * completed only because the deadline caught a stall that previously failed
+   * the whole render.
+   */
+  deFrameTimeouts: number;
 }
 
 // ── Global Augmentation ────────────────────────────────────────────────────────

--- a/packages/producer/src/services/render/capturePlan.test.ts
+++ b/packages/producer/src/services/render/capturePlan.test.ts
@@ -162,6 +162,28 @@ describe("CapturePlan", () => {
     });
   });
 
+  // A wedged renderer (PRINFRA-488) on the disk path recovers the same way. It
+  // needs its own failure kind because `sdr_disk` accepts no other, and the
+  // stall verified nothing — reusing the verification label would put a
+  // fabricated diagnosis in the retry telemetry.
+  it("forces the screenshot baseline on a disk plan after a renderer stall", () => {
+    const disk = createCapturePlan({
+      workerCount: 2,
+      forceScreenshot: false,
+      useStreamingEncode: false,
+      useLayeredComposite: false,
+      usePageSideCompositing: false,
+      hasHdrContent: false,
+      needsAlpha: false,
+    });
+    expect(replanAfterFailure(disk, { kind: "renderer_stall" })).toMatchObject({
+      kind: "sdr_disk",
+      forceScreenshot: true,
+      forceParallelStream: false,
+      workerCount: 2,
+    });
+  });
+
   it("rejects a streaming transition from a non-streaming plan", () => {
     const disk = createCapturePlan({
       workerCount: 2,

--- a/packages/producer/src/services/render/capturePlan.ts
+++ b/packages/producer/src/services/render/capturePlan.ts
@@ -66,6 +66,13 @@ export interface CreateCapturePlanInput {
 export type CapturePlanFailure =
   | Readonly<{ kind: "streaming_unavailable" }>
   | Readonly<{ kind: "draw_element_verification" }>
+  /**
+   * drawElement wedged the renderer and blew the per-frame deadline
+   * (PRINFRA-488). Distinct from `draw_element_verification` — nothing was
+   * verified and no score exists — but the recovery is identical: stay on this
+   * plan's path, force the screenshot baseline.
+   */
+  | Readonly<{ kind: "renderer_stall" }>
   | Readonly<{ kind: "capture_failure"; memoryExhaustion: boolean }>;
 
 function assertWorkerCount(workerCount: number): void {
@@ -126,8 +133,12 @@ function revertedRouting(routing: CaptureRouting): CaptureRouting {
 export function replanAfterFailure(plan: CapturePlan, failure: CapturePlanFailure): CapturePlan {
   // Disk-path drawElement self-verification (parallel disk workers under the
   // explicit fast-capture opt-in) can also trip — the retry stays on the disk
-  // path but forces the screenshot baseline.
-  if (plan.kind === "sdr_disk" && failure.kind === "draw_element_verification") {
+  // path but forces the screenshot baseline. A wedged renderer takes the same
+  // route: different diagnosis, same recovery.
+  if (
+    plan.kind === "sdr_disk" &&
+    (failure.kind === "draw_element_verification" || failure.kind === "renderer_stall")
+  ) {
     return createCapturePlan({
       ...plan,
       forceScreenshot: true,

--- a/packages/producer/src/services/render/perfSummary.ts
+++ b/packages/producer/src/services/render/perfSummary.ts
@@ -149,6 +149,7 @@ function aggregateDrawElement(
     blankRecaptures: drain?.blankRecaptures ?? 0,
     boundaryFrames: perfs.reduce((sum, p) => sum + (p.deBoundaryFrames ?? 0), 0),
     ncprFallbacks: perfs.reduce((sum, p) => sum + (p.deNcprFallbacks ?? 0), 0),
+    frameTimeouts: perfs.reduce((sum, p) => sum + (p.deFrameTimeouts ?? 0), 0),
   };
 }
 

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -34,6 +34,7 @@ import {
   resolveParallelRouterRetryPlan,
   resetCaptureAttemptProgress,
   shouldRetryViaPinnedFallback,
+  isDeRendererStallError,
   countElementTags,
   envInt,
   isDeParallelRouterEnabled,
@@ -2457,6 +2458,60 @@ describe("resolveParallelRouterRetryPlan (self-verify retry rollback)", () => {
 });
 
 describe("shouldRetryViaPinnedFallback (widen the self-verify retry to generic capture failures, including OOM)", () => {
+  // PRINFRA-488: a wedged renderer must be retryable on ANY routing. Before this,
+  // a comp that engaged drawElement on the ordinary single-worker path had no
+  // whole-render fallback, so one stalled frame failed the entire render.
+  it("retries a drawElement renderer stall even with no pinned routing", () => {
+    expect(
+      shouldRetryViaPinnedFallback({
+        isVerifyError: false,
+        isCancellation: false,
+        deWorkerInversion: undefined,
+        deParallelRouter: undefined,
+        isDeRendererStall: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("still does NOT retry a generic capture failure with no pinned routing", () => {
+    expect(
+      shouldRetryViaPinnedFallback({
+        isVerifyError: false,
+        isCancellation: false,
+        deWorkerInversion: undefined,
+        deParallelRouter: undefined,
+        isDeRendererStall: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("never retries a cancellation, even for a renderer stall", () => {
+    expect(
+      shouldRetryViaPinnedFallback({
+        isVerifyError: false,
+        isCancellation: true,
+        deWorkerInversion: undefined,
+        deParallelRouter: undefined,
+        isDeRendererStall: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("recognizes the engine's stall error across the package boundary", () => {
+    const byName = new Error("whatever");
+    byName.name = "DeFrameTimeoutError";
+    expect(isDeRendererStallError(byName)).toBe(true);
+    expect(
+      isDeRendererStallError(
+        new Error(
+          "drawElement frame 50 exceeded 15000ms (renderer stopped scheduling; see PRINFRA-488)",
+        ),
+      ),
+    ).toBe(true);
+    expect(isDeRendererStallError(new Error("some other capture failure"))).toBe(false);
+    expect(isDeRendererStallError("not an error")).toBe(false);
+  });
+
   it("always retries a drawElement self-verify failure, pinned or not", () => {
     expect(
       shouldRetryViaPinnedFallback({

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -529,9 +529,9 @@ export interface RenderPerfSummary {
      * `fallbackReason` being set is the "any fallback fired" signal.
      */
     selfVerifyFallback: boolean;
-    /** What tripped the fallback retry: psnr | blank | oom | capture_error. */
+    /** What tripped the fallback retry: psnr | blank | oom | de_renderer_stall | capture_error. */
     fallbackReason?: string;
-    /** The failing PSNR (dB) when `fallbackReason === "psnr"`; undefined for blank/oom/capture_error (no score exists). */
+    /** The failing PSNR (dB) when `fallbackReason === "psnr"`; undefined for every other reason (no score exists). */
     fallbackFailedDb?: number;
     /** Frame index the verification failure was detected at; set for both "psnr" and "blank" fallback reasons. */
     fallbackFrameIndex?: number;
@@ -545,6 +545,13 @@ export interface RenderPerfSummary {
     boundaryFrames: number;
     /** Per-frame "No cached paint record" screenshot fallbacks. */
     ncprFallbacks: number;
+    /**
+     * Frames that blew `HF_DE_FRAME_TIMEOUT_MS` — a wedged renderer
+     * (PRINFRA-488). Distinct from the other fallback counters: this one always
+     * costs a whole-render re-run via screenshot, so its rate is worth graphing
+     * on its own rather than inside `capture_error`.
+     */
+    frameTimeouts: number;
   };
 }
 
@@ -1808,10 +1815,32 @@ export function shouldRetryViaPinnedFallback(args: {
   isCancellation: boolean;
   deWorkerInversion: "inverted" | "reverted" | undefined;
   deParallelRouter: "routed" | "reverted" | undefined;
+  /**
+   * The drawElement capture wedged the renderer (PRINFRA-488). Retryable on ANY
+   * routing, not just a pinned one: the failure is a property of drawElement
+   * itself, and the retry re-renders on a fresh page via screenshot — the only
+   * recovery that works once the renderer stops scheduling. Without this a comp
+   * that engaged drawElement on the ordinary single-worker path (neither
+   * inverted nor routed) had NO whole-render fallback, so one wedged frame
+   * failed the entire render.
+   */
+  isDeRendererStall?: boolean;
 }): boolean {
   if (args.isCancellation) return false;
   if (args.isVerifyError) return true;
+  if (args.isDeRendererStall === true) return true;
   return args.deWorkerInversion === "inverted" || args.deParallelRouter === "routed";
+}
+
+/**
+ * True for the drawElement per-frame deadline breach raised by the engine when
+ * the renderer stops scheduling after `drawElementImage` returns (PRINFRA-488).
+ * Matched on name+message rather than by class because the error crosses the
+ * engine/producer package boundary.
+ */
+export function isDeRendererStallError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === "DeFrameTimeoutError" || err.message.includes("renderer stopped scheduling");
 }
 
 /**
@@ -3556,6 +3585,7 @@ async function executeRenderPipeline(input: {
           // spawns on retry. See shouldRetryViaPinnedFallback for exactly
           // which errors qualify.
           const isVerifyError = isDrawElementVerificationError(err);
+          const isDeStall = isDeRendererStallError(err);
           const isCancellation =
             err instanceof RenderCancelledError || executionSignal?.aborted === true;
           if (
@@ -3564,6 +3594,7 @@ async function executeRenderPipeline(input: {
               isCancellation,
               deWorkerInversion,
               deParallelRouter,
+              isDeRendererStall: isDeStall,
             })
           )
             throw err;
@@ -3576,7 +3607,11 @@ async function executeRenderPipeline(input: {
             deFallbackFrameIndex = t.frameIndex;
             deFallbackThresholdDb = t.thresholdDb;
           } else {
-            deFallbackReason = isMemoryExhaustion ? "oom" : "capture_error";
+            deFallbackReason = isMemoryExhaustion
+              ? "oom"
+              : isDeStall
+                ? "de_renderer_stall"
+                : "capture_error";
           }
           log.warn(
             isVerifyError

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -3772,32 +3772,50 @@ async function executeRenderPipeline(input: {
         try {
           captureRes = await invokeDiskCapture(capturePlan);
         } catch (err) {
-          // Disk-path drawElement self-verification tripped (a parallel disk
-          // worker's sampled frame diverged from its pre-injection ground
-          // truth — reachable only under the explicit fast-capture opt-in).
-          // Same recovery contract as the streaming drain: re-render on the
-          // screenshot baseline. Anything else keeps its existing semantics.
+          // Two disk-path failures re-render on the screenshot baseline, and
+          // they are NOT the same failure:
+          //  - self-verification tripped (a parallel disk worker's sampled frame
+          //    diverged from its pre-injection ground truth — reachable only
+          //    under the explicit fast-capture opt-in);
+          //  - the renderer wedged and blew the per-frame deadline
+          //    (PRINFRA-488). The streaming drain already routed this; without
+          //    it here, the same stall on the disk path threw straight out and
+          //    failed the whole render, which is the behaviour the deadline was
+          //    added to remove.
+          // Anything else keeps its existing semantics.
+          const isDiskDeStall = isDeRendererStallError(err);
           if (
-            !isDrawElementVerificationError(err) ||
+            (!isDrawElementVerificationError(err) && !isDiskDeStall) ||
             err instanceof RenderCancelledError ||
             executionSignal?.aborted === true
           ) {
             throw err;
           }
-          deSelfVerifyFallback = true;
-          const t = deVerifyFallbackTelemetry(err);
-          deFallbackReason = t.reason;
-          deFallbackFailedDb = t.failedDb;
-          deFallbackFrameIndex = t.frameIndex;
-          deFallbackThresholdDb = t.thresholdDb;
+          deSelfVerifyFallback = !isDiskDeStall;
+          if (isDiskDeStall) {
+            // No score exists for a stall, so only the reason is set — same
+            // shape the streaming catch uses for this reason.
+            deFallbackReason = "de_renderer_stall";
+          } else {
+            const t = deVerifyFallbackTelemetry(err);
+            deFallbackReason = t.reason;
+            deFallbackFailedDb = t.failedDb;
+            deFallbackFrameIndex = t.frameIndex;
+            deFallbackThresholdDb = t.thresholdDb;
+          }
           log.warn(
-            "[Render] drawElement self-verification failed on the parallel disk path; " +
-              "re-rendering via screenshot",
+            isDiskDeStall
+              ? "[Render] drawElement wedged the renderer on the parallel disk path; " +
+                  "re-rendering via screenshot"
+              : "[Render] drawElement self-verification failed on the parallel disk path; " +
+                  "re-rendering via screenshot",
             { error: err instanceof Error ? err.message : String(err) },
           );
           observability.checkpoint(
             "capture_disk",
-            "drawElement self-verify failed; retrying with forceScreenshot",
+            isDiskDeStall
+              ? "drawElement renderer stall; retrying with forceScreenshot"
+              : "drawElement self-verify failed; retrying with forceScreenshot",
           );
           // The failed attempt's frames are untrusted BUT satisfy the
           // completeness check — wipe them so the retry re-captures everything
@@ -3818,7 +3836,10 @@ async function executeRenderPipeline(input: {
             probeSession = null;
             await closeOrphanedProbeForRetry(orphaned, closeCaptureSession, log, "disk verify");
           }
-          capturePlan = replanAfterFailure(capturePlan, { kind: "draw_element_verification" });
+          capturePlan = replanAfterFailure(
+            capturePlan,
+            isDiskDeStall ? { kind: "renderer_stall" } : { kind: "draw_element_verification" },
+          );
           syncCapturePlan();
           updateCaptureObservability({
             forceScreenshot: capturePlan.forceScreenshot,


### PR DESCRIPTION
**Stack 2/3** — based on #3231. Review that first; this diff is one line of behaviour plus its rationale.

`threeDProjection` **does** run a depth test — `gl.enable(gl.DEPTH_TEST)` with `clearDepth(1)` and `depthFunc(LEQUAL)`. The comparison was inverted: CSS puts +z toward the viewer, GL treats larger ndc z as *farther*, and the ndc matrix passed CSS z through with a **positive** scale. So the nearest quad received the largest depth, lost the test, and was occluded by the quad behind it.

The y-flip on the row above changes handedness. That was already compensated for winding (`frontFace(gl.CW)`) but never for depth — which is why it only surfaced once two quads in one context could be visible simultaneously. A single-quad context has nothing to lose a depth test against.

### Measurement

Two planes at ±45° in one `preserve-3d` context, drawElement render vs a screenshot render of the same comp:

| | before | after |
|---|---|---|
| two planes ±45°, one preserve-3d context | **18.8 dB** — near plane painted behind the far one, labels and colours swapped | **51.2 dB**, visually identical to the screenshot arm |
| backface flip card at rest | 54.5 dB | 54.5 dB |
| perspective + rotationX | 51.1 dB | 51.1 dB |
| matrix3d() | 49.5 dB | 49.5 dB |

Single-quad cases are unaffected by the negation, as expected.

### Two things reviewers should know

**No unit test, and that is structural.** `initThreeDProjectionInPage` is contractually self-contained — shipped into the page via `page.evaluate`, no outer-scope references — so the matrix is unreachable from a test without breaking that contract. Verified at render level instead; the method is recorded at the call site so it can be repeated.

**The self-verify net cannot catch a regression here.** It captures ground-truth frames *after* this rewrite mutates the DOM, so it compares projected-DOM-via-drawElement against projected-DOM-via-screenshot — both carrying the same geometry. Measured: it passed the broken comp at 65 dB while the true output was 18.8 dB off. Do not treat it as the backstop for 3D changes.

### Scope note

This does **not** open up any renders. The 3D compile gate still clamps `perspective` / `preserve-3d` comps before capture, so projection is only reachable via `HF_FAST_CAPTURE_3D`. An earlier revision of this stack narrowed that gate; it was reverted after review found the gate is load-bearing for six pre-existing projection limitations this fix does not address (group-root paint, layout-animating quads, animated perspective, flat intermediates, self-quad ordering, mid-loop bails). Those are catalogued on PRINFRA-486 as the prerequisites for narrowing.

Refs PRINFRA-486

🤖 Generated with [Claude Code](https://claude.com/claude-code)