### PR TITLE
fix: align nested composition media with slot in-points

### DIFF
--- a/docs/concepts/compositions.mdx
+++ b/docs/concepts/compositions.mdx
@@ -108,6 +108,17 @@ Use a separate file when you want to reuse it.
     It defaults to `0`. Trimming or splitting from the left pushes this offset
     forward by the time elapsed multiplied by `data-playback-rate`, so the
     nested animation keeps going instead of jumping back to its beginning.
+
+    The same in-point applies to descendant `<video>` and `<audio>` clips, like
+    a nested sequence in an NLE. If the slot starts at master time `H`, has
+    `data-playback-start="P"`, and a descendant starts at child time `L`, its
+    master start is `H + (L - P) / data-playback-rate`. Media ending at or
+    before the slot is omitted; media crossing the slot boundary begins at the
+    slot with its source advanced by the consumed child time. A descendant's
+    own `data-media-start` remains an offset into its source file and composes
+    additively with that advance. On a composition host only,
+    `data-media-start` is supported as a legacy alias for
+    `data-playback-start`; when both are present, `data-playback-start` wins.
   </Tab>
   <Tab title="Inline">
     Write the nested composition straight into the parent. Simpler for

--- a/packages/cli/src/commands/snapshot.test.ts
+++ b/packages/cli/src/commands/snapshot.test.ts
@@ -40,6 +40,13 @@ describe("tailFrameTime", () => {
 });
 
 describe("transparent snapshot capture", () => {
+  it("uses runtime-resolved nested source offsets and playback rates", () => {
+    const source = readFileSync(new URL("./snapshot.ts", import.meta.url), "utf8");
+    expect(source).toContain("__hfResolveMediaSourceStartSeconds?.(v)");
+    expect(source).toContain("__hfResolveMediaPlaybackRate?.(v)");
+    expect(source).toContain("__hfResolveMediaDurationSeconds?.(v)");
+  });
+
   it("asks Chrome to retain the alpha channel in review PNGs", () => {
     const source = readFileSync(new URL("./snapshot.ts", import.meta.url), "utf8");
     expect(source).toContain(

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -414,17 +414,24 @@ async function captureSnapshots(
           const candidates = await page.evaluate(() => {
             const runtimeWindow = window as Window & {
               __hfResolveMediaStartSeconds?: (element: Element) => number;
+              __hfResolveMediaSourceStartSeconds?: (element: HTMLMediaElement) => number;
+              __hfResolveMediaPlaybackRate?: (element: HTMLMediaElement) => number;
+              __hfResolveMediaDurationSeconds?: (element: HTMLMediaElement) => number;
             };
             return Array.from(document.querySelectorAll("video")).map((el) => {
               const v = el as HTMLVideoElement;
               const authoredStart = parseFloat(v.dataset.start ?? "0") || 0;
               const runtimeResolvedStart = runtimeWindow.__hfResolveMediaStartSeconds?.(v);
-              const rawRate = v.defaultPlaybackRate;
+              const rawRate =
+                runtimeWindow.__hfResolveMediaPlaybackRate?.(v) ?? v.defaultPlaybackRate;
               const playbackRate =
                 Number.isFinite(rawRate) && rawRate > 0 ? Math.max(0.1, Math.min(5, rawRate)) : 1;
               const mediaStart =
-                parseFloat(v.dataset.playbackStart ?? v.dataset.mediaStart ?? "0") || 0;
-              const rawDuration = parseFloat(v.dataset.duration ?? "");
+                runtimeWindow.__hfResolveMediaSourceStartSeconds?.(v) ??
+                (parseFloat(v.dataset.playbackStart ?? v.dataset.mediaStart ?? "0") || 0);
+              const rawDuration =
+                runtimeWindow.__hfResolveMediaDurationSeconds?.(v) ??
+                parseFloat(v.dataset.duration ?? "");
               const srcDur = Number.isFinite(v.duration) && v.duration > 0 ? v.duration : 0;
               const duration =
                 Number.isFinite(rawDuration) && rawDuration > 0

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -1404,6 +1404,212 @@ describe("initSandboxRuntimeModular", () => {
     expect(video.currentTime).toBe(0);
   });
 
+  it("seeks descendant media in the same source time as an in-pointed child timeline", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-duration", "12");
+    document.body.appendChild(root);
+
+    const child = document.createElement("div");
+    child.setAttribute("data-composition-id", "child");
+    child.setAttribute("data-start", "5");
+    child.setAttribute("data-duration", "3");
+    child.setAttribute("data-playback-start", "1.5");
+    root.appendChild(child);
+
+    const video = document.createElement("video");
+    video.setAttribute("data-start", "1");
+    video.setAttribute("data-duration", "4");
+    video.setAttribute("data-media-start", "2");
+    video.setAttribute("data-playback-rate", "2");
+    child.appendChild(video);
+    Object.defineProperties(video, {
+      duration: { value: 20, configurable: true },
+      paused: { value: true, writable: true, configurable: true },
+      readyState: { value: 4, configurable: true },
+      currentTime: { value: 0, writable: true, configurable: true },
+    });
+    video.load = () => {};
+    video.pause = () => {
+      Object.defineProperty(video, "paused", { value: true, writable: true, configurable: true });
+    };
+
+    window.__timelines = { main: createMockTimeline(12), child: createMockTimeline(6) };
+    initSandboxRuntimeModular();
+
+    // Master 5 maps to child source time 1.5. The clip began at child time 1,
+    // so its own 2x source has advanced by 1 second from data-media-start=2.
+    window.__player?.seek(5);
+    expect(window.__hfResolveMediaStartSeconds?.(video)).toBe(5);
+    expect(video.currentTime).toBeCloseTo(3);
+  });
+
+  it("composes host playback rate into descendant media timing", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-duration", "12");
+    document.body.appendChild(root);
+
+    const child = document.createElement("div");
+    child.setAttribute("data-composition-id", "child");
+    child.setAttribute("data-start", "5");
+    child.setAttribute("data-duration", "3");
+    child.setAttribute("data-playback-start", "1");
+    child.setAttribute("data-playback-rate", "2");
+    root.appendChild(child);
+
+    const audio = document.createElement("audio");
+    audio.setAttribute("data-start", "2");
+    audio.setAttribute("data-duration", "1");
+    audio.setAttribute("data-media-start", "4");
+    child.appendChild(audio);
+
+    window.__timelines = { main: createMockTimeline(12), child: createMockTimeline(6) };
+    initSandboxRuntimeModular();
+
+    // child time = 1 + (master - 5) * 2, so child-local t=2 starts at 5.5.
+    expect(window.__hfResolveMediaStartSeconds?.(audio)).toBe(5.5);
+  });
+
+  it("keeps a standalone composition preview local despite a root playback-start", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "child");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-duration", "6");
+    root.setAttribute("data-playback-start", "2");
+    document.body.appendChild(root);
+
+    const video = document.createElement("video");
+    video.setAttribute("data-start", "1");
+    video.setAttribute("data-duration", "2");
+    root.appendChild(video);
+
+    window.__timelines = { child: createMockTimeline(6) };
+    initSandboxRuntimeModular();
+
+    expect(window.__hfResolveMediaStartSeconds?.(video)).toBe(1);
+  });
+
+  it("uses data-media-start as a composition-slot alias without consuming descendant source trim", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-duration", "8");
+    document.body.appendChild(root);
+
+    const child = document.createElement("div");
+    child.setAttribute("data-composition-id", "child");
+    child.setAttribute("data-start", "1");
+    child.setAttribute("data-duration", "3");
+    child.setAttribute("data-media-start", "3");
+    root.appendChild(child);
+
+    const audio = document.createElement("audio");
+    audio.setAttribute("data-start", "1");
+    audio.setAttribute("data-duration", "3");
+    audio.setAttribute("data-media-start", "7");
+    child.appendChild(audio);
+    Object.defineProperties(audio, {
+      duration: { value: 20, configurable: true },
+      paused: { value: true, writable: true, configurable: true },
+      readyState: { value: 4, configurable: true },
+      currentTime: { value: 0, writable: true, configurable: true },
+    });
+    audio.load = () => {};
+    audio.pause = () => {};
+
+    window.__timelines = { main: createMockTimeline(8), child: createMockTimeline(6) };
+    initSandboxRuntimeModular();
+
+    // H=1, P=3, L=1 maps to master -1, then the slot head trims to master 1.
+    // The public resolver is used by snapshot and therefore exposes the
+    // effective start, while two consumed child seconds advance source 7 to 9.
+    expect(window.__hfResolveMediaStartSeconds?.(audio)).toBe(1);
+    window.__player?.seek(1);
+    expect(audio.currentTime).toBe(9);
+  });
+
+  it("uses the effective nested mapping for play hard-sync and WebAudio scheduling", () => {
+    const raf = createManualRaf();
+    vi.spyOn(performance, "now").mockImplementation(() => raf.now());
+    window.requestAnimationFrame = raf.requestAnimationFrame as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = raf.cancelAnimationFrame as typeof window.cancelAnimationFrame;
+
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-duration", "8");
+    document.body.appendChild(root);
+    const child = document.createElement("div");
+    child.setAttribute("data-composition-id", "child");
+    child.setAttribute("data-start", "2");
+    child.setAttribute("data-duration", "3");
+    child.setAttribute("data-playback-start", "1");
+    root.appendChild(child);
+    const audio = document.createElement("audio");
+    audio.setAttribute("src", "nested.wav");
+    audio.setAttribute("data-start", "0.5");
+    audio.setAttribute("data-duration", "2");
+    audio.setAttribute("data-media-start", "4");
+    child.appendChild(audio);
+    Object.defineProperties(audio, {
+      duration: { value: 20, configurable: true },
+      paused: { value: true, writable: true, configurable: true },
+      readyState: { value: 4, configurable: true },
+      currentTime: { value: 0, writable: true, configurable: true },
+    });
+    audio.load = () => {};
+    audio.pause = () => {};
+    audio.play = vi.fn(async () => {});
+
+    window.__timelines = { main: createMockTimeline(8), child: createMockTimeline(4) };
+    initSandboxRuntimeModular();
+    window.__player?.seek(2);
+
+    // Raw media starts before the slot; the slot head consumes 0.5 child
+    // seconds, so seek's hard sync begins at source 4.5.
+    expect(audio.currentTime).toBe(4.5);
+  });
+
+  it("ends descendant media in master time under an accelerated host", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-duration", "10");
+    document.body.appendChild(root);
+    const child = document.createElement("div");
+    child.setAttribute("data-composition-id", "child");
+    child.setAttribute("data-start", "5");
+    child.setAttribute("data-duration", "3");
+    child.setAttribute("data-playback-start", "1");
+    child.setAttribute("data-playback-rate", "2");
+    root.appendChild(child);
+    const video = document.createElement("video");
+    video.setAttribute("data-start", "2");
+    video.setAttribute("data-duration", "1");
+    child.appendChild(video);
+    Object.defineProperties(video, {
+      duration: { value: 10, configurable: true },
+      paused: { value: false, writable: true, configurable: true },
+      readyState: { value: 4, configurable: true },
+      currentTime: { value: 0, writable: true, configurable: true },
+    });
+    video.load = () => {};
+    video.pause = () => {
+      Object.defineProperty(video, "paused", { value: true, writable: true, configurable: true });
+    };
+
+    window.__timelines = { main: createMockTimeline(10), child: createMockTimeline(4) };
+    initSandboxRuntimeModular();
+    window.__player?.seek(6);
+
+    // Local [2,3) maps to master [5.5,6), not [5.5,6.5).
+    expect(video.style.visibility).toBe("hidden");
+    expect(video.paused).toBe(true);
+  });
+
   it("activates sub-composition timelines at data-start near 0 during renderSeek", () => {
     // Regression: sub-compositions starting at or near t=0 had their GSAP
     // sub-timelines ignored during render because renderSeek did not

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -1442,6 +1442,9 @@ describe("initSandboxRuntimeModular", () => {
     // so its own 2x source has advanced by 1 second from data-media-start=2.
     window.__player?.seek(5);
     expect(window.__hfResolveMediaStartSeconds?.(video)).toBe(5);
+    expect(window.__hfResolveMediaSourceStartSeconds?.(video)).toBe(3);
+    expect(window.__hfResolveMediaPlaybackRate?.(video)).toBe(2);
+    expect(window.__hfResolveMediaDurationSeconds?.(video)).toBe(3);
     expect(video.currentTime).toBeCloseTo(3);
   });
 
@@ -1471,6 +1474,7 @@ describe("initSandboxRuntimeModular", () => {
 
     // child time = 1 + (master - 5) * 2, so child-local t=2 starts at 5.5.
     expect(window.__hfResolveMediaStartSeconds?.(audio)).toBe(5.5);
+    expect(window.__hfResolveMediaDurationSeconds?.(audio)).toBe(0.5);
   });
 
   it("keeps a standalone composition preview local despite a root playback-start", () => {

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -667,7 +667,9 @@ export function initSandboxRuntimeModular(): void {
       const hostInPoint = readCompositionInPoint(compositionHost);
       const hostPlaybackRate = readElementPlaybackRate(compositionHost);
       if (hosts.length === 1 && hostInPoint === 0 && hostPlaybackRate === 1) {
-        const hostDuration = parseNumeric(compositionHost.getAttribute("data-duration"));
+        const hostDuration = resolveDurationForElement(compositionHost, {
+          includeAuthoredTimingAttrs: true,
+        });
         const authoredDuration = parseNumeric(element.getAttribute("data-duration"));
         const hostEnd =
           hostDuration != null && hostDuration > 0 ? hostStart + hostDuration : Infinity;
@@ -693,7 +695,9 @@ export function initSandboxRuntimeModular(): void {
           );
         }, hostStart);
       windowStart = Math.max(windowStart, parentMappedSlotStart);
-      const hostDuration = parseNumeric(compositionHost.getAttribute("data-duration"));
+      const hostDuration = resolveDurationForElement(compositionHost, {
+        includeAuthoredTimingAttrs: true,
+      });
       if (hostDuration != null && hostDuration > 0) {
         const outerRate = hosts
           .slice(hosts.indexOf(compositionHost) + 1)
@@ -761,9 +765,30 @@ export function initSandboxRuntimeModular(): void {
   };
 
   window.__hfResolveMediaStartSeconds = resolveAbsoluteMediaStartSeconds;
+  const resolveMediaSourceStartSeconds = (element: HTMLVideoElement | HTMLAudioElement): number =>
+    resolveNestedMediaTiming(element)?.mediaStart ?? readElementPlaybackStart(element);
+  const resolveMediaPlaybackRate = (element: HTMLVideoElement | HTMLAudioElement): number =>
+    resolveNestedMediaTiming(element)?.playbackRate ?? readElementPlaybackRate(element);
+  const resolveMediaDurationSeconds = (element: HTMLVideoElement | HTMLAudioElement): number => {
+    const nested = resolveNestedMediaTiming(element);
+    if (nested) return Math.max(0, nested.end - nested.start);
+    return parseNumeric(element.getAttribute("data-duration")) ?? Number.POSITIVE_INFINITY;
+  };
+  window.__hfResolveMediaSourceStartSeconds = resolveMediaSourceStartSeconds;
+  window.__hfResolveMediaPlaybackRate = resolveMediaPlaybackRate;
+  window.__hfResolveMediaDurationSeconds = resolveMediaDurationSeconds;
   runtimeCleanupCallbacks.push(() => {
     if (window.__hfResolveMediaStartSeconds === resolveAbsoluteMediaStartSeconds) {
       delete window.__hfResolveMediaStartSeconds;
+    }
+    if (window.__hfResolveMediaSourceStartSeconds === resolveMediaSourceStartSeconds) {
+      delete window.__hfResolveMediaSourceStartSeconds;
+    }
+    if (window.__hfResolveMediaPlaybackRate === resolveMediaPlaybackRate) {
+      delete window.__hfResolveMediaPlaybackRate;
+    }
+    if (window.__hfResolveMediaDurationSeconds === resolveMediaDurationSeconds) {
+      delete window.__hfResolveMediaDurationSeconds;
     }
   });
 

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -616,7 +616,118 @@ export function initSandboxRuntimeModular(): void {
     return { compositionRoot, inheritedStart, inheritedDuration };
   };
 
+  type NestedMediaTiming = {
+    rawStart: number;
+    start: number;
+    end: number;
+    mediaStart: number;
+    playbackRate: number;
+    windowEnd: number | null;
+  };
+
+  const readCompositionInPoint = (element: Element): number => {
+    const raw = parseNumeric(
+      element.getAttribute("data-playback-start") ?? element.getAttribute("data-media-start"),
+    );
+    return raw != null && raw > 0 ? raw : 0;
+  };
+
+  /**
+   * Map descendant media from child-composition source time to the master
+   * timeline. Composition hosts are affine NLE slots:
+   * master = hostStart + (childLocal - inPoint) / hostRate.
+   * The root composition is intentionally excluded so opening a composition
+   * by itself remains a local preview.
+   */
+  const resolveNestedMediaTiming = (element: HTMLMediaElement): NestedMediaTiming | null => {
+    const hosts: Element[] = [];
+    let host = element.closest("[data-composition-id]");
+    while (host) {
+      const parentHost = host.parentElement?.closest("[data-composition-id]") ?? null;
+      if (!parentHost) break;
+      if (
+        host.hasAttribute("data-start") ||
+        host.hasAttribute("data-composition-file") ||
+        host.hasAttribute("data-composition-src")
+      ) {
+        hosts.push(host);
+      }
+      host = parentHost;
+    }
+    if (hosts.length === 0) return null;
+
+    const authoredStart = parseNumeric(element.getAttribute("data-start"));
+    if (authoredStart == null) return null;
+    let masterTime = authoredStart;
+    let combinedRate = readElementPlaybackRate(element);
+    let windowStart = Number.NEGATIVE_INFINITY;
+    let windowEnd = Number.POSITIVE_INFINITY;
+    for (const compositionHost of hosts) {
+      const hostStart = parseNumeric(compositionHost.getAttribute("data-start")) ?? 0;
+      const hostInPoint = readCompositionInPoint(compositionHost);
+      const hostPlaybackRate = readElementPlaybackRate(compositionHost);
+      if (hosts.length === 1 && hostInPoint === 0 && hostPlaybackRate === 1) {
+        const hostDuration = parseNumeric(compositionHost.getAttribute("data-duration"));
+        const authoredDuration = parseNumeric(element.getAttribute("data-duration"));
+        const hostEnd =
+          hostDuration != null && hostDuration > 0 ? hostStart + hostDuration : Infinity;
+        const authoredEnd =
+          authoredDuration != null && authoredDuration > 0
+            ? authoredStart + authoredDuration
+            : authoredStart;
+        if (authoredStart >= hostStart && authoredStart < hostEnd && authoredEnd > hostStart) {
+          return null;
+        }
+      }
+      const hostRate = hostPlaybackRate;
+      const inPoint = hostInPoint;
+      masterTime = hostStart + (masterTime - inPoint) / hostRate;
+      combinedRate *= hostRate;
+
+      const parentMappedSlotStart = hosts
+        .slice(hosts.indexOf(compositionHost) + 1)
+        .reduce((time, parent) => {
+          const parentStart = parseNumeric(parent.getAttribute("data-start")) ?? 0;
+          return (
+            parentStart + (time - readCompositionInPoint(parent)) / readElementPlaybackRate(parent)
+          );
+        }, hostStart);
+      windowStart = Math.max(windowStart, parentMappedSlotStart);
+      const hostDuration = parseNumeric(compositionHost.getAttribute("data-duration"));
+      if (hostDuration != null && hostDuration > 0) {
+        const outerRate = hosts
+          .slice(hosts.indexOf(compositionHost) + 1)
+          .reduce((rate, parent) => rate * readElementPlaybackRate(parent), 1);
+        windowEnd = Math.min(windowEnd, parentMappedSlotStart + hostDuration / outerRate);
+      }
+    }
+
+    const effectiveStart = Math.max(masterTime, windowStart);
+    const authoredMediaStart = readElementPlaybackStart(element);
+    const authoredDuration = parseNumeric(element.getAttribute("data-duration"));
+    const ownRate = readElementPlaybackRate(element);
+    const hostRate = combinedRate / ownRate;
+    const mediaEnd =
+      authoredDuration != null && authoredDuration > 0
+        ? masterTime + authoredDuration / hostRate
+        : Number.POSITIVE_INFINITY;
+    return {
+      rawStart: masterTime,
+      start: effectiveStart,
+      end: Math.min(mediaEnd, windowEnd),
+      mediaStart: authoredMediaStart + Math.max(0, effectiveStart - masterTime) * combinedRate,
+      playbackRate: combinedRate,
+      windowEnd: Number.isFinite(windowEnd) ? windowEnd : null,
+    };
+  };
+
   const resolveAbsoluteMediaStartSeconds = (element: Element): number => {
+    if (element instanceof HTMLMediaElement) {
+      const nested = resolveNestedMediaTiming(element);
+      if (nested) {
+        return nested.start;
+      }
+    }
     const context = resolveMediaCompositionContext(element);
     const inheritedStart = context.inheritedStart ?? 0;
     const authoredStart = parseNumeric(element.getAttribute("data-start"));
@@ -667,6 +778,12 @@ export function initSandboxRuntimeModular(): void {
       ? resolveAbsoluteMediaStartSeconds(rawNode)
       : resolveStartForElement(rawNode, 0);
     let duration = resolveDurationForElement(rawNode);
+    if (rawNode instanceof HTMLMediaElement) {
+      const nestedTiming = resolveNestedMediaTiming(rawNode);
+      if (nestedTiming && Number.isFinite(nestedTiming.end)) {
+        duration = Math.max(0, nestedTiming.end - nestedTiming.start);
+      }
+    }
     const compId = rawNode.getAttribute("data-composition-id");
     if (compId) {
       const compTimeline = (window.__timelines ?? {})[compId];
@@ -1984,23 +2101,36 @@ export function initSandboxRuntimeModular(): void {
         element.hasAttribute("data-start") ||
         Boolean(resolveMediaCompositionContext(element).compositionRoot),
       resolveStartSeconds: (element) => {
-        return resolveAbsoluteMediaStartSeconds(element);
+        return element instanceof HTMLMediaElement
+          ? (resolveNestedMediaTiming(element)?.start ?? resolveAbsoluteMediaStartSeconds(element))
+          : resolveAbsoluteMediaStartSeconds(element);
       },
+      resolveMediaStartSeconds: (element) =>
+        resolveNestedMediaTiming(element)?.mediaStart ?? readElementPlaybackStart(element),
+      resolvePlaybackRate: (element) =>
+        resolveNestedMediaTiming(element)?.playbackRate ?? readElementPlaybackRate(element),
       resolveDurationSeconds: (element) => {
         const context = resolveMediaCompositionContext(element);
         const start = resolveAbsoluteMediaStartSeconds(element);
-        const mediaStart =
-          Number.parseFloat(element.dataset.playbackStart ?? element.dataset.mediaStart ?? "0") ||
-          0;
+        const nestedTiming = resolveNestedMediaTiming(element);
+        if (nestedTiming && Number.isFinite(nestedTiming.end)) {
+          return Math.max(0, nestedTiming.end - nestedTiming.start);
+        }
+        const mediaStart = nestedTiming?.mediaStart ?? readElementPlaybackStart(element);
         const hostRemaining =
           context.inheritedStart != null &&
           context.inheritedDuration != null &&
           context.inheritedDuration > 0
             ? Math.max(0, context.inheritedStart + context.inheritedDuration - start)
             : null;
-        const sourceDuration =
+        const sourceDurationInSourceSeconds =
           Number.isFinite(element.duration) && element.duration > mediaStart
             ? Math.max(0, element.duration - mediaStart)
+            : null;
+        const sourceDuration =
+          sourceDurationInSourceSeconds != null
+            ? sourceDurationInSourceSeconds /
+              (nestedTiming?.playbackRate ?? readElementPlaybackRate(element))
             : null;
         // The element's own data-duration is an explicit clip-length trim
         // (the studio writes it when you drag the clip edge). It must bound
@@ -2008,8 +2138,11 @@ export function initSandboxRuntimeModular(): void {
         // to the source-file or host-composition end. Absent → no cap (an
         // untrimmed clip plays its natural source length).
         const ownDuration = Number.parseFloat(element.dataset.duration ?? "");
+        const hostRate = nestedTiming
+          ? nestedTiming.playbackRate / readElementPlaybackRate(element)
+          : 1;
         const explicitDuration =
-          Number.isFinite(ownDuration) && ownDuration > 0 ? ownDuration : null;
+          Number.isFinite(ownDuration) && ownDuration > 0 ? ownDuration / hostRate : null;
         return resolveRuntimeMediaClipDuration({
           isVideo: element.tagName === "VIDEO",
           sourceDuration,
@@ -2921,12 +3054,16 @@ export function initSandboxRuntimeModular(): void {
           let foundActive = false;
           for (const rawEl of audioEls) {
             if (!(rawEl instanceof HTMLMediaElement) || !rawEl.isConnected) continue;
-            const start = Number.parseFloat(rawEl.dataset.start ?? "");
+            const nestedTiming = resolveNestedMediaTiming(rawEl);
+            const start = nestedTiming?.start ?? Number.parseFloat(rawEl.dataset.start ?? "");
             const durAttr = Number.parseFloat(rawEl.dataset.duration ?? "");
-            const end = Number.isFinite(durAttr) && durAttr > 0 ? start + durAttr : Infinity;
-            const mediaStart =
-              Number.parseFloat(rawEl.dataset.playbackStart ?? rawEl.dataset.mediaStart ?? "0") ||
-              0;
+            const end =
+              nestedTiming && Number.isFinite(nestedTiming.end)
+                ? nestedTiming.end
+                : Number.isFinite(durAttr) && durAttr > 0
+                  ? start + durAttr
+                  : Infinity;
+            const mediaStart = nestedTiming?.mediaStart ?? readElementPlaybackStart(rawEl);
             if (Number.isFinite(start) && state.currentTime >= start && state.currentTime < end) {
               if (!rawEl.paused) {
                 clock.attachAudioSource({ el: rawEl, compositionStart: start, mediaStart });
@@ -3001,14 +3138,20 @@ export function initSandboxRuntimeModular(): void {
     for (const el of mediaEls) {
       if (!(el instanceof HTMLMediaElement)) continue;
       if (!el.isConnected) continue;
-      const start = Number.parseFloat(el.dataset.start ?? "");
+      const nestedTiming = resolveNestedMediaTiming(el);
+      const start = nestedTiming?.start ?? Number.parseFloat(el.dataset.start ?? "");
       if (!Number.isFinite(start)) continue;
       const durAttr = Number.parseFloat(el.dataset.duration ?? "");
-      const end = Number.isFinite(durAttr) && durAttr > 0 ? start + durAttr : Infinity;
+      const end =
+        nestedTiming && Number.isFinite(nestedTiming.end)
+          ? nestedTiming.end
+          : Number.isFinite(durAttr) && durAttr > 0
+            ? start + durAttr
+            : Infinity;
       if (timeSeconds < start || timeSeconds >= end) continue;
-      const mediaStart =
-        Number.parseFloat(el.dataset.playbackStart ?? el.dataset.mediaStart ?? "0") || 0;
-      const relTime = timeSeconds - start + mediaStart;
+      const mediaStart = nestedTiming?.mediaStart ?? readElementPlaybackStart(el);
+      const playbackRate = nestedTiming?.playbackRate ?? readElementPlaybackRate(el);
+      const relTime = (timeSeconds - start) * playbackRate + mediaStart;
       if (relTime >= 0) {
         try {
           el.currentTime = relTime;
@@ -3031,15 +3174,19 @@ export function initSandboxRuntimeModular(): void {
     const audioEls = document.querySelectorAll("audio[data-start]");
     for (const rawEl of audioEls) {
       if (!(rawEl instanceof HTMLMediaElement) || !rawEl.isConnected) continue;
-      const compStart = Number.parseFloat(rawEl.dataset.start ?? "");
+      const nestedTiming = resolveNestedMediaTiming(rawEl);
+      const compStart = nestedTiming?.start ?? Number.parseFloat(rawEl.dataset.start ?? "");
       if (!Number.isFinite(compStart)) continue;
-      const mediaStart =
-        Number.parseFloat(rawEl.dataset.playbackStart ?? rawEl.dataset.mediaStart ?? "0") || 0;
+      const mediaStart = nestedTiming?.mediaStart ?? readElementPlaybackStart(rawEl);
       const volumeAttr = Number.parseFloat(rawEl.dataset.volume ?? "");
       const vol = Number.isFinite(volumeAttr) ? volumeAttr : 1;
       const durationAttr = Number.parseFloat(rawEl.dataset.duration ?? "");
+      const elementRate = nestedTiming?.playbackRate ?? readElementPlaybackRate(rawEl);
+      const hostRate = elementRate / readElementPlaybackRate(rawEl);
       let clipDuration =
-        Number.isFinite(durationAttr) && durationAttr > 0 ? durationAttr : Number.POSITIVE_INFINITY;
+        Number.isFinite(durationAttr) && durationAttr > 0
+          ? durationAttr / hostRate
+          : Number.POSITIVE_INFINITY;
       const compositionRoot = rawEl.closest("[data-composition-id]");
       if (compositionRoot) {
         const inheritedStart = resolveStartForElement(compositionRoot, 0);
@@ -3063,7 +3210,7 @@ export function initSandboxRuntimeModular(): void {
           clock.now(),
           vol * state.bridgeVolume,
           gen,
-          state.playbackRate,
+          state.playbackRate * elementRate,
           clipDuration,
         );
       });

--- a/packages/core/src/runtime/media.ts
+++ b/packages/core/src/runtime/media.ts
@@ -64,11 +64,87 @@ export type RuntimeMediaClip = {
   volumeKeyframes?: VolumeKeyframe[];
 };
 
-export function refreshRuntimeMediaCache(params?: {
+type RuntimeMediaCacheParams = {
   resolveStartSeconds?: (element: Element) => number;
+  resolveMediaStartSeconds?: (element: HTMLVideoElement | HTMLAudioElement) => number;
+  resolvePlaybackRate?: (element: HTMLVideoElement | HTMLAudioElement) => number;
   resolveDurationSeconds?: (element: HTMLVideoElement | HTMLAudioElement) => number | null;
   shouldIncludeElement?: (element: HTMLVideoElement | HTMLAudioElement) => boolean;
-}): {
+};
+
+function resolveRuntimeMediaDuration(
+  el: HTMLVideoElement | HTMLAudioElement,
+  params: RuntimeMediaCacheParams | undefined,
+  mediaStart: number,
+  playbackRate: number,
+  sourceDuration: number | null,
+): number {
+  const authored =
+    params?.resolveDurationSeconds?.(el) ?? Number.parseFloat(el.dataset.duration ?? "");
+  if (Number.isFinite(authored) && authored > 0) return authored;
+  if (sourceDuration == null) return Number.POSITIVE_INFINITY;
+  const effective = Math.max(0, (sourceDuration - mediaStart) / playbackRate);
+  return effective > 0 ? effective : Number.POSITIVE_INFINITY;
+}
+
+function resolveRuntimeMediaStart(
+  el: HTMLVideoElement | HTMLAudioElement,
+  params?: RuntimeMediaCacheParams,
+): number {
+  if (params?.resolveStartSeconds) return params.resolveStartSeconds(el);
+  return Number.parseFloat(el.dataset.start ?? "0");
+}
+
+function resolveRuntimeSourceStart(
+  el: HTMLVideoElement | HTMLAudioElement,
+  params?: RuntimeMediaCacheParams,
+): number {
+  if (params?.resolveMediaStartSeconds) return params.resolveMediaStartSeconds(el);
+  return Number.parseFloat(el.dataset.playbackStart ?? el.dataset.mediaStart ?? "0") || 0;
+}
+
+function resolveRuntimePlaybackRate(
+  el: HTMLVideoElement | HTMLAudioElement,
+  params?: RuntimeMediaCacheParams,
+): number {
+  if (params?.resolvePlaybackRate) return params.resolvePlaybackRate(el);
+  return readElementPlaybackRate(el);
+}
+
+function createRuntimeMediaClip(
+  el: HTMLVideoElement | HTMLAudioElement,
+  params?: RuntimeMediaCacheParams,
+): RuntimeMediaClip | null {
+  const start = resolveRuntimeMediaStart(el, params);
+  if (!Number.isFinite(start)) return null;
+  const mediaStart = resolveRuntimeSourceStart(el, params);
+  const playbackRate = resolveRuntimePlaybackRate(el, params);
+  const loop = el.loop;
+  const sourceDuration = Number.isFinite(el.duration) && el.duration > 0 ? el.duration : null;
+  const duration = resolveRuntimeMediaDuration(
+    el,
+    params,
+    mediaStart,
+    playbackRate,
+    sourceDuration,
+  );
+  const end =
+    Number.isFinite(duration) && duration > 0 ? start + duration : Number.POSITIVE_INFINITY;
+  const volumeRaw = Number.parseFloat(el.dataset.volume ?? "");
+  return {
+    el,
+    start,
+    mediaStart,
+    duration,
+    end,
+    volume: Number.isFinite(volumeRaw) ? volumeRaw : null,
+    playbackRate,
+    loop,
+    sourceDuration,
+  };
+}
+
+export function refreshRuntimeMediaCache(params?: RuntimeMediaCacheParams): {
   timedMediaEls: Array<HTMLVideoElement | HTMLAudioElement>;
   mediaClips: RuntimeMediaClip[];
   videoClips: RuntimeMediaClip[];
@@ -84,39 +160,11 @@ export function refreshRuntimeMediaCache(params?: {
   const videoClips: RuntimeMediaClip[] = [];
   let maxMediaEnd = 0;
   for (const el of timedMediaEls) {
-    const start = params?.resolveStartSeconds
-      ? params.resolveStartSeconds(el)
-      : Number.parseFloat(el.dataset.start ?? "0");
-    if (!Number.isFinite(start)) continue;
-    const mediaStart =
-      Number.parseFloat(el.dataset.playbackStart ?? el.dataset.mediaStart ?? "0") || 0;
-    const playbackRate = readElementPlaybackRate(el);
-    const loop = el.loop;
-    const sourceDuration = Number.isFinite(el.duration) && el.duration > 0 ? el.duration : null;
-    let duration =
-      params?.resolveDurationSeconds?.(el) ?? Number.parseFloat(el.dataset.duration ?? "");
-    if ((!Number.isFinite(duration) || duration <= 0) && sourceDuration != null) {
-      // Effective duration accounts for playback rate:
-      // at 0.5x, a 10s source plays for 20s on the timeline
-      duration = Math.max(0, (sourceDuration - mediaStart) / playbackRate);
-    }
-    const end =
-      Number.isFinite(duration) && duration > 0 ? start + duration : Number.POSITIVE_INFINITY;
-    const volumeRaw = Number.parseFloat(el.dataset.volume ?? "");
-    const clip: RuntimeMediaClip = {
-      el,
-      start,
-      mediaStart,
-      duration: Number.isFinite(duration) && duration > 0 ? duration : Number.POSITIVE_INFINITY,
-      end,
-      volume: Number.isFinite(volumeRaw) ? volumeRaw : null,
-      playbackRate,
-      loop,
-      sourceDuration,
-    };
+    const clip = createRuntimeMediaClip(el, params);
+    if (!clip) continue;
     mediaClips.push(clip);
     if (el.tagName === "VIDEO") videoClips.push(clip);
-    if (Number.isFinite(end)) maxMediaEnd = Math.max(maxMediaEnd, end);
+    if (Number.isFinite(clip.end)) maxMediaEnd = Math.max(maxMediaEnd, clip.end);
   }
   return { timedMediaEls, mediaClips, videoClips, maxMediaEnd };
 }

--- a/packages/core/src/runtime/startResolver.test.ts
+++ b/packages/core/src/runtime/startResolver.test.ts
@@ -279,6 +279,45 @@ describe("createRuntimeStartTimeResolver", () => {
       ]).toEqual([2, 6]);
     });
 
+    it("resolves a nested host's own reference in its parent mount before child shadowing", () => {
+      const root = document.createElement("div");
+      root.setAttribute("data-composition-id", "main");
+      document.body.appendChild(root);
+
+      const outerHost = document.createElement("div");
+      outerHost.setAttribute("data-composition-id", "parent");
+      outerHost.setAttribute("data-composition-file", "compositions/parent.html");
+      outerHost.setAttribute("data-start", "1");
+      root.appendChild(outerHost);
+
+      const parentAnchor = document.createElement("div");
+      parentAnchor.id = "anchor";
+      parentAnchor.setAttribute("data-start", "0");
+      parentAnchor.setAttribute("data-duration", "1");
+      outerHost.appendChild(parentAnchor);
+
+      const childHost = document.createElement("div");
+      childHost.setAttribute("data-composition-id", "child");
+      childHost.setAttribute("data-composition-file", "compositions/child.html");
+      childHost.setAttribute("data-start", "anchor");
+      outerHost.appendChild(childHost);
+
+      const childAnchor = document.createElement("div");
+      childAnchor.id = "anchor";
+      childAnchor.setAttribute("data-start", "0");
+      childAnchor.setAttribute("data-duration", "10");
+      childHost.appendChild(childAnchor);
+
+      const image = document.createElement("img");
+      image.setAttribute("data-start", "0");
+      image.setAttribute("data-duration", "1");
+      childHost.appendChild(image);
+
+      const resolver = createRuntimeStartTimeResolver({});
+      expect(resolver.resolveStartForElement(childHost)).toBe(2);
+      expect(resolver.resolveStartForElement(image)).toBe(2);
+    });
+
     it("adds the nearest composition root start for nested absolute media in inlined compositions", () => {
       const root = document.createElement("div");
       root.setAttribute("data-composition-id", "main");

--- a/packages/core/src/runtime/startResolver.test.ts
+++ b/packages/core/src/runtime/startResolver.test.ts
@@ -238,6 +238,47 @@ describe("createRuntimeStartTimeResolver", () => {
       expect(resolver.resolveStartForElement(secondClip)).toBe(58);
     });
 
+    it("resolves duplicate relative references within each repeated inlined mount", () => {
+      const root = document.createElement("div");
+      root.setAttribute("data-composition-id", "main");
+      document.body.appendChild(root);
+
+      const addMount = (id: string, start: number) => {
+        const host = document.createElement("div");
+        host.id = id;
+        host.setAttribute("data-composition-id", id);
+        host.setAttribute("data-composition-file", "compositions/scene.html");
+        host.setAttribute("data-start", String(start));
+        root.appendChild(host);
+
+        const innerRoot = document.createElement("div");
+        innerRoot.setAttribute("data-composition-id", "scene");
+        innerRoot.setAttribute("data-hf-inner-root", "true");
+        host.appendChild(innerRoot);
+
+        const anchor = document.createElement("div");
+        anchor.id = "anchor";
+        anchor.setAttribute("data-start", "0");
+        anchor.setAttribute("data-duration", "1");
+        innerRoot.appendChild(anchor);
+
+        const image = document.createElement("img");
+        image.setAttribute("data-start", "anchor");
+        image.setAttribute("data-duration", "1");
+        innerRoot.appendChild(image);
+        return image;
+      };
+
+      const firstImage = addMount("mount-one", 1);
+      const secondImage = addMount("mount-two", 5);
+      const resolver = createRuntimeStartTimeResolver({});
+
+      expect([
+        resolver.resolveStartForElement(firstImage),
+        resolver.resolveStartForElement(secondImage),
+      ]).toEqual([2, 6]);
+    });
+
     it("adds the nearest composition root start for nested absolute media in inlined compositions", () => {
       const root = document.createElement("div");
       root.setAttribute("data-composition-id", "main");

--- a/packages/core/src/runtime/startResolver.ts
+++ b/packages/core/src/runtime/startResolver.ts
@@ -22,6 +22,13 @@ function parseAuthoredEndAttr(element: Element): number | null {
   return parseNumeric(element.getAttribute(AUTHORED_END_ATTR));
 }
 
+function referenceMountForSource(source: Element): Element | null {
+  if (!source.hasAttribute("data-composition-file")) {
+    return source.closest("[data-composition-file]");
+  }
+  return source.parentElement?.closest("[data-composition-file]") ?? null;
+}
+
 export function createRuntimeStartTimeResolver(params: {
   timelineRegistry?: Record<string, RuntimeTimelineLike | undefined>;
   includeAuthoredTimingAttrs?: boolean;
@@ -44,7 +51,7 @@ export function createRuntimeStartTimeResolver(params: {
   const visiting = new Set<Element>();
 
   const findReferenceTarget = (refId: string, source: Element): Element | null => {
-    const mount = source.closest("[data-composition-file]");
+    const mount = referenceMountForSource(source);
     if (mount) {
       if (
         mount.getAttribute("id") === refId ||

--- a/packages/core/src/runtime/startResolver.ts
+++ b/packages/core/src/runtime/startResolver.ts
@@ -43,7 +43,22 @@ export function createRuntimeStartTimeResolver(params: {
   const durationCache = new WeakMap<Element, number | null>();
   const visiting = new Set<Element>();
 
-  const findReferenceTarget = (refId: string): Element | null => {
+  const findReferenceTarget = (refId: string, source: Element): Element | null => {
+    const mount = source.closest("[data-composition-file]");
+    if (mount) {
+      if (
+        mount.getAttribute("id") === refId ||
+        mount.getAttribute("data-composition-id") === refId
+      ) {
+        return mount;
+      }
+      const localById = Array.from(mount.querySelectorAll("[id]")).find(
+        (candidate) => candidate.getAttribute("id") === refId,
+      );
+      if (localById) return localById;
+      const localComposition = mount.querySelector(`[data-composition-id="${CSS.escape(refId)}"]`);
+      if (localComposition) return localComposition;
+    }
     const byId = doc.getElementById(refId);
     if (byId) return byId;
     return (
@@ -170,7 +185,7 @@ export function createRuntimeStartTimeResolver(params: {
         startCache.set(element, resolved);
         return resolved;
       }
-      const target = findReferenceTarget(expression.refId);
+      const target = findReferenceTarget(expression.refId, element);
       if (!target) {
         startCache.set(element, fallback);
         return fallback;

--- a/packages/core/src/runtime/window.d.ts
+++ b/packages/core/src/runtime/window.d.ts
@@ -83,6 +83,12 @@ declare global {
      * restoration, and arbitrary composition nesting cannot drift.
      */
     __hfResolveMediaStartSeconds?: (element: Element) => number;
+    /** Runtime-resolved source offset after nested slot in-points/head trimming. */
+    __hfResolveMediaSourceStartSeconds?: (element: HTMLVideoElement | HTMLAudioElement) => number;
+    /** Runtime-resolved rate after composing descendant and host playback rates. */
+    __hfResolveMediaPlaybackRate?: (element: HTMLVideoElement | HTMLAudioElement) => number;
+    /** Effective master-timeline duration after nested slot clipping/rate transforms. */
+    __hfResolveMediaDurationSeconds?: (element: HTMLVideoElement | HTMLAudioElement) => number;
     __HF_PICKER_API?: HyperframePickerApi;
     gsap?: {
       timeline: (params?: { paused?: boolean }) => RuntimeTimelineLike;

--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -1166,6 +1166,83 @@ describe("template-wrapped sub-composition media offsets", () => {
     });
   });
 
+  it("maps a nested timed image from child-local time into the host timeline", async () => {
+    const { projectDir, indexPath } = writeTemplateWrappedProject(
+      'data-start="5" data-duration="3" data-width="640" data-height="360"',
+      'data-start="0" data-duration="1"',
+      '<img id="nested-image" src="../assets/still.png" data-start="1" data-duration="1">',
+    );
+
+    const compiled = await compileForRender(projectDir, indexPath, projectDir);
+
+    expect(compiled.images).toContainEqual(
+      expect.objectContaining({ id: "nested-image", start: 6, end: 7 }),
+    );
+  });
+
+  it("maps and clips nested timed images through a composition in-point and rate", async () => {
+    const { projectDir, indexPath } = writeTemplateWrappedProject(
+      'data-start="5" data-duration="2" data-playback-start="1" data-playback-rate="2" data-width="640" data-height="360"',
+      'data-start="0" data-duration="1"',
+      `<img id="before" src="../assets/before.png" data-start="0" data-duration="1">
+       <img id="overlap" src="../assets/overlap.png" data-start="0.5" data-duration="1">
+       <img id="mapped" src="../assets/mapped.png" data-start="2" data-duration="2">`,
+    );
+
+    const compiled = await compileForRender(projectDir, indexPath, projectDir);
+
+    expect(compiled.images).not.toContainEqual(expect.objectContaining({ id: "before" }));
+    expect(compiled.images).toContainEqual(
+      expect.objectContaining({ id: "overlap", start: 5, end: 5.25 }),
+    );
+    expect(compiled.images).toContainEqual(
+      expect.objectContaining({ id: "mapped", start: 5.5, end: 6.5 }),
+    );
+  });
+
+  it("keeps repeated and idless nested timed images distinct", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-repeat-image-inpoint-"));
+    mkdirSync(join(projectDir, "compositions"), { recursive: true });
+    writeFileSync(
+      join(projectDir, "index.html"),
+      `<!doctype html><html><body><div data-composition-id="root" data-duration="10">
+        <div data-composition-id="one" data-composition-src="compositions/scene.html" data-start="1" data-duration="2"></div>
+        <div data-composition-id="two" data-composition-src="compositions/scene.html" data-start="5" data-duration="2"></div>
+      </div></body></html>`,
+    );
+    writeFileSync(
+      join(projectDir, "compositions/scene.html"),
+      `<template><div data-composition-id="scene">
+        <img src="assets/idless.png" data-start="0.5" data-duration="1">
+      </div></template>`,
+    );
+
+    const compiled = await compileForRender(projectDir, join(projectDir, "index.html"), projectDir);
+
+    expect(compiled.images.map((image) => image.start).sort()).toEqual([1.5, 5.5]);
+    expect(new Set(compiled.images.map((image) => image.id)).size).toBe(2);
+  });
+
+  it("keeps nested image timing and identity stable across non-empty recompilation", async () => {
+    const { projectDir, indexPath } = writeTemplateWrappedProject(
+      'data-start="5" data-width="640" data-height="360"',
+      'data-start="0" data-duration="1"',
+      '<img id="nested-image" src="../assets/still.png" data-start="1" data-duration="1">',
+    );
+    const compiled = await compileForRender(projectDir, indexPath, projectDir);
+    const recompiled = await recompileWithResolutions(
+      compiled,
+      [{ id: "scene-host", duration: 3 }],
+      projectDir,
+      projectDir,
+    );
+
+    expect(recompiled.images).toEqual(compiled.images);
+    expect(recompiled.images).toContainEqual(
+      expect.objectContaining({ id: "nested-image", start: 6, end: 7 }),
+    );
+  });
+
   it("applies a composition in-point to descendant media with NLE head trimming", async () => {
     const { projectDir, indexPath } = writeTemplateWrappedProject(
       'data-start="5" data-end="7" data-playback-start="1.5" data-width="640" data-height="360"',

--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -1105,13 +1105,13 @@ describe("template-wrapped sub-composition media offsets", () => {
     expect(compiled.videos[0]).toMatchObject({
       id: "scene-video",
       start: 2,
-      end: 6,
+      end: 4,
     });
     expect(compiled.audios).toHaveLength(1);
     expect(compiled.audios[0]).toMatchObject({
       id: "scene-video-audio",
       start: 2,
-      end: 6,
+      end: 4,
     });
   });
 
@@ -1134,13 +1134,13 @@ describe("template-wrapped sub-composition media offsets", () => {
     expect(recompiled.videos[0]).toMatchObject({
       id: "scene-video",
       start: 2,
-      end: 6,
+      end: 4,
     });
     expect(recompiled.audios).toHaveLength(1);
     expect(recompiled.audios[0]).toMatchObject({
       id: "scene-video-audio",
       start: 2,
-      end: 6,
+      end: 4,
     });
   });
 
@@ -1164,6 +1164,133 @@ describe("template-wrapped sub-composition media offsets", () => {
       start: 21.5,
       end: 25.5,
     });
+  });
+
+  it("applies a composition in-point to descendant media with NLE head trimming", async () => {
+    const { projectDir, indexPath } = writeTemplateWrappedProject(
+      'data-start="5" data-end="7" data-playback-start="1.5" data-width="640" data-height="360"',
+      'data-start="1" data-duration="4" data-media-start="2" data-playback-rate="2"',
+      `<audio id="pre" src="../assets/pre.wav" data-start="0" data-duration="1.5"></audio>
+       <audio id="boundary" src="../assets/boundary.wav" data-start="0.5" data-duration="1"></audio>
+       <audio id="late" src="../assets/late.wav" data-start="2" data-duration="1"></audio>`,
+    );
+
+    const compiled = await compileForRender(projectDir, indexPath, projectDir);
+
+    expect(compiled.videos).toContainEqual(
+      expect.objectContaining({ id: "scene-video", start: 5, end: 7, mediaStart: 3 }),
+    );
+    expect(compiled.audios).not.toContainEqual(expect.objectContaining({ id: "pre" }));
+    expect(compiled.audios).not.toContainEqual(expect.objectContaining({ id: "boundary" }));
+    expect(compiled.audios).toContainEqual(
+      expect.objectContaining({ id: "late", start: 5.5, end: 6.5, mediaStart: 0 }),
+    );
+
+    const recompiled = await recompileWithResolutions(
+      compiled,
+      [{ id: "scene-host", duration: 2 }],
+      projectDir,
+      projectDir,
+    );
+    expect(recompiled.videos).toEqual(compiled.videos);
+    expect(recompiled.audios).toEqual(compiled.audios);
+  });
+
+  it("drops exact-boundary media and head-trims H=1 P=3 overlaps", async () => {
+    const { projectDir, indexPath } = writeTemplateWrappedProject(
+      'data-start="1" data-duration="2" data-playback-start="3" data-width="640" data-height="360"',
+      'data-start="2" data-duration="2" data-media-start="5"',
+      `<audio id="boundary" src="../assets/boundary.wav" data-start="1" data-duration="2"></audio>`,
+    );
+
+    const compiled = await compileForRender(projectDir, indexPath, projectDir);
+    expect(compiled.audios).not.toContainEqual(expect.objectContaining({ id: "boundary" }));
+    expect(compiled.videos).toContainEqual(
+      expect.objectContaining({ id: "scene-video", start: 1, end: 2, mediaStart: 6 }),
+    );
+  });
+
+  it("uses the canonical composition playback-start before its media-start alias", async () => {
+    const { projectDir, indexPath } = writeTemplateWrappedProject(
+      'data-start="5" data-duration="3" data-playback-start="1" data-media-start="2" data-width="640" data-height="360"',
+      'data-start="2" data-duration="1"',
+    );
+
+    const compiled = await compileForRender(projectDir, indexPath, projectDir);
+    expect(compiled.videos).toContainEqual(
+      expect.objectContaining({ id: "scene-video", start: 6, end: 7 }),
+    );
+  });
+
+  it("composes host playback rate and nested in-points for descendant media", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-nested-inpoint-"));
+    mkdirSync(join(projectDir, "compositions"), { recursive: true });
+    writeFileSync(
+      join(projectDir, "index.html"),
+      `<!doctype html><html><body>
+        <div data-composition-id="root" data-duration="12">
+          <div data-composition-id="outer" data-composition-src="compositions/outer.html"
+            data-start="5" data-duration="4" data-playback-start="1" data-playback-rate="2"></div>
+        </div></body></html>`,
+    );
+    writeFileSync(
+      join(projectDir, "compositions/outer.html"),
+      `<template><div data-composition-id="outer">
+        <div data-composition-id="inner" data-composition-src="compositions/inner.html"
+          data-start="2" data-duration="2" data-playback-start="0.5"></div>
+      </div></template>`,
+    );
+    writeFileSync(
+      join(projectDir, "compositions/inner.html"),
+      `<template><div data-composition-id="inner">
+        <video id="deep" src="assets/deep.mp4" data-start="1" data-duration="1"></video>
+      </div></template>`,
+    );
+
+    const compiled = await compileForRender(projectDir, join(projectDir, "index.html"), projectDir);
+    // Inner maps to outer source 2.5; outer source maps to master
+    // 5 + (2.5 - 1) / 2 = 5.75. The one-second inner clip spans 0.5s master.
+    expect(compiled.videos).toContainEqual(
+      expect.objectContaining({ id: "deep", start: 5.75, end: 6.25 }),
+    );
+  });
+
+  it("keeps repeated and idless sub-composition mounts as distinct render media", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-repeat-inpoint-"));
+    mkdirSync(join(projectDir, "compositions"), { recursive: true });
+    writeFileSync(
+      join(projectDir, "index.html"),
+      `<!doctype html><html><body><div data-composition-id="root" data-duration="10">
+        <div data-composition-id="one" data-composition-src="compositions/scene.html" data-start="1" data-duration="2"></div>
+        <div data-composition-id="two" data-composition-src="compositions/scene.html" data-start="5" data-duration="2"></div>
+      </div></body></html>`,
+    );
+    writeFileSync(
+      join(projectDir, "compositions/scene.html"),
+      `<template><div data-composition-id="scene">
+        <video src="assets/idless.mp4" data-start="0" data-duration="1"></video>
+        <audio id="duplicate" src="assets/same.wav" data-start="0.5" data-duration="1"></audio>
+      </div></template>`,
+    );
+
+    const first = await compileForRender(projectDir, join(projectDir, "index.html"), projectDir);
+    expect(first.videos.map((video) => video.start).sort()).toEqual([1, 5]);
+    expect(new Set(first.videos.map((video) => video.id)).size).toBe(2);
+    expect(
+      first.audios
+        .filter((audio) => audio.src.endsWith("same.wav"))
+        .map((audio) => audio.start)
+        .sort(),
+    ).toEqual([1.5, 5.5]);
+    expect(
+      new Set(
+        first.audios.filter((audio) => audio.src.endsWith("same.wav")).map((audio) => audio.id),
+      ).size,
+    ).toBe(2);
+
+    const second = await recompileWithResolutions(first, [], projectDir, projectDir);
+    expect(second.videos).toEqual(first.videos);
+    expect(second.audios).toEqual(first.audios);
   });
 
   it("includes explicit audio from template-wrapped sub-compositions", async () => {

--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -1300,6 +1300,75 @@ describe("template-wrapped sub-composition media offsets", () => {
     }
   });
 
+  async function compileRepeatedRelativeMounts(extraMediaMarkup: string) {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-repeat-relative-mount-"));
+    mkdirSync(join(projectDir, "compositions"), { recursive: true });
+    writeFileSync(
+      join(projectDir, "index.html"),
+      `<!doctype html><html><body><div data-composition-id="root" data-duration="10">
+        <div id="mount-one" data-composition-id="one" data-composition-src="compositions/scene.html" data-start="1" data-duration="3"></div>
+        <div id="mount-two" data-composition-id="two" data-composition-src="compositions/scene.html" data-start="5" data-duration="3"></div>
+      </div></body></html>`,
+    );
+    writeFileSync(
+      join(projectDir, "compositions/scene.html"),
+      `<template><div data-composition-id="scene" data-duration="3">
+        <div id="anchor" data-start="0" data-duration="1"></div>
+        ${extraMediaMarkup}
+      </div></template>`,
+    );
+
+    const compiled = await compileForRender(projectDir, join(projectDir, "index.html"), projectDir);
+    const recompiled = await recompileWithResolutions(
+      compiled,
+      [
+        { id: "mount-one", duration: 3 },
+        { id: "mount-two", duration: 3 },
+      ],
+      projectDir,
+      projectDir,
+    );
+    return { compiled, recompiled };
+  }
+
+  function mediaStartsByType(result: {
+    videos: Array<{ start: number }>;
+    audios: Array<{ start: number }>;
+    images: Array<{ start: number }>;
+  }) {
+    return {
+      videos: result.videos.map((media) => media.start).sort(),
+      audios: result.audios.map((media) => media.start).sort(),
+      images: result.images.map((media) => media.start).sort(),
+    };
+  }
+
+  it("scopes repeated-mount relative references for explicitly identified timed media", async () => {
+    const results = await compileRepeatedRelativeMounts(
+      `<video id="relative-video" src="../assets/relative.mp4" data-start="anchor" data-duration="1"></video>
+       <audio id="relative-audio" src="../assets/relative.wav" data-start="anchor" data-duration="1"></audio>
+       <img id="relative-image" src="../assets/relative.png" data-start="anchor" data-duration="1">`,
+    );
+
+    expect([results.compiled, results.recompiled].map(mediaStartsByType)).toEqual([
+      { videos: [2, 6], audios: [2, 2, 6, 6], images: [2, 6] },
+      { videos: [2, 6], audios: [2, 2, 6, 6], images: [2, 6] },
+    ]);
+  });
+
+  it("scopes repeated-mount relative references for idless timed media", async () => {
+    const results = await compileRepeatedRelativeMounts(
+      `<video src="../assets/relative.mp4" data-start="anchor" data-duration="1"></video>
+       <audio src="../assets/relative.wav" data-start="anchor" data-duration="1"></audio>
+       <img src="../assets/relative.png" data-start="anchor" data-duration="1">`,
+    );
+
+    expect([results.compiled, results.recompiled].map(mediaStartsByType)).toEqual([
+      { videos: [2, 6], audios: [2, 2, 6, 6], images: [2, 6] },
+      { videos: [2, 6], audios: [2, 2, 6, 6], images: [2, 6] },
+    ]);
+  });
+
   it("applies a composition in-point to descendant media with NLE head trimming", async () => {
     const { projectDir, indexPath } = writeTemplateWrappedProject(
       'data-start="5" data-end="7" data-playback-start="1.5" data-width="640" data-height="360"',

--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -1243,6 +1243,63 @@ describe("template-wrapped sub-composition media offsets", () => {
     );
   });
 
+  it("maps explicit local data-end for nested image, video, and audio through compile/recompile", async () => {
+    const { projectDir, indexPath } = writeTemplateWrappedProject(
+      'data-start="5" data-width="640" data-height="360"',
+      'data-start="1" data-end="2"',
+      `<audio id="explicit-audio" src="../assets/explicit.wav" data-start="1" data-end="2"></audio>
+       <img id="explicit-image" src="../assets/explicit.png" data-start="1" data-end="2">`,
+    );
+    const compiled = await compileForRender(projectDir, indexPath, projectDir);
+    const recompiled = await recompileWithResolutions(
+      compiled,
+      [{ id: "scene-host", duration: 4 }],
+      projectDir,
+      projectDir,
+    );
+
+    for (const result of [compiled, recompiled]) {
+      expect(result.videos).toContainEqual(
+        expect.objectContaining({ id: "scene-video", start: 6, end: 7 }),
+      );
+      expect(result.audios).toContainEqual(
+        expect.objectContaining({ id: "explicit-audio", start: 6, end: 7 }),
+      );
+      expect(result.images).toContainEqual(
+        expect.objectContaining({ id: "explicit-image", start: 6, end: 7 }),
+      );
+    }
+  });
+
+  it("resolves relative nested starts before in-point/rate mapping for all timed media", async () => {
+    const { projectDir, indexPath } = writeTemplateWrappedProject(
+      'data-start="5" data-playback-start="1" data-playback-rate="2" data-width="640" data-height="360"',
+      'data-start="anchor + 1" data-duration="1"',
+      `<div id="anchor" data-start="2" data-duration="1"></div>
+       <audio id="relative-audio" src="../assets/relative.wav" data-start="anchor + 1" data-duration="1"></audio>
+       <img id="relative-image" src="../assets/relative.png" data-start="anchor + 1" data-duration="1">`,
+    );
+    const compiled = await compileForRender(projectDir, indexPath, projectDir);
+    const recompiled = await recompileWithResolutions(
+      compiled,
+      [{ id: "scene-host", duration: 4 }],
+      projectDir,
+      projectDir,
+    );
+
+    for (const result of [compiled, recompiled]) {
+      expect(result.videos).toContainEqual(
+        expect.objectContaining({ id: "scene-video", start: 6.5, end: 7 }),
+      );
+      expect(result.audios).toContainEqual(
+        expect.objectContaining({ id: "relative-audio", start: 6.5, end: 7 }),
+      );
+      expect(result.images).toContainEqual(
+        expect.objectContaining({ id: "relative-image", start: 6.5, end: 7 }),
+      );
+    }
+  });
+
   it("applies a composition in-point to descendant media with NLE head trimming", async () => {
     const { projectDir, indexPath } = writeTemplateWrappedProject(
       'data-start="5" data-end="7" data-playback-start="1.5" data-width="640" data-height="360"',

--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -1369,6 +1369,66 @@ describe("template-wrapped sub-composition media offsets", () => {
     ]);
   });
 
+  it("resolves nested host references in the parent mount despite child ID shadowing", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-nested-reference-shadow-"));
+    mkdirSync(join(projectDir, "compositions"), { recursive: true });
+    writeFileSync(
+      join(projectDir, "index.html"),
+      `<!doctype html><html><body><div data-composition-id="root" data-duration="12">
+        <div id="parent-host" data-composition-id="parent" data-composition-src="compositions/parent.html" data-start="1" data-duration="10"></div>
+      </div></body></html>`,
+    );
+    writeFileSync(
+      join(projectDir, "compositions/parent.html"),
+      `<template><div data-composition-id="parent" data-duration="10">
+        <div id="anchor" data-start="0" data-duration="1"></div>
+        <div id="child-one" data-composition-id="child-one" data-composition-src="compositions/child.html" data-start="anchor" data-duration="3"></div>
+        <div id="child-two" data-composition-id="child-two" data-composition-src="compositions/child.html" data-start="anchor" data-duration="3"></div>
+      </div></template>`,
+    );
+    writeFileSync(
+      join(projectDir, "compositions/child.html"),
+      `<template><div data-composition-id="child" data-duration="3">
+        <div id="anchor" data-start="0" data-duration="10"></div>
+        <video id="explicit-video" src="assets/explicit.mp4" data-start="0" data-duration="1" data-media-start="0.25" data-has-audio="true"></video>
+        <audio id="explicit-audio" src="assets/explicit.wav" data-start="0" data-end="1" data-media-start="0.5"></audio>
+        <img id="explicit-image" src="assets/explicit.png" data-start="0" data-duration="1">
+        <video src="assets/idless.mp4" data-start="0" data-duration="1" data-media-start="0.25" data-has-audio="true"></video>
+        <audio src="assets/idless.wav" data-start="0" data-end="1" data-media-start="0.5"></audio>
+        <img src="assets/idless.png" data-start="0" data-duration="1">
+      </div></template>`,
+    );
+
+    const compiled = await compileForRender(projectDir, join(projectDir, "index.html"), projectDir);
+    const recompiled = await recompileWithResolutions(
+      compiled,
+      [
+        { id: "parent-host", duration: 10 },
+        { id: "child-one", duration: 3 },
+        { id: "child-two", duration: 3 },
+      ],
+      projectDir,
+      projectDir,
+    );
+
+    for (const result of [compiled, recompiled]) {
+      expect(
+        result.videos.map(({ start, end, mediaStart }) => ({ start, end, mediaStart })),
+      ).toEqual(Array(4).fill({ start: 2, end: 3, mediaStart: 0.25 }));
+      expect(result.audios.map(({ start, end }) => ({ start, end }))).toEqual(
+        Array(8).fill({ start: 2, end: 3 }),
+      );
+      expect(result.audios.map(({ mediaStart }) => mediaStart).sort()).toEqual([
+        0.25, 0.25, 0.25, 0.25, 0.5, 0.5, 0.5, 0.5,
+      ]);
+      expect(result.images.map(({ start, end }) => ({ start, end }))).toEqual(
+        Array(4).fill({ start: 2, end: 3 }),
+      );
+      expect(new Set(result.videos.map(({ id }) => id)).size).toBe(4);
+      expect(new Set(result.images.map(({ id }) => id)).size).toBe(4);
+    }
+  });
+
   it("applies a composition in-point to descendant media with NLE head trimming", async () => {
     const { projectDir, indexPath } = writeTemplateWrappedProject(
       'data-start="5" data-end="7" data-playback-start="1.5" data-width="640" data-height="360"',

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -275,7 +275,7 @@ function extractInlinedNestedMedia(html: string): {
   images: ImageElement[];
 } {
   const { document } = parseHTML(html);
-  const media = Array.from(document.querySelectorAll("video, audio"));
+  const media = Array.from(document.querySelectorAll("video, audio, img[data-start]"));
   const idCounts = new Map<string, number>();
   for (const element of media) {
     const id = element.getAttribute("id");
@@ -354,7 +354,9 @@ function extractInlinedNestedMedia(html: string): {
     return result;
   };
 
-  for (const element of Array.from(extractionDocument.querySelectorAll("video, audio"))) {
+  for (const element of Array.from(
+    extractionDocument.querySelectorAll("video, audio, img[data-start]"),
+  )) {
     const host = element.closest("[data-composition-file]");
     if (!host) continue;
     const transform = hostTransform(host);

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -34,6 +34,7 @@ import {
   readDeclaredDefaults,
   parseHostVariableValues,
 } from "@hyperframes/core/compiler";
+import { createRuntimeStartTimeResolver } from "@hyperframes/core/runtime/start-resolver";
 import {
   checkSubCompositionUsability,
   type ParsableDocumentLike,
@@ -316,6 +317,22 @@ function extractInlinedNestedMedia(html: string): {
   const outputHtml = document.toString();
 
   const extractionDocument = parseHTML(outputHtml).document;
+  const startResolver = createRuntimeStartTimeResolver({
+    documentRef: extractionDocument as unknown as Document,
+    includeAuthoredTimingAttrs: true,
+  });
+  const localStart = (element: Element, parent: Element): number =>
+    Math.max(
+      0,
+      startResolver.resolveStartForElement(element, 0) -
+        startResolver.resolveStartForElement(parent, 0),
+    );
+  const localDuration = (element: Element, start: number): number => {
+    const duration = finiteAttr(element, "data-duration", Number.NaN);
+    if (Number.isFinite(duration) && duration > 0) return duration;
+    const end = finiteAttr(element, "data-end", Number.NaN);
+    return Number.isFinite(end) && end > start ? end - start : Infinity;
+  };
   const transformCache = new Map<Element, InlinedHostTransform>();
   const hostTransform = (host: Element): InlinedHostTransform => {
     const cached = transformCache.get(host);
@@ -324,7 +341,11 @@ function extractInlinedNestedMedia(html: string): {
     const parent = parentHost
       ? hostTransform(parentHost)
       : { origin: 0, scale: 1, windowStart: Number.NEGATIVE_INFINITY, windowEnd: Infinity };
-    const hostStart = finiteAttr(host, "data-start");
+    const parentComposition =
+      parentHost ?? host.parentElement?.closest("[data-composition-id]") ?? null;
+    const hostStart = parentComposition
+      ? localStart(host, parentComposition)
+      : finiteAttr(host, "data-start");
     const inPoint = Math.max(
       0,
       finiteAttr(
@@ -334,13 +355,7 @@ function extractInlinedNestedMedia(html: string): {
     );
     const hostRate = Math.max(0.000001, finiteAttr(host, "data-playback-rate", 1));
     const slotStart = parent.origin + hostStart * parent.scale;
-    const authoredDuration = finiteAttr(host, "data-duration", Number.NaN);
-    const authoredEnd = finiteAttr(host, "data-end", Number.NaN);
-    const duration = Number.isFinite(authoredDuration)
-      ? authoredDuration
-      : Number.isFinite(authoredEnd)
-        ? authoredEnd - hostStart
-        : Infinity;
+    const duration = localDuration(host, hostStart);
     const result = {
       origin: slotStart - (inPoint * parent.scale) / hostRate,
       scale: parent.scale / hostRate,
@@ -360,11 +375,11 @@ function extractInlinedNestedMedia(html: string): {
     const host = element.closest("[data-composition-file]");
     if (!host) continue;
     const transform = hostTransform(host);
-    const localStart = finiteAttr(element, "data-start");
-    const localDuration = finiteAttr(element, "data-duration", Infinity);
-    const rawStart = transform.origin + localStart * transform.scale;
-    const rawEnd = Number.isFinite(localDuration)
-      ? transform.origin + (localStart + localDuration) * transform.scale
+    const resolvedLocalStart = localStart(element, host);
+    const resolvedLocalDuration = localDuration(element, resolvedLocalStart);
+    const rawStart = transform.origin + resolvedLocalStart * transform.scale;
+    const rawEnd = Number.isFinite(resolvedLocalDuration)
+      ? transform.origin + (resolvedLocalStart + resolvedLocalDuration) * transform.scale
       : Infinity;
     const start = Math.max(rawStart, transform.windowStart);
     const end = Math.min(rawEnd, transform.windowEnd);

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -317,15 +317,40 @@ function extractInlinedNestedMedia(html: string): {
   const outputHtml = document.toString();
 
   const extractionDocument = parseHTML(outputHtml).document;
-  const startResolver = createRuntimeStartTimeResolver({
-    documentRef: extractionDocument as unknown as Document,
-    includeAuthoredTimingAttrs: true,
-  });
+  const resolverCache = new WeakMap<Element, ReturnType<typeof createRuntimeStartTimeResolver>>();
+  const scopedStartResolver = (scope: Element) => {
+    const cached = resolverCache.get(scope);
+    if (cached) return cached;
+    const findById = (id: string): Element | null => {
+      if (scope.getAttribute("id") === id) return scope;
+      const byId = Array.from(scope.querySelectorAll("[id]")).find(
+        (element) => element.getAttribute("id") === id,
+      );
+      if (byId) return byId;
+      if (scope.getAttribute("data-composition-id") === id) return scope;
+      return (
+        Array.from(scope.querySelectorAll("[data-composition-id]")).find(
+          (element) => element.getAttribute("data-composition-id") === id,
+        ) ?? null
+      );
+    };
+    const query = (selector: string): Element | null =>
+      scope.matches(selector) ? scope : scope.querySelector(selector);
+    const resolver = createRuntimeStartTimeResolver({
+      documentRef: {
+        getElementById: findById,
+        querySelector: query,
+      } as unknown as Document,
+      includeAuthoredTimingAttrs: true,
+    });
+    resolverCache.set(scope, resolver);
+    return resolver;
+  };
   const localStart = (element: Element, parent: Element): number =>
     Math.max(
       0,
-      startResolver.resolveStartForElement(element, 0) -
-        startResolver.resolveStartForElement(parent, 0),
+      scopedStartResolver(parent).resolveStartForElement(element, 0) -
+        scopedStartResolver(parent).resolveStartForElement(parent, 0),
     );
   const localDuration = (element: Element, start: number): number => {
     const duration = finiteAttr(element, "data-duration", Number.NaN);

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -248,12 +248,147 @@ export interface RenderModeHints {
   reasons: RenderModeHint[];
 }
 
-function dedupeElementsById<T extends { id: string }>(elements: T[]): T[] {
-  const deduped = new Map<string, T>();
-  for (const element of elements) {
-    deduped.set(element.id, element);
+const AUTHORED_MEDIA_ID_ATTR = "data-hf-authored-id";
+const NESTED_MEDIA_ATTR = "data-hf-nested-media";
+
+function finiteAttr(element: Element, name: string, fallback = 0): number {
+  const value = Number.parseFloat(element.getAttribute(name) ?? "");
+  return Number.isFinite(value) ? value : fallback;
+}
+
+type InlinedHostTransform = {
+  origin: number;
+  scale: number;
+  windowStart: number;
+  windowEnd: number;
+};
+
+/**
+ * Build producer media metadata from the already-inlined DOM. This is the one
+ * place where repeated mounts are distinguishable, so it avoids global-id
+ * dedupe and applies the exact same affine child→master mapping as preview.
+ */
+function extractInlinedNestedMedia(html: string): {
+  html: string;
+  videos: VideoElement[];
+  audios: AudioElement[];
+  images: ImageElement[];
+} {
+  const { document } = parseHTML(html);
+  const media = Array.from(document.querySelectorAll("video, audio"));
+  const idCounts = new Map<string, number>();
+  for (const element of media) {
+    const id = element.getAttribute("id");
+    if (id) idCounts.set(id, (idCounts.get(id) ?? 0) + 1);
   }
-  return Array.from(deduped.values());
+  let generated = 0;
+  for (const element of media) {
+    if (!element.closest("[data-composition-file]")) continue;
+    let host = element.closest("[data-composition-file]");
+    let hasNonIdentityHost = false;
+    while (host) {
+      const inPoint = finiteAttr(
+        host,
+        host.hasAttribute("data-playback-start") ? "data-playback-start" : "data-media-start",
+      );
+      if (inPoint > 0 || Math.abs(finiteAttr(host, "data-playback-rate", 1) - 1) > 0.000001) {
+        hasNonIdentityHost = true;
+        break;
+      }
+      host = host.parentElement?.closest("[data-composition-file]") ?? null;
+    }
+    if (hasNonIdentityHost) element.setAttribute(NESTED_MEDIA_ATTR, "");
+    const authoredId =
+      element.getAttribute(AUTHORED_MEDIA_ID_ATTR) ?? element.getAttribute("id") ?? null;
+    if (element.hasAttribute(AUTHORED_MEDIA_ID_ATTR)) continue;
+    if (!authoredId || (idCounts.get(authoredId) ?? 0) > 1) {
+      const host = element.closest("[data-composition-file]");
+      const hostId = (host?.getAttribute("data-composition-id") ?? `mount-${generated}`).replace(
+        /[^a-zA-Z0-9_-]/g,
+        "-",
+      );
+      const base = authoredId ?? `hf-${element.tagName.toLowerCase()}-${generated}`;
+      element.setAttribute("id", `${base}__${hostId}`);
+      if (authoredId) element.setAttribute(AUTHORED_MEDIA_ID_ATTR, authoredId);
+      generated += 1;
+    }
+  }
+  const outputHtml = document.toString();
+
+  const extractionDocument = parseHTML(outputHtml).document;
+  const transformCache = new Map<Element, InlinedHostTransform>();
+  const hostTransform = (host: Element): InlinedHostTransform => {
+    const cached = transformCache.get(host);
+    if (cached) return cached;
+    const parentHost = host.parentElement?.closest("[data-composition-file]") ?? null;
+    const parent = parentHost
+      ? hostTransform(parentHost)
+      : { origin: 0, scale: 1, windowStart: Number.NEGATIVE_INFINITY, windowEnd: Infinity };
+    const hostStart = finiteAttr(host, "data-start");
+    const inPoint = Math.max(
+      0,
+      finiteAttr(
+        host,
+        host.hasAttribute("data-playback-start") ? "data-playback-start" : "data-media-start",
+      ),
+    );
+    const hostRate = Math.max(0.000001, finiteAttr(host, "data-playback-rate", 1));
+    const slotStart = parent.origin + hostStart * parent.scale;
+    const authoredDuration = finiteAttr(host, "data-duration", Number.NaN);
+    const authoredEnd = finiteAttr(host, "data-end", Number.NaN);
+    const duration = Number.isFinite(authoredDuration)
+      ? authoredDuration
+      : Number.isFinite(authoredEnd)
+        ? authoredEnd - hostStart
+        : Infinity;
+    const result = {
+      origin: slotStart - (inPoint * parent.scale) / hostRate,
+      scale: parent.scale / hostRate,
+      windowStart: Math.max(parent.windowStart, slotStart),
+      windowEnd: Math.min(
+        parent.windowEnd,
+        Number.isFinite(duration) ? slotStart + duration * parent.scale : Infinity,
+      ),
+    };
+    transformCache.set(host, result);
+    return result;
+  };
+
+  for (const element of Array.from(extractionDocument.querySelectorAll("video, audio"))) {
+    const host = element.closest("[data-composition-file]");
+    if (!host) continue;
+    const transform = hostTransform(host);
+    const localStart = finiteAttr(element, "data-start");
+    const localDuration = finiteAttr(element, "data-duration", Infinity);
+    const rawStart = transform.origin + localStart * transform.scale;
+    const rawEnd = Number.isFinite(localDuration)
+      ? transform.origin + (localStart + localDuration) * transform.scale
+      : Infinity;
+    const start = Math.max(rawStart, transform.windowStart);
+    const end = Math.min(rawEnd, transform.windowEnd);
+    if (end <= start) {
+      element.remove();
+      continue;
+    }
+    element.setAttribute("data-start", String(start));
+    element.setAttribute("data-end", String(end));
+    element.removeAttribute("data-duration");
+    if (element.tagName === "VIDEO" || element.tagName === "AUDIO") {
+      const ownRate = Math.max(0.000001, finiteAttr(element, "data-playback-rate", 1));
+      const mediaStart = finiteAttr(element, "data-media-start");
+      element.setAttribute(
+        "data-media-start",
+        String(mediaStart + ((start - rawStart) / transform.scale) * ownRate),
+      );
+    }
+  }
+  const extractionHtml = extractionDocument.toString();
+  return {
+    html: outputHtml,
+    videos: parseVideoElements(extractionHtml),
+    audios: parseAudioElements(extractionHtml),
+    images: parseImageElements(extractionHtml),
+  };
 }
 
 const INLINE_SCRIPT_PATTERN = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
@@ -1872,12 +2007,7 @@ export async function compileForRender(
   );
 
   // Parse sub-compositions first (extracts media + compiled HTML for each)
-  const {
-    videos: subVideos,
-    audios: subAudios,
-    images: subImages,
-    subCompositions,
-  } = await parseSubCompositions(compiledHtml, projectDir, downloadDir);
+  const { subCompositions } = await parseSubCompositions(compiledHtml, projectDir, downloadDir);
 
   // Ensure the HTML is a full document before inlining sub-compositions.
   // When index.html is a fragment (no <html>/<head>/<body>), linkedom.parseHTML()
@@ -2001,7 +2131,9 @@ export async function compileForRender(
   // Collect assets that resolve outside projectDir (e.g. ../shared-assets/hero.png).
   // These can't be served by the file server, so we map them to paths the
   // orchestrator will copy into the compiled output directory.
-  const { html, externalAssets } = collectExternalAssets(embeddedHtml, projectDir);
+  const { html: collectedHtml, externalAssets } = collectExternalAssets(embeddedHtml, projectDir);
+  const inlinedMedia = extractInlinedNestedMedia(collectedHtml);
+  const html = inlinedMedia.html;
 
   for (const [relPath, absPath] of remoteMediaAssets) {
     externalAssets.set(relPath, absPath);
@@ -2019,17 +2151,11 @@ export async function compileForRender(
     externalAssets.set(relPath, absPath);
   }
 
-  // Parse main HTML elements
-  const mainVideos = parseVideoElements(html);
-  const mainAudios = parseAudioElements(html);
-  const mainImages = parseImageElements(html);
-
-  // Keep inlined sub-composition media authoritative on ID collisions.
-  // inlineSubCompositions() hoists those nodes into the final HTML, so the
-  // producer should follow the same precedence the runtime sees in the merged DOM.
-  const videos = dedupeElementsById([...mainVideos, ...subVideos]);
-  const audios = dedupeElementsById([...mainAudios, ...subAudios]);
-  const images = dedupeElementsById([...mainImages, ...subImages]);
+  // Extraction is derived from the inlined DOM so repeated mounts retain
+  // distinct identities and nested in-points/rates have one canonical map.
+  const videos = inlinedMedia.videos;
+  const audios = inlinedMedia.audios;
+  const images = inlinedMedia.images;
 
   // Advisory video checks (sparse keyframes, VFR). Fire-and-forget — these spawn
   // ffprobe subprocesses and should not block compilation since they only produce warnings.
@@ -2115,6 +2241,8 @@ export interface BrowserMediaElement {
   volume: number;
   /** The `muted` attribute/property. Preview silences muted media; the mix must too. */
   muted: boolean;
+  /** Compiler marker: static metadata already carries the nested host/in-point transform. */
+  nested: boolean;
 }
 
 export interface BrowserAudioVolumeAutomation {
@@ -2136,6 +2264,7 @@ export async function discoverMediaFromBrowser(page: Page): Promise<BrowserMedia
       hasAudio: boolean;
       volume: number;
       muted: boolean;
+      nested: boolean;
     }[] = [];
 
     const autoImageIds = new Map<Element, string>();
@@ -2171,6 +2300,7 @@ export async function discoverMediaFromBrowser(page: Page): Promise<BrowserMedia
       const muted =
         !isImage &&
         (htmlEl.hasAttribute("muted") || (htmlEl as HTMLVideoElement | HTMLAudioElement).muted);
+      const nested = htmlEl.hasAttribute("data-hf-nested-media");
 
       results.push({
         id,
@@ -2184,6 +2314,7 @@ export async function discoverMediaFromBrowser(page: Page): Promise<BrowserMedia
         hasAudio,
         volume,
         muted,
+        nested,
       });
     });
 
@@ -2465,30 +2596,13 @@ export async function resolveCompositionDurations(
 export async function recompileWithResolutions(
   compiled: CompiledComposition,
   resolutions: ResolvedDuration[],
-  projectDir: string,
-  downloadDir: string,
+  _projectDir: string,
+  _downloadDir: string,
 ): Promise<CompiledComposition> {
   if (resolutions.length === 0) return compiled;
 
-  const html = injectDurations(compiled.html, resolutions);
-
-  // Re-parse sub-compositions with the updated parent bounds
-  const {
-    videos: subVideos,
-    audios: subAudios,
-    images: subImages,
-    subCompositions,
-  } = await parseSubCompositions(html, projectDir, downloadDir);
-
-  const mainVideos = parseVideoElements(html);
-  const mainAudios = parseAudioElements(html);
-  const mainImages = parseImageElements(html);
-
-  // Keep inlined sub-composition media authoritative on ID collisions.
-  const hasSubMedia = subVideos.length > 0 || subAudios.length > 0 || subImages.length > 0;
-  const videos = hasSubMedia ? dedupeElementsById([...mainVideos, ...subVideos]) : compiled.videos;
-  const audios = hasSubMedia ? dedupeElementsById([...mainAudios, ...subAudios]) : compiled.audios;
-  const images = hasSubMedia ? dedupeElementsById([...mainImages, ...subImages]) : compiled.images;
+  const resolvedHtml = injectDurations(compiled.html, resolutions);
+  const inlinedMedia = extractInlinedNestedMedia(resolvedHtml);
 
   const remaining = compiled.unresolvedCompositions.filter(
     (c) => !resolutions.some((r) => r.id === c.id),
@@ -2496,11 +2610,10 @@ export async function recompileWithResolutions(
 
   return {
     ...compiled,
-    html,
-    subCompositions,
-    videos,
-    audios,
-    images,
+    html: inlinedMedia.html,
+    videos: inlinedMedia.videos,
+    audios: inlinedMedia.audios,
+    images: inlinedMedia.images,
     unresolvedCompositions: remaining,
     renderModeHints: compiled.renderModeHints,
     hasShaderTransitions: compiled.hasShaderTransitions,

--- a/packages/producer/src/services/render/stages/probeStage.test.ts
+++ b/packages/producer/src/services/render/stages/probeStage.test.ts
@@ -412,8 +412,8 @@ describe("runProbeStage — forceScreenshot threading", () => {
         tagName: "video",
         src: "runtime-still.asset",
         start: 0,
-        end: 5,
-        duration: 5,
+        end: 7,
+        duration: 7,
         mediaStart: 0,
         loop: false,
         hasAudio: false,
@@ -441,7 +441,78 @@ describe("runProbeStage — forceScreenshot threading", () => {
     await runProbeStage(input);
 
     expect(input.composition.videos[0]?.src).toBe("runtime-still.asset");
+    expect(input.composition.videos[0]?.end).toBe(7);
     expect(mediaPreflightComposition).toBe(input.composition);
+  });
+
+  it("does not replace a compiler-shifted nested media offset with browser-local metadata", async () => {
+    resetRetryMocks();
+    browserMediaResults = [
+      {
+        id: "nested-clip",
+        tagName: "video",
+        src: "clip.mp4",
+        start: 1,
+        end: 5,
+        duration: 4,
+        mediaStart: 1,
+        loop: false,
+        hasAudio: true,
+        volume: 1,
+        muted: false,
+        nested: true,
+      },
+      {
+        id: "nested-audio",
+        tagName: "audio",
+        src: "runtime-audio.wav",
+        start: 1,
+        end: 5,
+        duration: 4,
+        mediaStart: 1,
+        loop: false,
+        hasAudio: true,
+        volume: 0.5,
+        muted: false,
+        nested: true,
+      },
+    ];
+    const { runProbeStage } = await import("./probeStage.js");
+    const input = makeProbeInput({});
+    input.composition.duration = 8;
+    input.composition.videos.push({
+      id: "nested-clip",
+      src: "clip.mp4",
+      start: 4,
+      end: 6,
+      mediaStart: 3,
+      loop: false,
+      hasAudio: true,
+    });
+    input.composition.audios.push({
+      id: "nested-audio",
+      src: "audio.wav",
+      start: 4,
+      end: 6,
+      mediaStart: 3,
+      layer: 0,
+      volume: 1,
+      type: "audio",
+    });
+    input.compiled.html =
+      '<video id="nested-clip" src="clip.mp4" data-var-src="clip_src" data-start="1" data-end="5" data-media-start="1">';
+    input.job.config.variables = { clip_src: "clip.mp4" };
+
+    await runProbeStage(input);
+
+    expect(input.composition.videos[0]?.start).toBe(4);
+    expect(input.composition.videos[0]?.end).toBe(6);
+    expect(input.composition.videos[0]?.mediaStart).toBe(3);
+    expect(input.composition.audios[0]?.src).toBe("runtime-audio.wav");
+    expect(input.composition.audios[0]?.start).toBe(4);
+    expect(input.composition.audios[0]?.end).toBe(6);
+    expect(input.composition.audios[0]?.mediaStart).toBe(3);
+    expect(input.composition.audios[0]?.volume).toBe(0.5);
   });
 
   it("passes cancellation through and closes probe-owned resources when preflight rejects", async () => {

--- a/packages/producer/src/services/render/stages/probeStage.ts
+++ b/packages/producer/src/services/render/stages/probeStage.ts
@@ -509,12 +509,14 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
                 resolveBrowserMediaEnd(el.start, el.end, el.duration),
               );
               if (
+                !el.nested &&
                 projectedEnd > 0 &&
                 (existing.end <= 0 || Math.abs(existing.end - projectedEnd) > BROWSER_MEDIA_EPSILON)
               ) {
                 existing.end = projectedEnd;
               }
               if (
+                !el.nested &&
                 el.mediaStart > 0 &&
                 (existing.mediaStart <= 0 ||
                   Math.abs(existing.mediaStart - el.mediaStart) > BROWSER_MEDIA_EPSILON)
@@ -555,12 +557,14 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
                 resolveBrowserMediaEnd(el.start, el.end, el.duration),
               );
               if (
+                !el.nested &&
                 projectedEnd > 0 &&
                 (existing.end <= 0 || Math.abs(existing.end - projectedEnd) > BROWSER_MEDIA_EPSILON)
               ) {
                 existing.end = projectedEnd;
               }
               if (
+                !el.nested &&
                 el.mediaStart > 0 &&
                 (existing.mediaStart <= 0 ||
                   Math.abs(existing.mediaStart - el.mediaStart) > BROWSER_MEDIA_EPSILON)


### PR DESCRIPTION
Fixes #3245

## What

Align descendant video and audio inside nested compositions with the composition slot's in-point in both preview and producer render. Pre-offset media is omitted; overlapping media starts at the slot with the corresponding source skip.

## Why

Seeking a nested composition with `data-playback-start` moved the child GSAP timeline, but descendant video/audio still began from local time zero. That broke NLE-style composition behavior and caused preview/render timing to diverge from the authored slot contract.

## How

- Compose nested media timing through each host slot using `hostStart + (childLocal - playbackStart) / hostRate`.
- Preserve descendant `data-media-start` as the source-file offset; host `data-media-start` remains only the documented fallback alias for `data-playback-start`.
- Apply the effective start, end, source offset, and playback rate consistently across runtime visibility, hard-sync/audio-master/WebAudio paths, CLI snapshotting, browser probe reconciliation, and producer compilation.
- Keep standalone child previews and identity/legacy nested-media behavior unchanged.
- Handle nested rates, exact boundaries, repeated/idless mounts, audio, and recompilation without shifting images.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated (if applicable)

Automated verification:

- Core focused runtime: 153 tests passed.
- Producer compiler and browser probe: 155 tests passed.
- CLI snapshot: 32 tests passed.
- Core, producer, and CLI typechecks/builds passed.
- Changed-file lint/format, diff-check, fallow, and hooks passed locally.

Exact route/runtime proof uses a sanitized time-coded source. With a 2s slot in-point, nested preview snapshot and strict producer render both show blue at 0.2s and yellow at 1.2s; the standalone child control remains red then green. The strict render is H.264, 320×180, 30fps, 60 frames, 2.0s.

The external reference commit was reviewed only as input; this implementation was independently derived and additionally covers rate composition, source trims, audio paths, boundary behavior, browser reconciliation, and actual preview/render parity.
