### PR TITLE
fix(skills): skip mirror fan-out to agents that read the universal store

### DIFF
--- a/packages/cli/src/utils/skillsMirror.test.ts
+++ b/packages/cli/src/utils/skillsMirror.test.ts
@@ -177,6 +177,30 @@ describe("mirrorGlobalSkills", () => {
     const link = join(home, ".cursor", "skills", "hyperframes");
     expect(realpathSync(link)).toBe(realpathSync(join(home, ".claude", "skills", "hyperframes")));
   });
+
+  // Pi natively discovers BOTH ~/.pi/agent/skills and the universal
+  // ~/.agents/skills (pi's packages/coding-agent/docs/skills.md#locations).
+  // A mirrored per-agent copy collides with the universal one and Pi skips
+  // the universal entry on name conflict (#3294), so the mirror must not fan
+  // out to it.
+  it("skips agents that natively read the universal store (pi, #3294)", () => {
+    const home = makeHome();
+    seedStore(home, ["hyperframes"]);
+    installMarker(home, ".pi/agent"); // Pi present
+    installMarker(home, ".cursor"); // a regular per-dir agent, for contrast
+
+    const { mirrored } = mirrorGlobalSkills({
+      skills: ["hyperframes"],
+      home,
+      platform: "linux",
+      env: ENV,
+    });
+    const agents = mirrored.map((m) => m.agent);
+    expect(agents).not.toContain("pi");
+    expect(agents).toContain("cursor");
+    // no per-agent copy created where the universal store already serves Pi
+    expect(existsSync(join(home, ".pi", "agent", "skills", "hyperframes"))).toBe(false);
+  });
 });
 
 describe("AGENT_GLOBAL_DIRS (generated table)", () => {

--- a/packages/cli/src/utils/skillsMirror.ts
+++ b/packages/cli/src/utils/skillsMirror.ts
@@ -9,7 +9,10 @@
 // populate.
 //
 // So we mirror the canonical Claude store into each of those per-agent dirs, but
-// only for agents the machine actually has (their marker dir exists). On Unix
+// only for agents the machine actually has (their marker dir exists). Agents
+// that already consume the universal ~/.agents/skills store globally (Pi) are
+// skipped: their universal copy is authoritative and a per-agent copy would
+// collide with it (#3294). On Unix
 // each skill is a relative symlink back into the store (one source of truth,
 // near-zero size, auto-fresh on update); on Windows it's a copy, because
 // symlinks there need admin / Developer Mode and otherwise silently dangle —
@@ -23,6 +26,22 @@ import { cpSync, existsSync, mkdirSync, readdirSync, rmSync, symlinkSync } from 
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative } from "node:path";
 import { AGENT_GLOBAL_DIRS, type AgentDirBase } from "./agentDirs.generated.js";
+
+/**
+ * Agents that natively discover the universal `~/.agents/skills` store globally
+ * in ADDITION to their own agent-specific directory. Mirroring into their own
+ * dir makes every skill discoverable twice.
+ *
+ * Pi is the known case (earendil-works/pi): it reads both `~/.pi/agent/skills/`
+ * and `~/.agents/skills/` as global locations (pi's packages/coding-agent/docs/
+ * skills.md#locations), so a mirrored entry collides with the universal copy
+ * and Pi skips the universal one on name conflict (#3294).
+ *
+ * The generated table cannot carry this capability — it is a plain
+ * (agent, base, sub) list synced from vercel-labs/skills — so the set lives
+ * here next to the mirror logic that needs it.
+ */
+const UNIVERSAL_STORE_READERS = new Set(["pi"]);
 
 export interface MirrorResult {
   /** The store mirrored from, or null when no global Claude store was found. */
@@ -128,6 +147,7 @@ export function mirrorGlobalSkills(opts: {
   for (const { agent, base, sub } of AGENT_GLOBAL_DIRS) {
     const targetDir = join(bases[base], ...sub.split("/").filter(Boolean));
     if (targetDir === source || targetDir === universalStore) continue; // install-owned
+    if (UNIVERSAL_STORE_READERS.has(agent)) continue; // already reads the universal store (#3294)
     if (!existsSync(dirname(targetDir))) continue; // agent not installed (no marker)
     if (mirrorInto(targetDir, source, skills, platform)) mirrored.push({ agent, dir: targetDir });
   }


### PR DESCRIPTION
## What

The global skills mirror no longer fans out into agent directories whose agent already discovers the universal `~/.agents/skills` store globally. Currently that set is `{ pi }`.

## Why

Pi discovers skills from **both** `~/.pi/agent/skills/` **and** `~/.agents/skills/` as global locations (see pi's `packages/coding-agent/docs/skills.md` → Locations). The global install already writes real files into the universal store, so mirroring an additional per-agent copy into `~/.pi/agent/skills` makes Pi discover every HyperFrames skill twice. Pi then reports a name collision, keeps the `~/.pi/agent/skills` entry, and **skips the universal entry**:

```text
"hyperframes" collision:
  ✓ auto (user) ~/.pi/agent/skills/hyperframes/SKILL.md
  ✗ ~/.agents/skills/hyperframes/SKILL.md (skipped)
```

Fixes #3294 (the deterministic duplicate-discovery half; the broader target-control surface proposed there is left for maintainers to design).

## How

- Added a `UNIVERSAL_STORE_READERS` capability set in `packages/cli/src/utils/skillsMirror.ts` (currently `pi`) and skip those agents in the fan-out loop, before the installed-marker check.
- The set deliberately lives in the mirror module, not in `agentDirs.generated.ts`: that file is `@generated` from vercel-labs/skills and a plain `(agent, base, sub)` list — it cannot carry per-agent capabilities, and any hand edit would be clobbered by the next `gen:agent-dirs` sync.
- Minimal by design: no cleanup of pre-existing `~/.pi/agent/skills` entries from earlier runs. Removing entries in a directory we no longer manage would risk deleting user-placed content (the mirror's replace-on-refresh precedent only applies to dirs it still mirrors). A one-time stale-link cleanup can be a follow-up if maintainers want it.

## Test plan

- [x] New test in `skillsMirror.test.ts`: with both Pi (`~/.pi/agent`) and cursor markers present, `mirrored` contains cursor and not pi, and no `~/.pi/agent/skills/hyperframes` entry is created.
- [x] Full skills-related suites pass: `skillsMirror`, `skillsManifest`, `skillsUpdateCheck`, `commands/skills` — 116/116.
- [x] `oxlint` / `oxfmt --check` clean on changed files; repo `check-skill-mirror` invariant still passes; lefthook pre-commit gates (format, fallow against synced main, typecheck after generating core runtime artifacts) pass.
- [ ] Manual testing performed (not applicable here — reproduction requires a Pi + HyperFrames co-install; covered by the deterministic unit test above)