### PR TITLE
perf: make propertyPanelColor scroll listener passive

### DIFF
--- a/packages/studio/src/components/editor/propertyPanelColor.tsx
+++ b/packages/studio/src/components/editor/propertyPanelColor.tsx
@@ -259,7 +259,7 @@ export function ColorField({
     updatePanelPosition();
     const handlePositionInvalidated = () => updatePanelPosition();
     window.addEventListener("resize", handlePositionInvalidated);
-    window.addEventListener("scroll", handlePositionInvalidated, true);
+    window.addEventListener("scroll", handlePositionInvalidated, { capture: true, passive: true });
     return () => {
       window.removeEventListener("resize", handlePositionInvalidated);
       window.removeEventListener("scroll", handlePositionInvalidated, true);


### PR DESCRIPTION
The third argument was `true` (capture only), so the browser blocks on this handler during scroll. The handler only repositions the panel — never calls preventDefault — so `{ capture: true, passive: true }` is safe and removes the scroll-blocking wait.