### PR TITLE
chore: release v0.7.109

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,25 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.109"
+  description="Released - 2026-08-14"
+  tags={["Release", "Engine", "Producer", "Studio"]}
+>
+Audio and video clips now continue from the correct source position after a split. Renders also honor mixer settings and carry diagnostic metadata.
+
+## Features
+
+- **Engine:** Add invisible, unsigned renderer and version metadata to encoded files for diagnostics ([f7d2260f9](https://github.com/heygen-com/hyperframes/commit/f7d2260f9d8edb33e708138067a0eaf393c1f214), [#3264](https://github.com/heygen-com/hyperframes/pull/3264)).
+
+## Fixes
+
+- **Producer:** Honor configured FFmpeg timeouts and master gain during audio mixing ([c32b8041d](https://github.com/heygen-com/hyperframes/commit/c32b8041dbd157178220b7a364071fe8e3cb783a), [#3239](https://github.com/heygen-com/hyperframes/pull/3239)).
+- **Studio:** Keep audio and video at the correct source position after splitting a clip ([b1b368d0f](https://github.com/heygen-com/hyperframes/commit/b1b368d0f0967506db02224ce1503f88b36b6487), [#3272](https://github.com/heygen-com/hyperframes/pull/3272)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.108...v0.7.109).
+</Update>
+
+<Update
   label="HyperFrames v0.7.108"
   description="Released - 2026-08-13"
   tags={["Release", "Studio", "Core", "Audio"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.109.md
+++ b/releases/v0.7.109.md
@@ -1,0 +1,18 @@
+# HyperFrames v0.7.109
+
+Released on 2026-08-14.
+
+Audio and video clips now continue from the correct source position after a split. Renders also honor mixer settings and carry diagnostic metadata.
+
+## Features
+
+- **Engine:** Add invisible, unsigned renderer and version metadata to encoded files for diagnostics ([f7d2260f9](https://github.com/heygen-com/hyperframes/commit/f7d2260f9d8edb33e708138067a0eaf393c1f214), [#3264](https://github.com/heygen-com/hyperframes/pull/3264)).
+
+## Fixes
+
+- **Producer:** Honor configured FFmpeg timeouts and master gain during audio mixing ([c32b8041d](https://github.com/heygen-com/hyperframes/commit/c32b8041dbd157178220b7a364071fe8e3cb783a), [#3239](https://github.com/heygen-com/hyperframes/pull/3239)).
+- **Studio:** Keep audio and video at the correct source position after splitting a clip ([b1b368d0f](https://github.com/heygen-com/hyperframes/commit/b1b368d0f0967506db02224ce1503f88b36b6487), [#3272](https://github.com/heygen-com/hyperframes/pull/3272)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.108...v0.7.109


### PR DESCRIPTION
## What

Bump all 13 publishable HyperFrames packages and the Claude, Codex, and Cursor plugin manifests from `0.7.108` to `0.7.109`. Add reviewed release notes for renderer diagnostics, media-split timing, and audio-mixer configuration.

## Why

Publish the stable fixes and diagnostics merged since v0.7.108. Audio and video clips now keep their source position after a split, and renders honor the configured FFmpeg timeout and master gain.

## How

Prepared with the repository release automation from `origin/main` at `c32b8041`. The local tag was intentionally not pushed. After this reviewed release PR merges, the publish workflow will pin the merge SHA, create `v0.7.109`, publish the fixed-version package set to npm `latest`, and create the GitHub Release.

## Test plan

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated (if applicable)

Verification performed:
- Release prepare/changelog tests: 16 passed
- Publish/channel guard tests: 14 passed
- Formatting: all 17 release files clean
- Version audit: all 13 publishable packages and 3 plugin manifests are `0.7.109`
- Full repository CI will run on this PR before merge