### PR TITLE
chore: release v0.8.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,26 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.2"
+  description="Released - 2026-08-18"
+  tags={["Release", "Catalog", "Skills"]}
+>
+The variables panel on a component's catalog page now changes its preview. Pick an accent or a size and the preview answers, so what you see is what the copied snippet installs.
+
+## Fixes
+
+- **Skills:** Count proxy-driver tweens in the animation map ([0d874adc6](https://github.com/heygen-com/hyperframes/commit/0d874adc685a94a519311cf9ed9e4107bb0347c9), [#3301](https://github.com/heygen-com/hyperframes/pull/3301)).
+- **Skills:** Declare the caption brand font's style axis, not just its weight ([a41da8651](https://github.com/heygen-com/hyperframes/commit/a41da8651768942adf588a959d9dc062c90c6a13), [#3300](https://github.com/heygen-com/hyperframes/pull/3300)).
+- **Skills:** Pin UTF-8 in Python scripts instead of the platform code page ([f8a1e2d31](https://github.com/heygen-com/hyperframes/commit/f8a1e2d315e51856491af003958914152371c29d), [#3298](https://github.com/heygen-com/hyperframes/pull/3298)).
+
+## Catalog
+
+- **Catalog:** Make component previews answer their variables panel ([406bf316a](https://github.com/heygen-com/hyperframes/commit/406bf316a38d8a6ff24c00696d9e537ee85997d4), [#3323](https://github.com/heygen-com/hyperframes/pull/3323)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.1...v0.8.2).
+</Update>
+
+<Update
   label="HyperFrames v0.8.1"
   description="Released - 2026-08-18"
   tags={["Release", "Docs", "Studio", "Add"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.2.md
+++ b/releases/v0.8.2.md
@@ -1,0 +1,19 @@
+# HyperFrames v0.8.2
+
+Released on 2026-08-18.
+
+The variables panel on a component's catalog page now changes its preview. Pick an accent or a size and the preview answers, so what you see is what the copied snippet installs.
+
+## Fixes
+
+- **Skills:** Count proxy-driver tweens in the animation map ([0d874adc6](https://github.com/heygen-com/hyperframes/commit/0d874adc685a94a519311cf9ed9e4107bb0347c9), [#3301](https://github.com/heygen-com/hyperframes/pull/3301)).
+- **Skills:** Declare the caption brand font's style axis, not just its weight ([a41da8651](https://github.com/heygen-com/hyperframes/commit/a41da8651768942adf588a959d9dc062c90c6a13), [#3300](https://github.com/heygen-com/hyperframes/pull/3300)).
+- **Skills:** Pin UTF-8 in Python scripts instead of the platform code page ([f8a1e2d31](https://github.com/heygen-com/hyperframes/commit/f8a1e2d315e51856491af003958914152371c29d), [#3298](https://github.com/heygen-com/hyperframes/pull/3298)).
+
+## Catalog
+
+- **Catalog:** Make component previews answer their variables panel ([406bf316a](https://github.com/heygen-com/hyperframes/commit/406bf316a38d8a6ff24c00696d9e537ee85997d4), [#3323](https://github.com/heygen-com/hyperframes/pull/3323)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.1...v0.8.2


### PR DESCRIPTION
## What

Release HyperFrames v0.8.2 from current `main`.

- Bumps all 13 publishable packages and three plugin manifests from v0.8.1 to v0.8.2.
- Carries the four commits that landed after v0.8.1: #3298, #3300, #3301 and #3323.

## Why

#3323 is the one users will feel. Every control on a component's catalog page did nothing: the panel offered accents and sizes, and the preview kept rendering its defaults whatever was picked.

A component ships two HTML files. The snippet is what the page hands you to paste, carrying its variable declarations and the script that reads them. `demo.html` stages that component and animates it. The catalog preview is built from the demo, and the demo had been authored as a copy of the snippet rather than a reference to it. Copies drift: 166 of the 168 components that declare variables had demos with no declaration and no reader.

So the panel and the preview now agree, which means what you see on the page is what the copied snippet installs. The invariant is enforced by a check in CI, so the two cannot drift apart again silently.

The other three are skills fixes: proxy-driver tweens are counted in the animation map (#3301), the caption brand font declares its style axis rather than only its weight (#3300), and Python scripts pin UTF-8 instead of inheriting the platform code page (#3298).

## How

Prepared with the repository's stable release workflow, drafted from the `v0.8.1` tag so the notes cover exactly what landed after it. The release commit sits on current `main`.

The publish workflow will use the immutable merge SHA, create `v0.8.2`, publish the npm packages to `latest`, and cut the GitHub release once this PR is merged.

## Test plan

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated (if applicable)

Validation completed locally on this branch:

- `bun run test:scripts`: 184 Node tests and 42 catalog Vitest tests passed.
- Release channel resolves to `latest` for `release/v0.8.2`, checked with the same validator the publish workflow runs.
- Both changelog artifacts are written and reviewed: `releases/v0.8.2.md` and the `docs/changelog.mdx` entry carry no TODO marker.
