### PR TITLE
chore: release v0.7.110

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,35 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.7.110"
+  description="Released - 2026-08-17"
+  tags={["Release", "Catalog", "Skills", "Studio"]}
+>
+A registry the CLI cannot reach no longer empties the catalog. Search and browse now fall back to the last copy on disk, so one network timeout cannot send you off to hand-write a move you already have. When a search finds nothing that fits, the CLI hands you the command to report the gap.
+
+Studio also gains a preview volume control.
+
+## Features
+
+- **Studio:** Add a preview volume control ([fecaf72d1](https://github.com/heygen-com/hyperframes/commit/fecaf72d1f6de66224b3857efb78a2f2c44c41bc), [#3282](https://github.com/heygen-com/hyperframes/pull/3282)).
+
+## Fixes
+
+- Create temp dirs with mkdtemp, not a name built from Date.now() ([de4062a93](https://github.com/heygen-com/hyperframes/commit/de4062a93300cbe1826edfbd8d71fbc44be25cb7), [#3241](https://github.com/heygen-com/hyperframes/pull/3241)).
+
+## Docs & Examples
+
+- **Skills:** Fix anime.js v3 syntax in v4 adapter guidance ([67edb01bf](https://github.com/heygen-com/hyperframes/commit/67edb01bf4aa2f5931e838e46e14e0f51a5809ee), [#3064](https://github.com/heygen-com/hyperframes/pull/3064)).
+
+## Catalog
+
+- **Catalog:** Survive an unreachable registry, and ask for the gap ([37f8c4844](https://github.com/heygen-com/hyperframes/commit/37f8c48449d6c846788a76edf055bf2a888b7be5), [#3299](https://github.com/heygen-com/hyperframes/pull/3299)).
+- **Registry:** Add avatar promo and Slack notification templates ([b9a4dfcbe](https://github.com/heygen-com/hyperframes/commit/b9a4dfcbe56de5141b9a379ff30605cf23984d1e), [#3279](https://github.com/heygen-com/hyperframes/pull/3279)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.109...v0.7.110).
+</Update>
+
+<Update
   label="HyperFrames v0.7.109"
   description="Released - 2026-08-14"
   tags={["Release", "Engine", "Producer", "Studio"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.109",
+  "version": "0.7.110",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.7.110.md
+++ b/releases/v0.7.110.md
@@ -1,0 +1,28 @@
+# HyperFrames v0.7.110
+
+Released on 2026-08-17.
+
+A registry the CLI cannot reach no longer empties the catalog. Search and browse now fall back to the last copy on disk, so one network timeout cannot send you off to hand-write a move you already have. When a search finds nothing that fits, the CLI hands you the command to report the gap.
+
+Studio also gains a preview volume control.
+
+## Features
+
+- **Studio:** Add a preview volume control ([fecaf72d1](https://github.com/heygen-com/hyperframes/commit/fecaf72d1f6de66224b3857efb78a2f2c44c41bc), [#3282](https://github.com/heygen-com/hyperframes/pull/3282)).
+
+## Fixes
+
+- Create temp dirs with mkdtemp, not a name built from Date.now() ([de4062a93](https://github.com/heygen-com/hyperframes/commit/de4062a93300cbe1826edfbd8d71fbc44be25cb7), [#3241](https://github.com/heygen-com/hyperframes/pull/3241)).
+
+## Docs & Examples
+
+- **Skills:** Fix anime.js v3 syntax in v4 adapter guidance ([67edb01bf](https://github.com/heygen-com/hyperframes/commit/67edb01bf4aa2f5931e838e46e14e0f51a5809ee), [#3064](https://github.com/heygen-com/hyperframes/pull/3064)).
+
+## Catalog
+
+- **Catalog:** Survive an unreachable registry, and ask for the gap ([37f8c4844](https://github.com/heygen-com/hyperframes/commit/37f8c48449d6c846788a76edf055bf2a888b7be5), [#3299](https://github.com/heygen-com/hyperframes/pull/3299)).
+- **Registry:** Add avatar promo and Slack notification templates ([b9a4dfcbe](https://github.com/heygen-com/hyperframes/commit/b9a4dfcbe56de5141b9a379ff30605cf23984d1e), [#3279](https://github.com/heygen-com/hyperframes/pull/3279)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.109...v0.7.110


### PR DESCRIPTION
## What

Stable release **v0.7.110**. Bumps all 13 packages in lockstep and adds the release notes.

Merging this PR is what publishes: the workflow checks out the merge SHA, creates the `v0.7.110` tag there, publishes to npm on the `latest` dist-tag, and cuts the GitHub Release. No tag was pushed from a laptop.

## Why

Five commits have landed since v0.7.109 and none of them are released. The catalog fix in particular only reaches anyone through a published CLI, since agents run `npx hyperframes`.

## How

`bun run release:prepare 0.7.110`, twice as designed: the first run drafted `releases/v0.7.110.md` and the changelog entry and stopped for review, the second created the release commit after the summary was written.

Contents, from the generated changelog:

- **Features** — Studio preview volume control (#3282).
- **Fixes** — temp dirs created with `mkdtemp` rather than a `Date.now()` name (#3241).
- **Catalog** — unreachable-registry survival plus the search-gap report (#3299); avatar promo and Slack notification templates (#3279).
- **Docs** — anime.js v3-in-v4 syntax correction in the adapter guidance (#3064).

Patch bump rather than minor, following the convention of the last several releases: 0.7.107 through 0.7.109 each carried `feat:` commits and stayed on a patch.

## Test plan

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated (if applicable)

No product code changes here, so there is nothing new to unit test. What was checked:

- All 13 `package.json` versions read `0.7.110`, along with the three plugin manifests.
- `releases/v0.7.110.md` and the `docs/changelog.mdx` entry both carry a written summary with the TODO marker removed. `release:prepare` refuses to tag otherwise, and that gate was exercised on the first run.
- Every commit in the range appears in the notes: `git log v0.7.109..main` is exactly the five entries listed above.

The code being released was verified on its own PRs. CI on this branch is the gate for the release commit itself.

## Note for reviewers

`CONTRIBUTING.md` still documents the older tag-push flow for stable releases (`git push origin v<version>`). The `release:prepare` script now prints the release-PR instructions instead and explicitly says not to push the local tag. The doc is stale rather than wrong about this PR, and worth correcting separately.
