### PR TITLE
chore: release v0.8.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,25 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.1"
+  description="Released - 2026-08-18"
+  tags={["Release", "Docs", "Studio", "Add"]}
+>
+Variables you pass to `hyperframes add` now reach the file it installs, instead of being dropped without a word. Studio also asks for FFmpeg before an export starts, rather than after one fails.
+
+## Features
+
+- **Studio:** Prompt to install FFmpeg before Export, not after ([5058236ed](https://github.com/heygen-com/hyperframes/commit/5058236eda13cc31536e39bd37cf7eb4f9a99025), [#3314](https://github.com/heygen-com/hyperframes/pull/3314)).
+
+## Fixes
+
+- **Docs:** Load the player from latest, not a pinned minor ([d7688f994](https://github.com/heygen-com/hyperframes/commit/d7688f9943814b44ab20b7d4b079ab50f7ca36df), [#3320](https://github.com/heygen-com/hyperframes/pull/3320)).
+- **Add:** Make chosen variables actually take effect, in the CLI and the preview ([ea7c48f37](https://github.com/heygen-com/hyperframes/commit/ea7c48f37249aff26211913562c74e29b85e8ddb), [#3316](https://github.com/heygen-com/hyperframes/pull/3316)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.0...v0.8.1).
+</Update>
+
+<Update
   label="HyperFrames v0.8.0"
   description="Released - 2026-08-17"
   tags={["Release", "Cloud", "Migration", "Catalog"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.1.md
+++ b/releases/v0.8.1.md
@@ -1,0 +1,18 @@
+# HyperFrames v0.8.1
+
+Released on 2026-08-18.
+
+Variables you pass to `hyperframes add` now reach the file it installs, instead of being dropped without a word. Studio also asks for FFmpeg before an export starts, rather than after one fails.
+
+## Features
+
+- **Studio:** Prompt to install FFmpeg before Export, not after ([5058236ed](https://github.com/heygen-com/hyperframes/commit/5058236eda13cc31536e39bd37cf7eb4f9a99025), [#3314](https://github.com/heygen-com/hyperframes/pull/3314)).
+
+## Fixes
+
+- **Docs:** Load the player from latest, not a pinned minor ([d7688f994](https://github.com/heygen-com/hyperframes/commit/d7688f9943814b44ab20b7d4b079ab50f7ca36df), [#3320](https://github.com/heygen-com/hyperframes/pull/3320)).
+- **Add:** Make chosen variables actually take effect, in the CLI and the preview ([ea7c48f37](https://github.com/heygen-com/hyperframes/commit/ea7c48f37249aff26211913562c74e29b85e8ddb), [#3316](https://github.com/heygen-com/hyperframes/pull/3316)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.0...v0.8.1


### PR DESCRIPTION
## What

Release HyperFrames v0.8.1 from current `main`.

- Bumps all 13 publishable packages and three plugin manifests from v0.8.0 to v0.8.1.
- Carries the three commits that landed after v0.8.0: #3316, #3314 and #3320.

## Why

#3316 is the one users will feel. A value picked with `--vars` was dropped on the way to the file `hyperframes add` writes, so the installed component rendered its defaults and nothing said otherwise. The same release fixes the catalog preview ignoring chosen values, and makes a failed install name the registry it could not reach and the actual reason.

#3314 moves Studio's FFmpeg prompt to before an export rather than after one fails.

#3320 is what lets the preview half of #3316 arrive at all. The docs pinned the player CDN URL to a minor line and the pin had gone stale, so a published fix never reached the catalog pages. They ask for `latest` now, which means this release reaches the docs on its own once npm has it. jsDelivr serves `latest` with a twelve hour edge cache, so the pages pick it up within about that, not instantly.

## How

Prepared with the repository's stable release workflow, drafted from the `v0.8.0` tag so the notes cover exactly what landed after it. This branch was rebuilt on top of current `main` after #3320 merged, so the release commit sits on the same tree the publish workflow will build.

The publish workflow will use the immutable merge SHA, create `v0.8.1`, publish npm packages to `latest`, and cut the GitHub release after this PR is approved and merged.

## Test plan

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated (if applicable)

Validation completed locally on the rebuilt branch:

- `bun run test:scripts`: 184 Node tests and 29 catalog Vitest tests passed.
- `bunx oxfmt --check docs/changelog.mdx releases/v0.8.1.md` passed.
- The release commit touches only version manifests and the reviewed changelog artifacts, 18 files, matching the shape of the v0.8.0 release commit.

## Not covered

Component catalog pages still will not answer their variables panel after this ships. That is a separate defect: their preview payload is built from a hand-copy of the snippet, and 166 of the 168 components declaring variables have a copy with the declaration missing, so there is nothing in the markup for a chosen value to reach. Blocks are unaffected and do respond.
