### PR TITLE
fix(studio): preserve media position after clip splits

### DIFF
--- a/packages/studio-server/src/helpers/sourceMutation.ts
+++ b/packages/studio-server/src/helpers/sourceMutation.ts
@@ -367,14 +367,18 @@ export function splitElementInHtml(
   // Keep the "clip" class — the runtime uses it to control visibility
   // based on data-start/data-duration timing.
 
-  // Adjust media trim offset for the second half
+  // A split creates two views over the same media source. Even an untrimmed
+  // audio/video element needs an explicit zero in-point stamped on the first
+  // half so the second half can advance from it instead of restarting at zero.
   const playbackStartAttr = el.hasAttribute("data-playback-start")
     ? "data-playback-start"
     : el.hasAttribute("data-media-start")
       ? "data-media-start"
       : fallbackTiming?.stampPlaybackStart
         ? "data-playback-start"
-        : null;
+        : el.matches("audio, video")
+          ? "data-media-start"
+          : null;
   if (playbackStartAttr) {
     const currentTrim =
       parseFloat(el.getAttribute(playbackStartAttr) ?? "") || fallbackTiming?.playbackStart || 0;

--- a/packages/studio-server/src/helpers/sourceMutationSplitAndGroup.test.ts
+++ b/packages/studio-server/src/helpers/sourceMutationSplitAndGroup.test.ts
@@ -123,6 +123,36 @@ describe("splitElementInHtml", () => {
     expect(result.html).toMatch(/id="box-split"[^>]*data-playback-start="2"/);
   });
 
+  it.each(["audio", "video"])(
+    "seeds the second %s half with a media in-point when the source starts at zero",
+    (tag) => {
+      const mediaSource = `<!DOCTYPE html><html><body><div data-composition-id="root"><${tag} id="media" class="clip" src="asset.mp4" data-start="1" data-duration="6"></${tag}></div></body></html>`;
+
+      const result = splitElementInHtml(mediaSource, { id: "media" }, 3, "media-split");
+      const { document } = parseHTML(result.html);
+
+      expect(result.matched).toBe(true);
+      expect(document.getElementById("media")?.getAttribute("data-media-start")).toBe("0");
+      expect(document.getElementById("media-split")?.getAttribute("data-media-start")).toBe("2");
+    },
+  );
+
+  it("advances a zero-based media in-point by playback rate", () => {
+    const mediaSource = `<!DOCTYPE html><html><body><div data-composition-id="root"><video id="media" class="clip" src="asset.mp4" data-start="1" data-duration="6" data-playback-rate="2"></video></div></body></html>`;
+
+    const result = splitElementInHtml(mediaSource, { id: "media" }, 3, "media-split");
+    const { document } = parseHTML(result.html);
+
+    expect(document.getElementById("media-split")?.getAttribute("data-media-start")).toBe("4");
+  });
+
+  it("does not add a media in-point to non-media elements", () => {
+    const result = splitElementInHtml(source, { id: "box" }, 3, "box-split");
+
+    expect(result.html).not.toContain("data-media-start");
+    expect(result.html).not.toContain("data-playback-start");
+  });
+
   it("stamps a legacy composition offset and advances the second half by playback rate", () => {
     const result = splitElementInHtml(source, { id: "box" }, 3, "box-split", {
       start: 1,

--- a/packages/studio-server/src/routes/files.test.ts
+++ b/packages/studio-server/src/routes/files.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
+import { parseHTML } from "linkedom";
 import {
   existsSync,
   mkdirSync,
@@ -107,6 +108,9 @@ function postCutBatch(
       splitTime: number;
       elementStart: number;
       elementDuration: number;
+      playbackStart?: number;
+      playbackRate?: number;
+      isComposition?: boolean;
     }>;
   }>,
 ): Promise<Response> {
@@ -849,6 +853,55 @@ describe("registerFileRoutes", () => {
       version: payload.files[0].version,
       writeToken: "cut-test",
     });
+  });
+
+  it("persists media in-points for audio and video in an atomic split-all cut", async () => {
+    const projectDir = createProjectDir();
+    const before =
+      '<audio id="audio" src="voice.mp3" data-start="0" data-duration="6"></audio>' +
+      '<video id="video" src="clip.mp4" data-start="0" data-duration="6" data-playback-rate="2"></video>';
+    writeFileSync(join(projectDir, "index.html"), before);
+    const app = new Hono();
+    registerFileRoutes(app, createAdapter(projectDir));
+
+    const response = await postCutBatch(app, [
+      {
+        path: "index.html",
+        expectedVersion: fileContentVersion(before),
+        targets: [
+          {
+            target: { id: "audio" },
+            originalId: "audio",
+            splitTime: 2,
+            elementStart: 0,
+            elementDuration: 6,
+            playbackStart: 0,
+            playbackRate: 1,
+          },
+          {
+            target: { id: "video" },
+            originalId: "video",
+            splitTime: 2,
+            elementStart: 0,
+            elementDuration: 6,
+            playbackStart: 0,
+            playbackRate: 2,
+          },
+        ],
+      },
+    ]);
+    const payload = (await response.json()) as {
+      files: Array<{ after: string; splitCount: number }>;
+    };
+    const { document } = parseHTML(payload.files[0].after);
+
+    expect(response.status).toBe(200);
+    expect(payload.files[0].splitCount).toBe(2);
+    expect(document.getElementById("audio")?.getAttribute("data-media-start")).toBe("0");
+    expect(document.getElementById("audio-split")?.getAttribute("data-media-start")).toBe("2");
+    expect(document.getElementById("video")?.getAttribute("data-media-start")).toBe("0");
+    expect(document.getElementById("video-split")?.getAttribute("data-media-start")).toBe("4");
+    expect(readFileSync(join(projectDir, "index.html"), "utf-8")).toBe(payload.files[0].after);
   });
 
   it("cuts multiple id-less selector targets against their original indices", async () => {


### PR DESCRIPTION
## What

Preserve the source-media position of audio and video elements when Studio splits a clip.

The left segment now carries an explicit zero in-point when the original clip was untrimmed, while the right segment starts at the split-adjusted source position. Existing modern and legacy in-point attributes remain supported, playback rate is included in the offset calculation, and non-media elements are unchanged.

## Why

Splitting a normal audio or video clip placed the right-hand segment correctly on the timeline but restarted playback from source time zero. Untrimmed media does not carry `data-playback-start` or `data-media-start`, and the splitter only advanced an in-point when one of those attributes already existed.

That made the persisted timeline and the audible/visible media position disagree after a split.

## How

`splitElementInHtml` now treats direct `<audio>` and `<video>` elements as zero-based media even when no explicit in-point attribute is present:

- the first half receives `data-media-start="0"`;
- the second half receives `splitDelta × playbackRate`;
- `data-playback-start` and legacy `data-media-start` inputs preserve their existing attribute family;
- non-media elements keep the previous behavior.

Regression coverage exercises both media types, playback-rate scaling, existing offset attributes, non-media behavior, and the atomic split-all route that persists multiple media splits to disk.

## Test plan

- Reproduced before the implementation: the new audio/video regressions failed on `main` (3 failed, 18 passed).
- Targeted split regressions: 21 passed.
- Atomic split-all route regression: passed with audio and 2× video source offsets persisted to disk.
- Full `@hyperframes/studio-server` suite: 446 passed.
- Typecheck, oxlint, oxfmt, and pre-commit Fallow audit: passed.
- Real Studio before/after verification uses the same 6-second source WAV and a split at 2.0 seconds: `main` restarts at the 330 Hz opening tone; this PR continues at the 660 Hz tone.

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (not applicable)
