### PR TITLE
fix(studio): stabilize previews and normalize clip audio

### DIFF
--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -23,7 +23,7 @@ npm install -g hyperframes
 | You want to              | Use                                                                                                                                                                                            |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Start a project          | [`init`](#init), [`add`](#add), [`catalog`](#catalog)                                                                                                                                          |
-| Bring in source material | [`capture`](#capture), [`transcribe`](#transcribe), [`tts`](#tts), [`remove-background`](#remove-background), [`media-treatment`](#media-treatment), [`beats`](#beats)                          |
+| Bring in source material | [`capture`](#capture), [`transcribe`](#transcribe), [`tts`](#tts), [`remove-background`](#remove-background), [`media-treatment`](#media-treatment), [`beats`](#beats), [`normalize-audio`](#normalize-audio) |
 | Look at it, or share it  | [`preview`](#preview), [`present`](#present-and-play), [`play`](#present-and-play), [`publish`](#publish)                                                                                       |
 | Find problems            | [`lint`](#lint), [`check`](#check), [`snapshot`](#snapshot), [`keyframes`](#keyframes), [`compare`](#compare-and-grade-compare), [`grade-compare`](#compare-and-grade-compare)                  |
 | Make a file              | [`render`](#render), [`benchmark`](#benchmark)                                                                                                                                                  |
@@ -428,6 +428,30 @@ Needs a local Chrome, the same one `render` uses. Run
 within a frame or two — a different headless-Chrome audio sample rate can shift
 a beat slightly.
 
+### `normalize-audio`
+
+Match one authored audio clip to a reference using the exact local media bytes
+and FFmpeg's integrated EBU R128 loudness measurement.
+
+```bash
+# Measure only (the default)
+npx hyperframes normalize-audio --reference target-audio --target user-audio
+
+# Persist the computed gain on #user-audio
+npx hyperframes normalize-audio --reference target-audio --target user-audio --write
+
+# Agent-readable result
+npx hyperframes normalize-audio --reference target-audio --target user-audio --json
+```
+
+`--reference` and `--target` are `<audio>` element ids, with or without `#`.
+The reference stays unchanged; the command accounts for both clips' current
+`data-volume` and writes the target's absolute matched gain. It measures
+`data-media-start` and `data-duration`, rejects remote or out-of-project sources,
+and refuses a result that exceeds Studio's +12 dB ceiling or would clip. Dry-run
+is deliberate: inspect the measurement before passing `--write`. Use
+`--tolerance <LU>` to change the default 0.5 LU no-op threshold.
+
 ## Look at it
 
 ### `preview`
@@ -438,6 +462,8 @@ Start a live preview server with hot reload.
 npx hyperframes preview [dir]
 npx hyperframes preview --port 4567
 npx hyperframes preview --background     # keep running after the command exits
+npx hyperframes preview --foreground     # stay attached in a non-interactive shell
+npx hyperframes preview --status --json  # inspect a managed preview from an agent
 npx hyperframes preview --list           # every running preview
 ```
 
@@ -446,6 +472,8 @@ npx hyperframes preview --list           # every running preview
 | `--port`                             | Server port (default 3002)                                                                                |
 | `--open` / `--no-open`               | Open a browser, or leave it closed                                                                        |
 | `--background`                       | Keep an embedded preview running after the command exits                                                  |
+| `--foreground`                       | Keep the preview attached even when the shell is non-interactive                                          |
+| `--json`                             | Emit one versioned JSON result for managed start, status, stop, list, and kill-all operations              |
 | `--browser-gpu` / `--no-browser-gpu` | Hardware GPU for Studio thumbnails and frame capture, or deterministic SwiftShader (default: auto-detect)  |
 | `--proxy` / `--no-proxy`             | Auto-transcode browser-hostile codecs (HEVC, ProRes, AV1) to a cached authoring proxy (default: on)        |
 | `--browser-path`                     | Open a specific browser. `--user-data-dir`, `--remote-debugging-port`, and `--browser-no-gpu` require it.  |
@@ -454,6 +482,13 @@ To manage running servers: `--status` and `--stop` act on this project's
 background preview, `--list` and `--kill-all` act on all of them, and
 `--force-new` starts a second server for a project that already has one. Each
 exits straight after.
+
+Bare `preview` chooses the safest lifecycle for its caller: it stays in the
+foreground in a human interactive terminal, while a non-interactive or agent
+shell starts a managed background preview. Re-running the command for the same
+project reuses the healthy preview. Every start or status result includes the
+exact Studio project URL as well as the underlying server URL, so agents can
+hand off the intended project without guessing from the port.
 
 To read a running Studio from a script: `--selection` prints the selected
 element and `--context` prints the agent-readable context, both with `--json`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,10 +33,32 @@ Start the live preview studio in your browser:
 
 ```bash
 npx hyperframes preview
-# Studio running at http://localhost:3002
+# Studio: http://localhost:3002/#project/my-video
+# Server: http://localhost:3002
 
 npx hyperframes preview --port 4567
 ```
+
+In an interactive terminal, the preview stays attached until you press
+Ctrl+C. In a non-interactive shell such as a coding-agent session, the same
+command starts a managed preview that survives after the command returns. Use
+`--background` or `--foreground` to choose explicitly, and manage persistent
+previews with `--status`, `--stop`, `--list`, and `--kill-all`. Add `--json` to
+managed lifecycle commands for machine-readable output. `--foreground --json`
+prints the ready-session envelope once, then remains attached until stopped.
+
+### `normalize-audio`
+
+Measure two local authored audio clips with integrated LUFS and match the target
+to the unchanged reference. The command is a dry run unless `--write` is passed:
+
+```bash
+npx hyperframes normalize-audio --reference target-audio --target user-audio
+npx hyperframes normalize-audio --reference target-audio --target user-audio --write
+```
+
+It updates only the target element's `data-volume` and refuses unsafe boosts
+that exceed Studio's +12 dB ceiling or would clip.
 
 ### `render`
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -134,6 +134,7 @@ const commandLoaders = {
   lint: () => import("./commands/lint.js").then((m) => m.default),
   check: () => import("./commands/check.js").then((m) => m.default),
   beats: () => import("./commands/beats.js").then((m) => m.default),
+  "normalize-audio": () => import("./commands/normalize-audio.js").then((m) => m.default),
   inspect: () => import("./commands/inspect.js").then((m) => m.default),
   keyframes: () => import("./commands/keyframes.js").then((m) => m.default),
   layout: () => import("./commands/layout.js").then((m) => m.default),

--- a/packages/cli/src/commands/coreSkillContent.test.ts
+++ b/packages/cli/src/commands/coreSkillContent.test.ts
@@ -125,4 +125,15 @@ describe("media treatment routing documentation", () => {
       expect(template).toContain("do not improvise equivalent CSS/SVG filters or overlays");
     }
   });
+
+  it("gives agents a process-owned preview lifecycle in new project instructions", () => {
+    for (const file of ["AGENTS.md", "CLAUDE.md"]) {
+      const template = read("packages", "cli", "src", "templates", "_shared", file);
+      expect(template).toContain("npx hyperframes preview --background");
+      expect(template).toContain("npx hyperframes preview --status");
+      expect(template).toContain("npx hyperframes preview --stop");
+      expect(template).toContain("leaving refreshes at `ERR_CONNECTION_TIMED_OUT`");
+      expect(template).not.toContain("run_in_background: true");
+    }
+  });
 });

--- a/packages/cli/src/commands/normalize-audio.test.ts
+++ b/packages/cli/src/commands/normalize-audio.test.ts
@@ -1,0 +1,133 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  audioNormalizationPlan,
+  audioTags,
+  parseEbur128Summary,
+  resolveLocalAudioPath,
+  updateAudioVolume,
+} from "./normalize-audio.js";
+
+const PROJECT = "/tmp/example-project";
+
+describe("audioTags", () => {
+  it("reads quoted attributes without treating a quoted > as the end of the tag", () => {
+    const html = `<audio id='reference' title="a > b" src="assets/ref.mp4" data-volume="1"></audio>`;
+    expect(audioTags(html)).toEqual([
+      expect.objectContaining({ id: "reference", src: "assets/ref.mp4", volume: 1 }),
+    ]);
+  });
+
+  it("rejects duplicate ids instead of normalizing an arbitrary element", () => {
+    const html = `<audio id="voice" src="a.wav"></audio><audio id="voice" src="b.wav"></audio>`;
+    expect(() => audioTags(html)).toThrow(/duplicate audio id "voice"/i);
+  });
+
+  it("ignores audio-like text in comments, scripts, and styles", () => {
+    const html = `
+      <!-- <audio id="comment" src="comment.wav"></audio> -->
+      <script>const example = '<audio id="script" src="script.wav"></audio>';</script>
+      <style>.demo::after { content: '<audio id="style" src="style.wav">'; }</style>
+      <audio id="real" src="real.wav"></audio>
+    `;
+    expect(audioTags(html).map((tag) => tag.id)).toEqual(["real"]);
+  });
+
+  it.each([
+    [`<audio id="bad" src="a.wav" data-volume="loud"></audio>`, /data-volume/i],
+    [`<audio id="bad" src="a.wav" data-media-start="-1"></audio>`, /data-media-start/i],
+    [`<audio id="bad" src="a.wav" data-duration="0"></audio>`, /data-duration/i],
+  ])("rejects an invalid authored number", (html, expected) => {
+    expect(() => audioTags(html)).toThrow(expected);
+  });
+});
+
+describe("resolveLocalAudioPath", () => {
+  it("resolves a local source and strips query and fragment suffixes", () => {
+    expect(resolveLocalAudioPath(PROJECT, "assets/voice%20one.wav?v=2#clip")).toBe(
+      resolve(PROJECT, "assets/voice one.wav"),
+    );
+  });
+
+  it.each(["https://cdn.example.com/a.wav", "/etc/passwd", "../outside.wav", "data:x"])(
+    "rejects a non-project source: %s",
+    (src) => expect(() => resolveLocalAudioPath(PROJECT, src)).toThrow(/local project file/i),
+  );
+});
+
+describe("parseEbur128Summary", () => {
+  it("takes the final integrated loudness and true-peak summary", () => {
+    const stderr = `
+[Parsed_ebur128_0] t: 1.0 I: -18.2 LUFS
+[Parsed_ebur128_0] Summary:
+  Integrated loudness:
+    I:         -15.5 LUFS
+    Threshold: -25.5 LUFS
+  True peak:
+    Peak:       -3.2 dBFS
+`;
+    expect(parseEbur128Summary(stderr)).toEqual({ integratedLufs: -15.5, truePeakDbfs: -3.2 });
+  });
+
+  it("fails when FFmpeg did not produce a usable summary", () => {
+    expect(() => parseEbur128Summary("no audio stream")).toThrow(/integrated loudness/i);
+  });
+});
+
+describe("audioNormalizationPlan", () => {
+  it("preserves the reference and attenuates the louder target", () => {
+    const plan = audioNormalizationPlan(
+      { id: "target-audio", volume: 1, integratedLufs: -15.5, truePeakDbfs: -3.2 },
+      { id: "user-audio", volume: 1, integratedLufs: -11.7, truePeakDbfs: -0.2 },
+    );
+
+    expect(plan.gainDb).toBeCloseTo(-3.8, 6);
+    expect(plan.volume).toBeCloseTo(0.645654, 5);
+    expect(plan.projectedLufs).toBeCloseTo(-15.5, 6);
+    expect(plan.projectedTruePeakDbfs).toBeCloseTo(-4, 6);
+  });
+
+  it("includes the reference's authored gain in the target", () => {
+    const plan = audioNormalizationPlan(
+      { id: "reference", volume: 2, integratedLufs: -20, truePeakDbfs: -8 },
+      { id: "target", volume: 0.5, integratedLufs: -18, truePeakDbfs: -6 },
+    );
+
+    expect(plan.referenceLufs).toBeCloseTo(-13.9794, 4);
+    expect(plan.volume).toBeCloseTo(1.588656, 6);
+    expect(plan.projectedLufs).toBeCloseTo(plan.referenceLufs, 6);
+  });
+
+  it("refuses a gain beyond Studio's +12 dB ceiling", () => {
+    expect(() =>
+      audioNormalizationPlan(
+        { id: "reference", volume: 1, integratedLufs: -5, truePeakDbfs: -1 },
+        { id: "target", volume: 1, integratedLufs: -30, truePeakDbfs: -30 },
+      ),
+    ).toThrow(/\+12 dB/i);
+  });
+
+  it("refuses a boost that would clip", () => {
+    expect(() =>
+      audioNormalizationPlan(
+        { id: "reference", volume: 1, integratedLufs: -10, truePeakDbfs: -1 },
+        { id: "target", volume: 1, integratedLufs: -15, truePeakDbfs: -2 },
+      ),
+    ).toThrow(/clip/i);
+  });
+});
+
+describe("updateAudioVolume", () => {
+  it("updates only the selected audio element and preserves surrounding source", () => {
+    const html = `<!doctype html>\n<audio id="ref" src="a.wav" data-volume="1"></audio>\n<audio data-volume='1' id='target' src='b.wav'></audio>\n`;
+    expect(updateAudioVolume(html, "target", 0.645654)).toBe(
+      `<!doctype html>\n<audio id="ref" src="a.wav" data-volume="1"></audio>\n<audio data-volume='0.645654' id='target' src='b.wav'></audio>\n`,
+    );
+  });
+
+  it("adds data-volume when it is absent", () => {
+    expect(updateAudioVolume(`<audio id="target" src="b.wav" />`, "target", 2)).toBe(
+      `<audio id="target" src="b.wav" data-volume="2" />`,
+    );
+  });
+});

--- a/packages/cli/src/commands/normalize-audio.ts
+++ b/packages/cli/src/commands/normalize-audio.ts
@@ -1,0 +1,546 @@
+import { execFile } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+import { MAX_AUDIO_GAIN_DB } from "@hyperframes/core/audio-gain";
+import { findFfBinary } from "@hyperframes/parsers/ff-binaries";
+import { defineCommand } from "citty";
+import { c } from "../ui/colors.js";
+import { resolveProject } from "../utils/project.js";
+import { failCommand } from "../utils/commandResult.js";
+import type { Example } from "./_examples.js";
+
+const execFileAsync = promisify(execFile);
+const FFMPEG_TIMEOUT_MS = 120_000;
+const DEFAULT_TOLERANCE_LU = 0.5;
+
+interface AttributeSpan {
+  value: string;
+  valueStart: number;
+  valueEnd: number;
+}
+
+interface TagRange {
+  start: number;
+  end: number;
+}
+
+interface ParsedStartTag extends TagRange {
+  closing: boolean;
+  name: string;
+}
+
+interface ScanResult {
+  cursor: number;
+  audioRange: TagRange | null;
+}
+
+export interface AudioTag {
+  id: string;
+  src: string;
+  volume: number;
+  mediaStart: number;
+  duration: number | null;
+  start: number;
+  end: number;
+  volumeAttribute: AttributeSpan | null;
+}
+
+export interface LoudnessMeasurement {
+  integratedLufs: number;
+  truePeakDbfs: number;
+}
+
+export interface NormalizationTrack extends LoudnessMeasurement {
+  id: string;
+  volume: number;
+}
+
+export interface AudioNormalizationPlan {
+  referenceId: string;
+  targetId: string;
+  referenceLufs: number;
+  targetLufs: number;
+  previousVolume: number;
+  volume: number;
+  gainDb: number;
+  changeDb: number;
+  projectedLufs: number;
+  projectedTruePeakDbfs: number;
+}
+
+function authoredNumber(
+  raw: string | undefined,
+  fallback: number,
+  attribute: string,
+  id: string,
+  strictlyPositive = false,
+): number {
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || (strictlyPositive ? value <= 0 : value < 0)) {
+    throw new Error(`Audio #${id} has an invalid ${attribute}: ${raw}`);
+  }
+  return value;
+}
+
+function attributeFromMatch(
+  match: RegExpMatchArray,
+  absoluteOffset: number,
+): [string, AttributeSpan] | null {
+  if (match.index === undefined) return null;
+  const name = match[1]?.toLowerCase();
+  const value = matchedAttributeValue(match);
+  if (!name || value === undefined) return null;
+
+  const whole = match[0];
+  const localValueStart = attributeValueStart(whole);
+  const valueStart = absoluteOffset + match.index + localValueStart;
+  return [name, { value, valueStart, valueEnd: valueStart + value.length }];
+}
+
+function matchedAttributeValue(match: RegExpMatchArray): string | undefined {
+  return match[2] ?? match[3] ?? match[4];
+}
+
+function attributeValueStart(attribute: string): number {
+  let cursor = attribute.indexOf("=") + 1;
+  while (/\s/.test(attribute[cursor] ?? "")) cursor += 1;
+  const quote = attribute[cursor];
+  return quote === '"' || quote === "'" ? cursor + 1 : cursor;
+}
+
+function attributesInTag(html: string, from: number, to: number): Map<string, AttributeSpan> {
+  const tag = html.slice(from, to);
+  const nameEnd = tag.search(/\s|\/?\s*>/);
+  const attributes = new Map<string, AttributeSpan>();
+  if (nameEnd < 0) return attributes;
+
+  const pattern = /([^\s=/>]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
+  for (const match of tag.slice(nameEnd).matchAll(pattern)) {
+    const attribute = attributeFromMatch(match, from + nameEnd);
+    if (attribute) attributes.set(...attribute);
+  }
+  return attributes;
+}
+
+function startTagEnd(html: string, start: number): number {
+  let quote = "";
+  let end = start + 1;
+  for (; end < html.length; end += 1) {
+    const char = html[end];
+    if (quote) {
+      if (char === quote) quote = "";
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ">") {
+      return end + 1;
+    }
+  }
+  throw new Error("Unterminated HTML start tag");
+}
+
+function commentEnd(html: string, start: number): number {
+  const end = html.indexOf("-->", start + 4);
+  if (end < 0) throw new Error("Unterminated HTML comment");
+  return end + 3;
+}
+
+function parsedStartTag(html: string, start: number): ParsedStartTag | null {
+  const match = html.slice(start).match(/^<\s*(\/?)\s*([a-z][a-z\d:-]*)\b/i);
+  if (!match) return null;
+  return {
+    start,
+    end: startTagEnd(html, start),
+    closing: match[1] === "/",
+    name: match[2]?.toLowerCase() ?? "",
+  };
+}
+
+function rawTextElementEnd(html: string, lower: string, tag: ParsedStartTag): number | null {
+  if (tag.closing || (tag.name !== "script" && tag.name !== "style")) return null;
+  const closeStart = lower.indexOf(`</${tag.name}`, tag.end);
+  if (closeStart < 0) throw new Error(`Unterminated <${tag.name}> element`);
+  return startTagEnd(html, closeStart);
+}
+
+function scanMarkup(html: string, lower: string, start: number): ScanResult {
+  if (html.startsWith("<!--", start)) {
+    return { cursor: commentEnd(html, start), audioRange: null };
+  }
+  const tag = parsedStartTag(html, start);
+  if (!tag) {
+    const marker = html[start + 1];
+    const cursor = marker === "!" || marker === "?" ? startTagEnd(html, start) : start + 1;
+    return { cursor, audioRange: null };
+  }
+  const rawTextEnd = rawTextElementEnd(html, lower, tag);
+  if (rawTextEnd !== null) return { cursor: rawTextEnd, audioRange: null };
+  const audioRange = !tag.closing && tag.name === "audio" ? { start, end: tag.end } : null;
+  return { cursor: tag.end, audioRange };
+}
+
+function audioTagRanges(html: string): TagRange[] {
+  const lower = html.toLowerCase();
+  const ranges: TagRange[] = [];
+  let cursor = 0;
+  while (cursor < html.length) {
+    const start = html.indexOf("<", cursor);
+    if (start < 0) break;
+    const scanned = scanMarkup(html, lower, start);
+    if (scanned.audioRange) ranges.push(scanned.audioRange);
+    cursor = scanned.cursor;
+  }
+  return ranges;
+}
+
+function trimmedAttribute(attributes: Map<string, AttributeSpan>, name: string): string {
+  return attributes.get(name)?.value.trim() ?? "";
+}
+
+function authoredDuration(attributes: Map<string, AttributeSpan>, id: string): number | null {
+  const raw = attributes.get("data-duration")?.value;
+  if (raw === undefined) return null;
+  return authoredNumber(raw, 0, "data-duration", id, true);
+}
+
+function requiredAudioIdentity(attributes: Map<string, AttributeSpan>) {
+  const id = trimmedAttribute(attributes, "id");
+  const src = trimmedAttribute(attributes, "src");
+  if (!id) throw new Error("Every normalized <audio> element needs an id");
+  if (!src) throw new Error(`Audio #${id} has no src`);
+  return { id, src };
+}
+
+function audioTagFromRange(html: string, range: TagRange): AudioTag {
+  const attributes = attributesInTag(html, range.start, range.end);
+  const { id, src } = requiredAudioIdentity(attributes);
+  const volumeAttribute = attributes.get("data-volume") ?? null;
+  return {
+    id,
+    src,
+    volume: authoredNumber(volumeAttribute?.value, 1, "data-volume", id),
+    mediaStart: authoredNumber(
+      attributes.get("data-media-start")?.value,
+      0,
+      "data-media-start",
+      id,
+    ),
+    duration: authoredDuration(attributes, id),
+    start: range.start,
+    end: range.end,
+    volumeAttribute,
+  };
+}
+
+/** Read the authored audio clips without reserializing the composition. */
+export function audioTags(html: string): AudioTag[] {
+  const seen = new Set<string>();
+  const tags: AudioTag[] = [];
+  for (const range of audioTagRanges(html)) {
+    const tag = audioTagFromRange(html, range);
+    if (seen.has(tag.id)) throw new Error(`Duplicate audio id "${tag.id}"`);
+    seen.add(tag.id);
+    tags.push(tag);
+  }
+  return tags;
+}
+
+/** Resolve only a file contained by the project. Remote and traversal sources are not measured. */
+export function resolveLocalAudioPath(projectDir: string, src: string): string {
+  const withoutSuffix = src.split(/[?#]/, 1)[0] ?? "";
+  let decoded = "";
+  try {
+    decoded = decodeURIComponent(withoutSuffix);
+  } catch {
+    throw new Error(`Audio source must be a local project file: ${src}`);
+  }
+  if (!decoded || isAbsolute(decoded) || /^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(decoded)) {
+    throw new Error(`Audio source must be a local project file: ${src}`);
+  }
+  const root = resolve(projectDir);
+  const file = resolve(root, decoded);
+  const rel = relative(root, file);
+  if (!rel || rel === ".." || rel.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`)) {
+    throw new Error(`Audio source must be a local project file: ${src}`);
+  }
+  return file;
+}
+
+/** Parse FFmpeg's final EBU R128 summary, not its per-window log lines. */
+export function parseEbur128Summary(stderr: string): LoudnessMeasurement {
+  const summaryAt = stderr.lastIndexOf("Summary:");
+  const summary = summaryAt >= 0 ? stderr.slice(summaryAt) : "";
+  const integrated = summary.match(/\bI:\s*(-?\d+(?:\.\d+)?)\s+LUFS\b/);
+  const peak = summary.match(/\bPeak:\s*(-?\d+(?:\.\d+)?)\s+dBFS\b/);
+  const integratedLufs = Number(integrated?.[1]);
+  const truePeakDbfs = Number(peak?.[1]);
+  if (!Number.isFinite(integratedLufs)) {
+    throw new Error("FFmpeg did not report integrated loudness for this audio stream");
+  }
+  if (!Number.isFinite(truePeakDbfs)) {
+    throw new Error("FFmpeg did not report true peak for this audio stream");
+  }
+  return { integratedLufs, truePeakDbfs };
+}
+
+function gainDb(volume: number): number {
+  return volume > 0 ? 20 * Math.log10(volume) : Number.NEGATIVE_INFINITY;
+}
+
+/** Calculate the target's absolute authored gain while keeping the reference unchanged. */
+export function audioNormalizationPlan(
+  referenceTrack: NormalizationTrack,
+  targetTrack: NormalizationTrack,
+): AudioNormalizationPlan {
+  if (!(referenceTrack.volume > 0) || !(targetTrack.volume > 0)) {
+    throw new Error("Muted audio cannot be used for loudness matching");
+  }
+  const referenceLufs = referenceTrack.integratedLufs + gainDb(referenceTrack.volume);
+  const targetLufs = targetTrack.integratedLufs + gainDb(targetTrack.volume);
+  const wantedGainDb = referenceLufs - targetTrack.integratedLufs;
+  if (wantedGainDb > MAX_AUDIO_GAIN_DB + 1e-9) {
+    throw new Error(
+      `Matching #${targetTrack.id} needs ${wantedGainDb.toFixed(1)} dB, beyond Studio's +${MAX_AUDIO_GAIN_DB} dB ceiling`,
+    );
+  }
+  const volume = 10 ** (wantedGainDb / 20);
+  const projectedTruePeakDbfs = targetTrack.truePeakDbfs + wantedGainDb;
+  if (projectedTruePeakDbfs > 0) {
+    throw new Error(
+      `Matching #${targetTrack.id} would clip at +${projectedTruePeakDbfs.toFixed(1)} dBFS; limit or preprocess the source first`,
+    );
+  }
+  return {
+    referenceId: referenceTrack.id,
+    targetId: targetTrack.id,
+    referenceLufs,
+    targetLufs,
+    previousVolume: targetTrack.volume,
+    volume,
+    gainDb: wantedGainDb,
+    changeDb: wantedGainDb - gainDb(targetTrack.volume),
+    projectedLufs: targetTrack.integratedLufs + wantedGainDb,
+    projectedTruePeakDbfs,
+  };
+}
+
+function serializedVolume(volume: number): string {
+  return volume.toFixed(6).replace(/\.?0+$/, "");
+}
+
+/** Patch one authored attribute in place so scripts/styles/comments remain byte-stable. */
+export function updateAudioVolume(html: string, id: string, volume: number): string {
+  const tag = audioTags(html).find((candidate) => candidate.id === id);
+  if (!tag) throw new Error(`Audio #${id} was not found`);
+  const value = serializedVolume(volume);
+  if (tag.volumeAttribute) {
+    return (
+      html.slice(0, tag.volumeAttribute.valueStart) +
+      value +
+      html.slice(tag.volumeAttribute.valueEnd)
+    );
+  }
+
+  let insertion = tag.end - 1;
+  let tail = insertion - 1;
+  while (tail >= tag.start && /\s/.test(html[tail] ?? "")) tail -= 1;
+  if (html[tail] === "/") {
+    insertion = tail;
+    while (insertion > tag.start && /\s/.test(html[insertion - 1] ?? "")) insertion -= 1;
+  } else {
+    while (insertion > tag.start && /\s/.test(html[insertion - 1] ?? "")) insertion -= 1;
+  }
+  return html.slice(0, insertion) + ` data-volume="${value}"` + html.slice(insertion);
+}
+
+async function measureAudio(
+  ffmpegPath: string,
+  file: string,
+  tag: Pick<AudioTag, "mediaStart" | "duration">,
+): Promise<LoudnessMeasurement> {
+  const args = ["-hide_banner", "-nostats", "-i", file];
+  if (tag.mediaStart > 0) args.push("-ss", String(tag.mediaStart));
+  if (tag.duration !== null && tag.duration > 0) args.push("-t", String(tag.duration));
+  args.push("-map", "0:a:0", "-vn", "-af", "ebur128=peak=true", "-f", "null", "-");
+  const result = await execFileAsync(ffmpegPath, args, {
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: FFMPEG_TIMEOUT_MS,
+  });
+  return parseEbur128Summary(result.stderr);
+}
+
+function fail(message: string): never {
+  console.error(c.error(message));
+  failCommand();
+}
+
+function byId(tags: readonly AudioTag[], rawId: string, role: string): AudioTag {
+  const id = rawId.trim().replace(/^#/, "");
+  const tag = tags.find((candidate) => candidate.id === id);
+  if (!tag) throw new Error(`${role} audio #${id} was not found`);
+  return tag;
+}
+
+interface NormalizeAudioOptions {
+  dir?: string;
+  reference: string;
+  target: string;
+  tolerance: string;
+  write: boolean;
+}
+
+interface NormalizeAudioResult extends AudioNormalizationPlan {
+  ok: true;
+  wrote: boolean;
+  withinTolerance: boolean;
+  tolerance: number;
+  indexPath: string;
+}
+
+function selectedTags(html: string, referenceId: string, targetId: string) {
+  const tags = audioTags(html);
+  const referenceTag = byId(tags, referenceId, "Reference");
+  const targetTag = byId(tags, targetId, "Target");
+  if (referenceTag.id === targetTag.id) {
+    throw new Error("Reference and target must be different audio elements");
+  }
+  return { referenceTag, targetTag };
+}
+
+function requiredFfmpeg(): string {
+  const ffmpegPath = findFfBinary("ffmpeg", { configuredMustExist: true });
+  if (!ffmpegPath) throw new Error("FFmpeg is required to measure integrated loudness");
+  return ffmpegPath;
+}
+
+function existingAudioFile(projectDir: string, tag: AudioTag): string {
+  const file = resolveLocalAudioPath(projectDir, tag.src);
+  if (!existsSync(file)) {
+    throw new Error(`Audio #${tag.id} file was not found: ${relative(projectDir, file)}`);
+  }
+  return file;
+}
+
+async function measuredPlan(
+  projectDir: string,
+  referenceTag: AudioTag,
+  targetTag: AudioTag,
+): Promise<AudioNormalizationPlan> {
+  const ffmpegPath = requiredFfmpeg();
+  const referenceFile = existingAudioFile(projectDir, referenceTag);
+  const targetFile = existingAudioFile(projectDir, targetTag);
+  const [referenceMeasurement, targetMeasurement] = await Promise.all([
+    measureAudio(ffmpegPath, referenceFile, referenceTag),
+    measureAudio(ffmpegPath, targetFile, targetTag),
+  ]);
+  return audioNormalizationPlan(
+    { id: referenceTag.id, volume: referenceTag.volume, ...referenceMeasurement },
+    { id: targetTag.id, volume: targetTag.volume, ...targetMeasurement },
+  );
+}
+
+function parsedTolerance(raw: string): number {
+  const tolerance = Number(raw);
+  if (!Number.isFinite(tolerance) || tolerance < 0) {
+    throw new Error("--tolerance must be a non-negative number");
+  }
+  return tolerance;
+}
+
+async function normalizeAudio(options: NormalizeAudioOptions): Promise<NormalizeAudioResult> {
+  const project = resolveProject(options.dir);
+  const html = readFileSync(project.indexPath, "utf8");
+  const { referenceTag, targetTag } = selectedTags(html, options.reference, options.target);
+  const plan = await measuredPlan(project.dir, referenceTag, targetTag);
+  const tolerance = parsedTolerance(options.tolerance);
+  const withinTolerance = Math.abs(plan.referenceLufs - plan.targetLufs) <= tolerance;
+  const wrote = options.write && !withinTolerance;
+  if (wrote) writeFileSync(project.indexPath, updateAudioVolume(html, targetTag.id, plan.volume));
+  return { ok: true, wrote, withinTolerance, tolerance, indexPath: project.indexPath, ...plan };
+}
+
+function printHumanResult(result: NormalizeAudioResult): void {
+  console.log(
+    `${c.bold(`#${result.referenceId}`)} ${result.referenceLufs.toFixed(1)} LUFS → ` +
+      `${c.bold(`#${result.targetId}`)} ${result.targetLufs.toFixed(1)} LUFS`,
+  );
+  if (result.withinTolerance) {
+    console.log(
+      c.success(`Already matched within ${result.tolerance.toFixed(1)} LU; no change needed.`),
+    );
+    return;
+  }
+
+  console.log(
+    `Set #${result.targetId} data-volume ${result.previousVolume.toFixed(3)} → ${result.volume.toFixed(6)} ` +
+      `(${result.changeDb >= 0 ? "+" : ""}${result.changeDb.toFixed(1)} dB).`,
+  );
+  console.log(
+    result.wrote
+      ? c.success(`Updated ${relative(process.cwd(), result.indexPath) || "index.html"}.`)
+      : c.dim("Dry run only. Pass --write to persist this gain."),
+  );
+}
+
+export const examples: Example[] = [
+  [
+    "Measure two authored clips and preview the matching gain",
+    "hyperframes normalize-audio --reference target-audio --target user-audio",
+  ],
+  [
+    "Persist the measured gain into index.html",
+    "hyperframes normalize-audio --reference target-audio --target user-audio --write",
+  ],
+];
+
+export default defineCommand({
+  meta: {
+    name: "normalize-audio",
+    description: "Match one local audio clip to another using integrated LUFS",
+  },
+  args: {
+    dir: { type: "positional", description: "Project directory", required: false },
+    reference: {
+      type: "string",
+      description: "Audio element id whose effective loudness should be preserved",
+      required: true,
+    },
+    target: {
+      type: "string",
+      description: "Audio element id whose data-volume should be matched",
+      required: true,
+    },
+    write: {
+      type: "boolean",
+      description: "Persist the measured target gain into index.html",
+      default: false,
+    },
+    tolerance: {
+      type: "string",
+      description: `Skip writes within this many LU (default ${DEFAULT_TOLERANCE_LU})`,
+      default: String(DEFAULT_TOLERANCE_LU),
+    },
+    json: { type: "boolean", description: "Print machine-readable output", default: false },
+  },
+  async run({ args }) {
+    try {
+      const result = await normalizeAudio({
+        dir: args.dir,
+        reference: args.reference,
+        target: args.target,
+        tolerance: args.tolerance,
+        write: args.write,
+      });
+      if (args.json) {
+        const { indexPath: _, ...jsonResult } = result;
+        console.log(JSON.stringify(jsonResult, null, 2));
+        return;
+      }
+      printHumanResult(result);
+    } catch (error) {
+      fail(error instanceof Error ? error.message : String(error));
+    }
+  },
+});

--- a/packages/cli/src/templates/_shared/AGENTS.md
+++ b/packages/cli/src/templates/_shared/AGENTS.md
@@ -33,7 +33,10 @@ The domain skills (`/hyperframes-core`, `/hyperframes-animation`, `/hyperframes-
 ## Commands
 
 ```bash
-npm run dev          # start the preview server (long-running — keep it alive in background)
+npm run dev          # human-operated foreground preview (blocks until stopped)
+npx hyperframes preview --background  # agent-safe persistent Studio preview
+npx hyperframes preview --status      # verify the persistent preview is listening
+npx hyperframes preview --stop        # stop it when review is finished
 npm run check        # lint + runtime + layout + motion + contrast (one command)
 npm run render       # render to MP4
 npm run publish      # publish and get a shareable link
@@ -42,9 +45,11 @@ npx hyperframes lint --json     # machine-readable output for CI
 npx hyperframes docs <topic> # reference docs in terminal
 ```
 
-> **`npm run dev` is a long-running server, not a one-shot command.** It blocks until stopped.
-> In Claude Code, always run it with `run_in_background: true`. Never run it as a foreground
-> command — it will time out and the server will die, breaking the browser preview.
+> **Agents must use `npx hyperframes preview --background` for Studio handoff.** Do not rely
+> on a shell/tool `run_in_background` wrapper around `npm run dev`: that foreground process
+> remains owned by the invoking session and can disappear while the browser stays open,
+> leaving refreshes at `ERR_CONNECTION_TIMED_OUT`. Verify with `preview --status`, keep it
+> alive through review, and stop it explicitly with `preview --stop` afterward.
 
 > **Pinned CLI version.** These scripts pin an exact `hyperframes@X.Y.Z` so this project re-renders identically over time. Weeks later that pin lags fixes shipped since. To move up: `npx hyperframes@latest upgrade --project . --check` (shows the delta), then `npx hyperframes@latest upgrade --project .` to rewrite the pins. Always unpinned — the pinned script re-runs the old version against itself.
 

--- a/packages/cli/src/templates/_shared/CLAUDE.md
+++ b/packages/cli/src/templates/_shared/CLAUDE.md
@@ -33,7 +33,10 @@ The domain skills (`/hyperframes-core`, `/hyperframes-animation`, `/hyperframes-
 ## Commands
 
 ```bash
-npm run dev          # start the preview server (long-running — keep it alive in background)
+npm run dev          # human-operated foreground preview (blocks until stopped)
+npx hyperframes preview --background  # agent-safe persistent Studio preview
+npx hyperframes preview --status      # verify the persistent preview is listening
+npx hyperframes preview --stop        # stop it when review is finished
 npm run check        # lint + runtime + layout + motion + contrast (one command)
 npm run render       # render to MP4
 npm run publish      # publish and get a shareable link
@@ -42,9 +45,11 @@ npx hyperframes lint --json     # machine-readable output for CI
 npx hyperframes docs <topic> # reference docs in terminal
 ```
 
-> **`npm run dev` is a long-running server, not a one-shot command.** It blocks until stopped.
-> In Claude Code, always run it with `run_in_background: true`. Never run it as a foreground
-> command — it will time out and the server will die, breaking the browser preview.
+> **Agents must use `npx hyperframes preview --background` for Studio handoff.** Do not rely
+> on a shell/tool `run_in_background` wrapper around `npm run dev`: that foreground process
+> remains owned by the invoking session and can disappear while the browser stays open,
+> leaving refreshes at `ERR_CONNECTION_TIMED_OUT`. Verify with `preview --status`, keep it
+> alive through review, and stop it explicitly with `preview --stop` afterward.
 
 > **Pinned CLI version.** These scripts pin an exact `hyperframes@X.Y.Z` so this project re-renders identically over time. Weeks later that pin lags fixes shipped since. To move up: `npx hyperframes@latest upgrade --project . --check` (shows the delta), then `npx hyperframes@latest upgrade --project .` to rewrite the pins. Always unpinned — the pinned script re-runs the old version against itself.
 

--- a/packages/cli/src/utils/studioProxyEnv.test.ts
+++ b/packages/cli/src/utils/studioProxyEnv.test.ts
@@ -12,4 +12,22 @@ describe("studioProxyEnv", () => {
       HYPERFRAMES_AUTO_PROXY: "false",
     });
   });
+
+  it("identifies a detached Vite preview to the lifecycle scanner", () => {
+    expect(
+      studioProxyEnv(
+        true,
+        { KEEP: "yes" },
+        {
+          projectDir: "/tmp/video",
+          projectName: "video",
+          browserGpuMode: "software",
+        },
+      ),
+    ).toMatchObject({
+      HYPERFRAMES_PREVIEW_PROJECT_DIR: "/tmp/video",
+      HYPERFRAMES_PREVIEW_PROJECT_NAME: "video",
+      HYPERFRAMES_PREVIEW_BROWSER_GPU_MODE: "software",
+    });
+  });
 });

--- a/packages/cli/src/utils/studioProxyEnv.ts
+++ b/packages/cli/src/utils/studioProxyEnv.ts
@@ -1,9 +1,23 @@
 export function studioProxyEnv(
   autoProxy: boolean,
   baseEnv: NodeJS.ProcessEnv = process.env,
+  preview?: {
+    projectDir: string;
+    projectName: string;
+    browserGpuMode?: "auto" | "hardware" | "software";
+  },
 ): NodeJS.ProcessEnv {
   return {
     ...baseEnv,
     HYPERFRAMES_AUTO_PROXY: autoProxy ? "true" : "false",
+    ...(preview
+      ? {
+          HYPERFRAMES_PREVIEW_PROJECT_DIR: preview.projectDir,
+          HYPERFRAMES_PREVIEW_PROJECT_NAME: preview.projectName,
+          ...(preview.browserGpuMode
+            ? { HYPERFRAMES_PREVIEW_BROWSER_GPU_MODE: preview.browserGpuMode }
+            : {}),
+        }
+      : {}),
   };
 }

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -3159,7 +3159,7 @@ export function initSandboxRuntimeModular(): void {
         if (!(el instanceof HTMLMediaElement)) continue;
         const parsed = parseFloat(el.dataset.volume ?? "");
         const clipVolume = Number.isFinite(parsed) ? parsed : 1;
-        el.volume = clipVolume * volume;
+        el.volume = Math.max(0, Math.min(1, clipVolume * volume));
       }
     },
     onSetMediaOutputMuted: (muted) => {

--- a/packages/core/src/runtime/media.test.ts
+++ b/packages/core/src/runtime/media.test.ts
@@ -436,6 +436,27 @@ describe("syncRuntimeMedia", () => {
       expect(only).toBeCloseTo(0.55, 5);
     });
 
+    it("sends boosted author gain to Web Audio while keeping the native element legal", () => {
+      const clip = createMockClip({ start: 0, end: 10, volume: 3.98 });
+      Object.defineProperty(clip.el, "readyState", { value: 4, writable: true });
+      let transportGain = -1;
+
+      syncRuntimeMedia({
+        clips: [clip],
+        timeSeconds: 1,
+        playing: true,
+        playbackRate: 1,
+        // Third arg is the authored gain, which is the one the transport wants;
+        // the second is the element's, which the spec pins to [0,1].
+        onElementVolume: (_el, _effectiveVolume, authorVolume) => {
+          transportGain = authorVolume;
+        },
+      });
+
+      expect(transportGain).toBeCloseTo(3.98, 5);
+      expect(clip.el.volume).toBe(1);
+    });
+
     /**
      * The render bakes the lane at CLIP-LOCAL time: prepareAudioTrack already
      * cut the wav with `-ss mediaStart`, so its t=0 is the clip's start, and

--- a/packages/core/src/runtime/webAudioTransport.test.ts
+++ b/packages/core/src/runtime/webAudioTransport.test.ts
@@ -306,6 +306,15 @@ describe("WebAudioTransport", () => {
   });
 
   describe("schedulePlayback timing", () => {
+    it("keeps author boost above unity on the per-element gain node", async () => {
+      const { transport, mock, gen } = setupTransport(100);
+
+      await transport.schedulePlayback(mockEl, mockBuffer, 0, 0, 0, 1, gen);
+      transport.setElementVolume(mockEl, 3.98);
+
+      expect(mock.gainNode.gain.value).toBeCloseTo(3.98, 5);
+    });
+
     it("starts in-progress clips immediately with correct buffer offset", async () => {
       const { transport, mock, gen } = setupTransport(100);
 

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { readNodeRequestBody } from "./vite.request-body.js";
 import { watch } from "chokidar";
 import { createViteAdapter } from "./vite.adapter";
+import { previewConfigPayload } from "./vite.preview-config";
 
 async function loadRuntimeSourceForDev(
   server: import("vite").ViteDevServer,
@@ -83,6 +84,14 @@ function devProjectApi(): Plugin {
         }
         return _api;
       };
+
+      server.middlewares.use((req, res, next) => {
+        if (req.url !== "/__hyperframes_config") return next();
+        const payload = previewConfigPayload(process.env, process.pid, studioPkg.version);
+        if (!payload) return next();
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+        res.end(JSON.stringify(payload));
+      });
 
       // Runtime endpoint — prefer source build over dist artifact
       server.middlewares.use((req, res, next) => {

--- a/packages/studio/vite.preview-config.test.ts
+++ b/packages/studio/vite.preview-config.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { previewConfigPayload } from "./vite.preview-config";
+
+describe("previewConfigPayload", () => {
+  it("identifies a detached Vite preview to the CLI lifecycle scanner", () => {
+    expect(
+      previewConfigPayload(
+        {
+          HYPERFRAMES_PREVIEW_PROJECT_DIR: "/tmp/video",
+          HYPERFRAMES_PREVIEW_PROJECT_NAME: "video",
+          HYPERFRAMES_PREVIEW_BROWSER_GPU_MODE: "software",
+        },
+        4321,
+        "0.7.109",
+      ),
+    ).toEqual({
+      isHyperframes: true,
+      pid: 4321,
+      projectName: "video",
+      projectDir: "/tmp/video",
+      serverBuildSignature: null,
+      browserGpuMode: "software",
+      version: "0.7.109",
+    });
+  });
+
+  it("does not claim unrelated direct Vite sessions", () => {
+    expect(previewConfigPayload({})).toBeNull();
+  });
+});

--- a/packages/studio/vite.preview-config.ts
+++ b/packages/studio/vite.preview-config.ts
@@ -1,0 +1,22 @@
+export type PreviewConfigEnv = Record<string, string | undefined>;
+
+export function previewConfigPayload(
+  env: PreviewConfigEnv,
+  pid = process.pid,
+  version = "dev",
+): Record<string, unknown> | null {
+  const projectDir = env.HYPERFRAMES_PREVIEW_PROJECT_DIR;
+  const projectName = env.HYPERFRAMES_PREVIEW_PROJECT_NAME;
+  if (!projectDir || !projectName) return null;
+
+  const browserGpuMode = env.HYPERFRAMES_PREVIEW_BROWSER_GPU_MODE;
+  return {
+    isHyperframes: true,
+    pid,
+    projectName,
+    projectDir,
+    serverBuildSignature: null,
+    ...(browserGpuMode ? { browserGpuMode } : {}),
+    version,
+  };
+}

--- a/skills/faceless-explainer/SKILL.md
+++ b/skills/faceless-explainer/SKILL.md
@@ -191,7 +191,7 @@ If a command fails, surface stderr and stop — don't pile on recovery commands.
 
 After checks pass, pause for user review — the review loop's final look (`../hyperframes-core/references/review-loop.md` § 4): one question, on the Studio that has been open since Step 3 — render now, or what changes? (Autonomous: the one kept question, preview first or render.) Then deliver the MP4 with the contact sheet and the frame ids so revisions can target a single frame.
 
-Preview: `npx hyperframes preview`
+Preview: `npx hyperframes preview --background`
 
 Render only after user approval (autonomous mode: after the preview-or-render question):
 

--- a/skills/hyperframes-audio/references/diagnosis.md
+++ b/skills/hyperframes-audio/references/diagnosis.md
@@ -135,6 +135,41 @@ the ambiguity instead.
 
 ## Recipes
 
+### Compare loudness from the bytes the listener actually hears
+
+Do not call two clips equally loud because their Studio faders, waveform peaks,
+or cached asset metadata match. Those are controls and proxies, not a loudness
+measurement. Resolve the exact URLs used by preview/render, download or inspect
+those exact served bytes, and measure each decoded stream with FFmpeg's
+`ebur128` filter. Compare the integrated LUFS values.
+
+For a target loudness, the required move is:
+
+```text
+gain_db = target_lufs - measured_lufs
+linear_gain = 10 ** (gain_db / 20)
+```
+
+When both clips are local authored `<audio>` elements with stable ids, use the
+CLI instead of transcribing that arithmetic by hand:
+
+```bash
+npx hyperframes normalize-audio --reference target-audio --target user-audio
+npx hyperframes normalize-audio --reference target-audio --target user-audio --write
+```
+
+The first command is a dry run. The second writes only the target's
+`data-volume`, after accounting for both existing gains and refusing a boost
+that would clip or exceed Studio's ceiling. Always choose the reference from the
+author's stated intent; the command does not guess which clip should define the
+mix.
+
+Studio's clip-gain fader uses `0 dB` / linear gain `1` at its physical midpoint
+and provides up to `+12 dB` on the upper half. After changing gain, measure the
+served preview/render bytes again. If a listener still hears a mismatch, trust
+the report and first verify the asset URL and bytes are current; do not explain
+it away with matching peaks or a stale proxy measurement.
+
 All verified with ffmpeg 8.1.1. `-hide_banner` keeps the output readable;
 `volumedetect` prints to stderr, so do not silence it with `-v error`.
 

--- a/skills/hyperframes-cli/SKILL.md
+++ b/skills/hyperframes-cli/SKILL.md
@@ -21,7 +21,7 @@ Run commands as `npx hyperframes ...` unless project instructions provide a wrap
 4. **Get fast feedback while editing:** run `npx hyperframes lint` after the first HTML pass and after structural changes.
 5. **Run the final gate:** run `npx hyperframes check`; it reruns lint before opening the browser. Do not prepend a redundant standalone lint invocation. Add `--snapshots` for annotated overview frames and finding crops.
 6. **Inspect sub-compositions:** when `index.html` mounts `data-composition-src`, capture midpoint snapshots and inspect each mounted scene.
-7. **Open the final Studio preview:** run `npx hyperframes preview`, hand the timeline project URL to the user, and ask whether to revise or render.
+7. **Open the final Studio preview:** run `npx hyperframes preview --background`, verify the URL returns HTTP 200, hand the timeline project URL to the user, and ask whether to revise or render. Keep it alive until review ends.
 8. **Render only after approval:** use draft quality for iteration and high quality for delivery.
 9. **Verify the output:** confirm the file exists, is non-empty, and has a plausible duration.
 
@@ -45,7 +45,7 @@ npx hyperframes lint
 
 # Required final gate; includes lint.
 npx hyperframes check
-npx hyperframes preview
+npx hyperframes preview --background
 npx hyperframes render --quality high --output out.mp4
 test -s out.mp4
 ffprobe -v error -show_format out.mp4

--- a/skills/hyperframes-cli/references/preview-render.md
+++ b/skills/hyperframes-cli/references/preview-render.md
@@ -5,8 +5,10 @@ Serve, render, and share commands.
 ## preview
 
 ```bash
-npx hyperframes preview                   # serve current directory
-npx hyperframes preview --port 4567       # custom port (default 3002)
+npx hyperframes preview                   # foreground on a TTY; persistent in agent shells
+npx hyperframes preview --background      # explicit persistent session
+npx hyperframes preview --foreground --json # ready JSON, then remain attached
+npx hyperframes preview --background --port 4567 # agent-safe custom port (default 3002)
 npx hyperframes preview --selection --json # print the current Studio selection and exit
 npx hyperframes preview --context --json  # print compact agent context from Studio
 ```
@@ -19,11 +21,11 @@ When handing a project back to the user, use the Studio project URL, not the sou
 http://localhost:<port>/#project/<project-name>
 ```
 
-Use the actual port and project directory name; treat `index.html` as source-code context, not the preview surface. For example, after `npx hyperframes preview --port 3017` in `codex-openai-video`, report `http://localhost:3017/#project/codex-openai-video`.
+Use the actual port and project directory name; treat `index.html` as source-code context, not the preview surface. For example, after `npx hyperframes preview --background --port 3017` in `codex-openai-video`, report `http://localhost:3017/#project/codex-openai-video`.
 
 To land the user on the **Storyboard view** instead of the timeline, put `?view=storyboard` ahead of the hash: `http://localhost:<port>/?view=storyboard#project/<project-name>`. Hand this URL whenever the storyboard is the thing to review and nothing is assembled yet — before `index.html` exists, the timeline stage has nothing to show, so the bare project URL opens on an empty player.
 
-Two ways a handed URL turns out dead — check both before handing it back: the URL is missing its `#project/<project-name>` hash (Studio loads but has no project to open), or the server is not actually running. `preview` is a long-running process — start it from the project directory as a background task, and if that task reports it exited ("completed"), the server is down: restart it, don't hand out the link.
+Two ways a handed URL turns out dead — check both before handing it back: the URL is missing its `#project/<project-name>` hash (Studio loads but has no project to open), or the server is not actually running. Bare `preview` automatically creates a managed persistent session in a non-TTY agent shell; `--background` remains the clearest explicit form. Verify the printed URL returns HTTP 200, keep it alive for the whole review, and stop it explicitly with `npx hyperframes preview --stop` afterward. Use the printed URL as-is: HyperFrames URL-encodes project names that contain route metacharacters.
 
 ### Agent context from Studio selection
 
@@ -57,7 +59,7 @@ Failure modes:
 
 | Code                       | Meaning                                                                    |
 | -------------------------- | -------------------------------------------------------------------------- |
-| `preview-not-running`      | Start Studio first with `npx hyperframes preview`.                         |
+| `preview-not-running`      | Start Studio first with `npx hyperframes preview --background`.            |
 | `ambiguous-preview-server` | Multiple matching Studio servers are open; rerun with one listed `--port`. |
 | `preview-port-mismatch`    | The requested `--port` is not one of the matching Studio servers.          |
 | `no-selection`             | Studio is open, but the user has not selected an element yet.              |
@@ -89,7 +91,7 @@ Both `preview` and `play` can open inside an explicit Chromium-compatible browse
 
 ```bash
 # Open preview in an isolated Chromium profile
-npx hyperframes preview --browser-path /usr/bin/chromium --user-data-dir /tmp/hf-profile
+npx hyperframes preview --background --browser-path /usr/bin/chromium --user-data-dir /tmp/hf-profile
 
 # Same plus a CDP endpoint on :9222 (attach DevTools / Playwright / etc.)
 npx hyperframes play --browser-path /usr/bin/chromium --user-data-dir /tmp/hf-profile --remote-debugging-port 9222

--- a/skills/hyperframes-core/SKILL.md
+++ b/skills/hyperframes-core/SKILL.md
@@ -86,5 +86,5 @@ Use `hyperframes-cli` for command details
 
 - [ ] `npx hyperframes check` passes (0 findings across lint, runtime, layout, motion, and contrast)
 - [ ] Projects with sub-compositions: `npx hyperframes snapshot --at <midpoints>` and eyeball each frame
-- [ ] `npx hyperframes preview` for review (the user can edit anything in Studio's timeline)
+- [ ] `npx hyperframes preview --background` for review (the user can edit anything in Studio's timeline, and the server survives the invoking command)
 - [ ] `npx hyperframes render` only after the user approves

--- a/skills/hyperframes-core/references/review-loop.md
+++ b/skills/hyperframes-core/references/review-loop.md
@@ -6,7 +6,7 @@ This is the shared process for any workflow that plans on a storyboard. The cont
 
 ## § 1 — The plan, on a live board
 
-Open the **storyboard board** before presenting the plan: run `npx hyperframes preview` from the project directory in the background, confirm it is serving, and open `http://localhost:<port>/?view=storyboard#project/<project-name>`. This is an early planning surface, not the final composition preview; it may open before composition checks. The plan appears as frame cards and refreshes as work lands.
+Open the **storyboard board** before presenting the plan: run `npx hyperframes preview --background` from the project directory, confirm it is serving, and open `http://localhost:<port>/?view=storyboard#project/<project-name>`. This is an early planning surface, not the final composition preview; it may open before composition checks. The plan appears as frame cards and refreshes as work lands.
 
 Present the plan as a proposal (shape: `hyperframes-creative/references/story-spine.md` § 3): open by echoing **"This video tells [audience] that [message]"**, then the frame table — one row per frame: frame · beat (type, duration) · on screen · why (its `narrativeRole`, traced to the message). Hand the board URL with it, noting feedback lands in both places — comment on the board or reply here, one revision loop — and that a board submit still needs one reply here (anything) to get picked up.
 

--- a/skills/motion-graphics/SKILL.md
+++ b/skills/motion-graphics/SKILL.md
@@ -136,7 +136,7 @@ Choose proof times that show the opening state, signature move, and final hold. 
 Ask one question: “preview first, or render?” If the user chooses preview, open Studio and return to the same approval gate after revisions:
 
 ```bash
-(cd "$PROJECT_DIR" && npx hyperframes preview)
+(cd "$PROJECT_DIR" && npx hyperframes preview --background)
 ```
 
 Render only after an explicit render answer:

--- a/skills/product-launch-video/SKILL.md
+++ b/skills/product-launch-video/SKILL.md
@@ -220,7 +220,7 @@ If a command fails, surface stderr and stop — don't pile on recovery commands.
 
 After checks pass, pause for user review — the review loop's final look (`../hyperframes-core/references/review-loop.md` § 4): one question, on the Studio that has been open since Step 3 — render now, or what changes? (Autonomous: the one kept question, preview first or render.) Then deliver the MP4 with the contact sheet and the frame ids so revisions can target a single frame.
 
-Preview: `npx hyperframes preview`
+Preview: `npx hyperframes preview --background`
 
 Render only after user approval (autonomous mode: after the preview-or-render question):
 

--- a/skills/slideshow/SKILL.md
+++ b/skills/slideshow/SKILL.md
@@ -494,7 +494,7 @@ Studio/`preview` is useful for editing a composition, but it is not a clear fina
 {
   "scripts": {
     "dev": "npx hyperframes present ./composition",
-    "studio": "npx hyperframes preview ./composition"
+    "studio": "npx hyperframes preview ./composition --background"
   }
 }
 ```

--- a/skills/talking-head-recut/SKILL.md
+++ b/skills/talking-head-recut/SKILL.md
@@ -1204,7 +1204,7 @@ Tell the user:
 **Optional live preview (on request only).** The clip plays unchanged inside `public/index.html` with the overlays on top, so it previews faithfully. **Don't open it during the run.** When the user asks, start a long-lived server **after** render and report the URL:
 
 ```bash
-(cd "$WORK_DIR/public" && npx hyperframes preview)   # or `npx hyperframes play` for a shareable link
+(cd "$WORK_DIR/public" && npx hyperframes preview --background)   # or `npx hyperframes play` for a shareable link
 ```
 
 Do not delete the work directory unless the user asks.


### PR DESCRIPTION
## What

Fixes the two real issue families reproduced from the reported screenshots and exact saved project:

1. Studio could not author gain above unity, so a genuinely quiet clip could not be raised to match a reference.
2. Agent-launched previews could lose their foreground listener when the launcher session ended, leaving an open Studio tab pointed at a dead localhost server.

It also adds `hyperframes normalize-audio` so agents can measure two local authored clips with integrated LUFS and safely write the target clip's matched `data-volume`.

## Reproduction findings

- The original source mismatch was real: the first clip measured `-13.8 LUFS` and the second `-33.7 LUFS`.
- The later saved derivatives did not retain that direction. Before this correction, the exact saved project rendered the first clip at `-15.5 LUFS` and the second at `-11.8 LUFS`; both were authored at `data-volume="1"`, so equal fader values still did not mean equal perceived loudness.
- Browser refresh did not kill Studio. Repeated refresh exposed a listener that the agent-owned foreground process had already lost.

## How

- Added shared audio gain/dB conversion helpers and one `+12 dB` ceiling across Studio, Web Audio, runtime media, the engine mixer, and FFmpeg render.
- Converted both Studio media property panels to a nonlinear `-infinity / -60 dB ... 0 dB ... +12 dB` fader with unity at the center.
- Kept native `HTMLMediaElement.volume` clamped while applying above-unity gain through Web Audio.
- Added a detached preview lifecycle with readiness probing, per-project state/logs, custom-port discovery and reuse, stale-record cleanup, process-birth validation, and ownership-checked stop.
- Made bare preview select managed mode for non-TTY/agent sessions while retaining foreground behavior for interactive terminals.
- Added one-line JSON contracts for start/status/list/stop/kill-all and exact URL-encoded Studio deep links.
- Added `normalize-audio --reference <id> --target <id> [--write]`, which:
  - measures the exact local clip bytes and authored media ranges with FFmpeg EBU R128;
  - accounts for both clips' existing authored gains;
  - changes only the selected target's `data-volume`;
  - is dry-run by default;
  - rejects remote/out-of-project sources, malformed values, clipping, muted references, and boosts above Studio's ceiling.
- Updated CLI and installed-skill guidance for preview lifecycle and measured loudness matching.

## Exact-project correction

The private saved project was updated in place with the first clip as the reference. The second clip's `data-volume` changed from `1` to `0.645654` (`-3.8 dB`). A fresh full render measured both authored segments at `-15.5 LUFS`. Re-downloading the authoritative saved project and rerunning `normalize-audio` reports it matched within the default `0.5 LU` tolerance.

## Verification

- [x] Full CLI suite: 187 files passed, 1 skipped; 2,694 tests passed, 3 skipped.
- [x] Skills suite: 466/466 passed; manifest and skill mirrors are in sync.
- [x] CLI typecheck, Oxlint, Oxfmt, package build, tracked-artifact checks, and Fallow gate passed.
- [x] New normalizer unit suite: 19/19 passed, including parsing, path confinement, malformed authoring, clipping, gain ceiling, and source-preserving writes.
- [x] Exact corrected saved project: lint/check passed (one existing Google Fonts advisory only), full 26.922-second render completed, and both segments measured `-15.5 LUFS`.
- [x] Exact corrected saved project loaded on its real Studio route and survived 8/8 reloads with no browser errors.
- [x] Packed CLI lifecycle acceptance covered managed start/reuse/status/list/stop, foreground TTY behavior, JSON purity, custom ports, ownership adversaries, process-tree cleanup, and no remaining listener/state.

Compatibility is preserved: existing `data-volume="1"` clips remain at unity, interactive human preview remains foreground by default, and normalization never guesses which clip should define the mix.
