### PR TITLE
fix(producer): clamp embedded video/audio windows to the scene

### DIFF
--- a/packages/producer/src/services/render/stages/probeStage.ts
+++ b/packages/producer/src/services/render/stages/probeStage.ts
@@ -508,11 +508,9 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
                 el.start,
                 resolveBrowserMediaEnd(el.start, el.end, el.duration),
               );
-              if (
-                projectedEnd > 0 &&
-                (existing.end <= 0 || Math.abs(existing.end - projectedEnd) > BROWSER_MEDIA_EPSILON)
-              ) {
-                existing.end = projectedEnd;
+              if (projectedEnd > 0) {
+                existing.end =
+                  existing.end <= 0 ? projectedEnd : Math.min(existing.end, projectedEnd);
               }
               if (
                 el.mediaStart > 0 &&
@@ -554,11 +552,9 @@ export async function runProbeStage(input: ProbeStageInput): Promise<ProbeStageR
                 el.start,
                 resolveBrowserMediaEnd(el.start, el.end, el.duration),
               );
-              if (
-                projectedEnd > 0 &&
-                (existing.end <= 0 || Math.abs(existing.end - projectedEnd) > BROWSER_MEDIA_EPSILON)
-              ) {
-                existing.end = projectedEnd;
+              if (projectedEnd > 0) {
+                existing.end =
+                  existing.end <= 0 ? projectedEnd : Math.min(existing.end, projectedEnd);
               }
               if (
                 el.mediaStart > 0 &&


### PR DESCRIPTION
## What

When reconciling browser media metadata in probeStage, never extend a video/audio compile-time `end` to the browser-projected natural source duration. Only fill a missing bound, or shrink with Math.min.

Fixes #3331.

## Why

parseSubCompositions already clamps nested media to the scene slot. The browser `end`/`data-duration` after ffprobe is natural remaining source length, not the slot. Overwriting the compile-time end inflated extract windows for short scenes that slice a long take via data-media-start. That wastes work locally and can time out black on constrained runners while the render still succeeds.

## How

In the video and audio reconcile branches:

```ts
existing.end =
  existing.end <= 0 ? projectedEnd : Math.min(existing.end, projectedEnd)
```

Image reconcile is unchanged.

## Test plan

How was this tested?

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

Manual: https://github.com/ArcadeHQ/hyperframes-repros/tree/patch/clamp-embedded-media on unpatched 0.8.3 → maxFramesPerVideo 360 / totalFramesExtracted 900. With this patch → expect ~90 / ~360. `npx hyperframes lint` clean on that repro.