### PR TITLE
chore: release v0.7.108

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,89 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.108"
+  description="Released - 2026-08-13"
+  tags={["Release", "Studio", "Core", "Audio"]}
+>
+Studio can now automate any effect parameter with keyframed lanes, complete with copy, retime, and reshape tools. The full audio FX rack ships behind a staged rollout, so it isn't visible yet.
+
+## Features
+
+- **Studio:** Instrument the audio FX rack, including work an agent did ([d6c4774ef](https://github.com/heygen-com/hyperframes/commit/d6c4774ef41c54f66dc02c6dd433facee822a8f8), [#3229](https://github.com/heygen-com/hyperframes/pull/3229)).
+- **Studio:** Fold a preset shut, and give each one its own title design ([e3ec48adc](https://github.com/heygen-com/hyperframes/commit/e3ec48adce494d40d787cd4cbca6464a3b53362f), [#3191](https://github.com/heygen-com/hyperframes/pull/3191)).
+- Switch a preset off, or ramp it, as one thing ([acdb11250](https://github.com/heygen-com/hyperframes/commit/acdb11250ce3bb97a70cdd63d080968900a2f003), [#3189](https://github.com/heygen-com/hyperframes/pull/3189)).
+- One knob for the five effects that cannot honestly have one ([29f516d49](https://github.com/heygen-com/hyperframes/commit/29f516d490c00697594f3b88a565d69115b7af12), [#3188](https://github.com/heygen-com/hyperframes/pull/3188)).
+- **Studio:** Family lettering, tints, and the rack as a signal path ([2020b82c9](https://github.com/heygen-com/hyperframes/commit/2020b82c9b8f2d2050b5b11c76bdb27323d64e07), [#3187](https://github.com/heygen-com/hyperframes/pull/3187)).
+- **Studio:** Two faces, and the shared frequency ruler ([96fd4d061](https://github.com/heygen-com/hyperframes/commit/96fd4d061ecddef59e3949b4fb3e30d51209bd76), [#3186](https://github.com/heygen-com/hyperframes/pull/3186)).
+- Offer the job, not the machine — the range IS the module ([31fa523b7](https://github.com/heygen-com/hyperframes/commit/31fa523b7ed71c6fbbc0c4b2558fb83bf636fc88), [#3185](https://github.com/heygen-com/hyperframes/pull/3185)).
+- **Studio:** Make the FX rack speak the author's language ([0e4da52c8](https://github.com/heygen-com/hyperframes/commit/0e4da52c8222b8d18a1211b34f2fb3bd0f7e79ee), [#3192](https://github.com/heygen-com/hyperframes/pull/3192)).
+- **Core:** Land the plain-language layer, and test that it covers the rack ([27cdd4d5b](https://github.com/heygen-com/hyperframes/commit/27cdd4d5b1684afae16f96fe3e4af30c73178e1a), [#3184](https://github.com/heygen-com/hyperframes/pull/3184)).
+- **Core:** The levelling script — "Even Out Levels" ([71066fc25](https://github.com/heygen-com/hyperframes/commit/71066fc25ba362a18d52ba0648b6b279e9ee3206), [#3180](https://github.com/heygen-com/hyperframes/pull/3180)).
+- **Studio:** The Tone module — a multi-band EQ on faders ([818a7b281](https://github.com/heygen-com/hyperframes/commit/818a7b281b44182b6a4e47b7f30f92df332f62a2), [#3179](https://github.com/heygen-com/hyperframes/pull/3179)).
+- **Core:** Name every preset node, and add a multi-band EQ over existing filters ([9f6762052](https://github.com/heygen-com/hyperframes/commit/9f676205239a4e1ce03498223ef9f6ce5448aeec), [#3178](https://github.com/heygen-com/hyperframes/pull/3178)).
+- **Studio:** Give the clips on a track one automation lane row ([9b18fa7a2](https://github.com/heygen-com/hyperframes/commit/9b18fa7a26bd5e7b4f8b4b4e10c984585767620b), [#3214](https://github.com/heygen-com/hyperframes/pull/3214)).
+- **Studio:** The carve is one module in the rack ([d18cbcb7f](https://github.com/heygen-com/hyperframes/commit/d18cbcb7f31862a37b9051b85ebb562f104a516c), [#3213](https://github.com/heygen-com/hyperframes/pull/3213)).
+- **Studio:** Show every automated knob at the playhead ([7d38fed97](https://github.com/heygen-com/hyperframes/commit/7d38fed97fd50f70e5a67229250a186baac98d3c), [#3210](https://github.com/heygen-com/hyperframes/pull/3210)).
+- **Studio:** Retime and edge-stretch an automation selection ([120ea37c2](https://github.com/heygen-com/hyperframes/commit/120ea37c2fbd7202a443b94c0ff21c1ee7a63996), [#3207](https://github.com/heygen-com/hyperframes/pull/3207)).
+- **Studio:** Copy and paste automation ranges across lanes ([c7c95e2f0](https://github.com/heygen-com/hyperframes/commit/c7c95e2f018efa961b7a5e06fb142a98fd14ecc9), [#3056](https://github.com/heygen-com/hyperframes/pull/3056)).
+- **Studio:** Shape and simplify an automation selection ([64a85e775](https://github.com/heygen-com/hyperframes/commit/64a85e775a2259938e24d2fc7dc279c402397761), [#3055](https://github.com/heygen-com/hyperframes/pull/3055)).
+- **Studio:** Select a time range on an automation lane ([3670e9a92](https://github.com/heygen-com/hyperframes/commit/3670e9a921ddcbcd84e5d448faec5b08fca0ba40), [#3050](https://github.com/heygen-com/hyperframes/pull/3050)).
+- **Studio:** Curve, snap and type a value in an automation lane ([e465a07a3](https://github.com/heygen-com/hyperframes/commit/e465a07a322db8a63fc757bda5a53a842a0c269f), [#3038](https://github.com/heygen-com/hyperframes/pull/3038)).
+- **Engine:** Let an FX tail decay instead of cutting it at the clip ([6a0e409fc](https://github.com/heygen-com/hyperframes/commit/6a0e409fc2704683613b0a94cc734635dd9ded94), [#3036](https://github.com/heygen-com/hyperframes/pull/3036)).
+- **Studio:** Automate and un-automate each effect parameter ([32f29721d](https://github.com/heygen-com/hyperframes/commit/32f29721d2fd9ab7e85c0cf87108aa2c1b9859a9), [#3026](https://github.com/heygen-com/hyperframes/pull/3026)).
+- **Studio:** Automate a parameter without reloading the preview ([7203e0a73](https://github.com/heygen-com/hyperframes/commit/7203e0a73ca9f51cde74f0820bc31fed16454972), [#3025](https://github.com/heygen-com/hyperframes/pull/3025)).
+- **Studio:** The automation lane itself ([0d3c0246d](https://github.com/heygen-com/hyperframes/commit/0d3c0246d00fe1cfb33492581fc06c5d0abf17ba), [#3024](https://github.com/heygen-com/hyperframes/pull/3024)).
+- **Studio:** The geometry and plumbing behind automation lanes ([3cfacf440](https://github.com/heygen-com/hyperframes/commit/3cfacf440d4d0631618df48ed50cd06f42922db6), [#3023](https://github.com/heygen-com/hyperframes/pull/3023)).
+- **Audio:** Play automation envelopes in preview and bake them at render ([23ba58cfd](https://github.com/heygen-com/hyperframes/commit/23ba58cfd33a5a5ec627e2e88d65da2cbc43a55c), [#3016](https://github.com/heygen-com/hyperframes/pull/3016)).
+- **Audio:** Automation envelope model ([fd97926cf](https://github.com/heygen-com/hyperframes/commit/fd97926cf67e860330624072050043c2bc03ccfe), [#3015](https://github.com/heygen-com/hyperframes/pull/3015)).
+- **Audio:** Hear the FX chain while previewing ([9b0c5e855](https://github.com/heygen-com/hyperframes/commit/9b0c5e85596efaf93823bf5f19b7f1d1216ca7d5), [#3014](https://github.com/heygen-com/hyperframes/pull/3014)).
+- **Engine:** Render the FX chain offline, and the carve analysis behind it ([cc40e35aa](https://github.com/heygen-com/hyperframes/commit/cc40e35aa0995c2731c4d34a4502d45927997a2d), [#3021](https://github.com/heygen-com/hyperframes/pull/3021)).
+
+## Fixes
+
+- **Studio:** Audition from the playhead while paused, and let an author out of a menu ([6bcf73939](https://github.com/heygen-com/hyperframes/commit/6bcf739390842dc00f94ba1e99f2baea1b989717), [#3190](https://github.com/heygen-com/hyperframes/pull/3190)).
+- **Core:** Give the chorus and phaser LFOs a phase, and unwire them on dispose ([b839dbd2c](https://github.com/heygen-com/hyperframes/commit/b839dbd2cc2c7e6e1da432fd8c000cf9e897375c), [#3183](https://github.com/heygen-com/hyperframes/pull/3183)).
+- **Core:** Retire worklet processors, retry failed registration, reuse FFT scratch ([f6cf3b242](https://github.com/heygen-com/hyperframes/commit/f6cf3b242bf425b6149a42c9708f287ddc36d905), [#3175](https://github.com/heygen-com/hyperframes/pull/3175)).
+- **Engine:** Duck before quantising, chunk the PCM, reschedule on rate change ([ea0344122](https://github.com/heygen-com/hyperframes/commit/ea0344122c22b6e82828216b8ce72e08afef3b46), [#3174](https://github.com/heygen-com/hyperframes/pull/3174)).
+- **Audio:** Eleven small correctness fixes across engine, core and the panel ([95751d6b1](https://github.com/heygen-com/hyperframes/commit/95751d6b10c44c982ce1aeed97b4abb44a7bb7d7), [#3173](https://github.com/heygen-com/hyperframes/pull/3173)).
+- **Studio:** The shared-row follow-ups ([df57ad4ba](https://github.com/heygen-com/hyperframes/commit/df57ad4bace78f97bef51d9b1dc32ec1f6ded431), [#3215](https://github.com/heygen-com/hyperframes/pull/3215)).
+- **Core:** Make audio automation survive being rescheduled ([69face9dc](https://github.com/heygen-com/hyperframes/commit/69face9dc6a8faab5c728860cc7a3f7170d17e07), [#3208](https://github.com/heygen-com/hyperframes/pull/3208)).
+- **Core:** Escape `\<` in compiler-emitted composition variable CSS ([f9a20692f](https://github.com/heygen-com/hyperframes/commit/f9a20692f8a0ee10330d0a95de1abd422e92d74a), [#3072](https://github.com/heygen-com/hyperframes/pull/3072)).
+- **Core:** Escape `\<` in the compiler-emitted variables script ([91db93aa3](https://github.com/heygen-com/hyperframes/commit/91db93aa345a8dfc2b68ec0ac18c81065a805cd9), [#3071](https://github.com/heygen-com/hyperframes/pull/3071)).
+- **Audio:** Two things the envelopes needed to be heard at all ([2c41a74ff](https://github.com/heygen-com/hyperframes/commit/2c41a74ff72bcfe21cbb9beb02c07de6fe247019), [#3017](https://github.com/heygen-com/hyperframes/pull/3017)).
+- **Capture:** Bound scroll/evaluate timeouts so heavy pages keep capturing ([43dba2205](https://github.com/heygen-com/hyperframes/commit/43dba22057e1fc131f6a2758e5ae3481b81efdc5), [#3236](https://github.com/heygen-com/hyperframes/pull/3236)).
+- **Fonts:** Supplement alias faces from the canonical family ([a16222d9a](https://github.com/heygen-com/hyperframes/commit/a16222d9a278e93b0eff8ebbc62fef04e3c979e9), [#3230](https://github.com/heygen-com/hyperframes/pull/3230)).
+
+## Docs & Examples
+
+- **Skills:** Add /hyperframes-audio, and key the waveform cache by file ([56d8df65c](https://github.com/heygen-com/hyperframes/commit/56d8df65ca0314f0089c366335c19cbf224546e2), [#3211](https://github.com/heygen-com/hyperframes/pull/3211)).
+
+## Catalog
+
+- **Core:** The audio FX preset catalogue, and applying one from the rack ([7d0d74dca](https://github.com/heygen-com/hyperframes/commit/7d0d74dcae1bd9110f64f6836101fc25e2146500), [#3177](https://github.com/heygen-com/hyperframes/pull/3177)).
+- **Catalog:** Restore the caption texture preview ([cbd38b32f](https://github.com/heygen-com/hyperframes/commit/cbd38b32f7a1cc38964e898991b8767d3a05506c), [#3258](https://github.com/heygen-com/hyperframes/pull/3258)).
+- **Catalog:** Center the menu morph preview ([c71fab322](https://github.com/heygen-com/hyperframes/commit/c71fab322e555463bde94953a006a1c46c0c2a12), [#3256](https://github.com/heygen-com/hyperframes/pull/3256)).
+- **Catalog:** Keep the text stagger preview inside the frame ([a2109a863](https://github.com/heygen-com/hyperframes/commit/a2109a863319e6c603b3d5758bc4a180c7cff064), [#3255](https://github.com/heygen-com/hyperframes/pull/3255)).
+- **Catalog:** Keep the animated bar chart preview in frame ([158f15e8f](https://github.com/heygen-com/hyperframes/commit/158f15e8f0739c08d72eca46b34904285dae09c5), [#3254](https://github.com/heygen-com/hyperframes/pull/3254)).
+- **Catalog:** Keep the typewriter preview inside the frame ([dc01a12d7](https://github.com/heygen-com/hyperframes/commit/dc01a12d71022b60ee0d12cad74c46a2e8753f81), [#3249](https://github.com/heygen-com/hyperframes/pull/3249)).
+- **Studio:** The FX panel, generated from the registry ([c2996c862](https://github.com/heygen-com/hyperframes/commit/c2996c8626135db5253519359d8a063d3bafad8d), [#3022](https://github.com/heygen-com/hyperframes/pull/3022)).
+- **Registry:** Add ChatGPT and Claude exchange templates ([0474d4ae2](https://github.com/heygen-com/hyperframes/commit/0474d4ae266ccc4b482ed6631fc46fb2dd19b1af), [#3244](https://github.com/heygen-com/hyperframes/pull/3244)).
+- Simplify the Catalog overview with a section tour ([9b1232965](https://github.com/heygen-com/hyperframes/commit/9b1232965201baae4764c470edd33878a0c1ceef), [#3240](https://github.com/heygen-com/hyperframes/pull/3240)).
+- **Core:** Web Audio graphs for the FX registry ([2350f9b69](https://github.com/heygen-com/hyperframes/commit/2350f9b69b10c32ec12d0f84800133aa5173804e), [#3020](https://github.com/heygen-com/hyperframes/pull/3020)).
+- **Core:** The audio FX registry ([5752d2249](https://github.com/heygen-com/hyperframes/commit/5752d224929f00ac2fa2757df02339f781cdd6fa), [#3019](https://github.com/heygen-com/hyperframes/pull/3019)).
+- **Registry:** Normalize ai chat portrait canvas ([93fbb6d7f](https://github.com/heygen-com/hyperframes/commit/93fbb6d7fd3e4c925927df994bf7cbab8d223d92), [#3235](https://github.com/heygen-com/hyperframes/pull/3235)).
+- **Registry:** Align notes reveal typing ([c69692464](https://github.com/heygen-com/hyperframes/commit/c69692464ea42d5d4c4ff878f60e0642f25e419e), [#3234](https://github.com/heygen-com/hyperframes/pull/3234)).
+
+## Internal
+
+- **Studio:** Lift the effect row out of the FX section file ([2f97fc2b8](https://github.com/heygen-com/hyperframes/commit/2f97fc2b89c67725a03b70f95e2510e0bc90b3a3), [#3182](https://github.com/heygen-com/hyperframes/pull/3182)).
+- **Studio:** Lift the carve out of the FX section file ([c327740c7](https://github.com/heygen-com/hyperframes/commit/c327740c79e2cb448a26cc1b848c45d4b3ecd7ed), [#3181](https://github.com/heygen-com/hyperframes/pull/3181)).
+- **Audio:** The review's cleanup list, and the design record behind the rack ([fd4d41153](https://github.com/heygen-com/hyperframes/commit/fd4d41153c76f25f50feb4f4c3b380787cbfb136), [#3176](https://github.com/heygen-com/hyperframes/pull/3176)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.107...v0.7.108).
+</Update>
+
+<Update
   label="HyperFrames v0.7.107"
   description="Released - 2026-08-11"
   tags={["Release", "Skills", "Capture", "Studio"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.108.md
+++ b/releases/v0.7.108.md
@@ -1,0 +1,82 @@
+# HyperFrames v0.7.108
+
+Released on 2026-08-13.
+
+Studio can now automate any effect parameter with keyframed lanes, complete with copy, retime, and reshape tools. The full audio FX rack ships behind a staged rollout, so it isn't visible yet.
+
+## Features
+
+- **Studio:** Instrument the audio FX rack, including work an agent did ([d6c4774ef](https://github.com/heygen-com/hyperframes/commit/d6c4774ef41c54f66dc02c6dd433facee822a8f8), [#3229](https://github.com/heygen-com/hyperframes/pull/3229)).
+- **Studio:** Fold a preset shut, and give each one its own title design ([e3ec48adc](https://github.com/heygen-com/hyperframes/commit/e3ec48adce494d40d787cd4cbca6464a3b53362f), [#3191](https://github.com/heygen-com/hyperframes/pull/3191)).
+- Switch a preset off, or ramp it, as one thing ([acdb11250](https://github.com/heygen-com/hyperframes/commit/acdb11250ce3bb97a70cdd63d080968900a2f003), [#3189](https://github.com/heygen-com/hyperframes/pull/3189)).
+- One knob for the five effects that cannot honestly have one ([29f516d49](https://github.com/heygen-com/hyperframes/commit/29f516d490c00697594f3b88a565d69115b7af12), [#3188](https://github.com/heygen-com/hyperframes/pull/3188)).
+- **Studio:** Family lettering, tints, and the rack as a signal path ([2020b82c9](https://github.com/heygen-com/hyperframes/commit/2020b82c9b8f2d2050b5b11c76bdb27323d64e07), [#3187](https://github.com/heygen-com/hyperframes/pull/3187)).
+- **Studio:** Two faces, and the shared frequency ruler ([96fd4d061](https://github.com/heygen-com/hyperframes/commit/96fd4d061ecddef59e3949b4fb3e30d51209bd76), [#3186](https://github.com/heygen-com/hyperframes/pull/3186)).
+- Offer the job, not the machine — the range IS the module ([31fa523b7](https://github.com/heygen-com/hyperframes/commit/31fa523b7ed71c6fbbc0c4b2558fb83bf636fc88), [#3185](https://github.com/heygen-com/hyperframes/pull/3185)).
+- **Studio:** Make the FX rack speak the author's language ([0e4da52c8](https://github.com/heygen-com/hyperframes/commit/0e4da52c8222b8d18a1211b34f2fb3bd0f7e79ee), [#3192](https://github.com/heygen-com/hyperframes/pull/3192)).
+- **Core:** Land the plain-language layer, and test that it covers the rack ([27cdd4d5b](https://github.com/heygen-com/hyperframes/commit/27cdd4d5b1684afae16f96fe3e4af30c73178e1a), [#3184](https://github.com/heygen-com/hyperframes/pull/3184)).
+- **Core:** The levelling script — "Even Out Levels" ([71066fc25](https://github.com/heygen-com/hyperframes/commit/71066fc25ba362a18d52ba0648b6b279e9ee3206), [#3180](https://github.com/heygen-com/hyperframes/pull/3180)).
+- **Studio:** The Tone module — a multi-band EQ on faders ([818a7b281](https://github.com/heygen-com/hyperframes/commit/818a7b281b44182b6a4e47b7f30f92df332f62a2), [#3179](https://github.com/heygen-com/hyperframes/pull/3179)).
+- **Core:** Name every preset node, and add a multi-band EQ over existing filters ([9f6762052](https://github.com/heygen-com/hyperframes/commit/9f676205239a4e1ce03498223ef9f6ce5448aeec), [#3178](https://github.com/heygen-com/hyperframes/pull/3178)).
+- **Studio:** Give the clips on a track one automation lane row ([9b18fa7a2](https://github.com/heygen-com/hyperframes/commit/9b18fa7a26bd5e7b4f8b4b4e10c984585767620b), [#3214](https://github.com/heygen-com/hyperframes/pull/3214)).
+- **Studio:** The carve is one module in the rack ([d18cbcb7f](https://github.com/heygen-com/hyperframes/commit/d18cbcb7f31862a37b9051b85ebb562f104a516c), [#3213](https://github.com/heygen-com/hyperframes/pull/3213)).
+- **Studio:** Show every automated knob at the playhead ([7d38fed97](https://github.com/heygen-com/hyperframes/commit/7d38fed97fd50f70e5a67229250a186baac98d3c), [#3210](https://github.com/heygen-com/hyperframes/pull/3210)).
+- **Studio:** Retime and edge-stretch an automation selection ([120ea37c2](https://github.com/heygen-com/hyperframes/commit/120ea37c2fbd7202a443b94c0ff21c1ee7a63996), [#3207](https://github.com/heygen-com/hyperframes/pull/3207)).
+- **Studio:** Copy and paste automation ranges across lanes ([c7c95e2f0](https://github.com/heygen-com/hyperframes/commit/c7c95e2f018efa961b7a5e06fb142a98fd14ecc9), [#3056](https://github.com/heygen-com/hyperframes/pull/3056)).
+- **Studio:** Shape and simplify an automation selection ([64a85e775](https://github.com/heygen-com/hyperframes/commit/64a85e775a2259938e24d2fc7dc279c402397761), [#3055](https://github.com/heygen-com/hyperframes/pull/3055)).
+- **Studio:** Select a time range on an automation lane ([3670e9a92](https://github.com/heygen-com/hyperframes/commit/3670e9a921ddcbcd84e5d448faec5b08fca0ba40), [#3050](https://github.com/heygen-com/hyperframes/pull/3050)).
+- **Studio:** Curve, snap and type a value in an automation lane ([e465a07a3](https://github.com/heygen-com/hyperframes/commit/e465a07a322db8a63fc757bda5a53a842a0c269f), [#3038](https://github.com/heygen-com/hyperframes/pull/3038)).
+- **Engine:** Let an FX tail decay instead of cutting it at the clip ([6a0e409fc](https://github.com/heygen-com/hyperframes/commit/6a0e409fc2704683613b0a94cc734635dd9ded94), [#3036](https://github.com/heygen-com/hyperframes/pull/3036)).
+- **Studio:** Automate and un-automate each effect parameter ([32f29721d](https://github.com/heygen-com/hyperframes/commit/32f29721d2fd9ab7e85c0cf87108aa2c1b9859a9), [#3026](https://github.com/heygen-com/hyperframes/pull/3026)).
+- **Studio:** Automate a parameter without reloading the preview ([7203e0a73](https://github.com/heygen-com/hyperframes/commit/7203e0a73ca9f51cde74f0820bc31fed16454972), [#3025](https://github.com/heygen-com/hyperframes/pull/3025)).
+- **Studio:** The automation lane itself ([0d3c0246d](https://github.com/heygen-com/hyperframes/commit/0d3c0246d00fe1cfb33492581fc06c5d0abf17ba), [#3024](https://github.com/heygen-com/hyperframes/pull/3024)).
+- **Studio:** The geometry and plumbing behind automation lanes ([3cfacf440](https://github.com/heygen-com/hyperframes/commit/3cfacf440d4d0631618df48ed50cd06f42922db6), [#3023](https://github.com/heygen-com/hyperframes/pull/3023)).
+- **Audio:** Play automation envelopes in preview and bake them at render ([23ba58cfd](https://github.com/heygen-com/hyperframes/commit/23ba58cfd33a5a5ec627e2e88d65da2cbc43a55c), [#3016](https://github.com/heygen-com/hyperframes/pull/3016)).
+- **Audio:** Automation envelope model ([fd97926cf](https://github.com/heygen-com/hyperframes/commit/fd97926cf67e860330624072050043c2bc03ccfe), [#3015](https://github.com/heygen-com/hyperframes/pull/3015)).
+- **Audio:** Hear the FX chain while previewing ([9b0c5e855](https://github.com/heygen-com/hyperframes/commit/9b0c5e85596efaf93823bf5f19b7f1d1216ca7d5), [#3014](https://github.com/heygen-com/hyperframes/pull/3014)).
+- **Engine:** Render the FX chain offline, and the carve analysis behind it ([cc40e35aa](https://github.com/heygen-com/hyperframes/commit/cc40e35aa0995c2731c4d34a4502d45927997a2d), [#3021](https://github.com/heygen-com/hyperframes/pull/3021)).
+
+## Fixes
+
+- **Studio:** Audition from the playhead while paused, and let an author out of a menu ([6bcf73939](https://github.com/heygen-com/hyperframes/commit/6bcf739390842dc00f94ba1e99f2baea1b989717), [#3190](https://github.com/heygen-com/hyperframes/pull/3190)).
+- **Core:** Give the chorus and phaser LFOs a phase, and unwire them on dispose ([b839dbd2c](https://github.com/heygen-com/hyperframes/commit/b839dbd2cc2c7e6e1da432fd8c000cf9e897375c), [#3183](https://github.com/heygen-com/hyperframes/pull/3183)).
+- **Core:** Retire worklet processors, retry failed registration, reuse FFT scratch ([f6cf3b242](https://github.com/heygen-com/hyperframes/commit/f6cf3b242bf425b6149a42c9708f287ddc36d905), [#3175](https://github.com/heygen-com/hyperframes/pull/3175)).
+- **Engine:** Duck before quantising, chunk the PCM, reschedule on rate change ([ea0344122](https://github.com/heygen-com/hyperframes/commit/ea0344122c22b6e82828216b8ce72e08afef3b46), [#3174](https://github.com/heygen-com/hyperframes/pull/3174)).
+- **Audio:** Eleven small correctness fixes across engine, core and the panel ([95751d6b1](https://github.com/heygen-com/hyperframes/commit/95751d6b10c44c982ce1aeed97b4abb44a7bb7d7), [#3173](https://github.com/heygen-com/hyperframes/pull/3173)).
+- **Studio:** The shared-row follow-ups ([df57ad4ba](https://github.com/heygen-com/hyperframes/commit/df57ad4bace78f97bef51d9b1dc32ec1f6ded431), [#3215](https://github.com/heygen-com/hyperframes/pull/3215)).
+- **Core:** Make audio automation survive being rescheduled ([69face9dc](https://github.com/heygen-com/hyperframes/commit/69face9dc6a8faab5c728860cc7a3f7170d17e07), [#3208](https://github.com/heygen-com/hyperframes/pull/3208)).
+- **Core:** Escape `<` in compiler-emitted composition variable CSS ([f9a20692f](https://github.com/heygen-com/hyperframes/commit/f9a20692f8a0ee10330d0a95de1abd422e92d74a), [#3072](https://github.com/heygen-com/hyperframes/pull/3072)).
+- **Core:** Escape `<` in the compiler-emitted variables script ([91db93aa3](https://github.com/heygen-com/hyperframes/commit/91db93aa345a8dfc2b68ec0ac18c81065a805cd9), [#3071](https://github.com/heygen-com/hyperframes/pull/3071)).
+- **Audio:** Two things the envelopes needed to be heard at all ([2c41a74ff](https://github.com/heygen-com/hyperframes/commit/2c41a74ff72bcfe21cbb9beb02c07de6fe247019), [#3017](https://github.com/heygen-com/hyperframes/pull/3017)).
+- **Capture:** Bound scroll/evaluate timeouts so heavy pages keep capturing ([43dba2205](https://github.com/heygen-com/hyperframes/commit/43dba22057e1fc131f6a2758e5ae3481b81efdc5), [#3236](https://github.com/heygen-com/hyperframes/pull/3236)).
+- **Fonts:** Supplement alias faces from the canonical family ([a16222d9a](https://github.com/heygen-com/hyperframes/commit/a16222d9a278e93b0eff8ebbc62fef04e3c979e9), [#3230](https://github.com/heygen-com/hyperframes/pull/3230)).
+
+## Docs & Examples
+
+- **Skills:** Add /hyperframes-audio, and key the waveform cache by file ([56d8df65c](https://github.com/heygen-com/hyperframes/commit/56d8df65ca0314f0089c366335c19cbf224546e2), [#3211](https://github.com/heygen-com/hyperframes/pull/3211)).
+
+## Catalog
+
+- **Core:** The audio FX preset catalogue, and applying one from the rack ([7d0d74dca](https://github.com/heygen-com/hyperframes/commit/7d0d74dcae1bd9110f64f6836101fc25e2146500), [#3177](https://github.com/heygen-com/hyperframes/pull/3177)).
+- **Catalog:** Restore the caption texture preview ([cbd38b32f](https://github.com/heygen-com/hyperframes/commit/cbd38b32f7a1cc38964e898991b8767d3a05506c), [#3258](https://github.com/heygen-com/hyperframes/pull/3258)).
+- **Catalog:** Center the menu morph preview ([c71fab322](https://github.com/heygen-com/hyperframes/commit/c71fab322e555463bde94953a006a1c46c0c2a12), [#3256](https://github.com/heygen-com/hyperframes/pull/3256)).
+- **Catalog:** Keep the text stagger preview inside the frame ([a2109a863](https://github.com/heygen-com/hyperframes/commit/a2109a863319e6c603b3d5758bc4a180c7cff064), [#3255](https://github.com/heygen-com/hyperframes/pull/3255)).
+- **Catalog:** Keep the animated bar chart preview in frame ([158f15e8f](https://github.com/heygen-com/hyperframes/commit/158f15e8f0739c08d72eca46b34904285dae09c5), [#3254](https://github.com/heygen-com/hyperframes/pull/3254)).
+- **Catalog:** Keep the typewriter preview inside the frame ([dc01a12d7](https://github.com/heygen-com/hyperframes/commit/dc01a12d71022b60ee0d12cad74c46a2e8753f81), [#3249](https://github.com/heygen-com/hyperframes/pull/3249)).
+- **Studio:** The FX panel, generated from the registry ([c2996c862](https://github.com/heygen-com/hyperframes/commit/c2996c8626135db5253519359d8a063d3bafad8d), [#3022](https://github.com/heygen-com/hyperframes/pull/3022)).
+- **Registry:** Add ChatGPT and Claude exchange templates ([0474d4ae2](https://github.com/heygen-com/hyperframes/commit/0474d4ae266ccc4b482ed6631fc46fb2dd19b1af), [#3244](https://github.com/heygen-com/hyperframes/pull/3244)).
+- Simplify the Catalog overview with a section tour ([9b1232965](https://github.com/heygen-com/hyperframes/commit/9b1232965201baae4764c470edd33878a0c1ceef), [#3240](https://github.com/heygen-com/hyperframes/pull/3240)).
+- **Core:** Web Audio graphs for the FX registry ([2350f9b69](https://github.com/heygen-com/hyperframes/commit/2350f9b69b10c32ec12d0f84800133aa5173804e), [#3020](https://github.com/heygen-com/hyperframes/pull/3020)).
+- **Core:** The audio FX registry ([5752d2249](https://github.com/heygen-com/hyperframes/commit/5752d224929f00ac2fa2757df02339f781cdd6fa), [#3019](https://github.com/heygen-com/hyperframes/pull/3019)).
+- **Registry:** Normalize ai chat portrait canvas ([93fbb6d7f](https://github.com/heygen-com/hyperframes/commit/93fbb6d7fd3e4c925927df994bf7cbab8d223d92), [#3235](https://github.com/heygen-com/hyperframes/pull/3235)).
+- **Registry:** Align notes reveal typing ([c69692464](https://github.com/heygen-com/hyperframes/commit/c69692464ea42d5d4c4ff878f60e0642f25e419e), [#3234](https://github.com/heygen-com/hyperframes/pull/3234)).
+
+## Internal
+
+- **Studio:** Lift the effect row out of the FX section file ([2f97fc2b8](https://github.com/heygen-com/hyperframes/commit/2f97fc2b89c67725a03b70f95e2510e0bc90b3a3), [#3182](https://github.com/heygen-com/hyperframes/pull/3182)).
+- **Studio:** Lift the carve out of the FX section file ([c327740c7](https://github.com/heygen-com/hyperframes/commit/c327740c79e2cb448a26cc1b848c45d4b3ecd7ed), [#3181](https://github.com/heygen-com/hyperframes/pull/3181)).
+- **Audio:** The review's cleanup list, and the design record behind the rack ([fd4d41153](https://github.com/heygen-com/hyperframes/commit/fd4d41153c76f25f50feb4f4c3b380787cbfb136), [#3176](https://github.com/heygen-com/hyperframes/pull/3176)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.107...v0.7.108


### PR DESCRIPTION
Automated release PR — merging this checks out the merge SHA, creates the v0.7.108 tag there, publishes npm, and cuts the GitHub release. See releases/v0.7.108.md for changelog.