### PR TITLE
fix(skills): stage SVGs that capture wrote into capture/assets/svgs/

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -6,7 +6,7 @@
       "files": 138
     },
     "faceless-explainer": {
-      "hash": "f37cb1dba2890b79",
+      "hash": "7d587ff36c975d9a",
       "files": 24
     },
     "figma": {
@@ -62,12 +62,12 @@
       "files": 132
     },
     "pr-to-video": {
-      "hash": "8ea0227e18ab5fc6",
+      "hash": "14250b018114d26d",
       "files": 30
     },
     "product-launch-video": {
-      "hash": "e89a8d11d99b4edf",
-      "files": 28
+      "hash": "12c0895d4963aa90",
+      "files": 29
     },
     "remotion-to-hyperframes": {
       "hash": "bf184a65059b95e8",

--- a/skills/faceless-explainer/scripts/lib/assets.mjs
+++ b/skills/faceless-explainer/scripts/lib/assets.mjs
@@ -17,8 +17,8 @@ export function basenamesFromCandidates(value) {
 }
 
 // Copy each frame's asset_candidates from capture/{assets,assets/videos,
-// screenshots} into assets/. Already-staged files are left as is (first-wins),
-// so calling this twice is safe. Returns { staged, wanted, anomalies }.
+// assets/svgs, screenshots} into assets/. Already-staged files are left as is
+// (first-wins), so calling this twice is safe. Returns { staged, wanted, anomalies }.
 export function stageAssets({ hyperframesDir, frames }) {
   const wanted = new Set();
   for (const f of frames) {
@@ -27,6 +27,7 @@ export function stageAssets({ hyperframesDir, frames }) {
   const captureDirs = [
     join(hyperframesDir, "capture/assets"),
     join(hyperframesDir, "capture/assets/videos"), // videos download into a subdir
+    join(hyperframesDir, "capture/assets/svgs"), // inline SVGs extract into a subdir
     join(hyperframesDir, "capture/screenshots"),
   ];
   const assetsDir = join(hyperframesDir, "assets");

--- a/skills/pr-to-video/scripts/lib/assets.mjs
+++ b/skills/pr-to-video/scripts/lib/assets.mjs
@@ -17,8 +17,8 @@ export function basenamesFromCandidates(value) {
 }
 
 // Copy each frame's asset_candidates from capture/{assets,assets/videos,
-// screenshots} into assets/. Already-staged files are left as is (first-wins),
-// so calling this twice is safe. Returns { staged, wanted, anomalies }.
+// assets/svgs, screenshots} into assets/. Already-staged files are left as is
+// (first-wins), so calling this twice is safe. Returns { staged, wanted, anomalies }.
 export function stageAssets({ hyperframesDir, frames }) {
   const wanted = new Set();
   for (const f of frames) {
@@ -27,6 +27,7 @@ export function stageAssets({ hyperframesDir, frames }) {
   const captureDirs = [
     join(hyperframesDir, "capture/assets"),
     join(hyperframesDir, "capture/assets/videos"), // videos download into a subdir
+    join(hyperframesDir, "capture/assets/svgs"), // inline SVGs extract into a subdir
     join(hyperframesDir, "capture/screenshots"),
   ];
   const assetsDir = join(hyperframesDir, "assets");

--- a/skills/product-launch-video/scripts/lib/assets.mjs
+++ b/skills/product-launch-video/scripts/lib/assets.mjs
@@ -17,8 +17,8 @@ export function basenamesFromCandidates(value) {
 }
 
 // Copy each frame's asset_candidates from capture/{assets,assets/videos,
-// screenshots} into assets/. Already-staged files are left as is (first-wins),
-// so calling this twice is safe. Returns { staged, wanted, anomalies }.
+// assets/svgs, screenshots} into assets/. Already-staged files are left as is
+// (first-wins), so calling this twice is safe. Returns { staged, wanted, anomalies }.
 export function stageAssets({ hyperframesDir, frames }) {
   const wanted = new Set();
   for (const f of frames) {
@@ -27,6 +27,7 @@ export function stageAssets({ hyperframesDir, frames }) {
   const captureDirs = [
     join(hyperframesDir, "capture/assets"),
     join(hyperframesDir, "capture/assets/videos"), // videos download into a subdir
+    join(hyperframesDir, "capture/assets/svgs"), // inline SVGs extract into a subdir
     join(hyperframesDir, "capture/screenshots"),
   ];
   const assetsDir = join(hyperframesDir, "assets");

--- a/skills/product-launch-video/scripts/stage-assets.test.mjs
+++ b/skills/product-launch-video/scripts/stage-assets.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { stageAssets } from "./lib/assets.mjs";
+
+// ── captured SVGs are stageable ──────────────────────────────────────────────
+// Regression: `hyperframes capture` extracts inline SVGs into capture/assets/svgs/
+// (assetDownloader.ts), and the capture manifest advertises them to the agent as
+// `assets/svgs/<name>.svg`, so a frame names one in `asset_candidates` exactly as
+// it names a screenshot. stageAssets only searched capture/{assets,assets/videos,
+// screenshots}, so every captured SVG resolved to nothing — reported as a
+// non-fatal anomaly, and the frame 404'd the logo it had been told to use.
+
+function projectWithCapturedSvg() {
+  const dir = mkdtempSync(join(tmpdir(), "product-launch-stage-assets-"));
+  mkdirSync(join(dir, "capture/assets/svgs"), { recursive: true });
+  mkdirSync(join(dir, "capture/screenshots"), { recursive: true });
+  writeFileSync(join(dir, "capture/assets/svgs/brand-mark.svg"), "<svg/>");
+  writeFileSync(join(dir, "capture/screenshots/hero.png"), "png");
+  return dir;
+}
+
+const frames = [
+  { extra: { asset_candidates: "assets/svgs/brand-mark.svg — the mark; assets/hero.png — hero" } },
+];
+
+test("stages an SVG that capture wrote into capture/assets/svgs/", () => {
+  const dir = projectWithCapturedSvg();
+
+  const { staged, wanted, anomalies } = stageAssets({ hyperframesDir: dir, frames });
+
+  assert.equal(wanted.size, 2);
+  assert.equal(staged, 2, `expected both assets staged, got anomalies: ${anomalies.join("; ")}`);
+  assert.deepEqual(anomalies, []);
+  assert.ok(existsSync(join(dir, "assets/brand-mark.svg")));
+  assert.ok(existsSync(join(dir, "assets/hero.png")));
+});
+
+test("still reports an asset that exists nowhere under capture/", () => {
+  const dir = projectWithCapturedSvg();
+
+  const { staged, anomalies } = stageAssets({
+    hyperframesDir: dir,
+    frames: [{ extra: { asset_candidates: "assets/svgs/absent.svg — never captured" } }],
+  });
+
+  assert.equal(staged, 0);
+  assert.equal(anomalies.length, 1);
+  assert.match(anomalies[0], /absent\.svg/);
+});


### PR DESCRIPTION
## What

`stageAssets` now searches `capture/assets/svgs/`, so an SVG that `hyperframes capture` extracted can be staged into `assets/` like any other captured asset.

## Why

`capture` writes inline SVGs to `capture/assets/svgs/` (`packages/cli/src/capture/assetDownloader.ts`), and the capture manifest advertises them to the agent as `assets/svgs/<name>.svg`. So a frame names one in `asset_candidates` exactly the way it names a screenshot.

The staging search list covered `capture/{assets,assets/videos,screenshots}` only. Every captured SVG resolved to nothing: logged as a non-fatal anomaly, and the frame 404'd the brand mark it had been told to use. Found running `/product-launch-video` end to end.

## How

One entry added to `captureDirs`.

`lib/assets.mjs` is byte-identical across `product-launch-video`, `faceless-explainer` and `pr-to-video`, so the fix lands in all three.

**Not covered:** the triplication itself. Folding `lib/assets.mjs` into `hyperframes-core/scripts/lib/`, where `frame-packets-core.mjs` already lives, is a separate change and not in this PR.

## Test plan

New `skills/product-launch-video/scripts/stage-assets.test.mjs`, covering both the captured-SVG case and an asset that genuinely exists nowhere (so the anomaly path is still exercised).

Verified it fails on the parent commit and passes here.

Manual: a fixture project with a captured SVG, a screenshot and a root capture asset, all three named by one frame.

- Before: `✓ staged 2/3 asset(s) into assets/` plus `asset "brand-mark.svg" named by a frame but not found under capture/`
- After: `✓ staged 3/3 asset(s) into assets/`

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)
