### PR TITLE
chore: release v0.8.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,25 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.3"
+  description="Released - 2026-08-18"
+  tags={["Release"]}
+>
+Studio now keeps voices natural at every preview speed and applies authored track gain and user volume exactly once.
+Creator skills also add copyable recipes for cuts, trims, zooms, masks, transitions, and placed audio.
+
+## Features
+
+- Make creator media edits render-safe ([afafca4b9](https://github.com/heygen-com/hyperframes/commit/afafca4b9670cad60afd66475207ef6a016a759b), [#3322](https://github.com/heygen-com/hyperframes/pull/3322)).
+
+## Fixes
+
+- Separate Studio author and user audio gain ([995c9e346](https://github.com/heygen-com/hyperframes/commit/995c9e346e5b1bfff015db3979896ec576cff12c), [#3328](https://github.com/heygen-com/hyperframes/pull/3328)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.2...v0.8.3).
+</Update>
+
+<Update
   label="HyperFrames v0.8.2"
   description="Released - 2026-08-18"
   tags={["Release", "Catalog", "Skills"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.3.md
+++ b/releases/v0.8.3.md
@@ -1,0 +1,18 @@
+# HyperFrames v0.8.3
+
+Released on 2026-08-18.
+
+Studio now keeps voices natural at every preview speed and applies authored track gain and user volume exactly once.
+Creator skills also add copyable recipes for cuts, trims, zooms, masks, transitions, and placed audio.
+
+## Features
+
+- Make creator media edits render-safe ([afafca4b9](https://github.com/heygen-com/hyperframes/commit/afafca4b9670cad60afd66475207ef6a016a759b), [#3322](https://github.com/heygen-com/hyperframes/pull/3322)).
+
+## Fixes
+
+- Separate Studio author and user audio gain ([995c9e346](https://github.com/heygen-com/hyperframes/commit/995c9e346e5b1bfff015db3979896ec576cff12c), [#3328](https://github.com/heygen-com/hyperframes/pull/3328)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.2...v0.8.3


### PR DESCRIPTION
## What\n\n- Bumps all 13 publishable HyperFrames packages and 3 agent-plugin manifests from 0.8.2 to 0.8.3.\n- Adds reviewed GitHub and docs changelog entries for the Studio voice-pitch and gain-ownership fixes plus creator editing guidance.\n- Publishes the shared-runtime fix to both @hyperframes/core and @hyperframes/player.\n\n## Release range\n\nv0.8.2...995c9e346e5b1bfff015db3979896ec576cff12c\n\nIncludes:\n- #3322 creator media timing and pitch-preserving Studio playback\n- #3328 separate authored/automation gain from Studio user volume and mute\n\n## Verification\n\n- bun run test:scripts: 184 node tests and 42 catalog tests passed\n- bun run format:check passed across 4,748 files\n- git diff --check passed\n- Release tooling created exactly 13 package bumps, 3 plugin bumps, and 2 reviewed changelog artifacts\n- The local v0.8.3 tag was retargeted to the rebased release commit and was not pushed; merging this release/v0.8.3 PR is the single stable publish path\n\nMerging this PR creates the immutable v0.8.3 tag, publishes npm latest, and creates the GitHub release.