### PR TITLE
fix(runtime): decide a nested clip's timing convention by its start, not its end

### DIFF
--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -1633,6 +1633,78 @@ describe("initSandboxRuntimeModular", () => {
     expect(pipVideo.style.visibility).toBe("hidden");
   });
 
+  it("keeps a composition-local clip visible for its whole slot when its duration exceeds the mount offset", () => {
+    // TAB-792, from a user report: a scene went black for the last 3s of its
+    // own 4.375s slot. The clip is composition-local (`data-start="0"`) inside a
+    // host mounted at 2.96s, and the convention test used to look at the
+    // authored END: 0 + 4.375 = 4.375 > 2.96, so it read as root-global and was
+    // scheduled 0..4.375. The ancestor gate clipped the front, leaving
+    // 2.96..4.375 visible and 4.375..7.335 black.
+    //
+    // The giveaway was that making the clip LONGER made the hole BIGGER, which
+    // is why this asserts a late instant inside the slot rather than just the
+    // resolved start.
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-width", "720");
+    root.setAttribute("data-height", "720");
+    document.body.appendChild(root);
+
+    const host = document.createElement("div");
+    host.setAttribute("data-composition-id", "scene-1");
+    host.setAttribute("data-composition-file", "compositions/scene-1.html");
+    host.setAttribute("data-start", "2.96");
+    host.setAttribute("data-duration", "4.375");
+    root.appendChild(host);
+
+    const innerRoot = document.createElement("div");
+    innerRoot.setAttribute("data-composition-id", "scene-1");
+    host.appendChild(innerRoot);
+
+    const sceneVideo = document.createElement("video");
+    sceneVideo.setAttribute("data-start", "0.000");
+    sceneVideo.setAttribute("data-duration", "4.375");
+    sceneVideo.setAttribute("data-media-start", "0.000");
+    Object.defineProperty(sceneVideo, "paused", { value: true, configurable: true });
+    Object.defineProperty(sceneVideo, "readyState", { value: 0, configurable: true });
+    Object.defineProperty(sceneVideo, "currentTime", {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+    sceneVideo.load = () => {};
+    innerRoot.appendChild(sceneVideo);
+
+    (window as Window & { __timelines?: Record<string, RuntimeTimelineLike> }).__timelines = {
+      main: createMockTimeline(18.88),
+      "scene-1": createMockTimeline(4.375),
+    };
+
+    initSandboxRuntimeModular();
+
+    // Composition-local: the host offset applies.
+    expect(window.__hfResolveMediaStartSeconds?.(sceneVideo)).toBeCloseTo(2.96);
+
+    const player = (window as Window & { __player?: { seek: (timeSeconds: number) => void } })
+      .__player;
+    expect(player).toBeDefined();
+
+    player?.seek(3.5);
+    expect(sceneVideo.style.visibility).toBe("visible");
+    // The instants that were black before the fix.
+    player?.seek(5.5);
+    expect(sceneVideo.style.visibility).toBe("visible");
+    player?.seek(7.2);
+    expect(sceneVideo.style.visibility).toBe("visible");
+    // Still bounded by its own slot.
+    player?.seek(7.4);
+    expect(sceneVideo.style.visibility).toBe("hidden");
+    player?.seek(2.5);
+    expect(sceneVideo.style.visibility).toBe("hidden");
+  });
+
   it("shows auto-injected video at host time, not at t=0", () => {
     const root = document.createElement("div");
     root.setAttribute("data-composition-id", "main");

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -631,22 +631,26 @@ export function initSandboxRuntimeModular(): void {
     // Both timing conventions exist in shipped projects:
     //   - composition-local media, e.g. host@20 + video@0 => root@20
     //   - legacy root-global PIP media, e.g. host@45.4 + video@45.4 => root@45.4
-    // Preserve the global value when its authored window already intersects
-    // the host's absolute window. Otherwise it is unambiguously local and
-    // must inherit the recursively-resolved host start.
-    const authoredDuration = parseNumeric(element.getAttribute("data-duration"));
+    // Which one a clip uses is decided by where it *starts*, never by where it
+    // ends. A composition-local clip is authored from its host's zero, so its
+    // start sits below the host's absolute start; a root-global clip is already
+    // in root time and starts at or after its host.
+    //
+    // TAB-792: this used to test the authored *end* instead, so any
+    // composition-local clip whose duration merely exceeded the mount offset
+    // was misread as root-global — `data-start="0"` with a 4.375s duration in a
+    // host mounted at 2.96s scheduled itself 0..4.375, the ancestor gate
+    // clipped the front, and the scene went black for the remaining 3s of its
+    // own slot. The tell was that making the clip *longer* made the hole
+    // bigger. The two branches below disagreed, and the start-based one was
+    // the correct half.
     const hostDuration = context.inheritedDuration;
     const hostEnd = hostDuration != null && hostDuration > 0 ? inheritedStart + hostDuration : null;
-    const authoredEnd =
-      authoredDuration != null && authoredDuration > 0
-        ? authoredStart + authoredDuration
-        : authoredStart;
-    const overlapsHostWindow =
+    const authoredStartIsRootGlobal =
       hostEnd == null
         ? authoredStart >= inheritedStart
-        : authoredStart < hostEnd &&
-          (authoredEnd > inheritedStart || authoredStart === inheritedStart);
-    return overlapsHostWindow ? authoredStart : inheritedStart + authoredStart;
+        : authoredStart >= inheritedStart && authoredStart < hostEnd;
+    return authoredStartIsRootGlobal ? authoredStart : inheritedStart + authoredStart;
   };
 
   window.__hfResolveMediaStartSeconds = resolveAbsoluteMediaStartSeconds;


### PR DESCRIPTION
## Summary

`resolveAbsoluteMediaStartSeconds` picks between the two conventions #2859 identified by testing the clip's authored **end**. What actually distinguishes them is where the clip **starts**, so a composition-local clip is misread as root-global whenever its duration merely exceeds its host's mount offset — and it renders blank for the tail of its own slot.

This is the same failure #2859 fixed, one case further along.

## The bug

```js
const authoredEnd = authoredDuration > 0 ? authoredStart + authoredDuration : authoredStart;
const overlapsHostWindow =
  hostEnd == null
    ? authoredStart >= inheritedStart                    // start-based
    : authoredStart < hostEnd &&
      (authoredEnd > inheritedStart || authoredStart === inheritedStart);   // end-based
return overlapsHostWindow ? authoredStart : inheritedStart + authoredStart;
```

A composition-local clip is authored from its host's zero, so what identifies it is that its **start** sits below the host's absolute start. Its duration says nothing about which convention it uses.

Worked example, from a real project:

```
host slot   data-start="2.96"  data-duration="4.375"     (2.96 .. 7.335)
inner video data-start="0.000" data-duration="4.375"     (composition-local)

authoredEnd = 0 + 4.375 = 4.375  >  inheritedStart 2.96   ->  read as ROOT-GLOBAL
-> scheduled 0 .. 4.375
-> the ancestor visibility gate clips the front to the host window
-> visible 2.96 .. 4.375, blank for the remaining ~3s of its own slot
```

Note the two branches above already disagree with each other — the `hostEnd == null` branch tests the start. This PR makes both use the start, which is also what the comment above them describes.

## Why it hides

The misreading only produces a *visible* hole when `0 < mountOffset < duration`.

| scene | mount | duration | verdict on `main` | outcome |
|---|---|---|---|---|
| 0 | 0 | 2.958 | `inheritedStart <= 0` → early return | fine |
| **1** | **2.96** | **4.375** | 4.375 > 2.96 → "root-global" | **~3s blank** |
| 2 | 7.333 | 2.583 | 2.583 < 7.333 → local | fine |
| 3–5 | later | shorter | local | fine |

Every other scene in that project mounts later than its own duration, so it fell through to the correct branch **by accident**. Five scenes correct by luck and one broken looks exactly like a healthy project.

## How to reproduce

**1. Deterministic, in this repo — the added test.** `packages/core/src/runtime/init.test.ts`:

```
keeps a composition-local clip visible for its whole slot when its duration exceeds the mount offset
```

It builds a host at `data-start="2.96" data-duration="4.375"` containing a video at `data-start="0.000" data-duration="4.375"`, then asserts `__hfResolveMediaStartSeconds` resolves to `2.96` and that the clip is still visible at `t=7.2` (late in its own slot).

On `main` it fails:

```
bunx vitest run --config packages/core/vitest.config.ts \
  packages/core/src/runtime/init.test.ts
```

It asserts a **late instant inside the slot**, not just the resolved start — the resolved start alone was never the visible symptom.

**2. In a render.** Mean frame luminance is the cheapest way to ask "did anything paint?":

```bash
hyperframes render <project> --output /tmp/r.mp4
ffmpeg -ss 5.5 -i /tmp/r.mp4 -frames:v 1 -vf format=gray -f rawvideo - \
  | python3 -c "import sys;d=sys.stdin.buffer.read();print(sum(d)/len(d))"
```

On the project above (backdrop `#0B0B0F` ≈ 15 = nothing painted, content ≈ 90–120):

| t (s) | 0.5 | 2.5 | 3.5 | **4.5** | **5.5** | **6.5** | 7.5 | 9.5 | 12.5 | 15.5 |
|---|---|---|---|---|---|---|---|---|---|---|
| before | 107 | 107 | 104 | **15** | **16** | **16** | 161 | 131 | 107 | 128 |
| after | 107 | 107 | 104 | **89** | **73** | **75** | 161 | 131 | 107 | 128 |

After the change, a 76-frame scan at 0.25s across the full 18.9s render finds no unpainted frame.

**Honest caveat on repro:** I could not get this to reproduce in a *stripped-down standalone* project — a two-file project with the same attribute values, and even one built by lifting the failing slot and composition verbatim out of the real project, both rendered correctly on unpatched code. So something about the surrounding project context is part of the trigger and I have not isolated it. The unit test above is deterministic and does fail on `main`, and the real-project before/after is measured, but if you want a minimal standalone fixture, that gap is real and I'd rather flag it than hand you something I hadn't verified.

## The evidence that identified the mechanism

Rather than fit a theory to the failure, I made it predict something counterintuitive: if a clip's *duration* is what tips it into being misread, then making a **healthy** clip **longer** should **create** a new hole.

scene-2 above is healthy. Its duration `2.583` → `8.000`, slot untouched at 7.333–9.917:

```
t=7.5   base 161.4    ->  161.4
t=7.9   base 160.2    ->  160.1
t=8.1   base 160.6    ->   15.4   <- new hole, at exactly 8.0
t=9.5   base 131.2    ->   15.5
```

A longer clip rendering *less*, with the cutoff landing exactly on the new duration.

Three other hypotheses were eliminated first, each by a single-variable render: absolute-vs-relative composition time (changing the inner `data-start` `0.000`→`2.960` produced exactly the *relative*-semantics result), occlusion by a backdrop, and z-order via `data-track-index` (moving the affected slot to track 0 and a healthy one to track 5 gave byte-identical renders).

## Blast radius

Behaviour changes **only** for clips with `0 <= authoredStart < hostStart`. Everything else takes the same branch as before.

- `pip-video-late-host` — `data-start="3.0"` inside a host at `3.0` — is unaffected, since `>=` still reads it as root-global. Its unit test and golden render both pass.
- `nested-sequential-video-local-start` (from #2859) passes.
- I could find no fixture in this repo in the changed class.

That last point cuts both ways: the class I changed is **untested here either way**, so the `>=` choice for `0 < authoredStart < hostStart` is a judgement call rather than something your fixtures pin. If you know of a shipped project shape where a root-global clip legitimately starts *before* its host, that case would want a different rule and I'd defer to you on it.

## Verification

- `packages/core`: 117 files / 2337 tests pass
- regression harness: `nested-sequential-video-local-start` and `pip-video-late-host` — 2/2 passed, 0 failed frames
- lint, format, typecheck clean
- Negative control: restoring the end-based test fails **exactly** the new test, and leaves the legacy PIP test passing
