### PR TITLE
feat: add MiniMax music generation

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,8 +46,8 @@
       "files": 12
     },
     "media-use": {
-      "hash": "7e329ade41b1c1ba",
-      "files": 152
+      "hash": "782acf37a67f42c8",
+      "files": 155
     },
     "motion-graphics": {
       "hash": "1434e22bb0259bbb",

--- a/skills/media-use/audio/references/bgm.md
+++ b/skills/media-use/audio/references/bgm.md
@@ -3,6 +3,7 @@
 One music bed per composition, produced by the shared audio engine (`scripts/audio.mjs` → `scripts/lib/bgm.mjs`). Two routes, chosen by the engine's one switch — whether a HeyGen credential is present:
 
 - **HeyGen retrieval — the default when credentialed.** Search HeyGen's music catalog by mood, download the top track. No generation; same `~/.heygen` / `$HEYGEN_API_KEY` credential as TTS.
+- **MiniMax generation — preferred for generation when `$MINIMAX_API_KEY` is set.** Generate a music file from a prompt, lyrics, or a supported cover input.
 - **Local generation (Lyria → MusicGen) — the fallback when there is no credential** (or when asked for explicitly). Generate a WAV from a mood prompt. There is **no `npx hyperframes bgm` command**; the engine spawns `scripts/lyria-recipe.py` or an inline MusicGen script directly.
 
 > **Run the Preflight first — no credential is not a green light to silently generate locally.** Before generating, complete the sign-in **Preflight** (see `../SKILL.md` → Preflight): run `npx hyperframes auth status`, recommend signing in, and **STOP for the user's choice** (sign in for HeyGen's music library, or continue offline with local generation). This applies to a one-off "generate a BGM" request just as much as inside a full workflow.
@@ -32,6 +33,21 @@ One music bed per composition, produced by the shared audio engine (`scripts/aud
 `volume` comes from the engine's `bgmDefaultVolume()`: `BGM_BED_VOLUME` (currently `0.12` ≈ -18 dB — a bed under the voice) under narration, `BGM_SILENT_VOLUME` (currently `0.9`) for a silent film (no voice). Tune those constants in `scripts/lib/bgm.mjs`, not call sites. An explicit `volume` in `audio_meta.json` always overrides this default. `bgm_pending` is `false` — the file is on disk when the engine returns.
 
 For short launch videos, do not assume the beginning of the retrieved file is the best edit point. Check the opening against later five-second sections. If the track starts with a quiet build but a later section has a stronger, clean musical entrance, trim from that section and apply a short fade-in and longer fade-out. Repeat this check whenever the composition duration changes; the final music file must cover the full cut without a silent tail.
+
+## MiniMax generation
+
+Set `$MINIMAX_API_KEY` and use `bgm.mode: generate`. The optional request fields are `model`, `region`, `prompt`, `lyrics`, `lyrics_optimizer`, `is_instrumental`, and `aigc_watermark`. The last field is sent only for the China endpoint.
+
+| Region | Endpoint                                       |
+| ------ | ---------------------------------------------- |
+| Global | `https://api.minimax.io/v1/music_generation`   |
+| China  | `https://api.minimaxi.com/v1/music_generation` |
+
+Generation models are `music-3.0` (default), `music-2.6`, `music-3.0-free`, and `music-2.6-free`. Cover models are `music-cover` and `music-cover-free`; they require exactly one of `audio_url` or `audio_base64`, accept 6–360 seconds of source audio, and limit uploads to 50 MB. `cover_feature_id` is optional.
+
+The API supports `url` and `hex` output, with `hex` required for streaming. Audio formats are `mp3`, `wav`, and `pcm`; generated BGM uses hex-encoded WAV so the existing audio pipeline receives a local file. URL output expires after 24 hours and is downloaded before the pipeline continues.
+
+Response handling checks `base_resp.status_code` for zero, treats `data.status` 1 as in progress and 2 as completed, and reads audio from `data.audio`.
 
 ## Local generation (fallback) — Lyria → MusicGen
 

--- a/skills/media-use/audio/references/bgm.md
+++ b/skills/media-use/audio/references/bgm.md
@@ -10,7 +10,7 @@ One music bed per composition, produced by the shared audio engine (`scripts/aud
 
 ## Driving it from the request
 
-`audio_request.json` → `bgm: { mode?, query?, prompt? }`:
+`audio_request.json` → `bgm: { mode?, query?, prompt?, ... }`:
 
 - **`mode`** — `retrieve | generate | none`. Omit for **auto** (retrieve when credentialed, else generate). An **explicit** `retrieve` is strict: no credential ⇒ skip, never a detached generate (so a caller with no `wait-bgm` step, e.g. product-launch, can't get a pending job it won't await).
 - **`query`** — the mood, used for retrieval and as a fallback prompt seed (e.g. a storyboard's `music:` field, falling back to `message` → `arc` → `"calm cinematic underscore"`).
@@ -36,7 +36,9 @@ For short launch videos, do not assume the beginning of the retrieved file is th
 
 ## MiniMax generation
 
-Set `$MINIMAX_API_KEY` and use `bgm.mode: generate`. The optional request fields are `model`, `region`, `prompt`, `lyrics`, `lyrics_optimizer`, `is_instrumental`, and `aigc_watermark`. The last field is sent only for the China endpoint.
+Set `$MINIMAX_API_KEY` and use `bgm.mode: generate`. In addition to `prompt`, the request accepts `model`, `region`, `lyrics`, `stream`, `output_format`, `audio_setting`, `lyrics_optimizer`, `is_instrumental`, `audio_url`, `audio_base64`, `cover_feature_id`, and `aigc_watermark`. The last field is sent only for the China endpoint.
+
+The detached runner reads these values from the same `audio_request.json`; this keeps large base64 cover inputs off the process command line. Explicit runner flags override request-file values.
 
 | Region | Endpoint                                       |
 | ------ | ---------------------------------------------- |

--- a/skills/media-use/audio/scripts/audio.mjs
+++ b/skills/media-use/audio/scripts/audio.mjs
@@ -23,7 +23,10 @@
 //     "bgm": { "mode": "retrieve", // retrieve|generate|none (override: --bgm-mode / --no-bgm)
 //              "query": "calm cinematic underscore",   // mood for retrieval
 //              "prompt": null,      // full prompt for generation (else inferred)
-//              "blob": "...", "archetype": "...", "arc": "..." }  // optional mood-inference hints
+//              "blob": "...", "archetype": "...", "arc": "...",   // optional mood-inference hints
+//              "model": "music-3.0", "region": "global_en",
+//              "lyrics": "...", "output_format": "hex", "audio_setting": { "format": "wav" },
+//              "audio_url": "...", "audio_base64": "...", "cover_feature_id": "..." }
 //   }
 //
 // ── audio_meta.json (output, id-keyed) ───────────────────────────────────────
@@ -232,6 +235,7 @@ if (only.has("bgm")) {
       durationS: totalDuration || 30,
       hyperframesDir,
       lyriaRecipe: existsSync(lyriaRecipe) ? lyriaRecipe : null,
+      requestPath,
       seedSeconds,
       hasVoice,
       miniMax: {

--- a/skills/media-use/audio/scripts/audio.mjs
+++ b/skills/media-use/audio/scripts/audio.mjs
@@ -234,6 +234,14 @@ if (only.has("bgm")) {
       lyriaRecipe: existsSync(lyriaRecipe) ? lyriaRecipe : null,
       seedSeconds,
       hasVoice,
+      miniMax: {
+        model: request.bgm?.model,
+        region: request.bgm?.region,
+        lyrics: request.bgm?.lyrics,
+        lyrics_optimizer: request.bgm?.lyrics_optimizer,
+        is_instrumental: request.bgm?.is_instrumental,
+        aigc_watermark: request.bgm?.aigc_watermark,
+      },
     });
     if (gen.disabled) {
       anomalies.push(`bgm: ${gen.reason}`);

--- a/skills/media-use/audio/scripts/lib/bgm.mjs
+++ b/skills/media-use/audio/scripts/lib/bgm.mjs
@@ -113,8 +113,9 @@ export function inferBgmPrompt({ blob = "", archetype = "", arc = "", userPrompt
   return `${base}, BPM ${bpm}, MAJOR`;
 }
 
-export function miniMaxMusicRunnerArgs({ outputPath, prompt, options = {} }) {
+export function miniMaxMusicRunnerArgs({ outputPath, prompt, requestPath, options = {} }) {
   const args = [MINIMAX_MUSIC_RUNNER, "--output", outputPath, "--prompt", prompt];
+  if (requestPath) args.push("--request", requestPath);
   const optionalFlags = [
     ["model", options.model],
     ["region", options.region],
@@ -145,6 +146,7 @@ export function generateBgmDetached({
   durationS,
   hyperframesDir,
   lyriaRecipe,
+  requestPath,
   seedSeconds = 28,
   hasVoice,
   miniMax = {},
@@ -160,7 +162,12 @@ export function generateBgmDetached({
   const lyriaConfigured = !!lyriaKey() && !!lyriaRecipe && existsSync(lyriaRecipe);
 
   if (miniMaxConfigured) {
-    const args = miniMaxMusicRunnerArgs({ outputPath: abs, prompt, options: miniMax });
+    const args = miniMaxMusicRunnerArgs({
+      outputPath: abs,
+      prompt,
+      requestPath,
+      options: miniMax,
+    });
 
     const fd = openSync(log, "w");
     const proc = spawn(process.execPath, args, { detached: true, stdio: ["ignore", fd, fd] });

--- a/skills/media-use/audio/scripts/lib/bgm.mjs
+++ b/skills/media-use/audio/scripts/lib/bgm.mjs
@@ -13,12 +13,19 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, openSync, closeSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { downloadTo, searchSounds } from "./heygen.mjs";
 import { pythonInvocation } from "./python.mjs";
 
 const r3 = (x) => Number(x.toFixed(3));
 const lyriaKey = () => process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY || "";
+const miniMaxKey = () => process.env.MINIMAX_API_KEY || "";
+const MINIMAX_MUSIC_RUNNER = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "minimax-music.mjs",
+);
 
 // Default BGM level. Under narration music is a bed that must stay under the
 // voice — 0.12 linear ≈ -18 dB. A silent film (no voice) has no voice to duck
@@ -106,6 +113,29 @@ export function inferBgmPrompt({ blob = "", archetype = "", arc = "", userPrompt
   return `${base}, BPM ${bpm}, MAJOR`;
 }
 
+export function miniMaxMusicRunnerArgs({ outputPath, prompt, options = {} }) {
+  const args = [MINIMAX_MUSIC_RUNNER, "--output", outputPath, "--prompt", prompt];
+  const optionalFlags = [
+    ["model", options.model],
+    ["region", options.region],
+    ["lyrics", options.lyrics],
+  ];
+  for (const [name, value] of optionalFlags) {
+    if (value !== undefined && value !== null && value !== "")
+      args.push(`--${name}`, String(value));
+  }
+  const booleanFlags = [
+    ["lyrics-optimizer", options.lyrics_optimizer],
+    ["instrumental", options.is_instrumental],
+    ["aigc-watermark", options.aigc_watermark],
+  ];
+  for (const [name, value] of booleanFlags) {
+    if (value === true) args.push(`--${name}`);
+    if (value === false) args.push(`--no-${name}`);
+  }
+  return args;
+}
+
 // ── generation (Lyria → MusicGen, detached) ──────────────────────────────────
 // Returns a bgmMeta the caller folds into audio_meta:
 //   { path, mode, volume, provider, pid, log, target_duration_s, seed_duration_s,
@@ -117,6 +147,7 @@ export function generateBgmDetached({
   lyriaRecipe,
   seedSeconds = 28,
   hasVoice,
+  miniMax = {},
 }) {
   const rel = "assets/bgm/track.wav";
   const abs = join(hyperframesDir, rel);
@@ -125,7 +156,25 @@ export function generateBgmDetached({
   const targetS = Math.max(1, durationS);
   const baseMeta = { path: rel, mode: null, volume: bgmDefaultVolume(hasVoice), pending: true };
 
+  const miniMaxConfigured = !!miniMaxKey() && existsSync(MINIMAX_MUSIC_RUNNER);
   const lyriaConfigured = !!lyriaKey() && !!lyriaRecipe && existsSync(lyriaRecipe);
+
+  if (miniMaxConfigured) {
+    const args = miniMaxMusicRunnerArgs({ outputPath: abs, prompt, options: miniMax });
+
+    const fd = openSync(log, "w");
+    const proc = spawn(process.execPath, args, { detached: true, stdio: ["ignore", fd, fd] });
+    proc.unref();
+    closeSync(fd);
+    return {
+      ...baseMeta,
+      mode: "detached-single",
+      provider: "minimax",
+      pid: proc.pid,
+      log,
+      target_duration_s: r3(targetS),
+    };
+  }
 
   // Make a backend runnable: prefer Lyria when configured (install google-genai
   // on demand), else ensure local MusicGen deps. Installs are synchronous here —

--- a/skills/media-use/audio/scripts/lib/bgm.test.mjs
+++ b/skills/media-use/audio/scripts/lib/bgm.test.mjs
@@ -38,6 +38,7 @@ test("MiniMax BGM options are forwarded to the detached runner", () => {
   const args = miniMaxMusicRunnerArgs({
     outputPath: "/tmp/track.wav",
     prompt: "Bright instrumental",
+    requestPath: "/tmp/audio_request.json",
     options: {
       model: "music-3.0",
       region: "cn_zh",
@@ -52,6 +53,8 @@ test("MiniMax BGM options are forwarded to the detached runner", () => {
     "/tmp/track.wav",
     "--prompt",
     "Bright instrumental",
+    "--request",
+    "/tmp/audio_request.json",
     "--model",
     "music-3.0",
     "--region",

--- a/skills/media-use/audio/scripts/lib/bgm.test.mjs
+++ b/skills/media-use/audio/scripts/lib/bgm.test.mjs
@@ -1,6 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { BGM_BED_VOLUME, BGM_SILENT_VOLUME, bgmDefaultVolume } from "./bgm.mjs";
+import {
+  BGM_BED_VOLUME,
+  BGM_SILENT_VOLUME,
+  bgmDefaultVolume,
+  miniMaxMusicRunnerArgs,
+} from "./bgm.mjs";
 
 // Regression: narrated pipelines used to ship BGM at 0.8 (≈ -2 dB), ~16 dB
 // hotter than a music bed under a voice should be. The default under narration
@@ -27,4 +32,34 @@ test("the narrated default is well below the voice (≈ 0 dBFS)", () => {
     separation >= 16,
     `bed should sit ≥16 dB under the voice, got ${separation.toFixed(1)} dB`,
   );
+});
+
+test("MiniMax BGM options are forwarded to the detached runner", () => {
+  const args = miniMaxMusicRunnerArgs({
+    outputPath: "/tmp/track.wav",
+    prompt: "Bright instrumental",
+    options: {
+      model: "music-3.0",
+      region: "cn_zh",
+      lyrics: "A new day begins",
+      lyrics_optimizer: true,
+      is_instrumental: false,
+      aigc_watermark: true,
+    },
+  });
+  assert.deepEqual(args.slice(1), [
+    "--output",
+    "/tmp/track.wav",
+    "--prompt",
+    "Bright instrumental",
+    "--model",
+    "music-3.0",
+    "--region",
+    "cn_zh",
+    "--lyrics",
+    "A new day begins",
+    "--lyrics-optimizer",
+    "--no-instrumental",
+    "--aigc-watermark",
+  ]);
 });

--- a/skills/media-use/audio/scripts/lib/minimax-music.mjs
+++ b/skills/media-use/audio/scripts/lib/minimax-music.mjs
@@ -1,0 +1,187 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export const MINIMAX_MUSIC_ENDPOINTS = Object.freeze({
+  global_en: "https://api.minimax.io/v1/music_generation",
+  cn_zh: "https://api.minimaxi.com/v1/music_generation",
+});
+
+export const MINIMAX_MUSIC_MODELS = Object.freeze({
+  generation: Object.freeze(["music-3.0", "music-2.6", "music-3.0-free", "music-2.6-free"]),
+  cover: Object.freeze(["music-cover", "music-cover-free"]),
+});
+
+export const MINIMAX_MUSIC_DEFAULT_MODEL = "music-3.0";
+export const MINIMAX_MUSIC_OUTPUT_FORMATS = Object.freeze(["url", "hex"]);
+export const MINIMAX_MUSIC_STREAM_OUTPUT_FORMATS = Object.freeze(["hex"]);
+export const MINIMAX_MUSIC_AUDIO_FORMATS = Object.freeze(["mp3", "wav", "pcm"]);
+export const MINIMAX_MUSIC_URL_TTL_HOURS = 24;
+export const MINIMAX_MUSIC_COVER_LIMITS = Object.freeze({
+  inputMinSeconds: 6,
+  inputMaxSeconds: 360,
+  inputMaxBytes: 50 * 1024 * 1024,
+});
+
+const ALL_MODELS = new Set([...MINIMAX_MUSIC_MODELS.generation, ...MINIMAX_MUSIC_MODELS.cover]);
+const COVER_MODELS = new Set(MINIMAX_MUSIC_MODELS.cover);
+
+function requireChoice(value, choices, label) {
+  if (!choices.includes(value)) {
+    throw new Error(`Unsupported MiniMax music ${label}: ${value}`);
+  }
+}
+
+export function resolveMiniMaxMusicEndpoint(region = "global_en") {
+  const endpoint = MINIMAX_MUSIC_ENDPOINTS[region];
+  if (!endpoint) throw new Error(`Unsupported MiniMax music region: ${region}`);
+  return endpoint;
+}
+
+export function buildMiniMaxMusicRequest({
+  model = MINIMAX_MUSIC_DEFAULT_MODEL,
+  prompt,
+  lyrics,
+  stream = false,
+  outputFormat = "hex",
+  audioFormat = "wav",
+  audioSetting = {},
+  lyricsOptimizer,
+  isInstrumental,
+  audioUrl,
+  audioBase64,
+  coverFeatureId,
+  region = "global_en",
+  aigcWatermark,
+} = {}) {
+  if (!ALL_MODELS.has(model)) throw new Error(`Unsupported MiniMax music model: ${model}`);
+  requireChoice(outputFormat, MINIMAX_MUSIC_OUTPUT_FORMATS, "output format");
+  requireChoice(audioFormat, MINIMAX_MUSIC_AUDIO_FORMATS, "audio format");
+  if (stream)
+    requireChoice(outputFormat, MINIMAX_MUSIC_STREAM_OUTPUT_FORMATS, "stream output format");
+  resolveMiniMaxMusicEndpoint(region);
+
+  const hasAudioUrl = typeof audioUrl === "string" && audioUrl.length > 0;
+  const hasAudioBase64 = typeof audioBase64 === "string" && audioBase64.length > 0;
+  if (COVER_MODELS.has(model) && hasAudioUrl === hasAudioBase64) {
+    throw new Error("MiniMax music cover requires exactly one of audioUrl or audioBase64");
+  }
+  if (hasAudioBase64) {
+    const encoded = audioBase64.replace(/^data:[^;]+;base64,/, "");
+    const inputBytes = Buffer.from(encoded, "base64").byteLength;
+    if (inputBytes > MINIMAX_MUSIC_COVER_LIMITS.inputMaxBytes) {
+      throw new Error("MiniMax music cover input exceeds 50 MB");
+    }
+  }
+
+  const request = {
+    model,
+    stream,
+    output_format: outputFormat,
+    audio_setting: { ...audioSetting, format: audioFormat },
+  };
+  if (prompt !== undefined) request.prompt = prompt;
+  if (lyrics !== undefined) request.lyrics = lyrics;
+  if (lyricsOptimizer !== undefined) request.lyrics_optimizer = lyricsOptimizer;
+  if (isInstrumental !== undefined) request.is_instrumental = isInstrumental;
+  if (hasAudioUrl) request.audio_url = audioUrl;
+  if (hasAudioBase64) request.audio_base64 = audioBase64;
+  if (coverFeatureId !== undefined) request.cover_feature_id = coverFeatureId;
+  if (region === "cn_zh" && aigcWatermark !== undefined) {
+    request.aigc_watermark = aigcWatermark;
+  }
+  return request;
+}
+
+function assertSuccessfulPayload(payload) {
+  const statusCode = payload?.base_resp?.status_code;
+  if (statusCode !== 0) {
+    const message = payload?.base_resp?.status_msg || "unknown error";
+    throw new Error(`MiniMax music API error ${statusCode ?? "unknown"}: ${message}`);
+  }
+}
+
+export function parseMiniMaxMusicResponse(payload) {
+  assertSuccessfulPayload(payload);
+  const status = payload?.data?.status;
+  if (status !== 1 && status !== 2) {
+    throw new Error(`Unexpected MiniMax music status: ${status ?? "missing"}`);
+  }
+  const audio = payload?.data?.audio;
+  if (typeof audio !== "string" || audio.length === 0) {
+    throw new Error("MiniMax music response did not include audio");
+  }
+  return { audio, status, completed: status === 2 };
+}
+
+export function parseMiniMaxMusicStream(text) {
+  const partialAudio = [];
+  let completedAudio = "";
+  let status = 1;
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line.startsWith("data:")) continue;
+    const data = line.slice(5).trim();
+    if (!data || data === "[DONE]") continue;
+    const payload = JSON.parse(data);
+    assertSuccessfulPayload(payload);
+    const nextStatus = payload?.data?.status;
+    if (nextStatus === 1 || nextStatus === 2) status = nextStatus;
+    const audio = payload?.data?.audio;
+    if (typeof audio !== "string" || audio.length === 0) continue;
+    if (nextStatus === 2) completedAudio = audio;
+    else partialAudio.push(audio);
+  }
+  const audio = partialAudio.length > 0 ? partialAudio.join("") : completedAudio;
+  if (!audio) throw new Error("MiniMax music stream did not include audio");
+  return { audio, status, completed: status === 2 };
+}
+
+function decodeHexAudio(value) {
+  if (value.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(value)) {
+    throw new Error("MiniMax music response contained invalid hex audio");
+  }
+  return Buffer.from(value, "hex");
+}
+
+export async function generateMiniMaxMusic({
+  apiKey = process.env.MINIMAX_API_KEY,
+  fetchImpl = globalThis.fetch,
+  endpoint,
+  ...options
+} = {}) {
+  if (!apiKey) throw new Error("MINIMAX_API_KEY is required for MiniMax music generation");
+  if (typeof fetchImpl !== "function") throw new Error("A fetch implementation is required");
+
+  const region = options.region ?? process.env.MINIMAX_API_REGION ?? "global_en";
+  const request = buildMiniMaxMusicRequest({ ...options, region });
+  const response = await fetchImpl(endpoint ?? resolveMiniMaxMusicEndpoint(region), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(request),
+  });
+  if (!response.ok) throw new Error(`MiniMax music request failed with HTTP ${response.status}`);
+
+  const result = request.stream
+    ? parseMiniMaxMusicStream(await response.text())
+    : parseMiniMaxMusicResponse(await response.json());
+  if (request.output_format === "url") return { ...result, audioUrl: result.audio };
+  return { ...result, audioBytes: decodeHexAudio(result.audio) };
+}
+
+export async function writeMiniMaxMusic({ outputPath, fetchImpl = globalThis.fetch, ...options }) {
+  if (!outputPath) throw new Error("An output path is required for MiniMax music generation");
+  const result = await generateMiniMaxMusic({ ...options, fetchImpl });
+  let audio = result.audioBytes;
+  if (!audio && result.audioUrl) {
+    const response = await fetchImpl(result.audioUrl);
+    if (!response.ok) throw new Error(`MiniMax music download failed with HTTP ${response.status}`);
+    audio = Buffer.from(await response.arrayBuffer());
+  }
+  if (!audio) throw new Error("MiniMax music generation produced no writable audio");
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, audio);
+  return { outputPath, status: result.status, completed: result.completed };
+}

--- a/skills/media-use/audio/scripts/lib/minimax-music.mjs
+++ b/skills/media-use/audio/scripts/lib/minimax-music.mjs
@@ -31,6 +31,25 @@ function requireChoice(value, choices, label) {
   }
 }
 
+export function miniMaxMusicOptionsFromRequest(bgm = {}) {
+  if (!bgm || typeof bgm !== "object") bgm = {};
+  return {
+    model: bgm.model,
+    region: bgm.region,
+    prompt: bgm.prompt,
+    lyrics: bgm.lyrics,
+    stream: bgm.stream,
+    outputFormat: bgm.output_format,
+    audioSetting: bgm.audio_setting,
+    lyricsOptimizer: bgm.lyrics_optimizer,
+    isInstrumental: bgm.is_instrumental,
+    audioUrl: bgm.audio_url,
+    audioBase64: bgm.audio_base64,
+    coverFeatureId: bgm.cover_feature_id,
+    aigcWatermark: bgm.aigc_watermark,
+  };
+}
+
 export function resolveMiniMaxMusicEndpoint(region = "global_en") {
   const endpoint = MINIMAX_MUSIC_ENDPOINTS[region];
   if (!endpoint) throw new Error(`Unsupported MiniMax music region: ${region}`);

--- a/skills/media-use/audio/scripts/lib/minimax-music.test.mjs
+++ b/skills/media-use/audio/scripts/lib/minimax-music.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import {
+  MINIMAX_MUSIC_AUDIO_FORMATS,
+  MINIMAX_MUSIC_COVER_LIMITS,
+  MINIMAX_MUSIC_DEFAULT_MODEL,
+  MINIMAX_MUSIC_ENDPOINTS,
+  MINIMAX_MUSIC_MODELS,
+  MINIMAX_MUSIC_OUTPUT_FORMATS,
+  MINIMAX_MUSIC_STREAM_OUTPUT_FORMATS,
+  MINIMAX_MUSIC_URL_TTL_HOURS,
+  buildMiniMaxMusicRequest,
+  generateMiniMaxMusic,
+  parseMiniMaxMusicResponse,
+  parseMiniMaxMusicStream,
+  writeMiniMaxMusic,
+} from "./minimax-music.mjs";
+
+test("exports the current endpoints, models, and formats", () => {
+  assert.deepEqual(MINIMAX_MUSIC_ENDPOINTS, {
+    global_en: "https://api.minimax.io/v1/music_generation",
+    cn_zh: "https://api.minimaxi.com/v1/music_generation",
+  });
+  assert.equal(MINIMAX_MUSIC_DEFAULT_MODEL, "music-3.0");
+  assert.deepEqual(MINIMAX_MUSIC_MODELS.generation, [
+    "music-3.0",
+    "music-2.6",
+    "music-3.0-free",
+    "music-2.6-free",
+  ]);
+  assert.deepEqual(MINIMAX_MUSIC_MODELS.cover, ["music-cover", "music-cover-free"]);
+  assert.deepEqual(MINIMAX_MUSIC_OUTPUT_FORMATS, ["url", "hex"]);
+  assert.deepEqual(MINIMAX_MUSIC_STREAM_OUTPUT_FORMATS, ["hex"]);
+  assert.deepEqual(MINIMAX_MUSIC_AUDIO_FORMATS, ["mp3", "wav", "pcm"]);
+  assert.equal(MINIMAX_MUSIC_URL_TTL_HOURS, 24);
+});
+
+test("builds generation requests with lyrics and China-only watermarking", () => {
+  assert.deepEqual(
+    buildMiniMaxMusicRequest({
+      region: "cn_zh",
+      prompt: "Bright cinematic instrumental",
+      lyrics: "A new day begins",
+      stream: false,
+      outputFormat: "url",
+      audioFormat: "mp3",
+      lyricsOptimizer: true,
+      isInstrumental: false,
+      aigcWatermark: true,
+    }),
+    {
+      model: "music-3.0",
+      prompt: "Bright cinematic instrumental",
+      lyrics: "A new day begins",
+      stream: false,
+      output_format: "url",
+      audio_setting: { format: "mp3" },
+      lyrics_optimizer: true,
+      is_instrumental: false,
+      aigc_watermark: true,
+    },
+  );
+});
+
+test("validates music cover inputs and publishes their limits", () => {
+  assert.deepEqual(MINIMAX_MUSIC_COVER_LIMITS, {
+    inputMinSeconds: 6,
+    inputMaxSeconds: 360,
+    inputMaxBytes: 50 * 1024 * 1024,
+  });
+  assert.throws(
+    () => buildMiniMaxMusicRequest({ model: "music-cover" }),
+    /exactly one of audioUrl or audioBase64/,
+  );
+  const request = buildMiniMaxMusicRequest({
+    model: "music-cover-free",
+    audioUrl: "https://media.example.test/source.wav",
+    coverFeatureId: "feature-1",
+  });
+  assert.equal(request.audio_url, "https://media.example.test/source.wav");
+  assert.equal(request.cover_feature_id, "feature-1");
+  assert.equal(
+    buildMiniMaxMusicRequest({
+      model: "music-cover",
+      audioBase64: Buffer.from("audio").toString("base64"),
+    }).audio_base64,
+    "YXVkaW8=",
+  );
+});
+
+test("parses completed JSON responses and rejects API errors", () => {
+  assert.deepEqual(
+    parseMiniMaxMusicResponse({
+      data: { status: 2, audio: "494433" },
+      base_resp: { status_code: 0 },
+    }),
+    { status: 2, audio: "494433", completed: true },
+  );
+  assert.throws(
+    () =>
+      parseMiniMaxMusicResponse({
+        data: { status: 2 },
+        base_resp: { status_code: 1001, status_msg: "invalid request" },
+      }),
+    /1001: invalid request/,
+  );
+});
+
+test("combines streaming hex chunks without duplicating the final summary", () => {
+  const stream = [
+    'data: {"data":{"status":1,"audio":"4944"},"base_resp":{"status_code":0}}',
+    'data: {"data":{"status":1,"audio":"33"},"base_resp":{"status_code":0}}',
+    'data: {"data":{"status":2,"audio":"494433"},"base_resp":{"status_code":0}}',
+    "data: [DONE]",
+  ].join("\n");
+  assert.deepEqual(parseMiniMaxMusicStream(stream), {
+    audio: "494433",
+    status: 2,
+    completed: true,
+  });
+});
+
+test("sends bearer authorization and decodes hex audio", async () => {
+  let request;
+  const fetchImpl = async (url, init) => {
+    request = { url, init };
+    return new Response(
+      JSON.stringify({
+        data: { status: 2, audio: "494433" },
+        base_resp: { status_code: 0 },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  };
+  const result = await generateMiniMaxMusic({
+    apiKey: "test-key",
+    fetchImpl,
+    prompt: "Instrumental bed",
+  });
+  assert.equal(request.url, MINIMAX_MUSIC_ENDPOINTS.global_en);
+  assert.equal(request.init.headers.Authorization, "Bearer test-key");
+  assert.equal(JSON.parse(request.init.body).model, "music-3.0");
+  assert.deepEqual(result.audioBytes, Buffer.from("ID3"));
+});
+
+test("downloads URL output before writing the music file", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "minimax-music-"));
+  const outputPath = join(directory, "track.mp3");
+  const fetchImpl = async (url) => {
+    if (url === MINIMAX_MUSIC_ENDPOINTS.global_en) {
+      return new Response(
+        JSON.stringify({
+          data: { status: 2, audio: "https://media.example.test/track.mp3" },
+          base_resp: { status_code: 0 },
+        }),
+        { status: 200 },
+      );
+    }
+    assert.equal(url, "https://media.example.test/track.mp3");
+    return new Response(Buffer.from("music"), { status: 200 });
+  };
+  try {
+    await writeMiniMaxMusic({
+      outputPath,
+      apiKey: "test-key",
+      fetchImpl,
+      outputFormat: "url",
+      audioFormat: "mp3",
+    });
+    assert.deepEqual(await readFile(outputPath), Buffer.from("music"));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/skills/media-use/audio/scripts/lib/minimax-music.test.mjs
+++ b/skills/media-use/audio/scripts/lib/minimax-music.test.mjs
@@ -14,10 +14,48 @@ import {
   MINIMAX_MUSIC_URL_TTL_HOURS,
   buildMiniMaxMusicRequest,
   generateMiniMaxMusic,
+  miniMaxMusicOptionsFromRequest,
   parseMiniMaxMusicResponse,
   parseMiniMaxMusicStream,
   writeMiniMaxMusic,
 } from "./minimax-music.mjs";
+
+test("maps every supported BGM request field to the MiniMax client", () => {
+  const audioSetting = { format: "mp3", sample_rate: 44100, bitrate: 256000 };
+  assert.deepEqual(
+    miniMaxMusicOptionsFromRequest({
+      model: "music-cover",
+      region: "cn_zh",
+      prompt: "Cinematic cover",
+      lyrics: "A new day begins",
+      stream: true,
+      output_format: "hex",
+      audio_setting: audioSetting,
+      lyrics_optimizer: true,
+      is_instrumental: false,
+      audio_url: "https://media.example.test/source.wav",
+      audio_base64: "YXVkaW8=",
+      cover_feature_id: "feature-1",
+      aigc_watermark: true,
+    }),
+    {
+      model: "music-cover",
+      region: "cn_zh",
+      prompt: "Cinematic cover",
+      lyrics: "A new day begins",
+      stream: true,
+      outputFormat: "hex",
+      audioSetting,
+      lyricsOptimizer: true,
+      isInstrumental: false,
+      audioUrl: "https://media.example.test/source.wav",
+      audioBase64: "YXVkaW8=",
+      coverFeatureId: "feature-1",
+      aigcWatermark: true,
+    },
+  );
+  assert.equal(miniMaxMusicOptionsFromRequest(null).model, undefined);
+});
 
 test("exports the current endpoints, models, and formats", () => {
   assert.deepEqual(MINIMAX_MUSIC_ENDPOINTS, {

--- a/skills/media-use/audio/scripts/minimax-music.mjs
+++ b/skills/media-use/audio/scripts/minimax-music.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import { resolve } from "node:path";
+import { writeMiniMaxMusic } from "./lib/minimax-music.mjs";
+
+const argv = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const index = argv.indexOf(`--${name}`);
+  return index >= 0 && index + 1 < argv.length ? argv[index + 1] : fallback;
+};
+const has = (name) => argv.includes(`--${name}`);
+
+const outputPath = flag("output", "");
+if (!outputPath) throw new Error("--output is required");
+
+const lyrics = flag("lyrics", undefined);
+await writeMiniMaxMusic({
+  outputPath: resolve(outputPath),
+  model: flag("model", process.env.MINIMAX_MUSIC_MODEL || "music-3.0"),
+  region: flag("region", process.env.MINIMAX_API_REGION || "global_en"),
+  prompt: flag("prompt", undefined),
+  lyrics,
+  stream: has("stream"),
+  outputFormat: flag("output-format", "hex"),
+  audioFormat: flag("audio-format", "wav"),
+  lyricsOptimizer: has("lyrics-optimizer") ? true : has("no-lyrics-optimizer") ? false : undefined,
+  isInstrumental: has("instrumental") ? true : has("no-instrumental") ? false : !lyrics,
+  aigcWatermark: has("aigc-watermark") ? true : has("no-aigc-watermark") ? false : undefined,
+});

--- a/skills/media-use/audio/scripts/minimax-music.mjs
+++ b/skills/media-use/audio/scripts/minimax-music.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { writeMiniMaxMusic } from "./lib/minimax-music.mjs";
+import { miniMaxMusicOptionsFromRequest, writeMiniMaxMusic } from "./lib/minimax-music.mjs";
 
 const argv = process.argv.slice(2);
 const flag = (name, fallback) => {
@@ -9,21 +10,35 @@ const flag = (name, fallback) => {
   return index >= 0 && index + 1 < argv.length ? argv[index + 1] : fallback;
 };
 const has = (name) => argv.includes(`--${name}`);
+const booleanFlag = (name, fallback) => (has(name) ? true : has(`no-${name}`) ? false : fallback);
 
 const outputPath = flag("output", "");
 if (!outputPath) throw new Error("--output is required");
 
-const lyrics = flag("lyrics", undefined);
+const requestPath = flag("request", "");
+let requestOptions = {};
+if (requestPath) {
+  const request = JSON.parse(readFileSync(resolve(requestPath), "utf8"));
+  requestOptions = miniMaxMusicOptionsFromRequest(request.bgm);
+}
+
+const model = flag("model", requestOptions.model ?? process.env.MINIMAX_MUSIC_MODEL ?? "music-3.0");
+const lyrics = flag("lyrics", requestOptions.lyrics);
+const audioSetting = requestOptions.audioSetting ?? {};
 await writeMiniMaxMusic({
   outputPath: resolve(outputPath),
-  model: flag("model", process.env.MINIMAX_MUSIC_MODEL || "music-3.0"),
-  region: flag("region", process.env.MINIMAX_API_REGION || "global_en"),
-  prompt: flag("prompt", undefined),
+  model,
+  region: flag("region", requestOptions.region ?? process.env.MINIMAX_API_REGION ?? "global_en"),
+  prompt: flag("prompt", requestOptions.prompt),
   lyrics,
-  stream: has("stream"),
-  outputFormat: flag("output-format", "hex"),
-  audioFormat: flag("audio-format", "wav"),
-  lyricsOptimizer: has("lyrics-optimizer") ? true : has("no-lyrics-optimizer") ? false : undefined,
-  isInstrumental: has("instrumental") ? true : has("no-instrumental") ? false : !lyrics,
-  aigcWatermark: has("aigc-watermark") ? true : has("no-aigc-watermark") ? false : undefined,
+  stream: booleanFlag("stream", requestOptions.stream ?? false),
+  outputFormat: flag("output-format", requestOptions.outputFormat ?? "hex"),
+  audioFormat: flag("audio-format", audioSetting.format ?? "wav"),
+  audioSetting,
+  lyricsOptimizer: booleanFlag("lyrics-optimizer", requestOptions.lyricsOptimizer),
+  isInstrumental: booleanFlag("instrumental", requestOptions.isInstrumental ?? !lyrics),
+  audioUrl: flag("audio-url", requestOptions.audioUrl),
+  audioBase64: flag("audio-base64", requestOptions.audioBase64),
+  coverFeatureId: flag("cover-feature-id", requestOptions.coverFeatureId),
+  aigcWatermark: booleanFlag("aigc-watermark", requestOptions.aigcWatermark),
 });

--- a/skills/media-use/references/audio.md
+++ b/skills/media-use/references/audio.md
@@ -9,7 +9,7 @@ shot), use the shared engine at `audio/scripts/audio.mjs`. It takes a neutral
 node <SKILL_DIR>/audio/scripts/audio.mjs --request ./audio_request.json --out ./audio_meta.json
 ```
 
-- **Request** `{ provider?, lang?, speed?, lines: [{ id, text, sfx?: [names] }], bgm: { mode?, query?, prompt? } }`: `id` joins each line back to your model; `bgm.mode` = `retrieve | generate | none` (omit for auto). `--only tts,bgm,sfx` runs a subset and merges into an existing `--out`.
+- **Request** `{ provider?, lang?, speed?, lines: [{ id, text, sfx?: [names] }], bgm: { mode?, query?, prompt?, model?, region?, lyrics?, stream?, output_format?, audio_setting?, lyrics_optimizer?, is_instrumental?, audio_url?, audio_base64?, cover_feature_id?, aigc_watermark? } }`: `id` joins each line back to your model; `bgm.mode` = `retrieve | generate | none` (omit for auto). `--only tts,bgm,sfx` runs a subset and merges into an existing `--out`.
 - **Output** `audio_meta.json` (id-keyed): `voices[].{path,duration_s,words[]}` (word timestamps for captions), `sfx[]`, `bgm`, `total_duration_s`.
 - **HeyGen free-usage path**: HeyGen CLI auth unlocks TTS plus music/SFX retrieval. Local/provider-specific generators are explicit alternatives where installed; run `node <SKILL_DIR>/scripts/resolve.mjs --doctor` before assuming retrieval or TTS will work.
 - If BGM took the generate path (`bgm_pending: true`), run `audio/scripts/wait-bgm.mjs` before final render.


### PR DESCRIPTION
Reason: Add MiniMax music generation to the shared BGM pipeline.

## Changes

- Add regional MiniMax music endpoints and current generation and cover model presets.
- Support prompt, lyrics, instrumental, cover input, streaming, output format, and audio format request fields.
- Parse response status and audio data for URL, hex, and streaming results.
- Launch MiniMax generation through the existing detached BGM workflow and document its configuration.
- Add focused tests for request mapping, endpoint selection, cover constraints, output handling, and API errors.

## Checks

- `node --test skills/media-use/audio/scripts/lib/minimax-music.test.mjs skills/media-use/audio/scripts/lib/bgm.test.mjs skills/media-use/audio/scripts/audio.test.mjs`
- `bunx oxfmt --check skills/media-use/audio/scripts/lib/minimax-music.mjs skills/media-use/audio/scripts/minimax-music.mjs skills/media-use/audio/scripts/lib/minimax-music.test.mjs skills/media-use/audio/scripts/lib/bgm.mjs skills/media-use/audio/scripts/lib/bgm.test.mjs skills/media-use/audio/scripts/audio.mjs skills/media-use/audio/references/bgm.md`
- `bunx oxlint skills/media-use/audio/scripts/lib/minimax-music.mjs skills/media-use/audio/scripts/minimax-music.mjs skills/media-use/audio/scripts/lib/minimax-music.test.mjs skills/media-use/audio/scripts/lib/bgm.mjs skills/media-use/audio/scripts/lib/bgm.test.mjs skills/media-use/audio/scripts/audio.mjs`
- `git diff --check`
