### PR TITLE
feat(studio): make presets the primary path into the FX rack

### DIFF
--- a/packages/studio/src/components/editor/propertyPanelAudioFxGroup.test.tsx
+++ b/packages/studio/src/components/editor/propertyPanelAudioFxGroup.test.tsx
@@ -469,7 +469,7 @@ describe("AudioFxGroup dynamic carve", () => {
     });
     document.getElementById("bed")?.setAttribute("src", "bed.wav");
     act(() => byTextButton(host, "Audio FX")?.click());
-    act(() => byTextButton(host, "Add effect")?.click());
+    act(() => byTextButton(host, "+ effect")?.click());
     await act(async () => {
       byTextButton(host, "Even Out Levels")?.click();
       await new Promise((r) => setTimeout(r, 0));
@@ -581,7 +581,7 @@ describe("AudioFxGroup dynamic carve", () => {
     const { release, decoded } = stubGatedDecode();
     const { host, onSetAttributeLive } = mount({ "fx-chain": CHAIN });
     document.getElementById("bed")?.setAttribute("src", "bed.wav");
-    act(() => byTextButton(host, "Add effect")?.click());
+    act(() => byTextButton(host, "+ effect")?.click());
     const level = byTextButton(host, "Even Out Levels");
     expect(level, "the levelling button was not offered").toBeTruthy();
     act(() => level?.focus());
@@ -611,7 +611,7 @@ describe("AudioFxGroup dynamic carve", () => {
     const { release, decoded } = stubGatedDecode();
     const { host, onSetAttributeLive } = mount({ "fx-chain": CHAIN });
     document.getElementById("bed")?.setAttribute("src", "bed.wav");
-    act(() => byTextButton(host, "Add effect")?.click());
+    act(() => byTextButton(host, "+ effect")?.click());
     act(() => byTextButton(host, "Even Out Levels")?.focus());
     // Straight to a neighbour, without ever leaving the shelf.
     act(() =>

--- a/packages/studio/src/components/editor/propertyPanelFxSection.test.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFxSection.test.tsx
@@ -875,7 +875,7 @@ describe("FxSection chain", () => {
 
       click(host.querySelector(".hf-fx-add"));
       expect(host.querySelector(".hf-fx-add-menu")).toBeNull();
-      expect(byText(host, "button", "Add effect")).toBeTruthy();
+      expect(byText(host, "button", "+ effect")).toBeTruthy();
     });
 
     it("opens one menu in place of the other", () => {
@@ -1046,7 +1046,7 @@ describe("FxSection chain", () => {
 
     it("auditions an effect the add menu is offering", () => {
       const { host, onChainPreview, onChainChange } = mount({ chain: chainOf("peaking") });
-      click(byText(host, "button", "Add effect"));
+      click(byText(host, "button", "+ effect"));
       enter(byText(host, "button", EFFECT_COPY.reverb?.title ?? ""));
 
       const heard = onChainPreview.mock.calls.at(-1)?.[0] as HfAudioFxChain;
@@ -1063,7 +1063,7 @@ describe("FxSection chain", () => {
         onLevel: vi.fn(),
         onAuditionLevel,
       });
-      click(byText(host, "button", "Add effect"));
+      click(byText(host, "button", "+ effect"));
       enter(byText(host, "button", "Even Out Levels"));
       expect(onAuditionLevel).toHaveBeenLastCalledWith(true);
       leave(host, ".hf-fx-add-menu");

--- a/packages/studio/src/components/editor/propertyPanelFxSection.tsx
+++ b/packages/studio/src/components/editor/propertyPanelFxSection.tsx
@@ -511,10 +511,10 @@ export function FxSection({
           opened one and changed their mind had no way back: picking something
           was the only thing that set these false, so the only exits were adding
           an effect they did not want or deselecting the clip. */}
-      <div className="flex gap-1">
+      <div className="flex flex-col gap-1">
         <button
           type="button"
-          className="hf-fx-preset w-full rounded-[4px] border border-dashed border-panel-border-input py-1 text-[11px] text-panel-text-2 hover:text-panel-text-0 disabled:opacity-40"
+          className="hf-fx-preset w-full rounded-[4px] border border-panel-text-0 py-1.5 text-[11px] font-semibold text-panel-text-0 disabled:opacity-40"
           aria-expanded={picking}
           disabled={disabled}
           onClick={() => {
@@ -530,7 +530,7 @@ export function FxSection({
         </button>
         <button
           type="button"
-          className="hf-fx-add w-full rounded-[4px] border border-dashed border-panel-border-input py-1 text-[11px] text-panel-text-2 hover:text-panel-text-0 disabled:opacity-40"
+          className="hf-fx-add self-end px-1 text-[10px] text-panel-text-2 hover:text-panel-text-0 disabled:opacity-40"
           aria-expanded={adding}
           disabled={disabled}
           onClick={() => {
@@ -542,7 +542,7 @@ export function FxSection({
             setPicking(false);
           }}
         >
-          {adding ? "Close" : "Add effect"}
+          {adding ? "Close" : "+ effect"}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Presets button is now the stacked primary control (bold, filled outline); Add-effect is demoted to a small trailing `+ effect` link.
- Both buttons' `onClick` bodies (audition-revert logic) are byte-identical to before — only layout/labels/classes changed.
- Updates the 8 test assertions on the old `"Add effect"` label to `"+ effect"` across `propertyPanelFxSection.test.tsx` and `propertyPanelAudioFxGroup.test.tsx`.

Per `plans/audio-execution/A1-preset-primary.md` (step A1 of the audio-groups/mute-solo/pitch-shift execution runbook).

## Test plan
- [x] `bunx vitest run src/components/editor/propertyPanelFxSection.test.tsx src/components/editor/propertyPanelAudioFxGroup.test.tsx` — 182 tests pass
- [x] `bun run test` (full studio suite) — 4241 pass, 0 regressions
- [x] `bunx oxfmt` / `bunx oxlint` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)