### PR TITLE
fix(lint): deduplicate CSS transform text in gsap_css_transform_conflict finding

### DIFF
--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -584,6 +584,12 @@ describe("GSAP rules", () => {
     const conflicts = result.findings.filter((f) => f.code === "gsap_css_transform_conflict");
     expect(conflicts).toHaveLength(1);
     expect(conflicts[0]?.message).toMatch(/x\/scale|scale\/x/);
+    // Regression: a single CSS declaration with both translate and scale must
+    // not produce doubled transform text in the message or fixHint (#3263).
+    const msg = conflicts[0]?.message ?? "";
+    const hint = conflicts[0]?.fixHint ?? "";
+    expect(msg).not.toContain("translateX(-50%) scale(0.8) translateX(-50%) scale(0.8)");
+    expect(hint).not.toContain("translateX(-50%) scale(0.8) translateX(-50%) scale(0.8)");
   });
 
   // --- Inline style transform detection tests ---

--- a/packages/lint/src/rules/gsap.ts
+++ b/packages/lint/src/rules/gsap.ts
@@ -1352,8 +1352,13 @@ export const gsapRules: LintRule<LintContext>[] = [
         const cssFromScale =
           scaleProps.length > 0 ? matchCssTransform(sel, cssScaleSelectors) : undefined;
         if (!cssFromTranslate && !cssFromScale) continue;
+        // When a single CSS declaration contains both translate and scale,
+        // both maps store the same transformVal for the same selector.
+        // Deduplicate to prevent doubled text in the finding message/fixHint.
+        const parts = [cssFromTranslate, cssFromScale].filter(Boolean);
+        const cssTransform = [...new Set(parts)].join(" ");
         const existing = conflicts.get(sel) ?? {
-          cssTransform: [cssFromTranslate, cssFromScale].filter(Boolean).join(" "),
+          cssTransform,
           props: new Set<string>(),
           raw: call.raw,
         };


### PR DESCRIPTION
## Problem

In the `gsap_css_transform_conflict` lint rule, when a **single** CSS
`transform` declaration contains both translate and scale functions
(e.g. `transform: scale(1.08) translate3d(1.5%, 0, 0)`), the rule
stores the same `transformVal` in both `cssTranslateSelectors` and
`cssScaleSelectors` for the same selector. The finding `message` and
`fixHint` then concatenate the identical string via
`[cssFromTranslate, cssFromScale].filter(Boolean).join(" ")`, producing
doubled text like:

> `".scene-1" has CSS transform: scale(1.08) translate3d(1.5%, 0, 0) scale(1.08) translate3d(1.5%, 0, 0)`

instead of the correct:

> `".scene-1" has CSS transform: scale(1.08) translate3d(1.5%, 0, 0)`

**Root cause:** `gsap.ts` line ~1356 — the join has no deduplication,
so when both maps resolve to the same value for the same selector, it
appears twice.

## Triage / Root cause

`packages/lint/src/rules/gsap.ts` — `gsap_css_transform_conflict` rule
handler. The two regex tests (`/translate/i` and `/scale/i`) both match
the same combined declaration, so both `cssTranslateSelectors` and
`cssScaleSelectors` store the identical `transformVal`. The downstream
`.filter(Boolean).join(" ")` then doubles it.

## Fix

- Deduplicate `[cssFromTranslate, cssFromScale]` via `new Set()` before
  joining into `cssTransform`.
- This is a no-op when the two values are different (separate
  translate-only and scale-only CSS declarations for the same selector)
  and corrects the doubling when they are identical.
- Added a regression test to the existing "combined CSS transform
  conflicts with multiple GSAP properties" test case that asserts the
  message and fixHint do **not** contain the doubled transform text.

## Verification

```
bun test packages/lint/src/rules/gsap.test.ts
```

162 tests pass (0 fail). The new assertion confirms no doubling:

```
expect(msg).not.toContain("translateX(-50%) scale(0.8) translateX(-50%) scale(0.8)");
expect(hint).not.toContain("translateX(-50%) scale(0.8) translateX(-50%) scale(0.8)");
```

## Notes / Risks

- Minimal change — only affects the string construction path, not the
  conflict detection logic itself.
- No existing behavior changes for the common case where translate-only
  and scale-only CSS rules are separate (the `new Set()` is a no-op
  when parts contain different values).

Closes #3263