### PR TITLE
fix(studio): allow hfId-only clips to move and trim on the timeline

### DIFF
--- a/packages/studio/src/player/components/timelineAuthoredMoveTarget.ts
+++ b/packages/studio/src/player/components/timelineAuthoredMoveTarget.ts
@@ -11,6 +11,7 @@ export function canMoveTimelineElement(element: TimelineElement): boolean {
     duration: element.duration,
     domId: element.domId,
     selector: element.selector,
+    hfId: element.hfId,
     compositionSrc: element.compositionSrc,
     playbackStart: element.playbackStart,
     playbackStartAttr: element.playbackStartAttr,

--- a/packages/studio/src/player/components/timelineEditCapabilities.ts
+++ b/packages/studio/src/player/components/timelineEditCapabilities.ts
@@ -23,8 +23,17 @@ function isDeterministicTimelineWindow(input: {
   return ["video", "audio", "img"].includes(input.tag.toLowerCase());
 }
 
-export function hasPatchableTimelineTarget(input: { domId?: string; selector?: string }): boolean {
-  return Boolean(input.domId || input.selector);
+export function hasPatchableTimelineTarget(input: {
+  domId?: string;
+  selector?: string;
+  hfId?: string;
+}): boolean {
+  // hfId counts as a stable target: Studio stamps data-hf-id into the source and
+  // findElementForSelection resolves it before id/selector, so a clip carrying only
+  // an hfId is just as patchable as one with an author-written id. Omitting it here
+  // made those clips report canMove:false and surface "This clip can't be moved or
+  // resized from the timeline yet", even though the write path fully supported them.
+  return Boolean(input.domId || input.selector || input.hfId);
 }
 
 export function getTimelineEditCapabilities(input: {
@@ -33,6 +42,7 @@ export function getTimelineEditCapabilities(input: {
   duration: number;
   domId?: string;
   selector?: string;
+  hfId?: string;
   compositionSrc?: string;
   playbackStart?: number;
   playbackStartAttr?: "media-start" | "playback-start";

--- a/packages/studio/src/player/components/timelineEditing.test.ts
+++ b/packages/studio/src/player/components/timelineEditing.test.ts
@@ -377,12 +377,58 @@ describe("hasPatchableTimelineTarget", () => {
     expect(hasPatchableTimelineTarget({ selector: ".hero-card" })).toBe(true);
   });
 
+  it("returns true when the clip only has an hfId", () => {
+    // Studio stamps data-hf-id into the source and resolves it ahead of id/selector,
+    // so an hfId-only clip is patchable. Regression: it used to report false, which
+    // blocked dragging any authored clip the user had not given an id.
+    expect(hasPatchableTimelineTarget({ hfId: "hf-6wbt" })).toBe(true);
+  });
+
   it("returns false when the clip has no stable patch target", () => {
     expect(hasPatchableTimelineTarget({})).toBe(false);
   });
 });
 
 describe("getTimelineEditCapabilities", () => {
+  it("lets an hfId-only authored clip move and trim", () => {
+    // A plain <div class="clip" data-start data-duration> with no author id: the
+    // exact shape that produced "This clip can't be moved or resized from the
+    // timeline yet" while the DOM-edit path considered the same element editable.
+    expect(
+      getTimelineEditCapabilities({
+        tag: "div",
+        kind: "element",
+        duration: 2.6,
+        hfId: "hf-opwy",
+        timingSource: "authored",
+      }),
+    ).toEqual({ canMove: true, canTrimStart: true, canTrimEnd: true });
+  });
+
+  it("still refuses an hfId-only clip whose timing is implicit", () => {
+    expect(
+      getTimelineEditCapabilities({
+        tag: "div",
+        kind: "element",
+        duration: 2.6,
+        hfId: "hf-opwy",
+        timingSource: "implicit",
+      }).canMove,
+    ).toBe(false);
+  });
+
+  it("still refuses an hfId-only clip on a locked row", () => {
+    expect(
+      getTimelineEditCapabilities({
+        tag: "div",
+        kind: "element",
+        duration: 2.6,
+        hfId: "hf-opwy",
+        timelineLocked: true,
+      }).canMove,
+    ).toBe(false);
+  });
+
   it("does not disable editable audio just because it spans multiple scenes", () => {
     expect(
       getTimelineEditCapabilities({

--- a/packages/studio/src/player/components/timelineGroupEditing.ts
+++ b/packages/studio/src/player/components/timelineGroupEditing.ts
@@ -193,6 +193,7 @@ function canTrimEdge(element: TimelineElement, edge: TimelineGroupResizeEdge): b
     duration: element.duration,
     domId: element.domId,
     selector: element.selector,
+    hfId: element.hfId,
     compositionSrc: element.compositionSrc,
     playbackStart: element.playbackStart,
     playbackStartAttr: element.playbackStartAttr,

--- a/packages/studio/src/player/lib/timelineDOM.test.ts
+++ b/packages/studio/src/player/lib/timelineDOM.test.ts
@@ -6,6 +6,8 @@ import {
   createImplicitTimelineLayersFromDOM,
   mergeTimelineElementsPreservingDowngrades,
 } from "./timelineDOM";
+import { findTimelineDomNodeForClip } from "./timelineElementHelpers";
+import type { ClipManifestClip } from "./playbackTypes";
 import type { TimelineElement } from "../store/playerStore";
 
 function el(id: string, extra: Partial<TimelineElement> = {}): TimelineElement {
@@ -327,5 +329,71 @@ describe("audio FX attributes on parsed elements", () => {
     const [bgm] = parseTimelineFromDOM(doc, 10).filter((e) => e.domId === "bgm");
     expect(bgm?.fxChain).toBeUndefined();
     expect(bgm?.automation).toBeUndefined();
+  });
+});
+
+describe("findTimelineDomNodeForClip — positional fallback never crosses tags", () => {
+  // Regression: a clip whose own element carries no [data-start] is not a
+  // candidate here. Before the tag guard it took candidates[fallbackIndex] — an
+  // unrelated scene <div> — which corrupted two clips at once: the img clip got a
+  // host that was not its element, and the div clip that owned that node was
+  // starved to null, losing hfId/domId/selector and therefore canMove. That is
+  // what surfaced as "This clip can't be moved or resized from the timeline yet".
+  const html = `
+    <div data-composition-id="root" data-start="0" data-duration="14">
+      <div data-hf-id="hf-a" class="s clip" data-start="0" data-duration="3" data-track-index="1"></div>
+      <div data-hf-id="hf-b" class="s clip" data-start="6" data-duration="2.6" data-track-index="1"></div>
+    </div>`;
+
+  const imgClip: ClipManifestClip = {
+    id: null,
+    label: "Site Hero",
+    start: 0,
+    duration: 14,
+    track: 2,
+    kind: "image",
+    tagName: "img",
+    compositionId: null,
+    parentCompositionId: null,
+    compositionSrc: null,
+    assetUrl: null,
+  };
+
+  it("returns null instead of stealing a div for an img clip", () => {
+    const doc = makeDoc(html);
+    expect(findTimelineDomNodeForClip(doc, imgClip, 0)).toBeNull();
+  });
+
+  it("leaves the div clips resolvable after an unmatched img clip", () => {
+    const doc = makeDoc(html);
+    const used = new Set<Element>();
+    const stolen = findTimelineDomNodeForClip(doc, imgClip, 0, used);
+    if (stolen) used.add(stolen);
+
+    const divClip: ClipManifestClip = {
+      ...imgClip,
+      label: "S",
+      start: 6,
+      duration: 2.6,
+      track: 1,
+      kind: "element",
+      tagName: "div",
+    };
+    const host = findTimelineDomNodeForClip(doc, divClip, 1, used);
+    expect(host?.getAttribute("data-hf-id")).toBe("hf-b");
+  });
+
+  it("still allows a same-tag positional fallback when attributes drift", () => {
+    const doc = makeDoc(html);
+    const drifted: ClipManifestClip = {
+      ...imgClip,
+      label: "S",
+      start: 99,
+      duration: 99,
+      track: 9,
+      kind: "element",
+      tagName: "div",
+    };
+    expect(findTimelineDomNodeForClip(doc, drifted, 0)?.getAttribute("data-hf-id")).toBe("hf-a");
   });
 });

--- a/packages/studio/src/player/lib/timelineElementHelpers.ts
+++ b/packages/studio/src/player/lib/timelineElementHelpers.ts
@@ -419,7 +419,18 @@ export function findTimelineDomNodeForClip(
   const exact = candidates.find((node) => nodeMatchesManifestClip(node, clip));
   if (exact) return exact;
 
-  return candidates[fallbackIndex] ?? null;
+  // Positional fallback, but never across tags. A clip whose element carries no
+  // [data-start] of its own (an expanded child row, say) is not a candidate here,
+  // so without this guard it takes candidates[fallbackIndex] — an unrelated node —
+  // and corrupts TWO clips at once: the thief gets a host that is not its element,
+  // and the rightful owner is starved to null, losing hfId/domId/selector and with
+  // them canMove. That is what produced "This clip can't be moved or resized from
+  // the timeline yet" on clips that were perfectly well-formed.
+  const positional = candidates[fallbackIndex];
+  if (!positional) return null;
+  const clipTag = clip.tagName?.toLowerCase();
+  if (clipTag && positional.tagName.toLowerCase() !== clipTag) return null;
+  return positional;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes **"This clip can't be moved or resized from the timeline yet"** on clips that are perfectly well-formed.

## Root cause

`findTimelineDomNodeForClip` ends with a positional fallback:

```ts
return candidates[fallbackIndex] ?? null;
```

`candidates` is only nodes carrying `[data-start]`. A clip whose own element has none — an expanded child row, for instance — is never among them, so it falls through and is handed **an unrelated node by index**.

That corrupts **two** clips per collision:
- the caller gets a host that is not its element, and
- the clip that actually owned that node is starved to `null`, losing `hfId`, `domId` and `selector` — and with them `canMove`.

Instrumented on a six-scene composition, the resolver's own decisions:

```
clip s=0    d=14  trk=2 tag=img | branch=positional picked=hf-opwy   ← took the 6.0s scene div
clip s=0    d=14  trk=3 tag=img | branch=positional picked=hf-bxz4   ← took the 11.2s scene div
clip s=6    d=2.6 trk=1 tag=div | branch=none       picked=null      ← starved → refused
clip s=11.2 d=1.5 trk=1 tag=div | branch=none       picked=null      ← starved → refused
```

Those two starved scenes were **exactly** the two clips the timeline refused to move. The other four resolved normally and dragged fine.

## Fix

Require the positional candidate to share the clip's tag. Same-tag attribute drift still resolves, which is what the fallback exists for; cross-tag theft cannot happen.

Also included (found while chasing this, kept because it is a real latent inconsistency): `hasPatchableTimelineTarget` accepts `hfId`, matching `resolveDomEditCapabilities` (`Boolean(args.selector || args.hfId)`) and `timelineElementSplit.ts` (`Boolean(el.hfId || el.domId || el.selector)`). `TimelineElement` already carries `hfId`, `findElementForSelection` resolves `data-hf-id` ahead of id/selector, and the move handler's primary persist is `sdkTimingPersist(element.hfId, …)`.

## Verification

**End to end, in a Studio built from this branch:**
1. Opened a composition whose scene clips are plain `<div class="s clip" data-start data-duration>`.
2. Dragged the clip that was previously refused.
3. No toast. Timeline row moved `6.0 → 13.3`.
4. **Source file updated: `data-start="6"` → `data-start="13.28"`.**

**Tests** — `77/77` in the two touched files with the project's vitest config:
- `returns null instead of stealing a div for an img clip` — **fails on `main`**, passes here.
- `leaves the div clips resolvable after an unmatched img clip`.
- `still allows a same-tag positional fallback when attributes drift` — pins the behaviour the fallback is for, so this is not an over-fix.
- 4 capability tests for `hfId`, two of which fail on `main`.

lint, format, fallow, typecheck and commitlint all pass via pre-commit hooks.

## Note on scope

This supersedes my earlier framing of this PR. The `hfId` change alone did **not** fix dragging — I verified that and said so — and the positional fallback is the real cause. Both commits are here; the second is the fix.