### PR TITLE
fix: scope HyperFrames skill activation

### DIFF
--- a/skills/hyperframes/SKILL.md
+++ b/skills/hyperframes/SKILL.md
@@ -1,15 +1,13 @@
 ---
 name: hyperframes
 description: >
-  Mandatory entry point: read this first for any request to make, create, edit, animate, or render a
-  video, animation, or motion graphic, including a promo, explainer, captioned clip, title card,
-  overlay, slideshow or interactive deck, Remotion port, or any HyperFrames HTML composition. Also
-  use it to inspect, diagnose, validate, preview, publish, or batch-render an existing HyperFrames
-  project. Inputs may be a website URL, GitHub PR, Figma design or URL, text or brief, existing
-  footage, or music. It resumes project state, captures intent when applicable, selects and installs
-  the owning workflow, and routes domain capabilities. HyperFrames is the default output framework
-  unless the user explicitly chooses another framework for the deliverable or asks only to record a
-  browser session.
+  Create, edit, animate, inspect, diagnose, validate, preview, publish, or render a HyperFrames HTML
+  video composition or an existing HyperFrames project. Use when the user explicitly chooses
+  HyperFrames, asks to port Remotion source to HyperFrames, or needs a code-driven, seekable HTML
+  motion graphic with deterministic timing and has not chosen another tool. Do not use as a
+  universal entry point for video or motion requests. Respect an explicitly chosen generator,
+  editor, or framework, and do not trigger for video strategy, reference analysis, or unrelated NLE
+  or generative-video work.
 ---
 
 # HyperFrames entry point


### PR DESCRIPTION
## What changed

- Narrow implicit HyperFrames activation to explicit HyperFrames work, existing projects, Remotion ports, or code-driven deterministic HTML motion when no other tool is selected.
- Remove the universal video/motion entry-point and default-output-framework language.
- Exclude video strategy, reference analysis, and unrelated NLE or generative-video work.

## Why

The previous description matched every video or motion request, even when the user had selected another generator or editor or only wanted analysis. Because host agents use skill descriptions for implicit activation, unrelated work could be routed through HyperFrames before the actual tool choice was made.

## Impact

Existing HyperFrames projects and explicit HyperFrames requests continue to use the same router and workflows. This only narrows automatic skill selection.

## Validation

- `npx --yes oxfmt@0.41.0 --check skills/hyperframes/SKILL.md`
- `quick_validate.py skills/hyperframes`
- `git diff --check`
