### PR TITLE
chore: release v0.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,29 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.0"
+  description="Released - 2026-08-17"
+  tags={["Release", "Cloud", "Migration", "Catalog"]}
+>
+HyperFrames 0.8 establishes the supported version boundary for Plan v2 as the default distributed cloud transport.
+
+Version 0.7.111 already contained this behavior. Version 0.8.0 adds no further cloud runtime changes beyond that release.
+
+## Migration
+
+- Redeploy AWS Lambda, SAM, or CDK infrastructure from version 0.8.0 before upgrading SDK callers to 0.8.0.
+- Redeploy GCP Cloud Run services and workflows from version 0.8.0 before upgrading SDK callers to 0.8.0.
+- Omitting `planProtocol` selects Plan v2. Explicit `"v1"` remains available for compatibility while older work drains.
+- Keep the producer, SDK, and cloud adapter packages on the same version during the upgrade.
+
+## Catalog
+
+- **Catalog:** Remove two AI UI items ([ed18f1ea9](https://github.com/heygen-com/hyperframes/commit/ed18f1ea9aae00c26fdb712b231ac123e9170086), [#3317](https://github.com/heygen-com/hyperframes/pull/3317)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.7.111...v0.8.0).
+</Update>
+
+<Update
   label="HyperFrames v0.7.111"
   description="Released - 2026-08-17"
   tags={["Release", "Cloud", "Catalog", "Studio"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.7.111",
+  "version": "0.8.0",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.0.md
+++ b/releases/v0.8.0.md
@@ -1,0 +1,22 @@
+# HyperFrames v0.8.0
+
+Released on 2026-08-17.
+
+HyperFrames 0.8 establishes the supported version boundary for Plan v2 as the default distributed cloud transport.
+
+Version 0.7.111 already contained this behavior. Version 0.8.0 adds no further cloud runtime changes beyond that release.
+
+## Migration
+
+- Redeploy AWS Lambda, SAM, or CDK infrastructure from version 0.8.0 before upgrading SDK callers to 0.8.0.
+- Redeploy GCP Cloud Run services and workflows from version 0.8.0 before upgrading SDK callers to 0.8.0.
+- Omitting `planProtocol` selects Plan v2. Explicit `"v1"` remains available for compatibility while older work drains.
+- Keep the producer, SDK, and cloud adapter packages on the same version during the upgrade.
+
+## Catalog
+
+- **Catalog:** Remove two AI UI items ([ed18f1ea9](https://github.com/heygen-com/hyperframes/commit/ed18f1ea9aae00c26fdb712b231ac123e9170086), [#3317](https://github.com/heygen-com/hyperframes/pull/3317)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.7.111...v0.8.0


### PR DESCRIPTION
## What

Release HyperFrames v0.8.0 from current `main`.

- Bumps all 13 publishable packages and three plugin manifests from v0.7.111 to v0.8.0.
- Documents v0.8.0 as the supported minor-version boundary for Plan v2 becoming the default distributed cloud transport.
- Includes the catalog-only removal from #3317, the sole commit after v0.7.111.

## Why

PR #3311 changed the behavior of an omitted `planProtocol` from Plan v1 to Plan v2. That behavior shipped in v0.7.111, but it warrants a minor-version boundary rather than another 0.7 patch.

The release notes are explicit that v0.8.0 adds no further cloud runtime delta beyond v0.7.111 and that users must redeploy matched-version cloud infrastructure before upgrading SDK callers.

## How

Prepared with the repository's stable release workflow. The publish workflow will use the immutable merge SHA, create `v0.8.0`, publish npm packages to `latest`, and create the GitHub release only after this PR is approved and merged.

## Test plan

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] Documentation updated (if applicable)

Validation completed locally:

- `bun run test:scripts`: 182 Node tests and 29 catalog Vitest tests passed.
- `bunx oxfmt --check docs/changelog.mdx releases/v0.8.0.md` passed.
- Release commit guard accepted only version manifests and reviewed changelog artifacts.

No internal service, staging, or production deployment is part of this PR.
