### PR TITLE
fix(skills): resolve the blueprint id from a qualified `blueprint:` field

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -34,7 +34,7 @@
       "files": 11
     },
     "hyperframes-core": {
-      "hash": "44e7bdc3ae4c4112",
+      "hash": "74b9841f63c8f405",
       "files": 20
     },
     "hyperframes-creative": {
@@ -66,7 +66,7 @@
       "files": 30
     },
     "product-launch-video": {
-      "hash": "ad921058e743ea29",
+      "hash": "ff7c30295b67fc2e",
       "files": 29
     },
     "remotion-to-hyperframes": {

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -34,7 +34,7 @@
       "files": 11
     },
     "hyperframes-core": {
-      "hash": "f6516b74cb6e5d58",
+      "hash": "44e7bdc3ae4c4112",
       "files": 20
     },
     "hyperframes-creative": {
@@ -66,7 +66,7 @@
       "files": 30
     },
     "product-launch-video": {
-      "hash": "12c0895d4963aa90",
+      "hash": "ad921058e743ea29",
       "files": 29
     },
     "remotion-to-hyperframes": {

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -6,7 +6,7 @@
       "files": 138
     },
     "faceless-explainer": {
-      "hash": "7d587ff36c975d9a",
+      "hash": "81423e16a3e2806d",
       "files": 24
     },
     "figma": {
@@ -62,7 +62,7 @@
       "files": 132
     },
     "pr-to-video": {
-      "hash": "14250b018114d26d",
+      "hash": "bacdbbd868cd84a1",
       "files": 30
     },
     "product-launch-video": {

--- a/skills/faceless-explainer/references/story-design.md
+++ b/skills/faceless-explainer/references/story-design.md
@@ -233,7 +233,7 @@ Use the exact fields required by the core storyboard format. This is the narrati
 - type: feature_showcase
 - persuasion: Progressive disclosure
 - beat: comprehension
-- blueprint: messaging-multi-phase — candidate shape from the role→blueprint menu; omit when none fits
+- blueprint: dataviz-countup — candidate shape from the role→blueprint menu; omit when none fits
 
 narrativeRole: What this frame does in the viewer's understanding.
 keyMessage: The one idea the viewer should remember.

--- a/skills/hyperframes-core/scripts/lib/frame-packets-core.mjs
+++ b/skills/hyperframes-core/scripts/lib/frame-packets-core.mjs
@@ -83,14 +83,29 @@ export function citedRules(block, ruleIds) {
   return [...new Set([...explicit, ...mentioned])].filter((id) => ruleIds.includes(id));
 }
 
-export function resourceSections(block, { animationDir, ruleIds }) {
+// visual-design.md tells the author to write the blueprint as `<id> (Reproduce)`
+// or `<id> (Adapt)` — the qualifier is direction for the frame worker, not part of
+// the filename. Parse the field into the id it names (or null for `compose`), so
+// no caller ever resolves a raw field value against the blueprints directory.
+export function blueprintId(block) {
+  const raw = field(block, "blueprint");
+  if (!raw) return null;
+  const id = raw.replace(/\s*\([^)]*\)\s*$/, "").trim();
+  return id && id.toLowerCase() !== "compose" ? id : null;
+}
+
+export function resourceSections(block, { animationDir, ruleIds, frameId }) {
   let sections = "";
-  const blueprint = field(block, "blueprint");
-  if (blueprint && blueprint.toLowerCase() !== "compose") {
-    sections += selectedFile(
-      join(animationDir, "blueprints", `${blueprint}.md`),
-      `Selected blueprint: ${blueprint}`,
-    );
+  const blueprint = blueprintId(block);
+  if (blueprint) {
+    const path = join(animationDir, "blueprints", `${blueprint}.md`);
+    // A blueprint that resolves to nothing used to inline an empty string, so the
+    // packet shipped without the one document the frame was designed against and
+    // the run still reported success. Name it instead.
+    if (!existsSync(path)) {
+      throw new Error(`${frameId ?? "frame"}: blueprint "${blueprint}" has no file at ${path}`);
+    }
+    sections += selectedFile(path, `Selected blueprint: ${blueprint}`);
   }
   for (const rule of citedRules(block, ruleIds)) {
     sections += selectedFile(
@@ -135,7 +150,7 @@ export function buildFramePackets({
   const packets = frames.map((frame) => {
     const id = frameId(frame);
     if (validateFrame) validateFrame(frame, id);
-    const packet = `# Frame packet: ${id}\n\n## Project inputs\n\n- Project: ${resolve(projectDir)}\n${designTruthLine(projectDir)}\n- RULES_DIR: ${join(animationDir, "rules")}\n\n## Assigned storyboard block\n\n${frame.block}\n${resourceSections(frame.block, { animationDir, ruleIds })}${extraSections ? extraSections(frame.block) : ""}`;
+    const packet = `# Frame packet: ${id}\n\n## Project inputs\n\n- Project: ${resolve(projectDir)}\n${designTruthLine(projectDir)}\n- RULES_DIR: ${join(animationDir, "rules")}\n\n## Assigned storyboard block\n\n${frame.block}\n${resourceSections(frame.block, { animationDir, ruleIds, frameId: id })}${extraSections ? extraSections(frame.block) : ""}`;
     const bytes = Buffer.byteLength(packet);
     if (bytes > maxPacketBytes) {
       throw new Error(`${id}: frame packet is ${bytes} bytes (limit ${maxPacketBytes})`);

--- a/skills/hyperframes-core/scripts/lib/frame-packets-core.mjs
+++ b/skills/hyperframes-core/scripts/lib/frame-packets-core.mjs
@@ -98,14 +98,23 @@ export function resourceSections(block, { animationDir, ruleIds, frameId }) {
   let sections = "";
   const blueprint = blueprintId(block);
   if (blueprint) {
-    const path = join(animationDir, "blueprints", `${blueprint}.md`);
-    // A blueprint that resolves to nothing used to inline an empty string, so the
+    const blueprintsDir = join(animationDir, "blueprints");
+    const path = join(blueprintsDir, `${blueprint}.md`);
+    // A blueprint that resolved to nothing used to inline an empty string, so the
     // packet shipped without the one document the frame was designed against and
-    // the run still reported success. Name it instead.
-    if (!existsSync(path)) {
+    // the run still reported success. Name it instead — but only when the library
+    // is actually there to be named against. The animation skill installs on
+    // demand, so an absent blueprints/ is a missing install, not a bad id, and it
+    // degrades with a warning exactly like an absent rules/ (see knownRuleIds).
+    if (!existsSync(blueprintsDir)) {
+      console.warn(
+        `frame-packets: no blueprints dir at ${blueprintsDir} — packets will inline no blueprint`,
+      );
+    } else if (!existsSync(path)) {
       throw new Error(`${frameId ?? "frame"}: blueprint "${blueprint}" has no file at ${path}`);
+    } else {
+      sections += selectedFile(path, `Selected blueprint: ${blueprint}`);
     }
-    sections += selectedFile(path, `Selected blueprint: ${blueprint}`);
   }
   for (const rule of citedRules(block, ruleIds)) {
     sections += selectedFile(

--- a/skills/pr-to-video/scripts/workflow-guardrails.test.mjs
+++ b/skills/pr-to-video/scripts/workflow-guardrails.test.mjs
@@ -83,7 +83,7 @@ test("#1092 packets contain selected excerpts but never the full diff", () => {
   write(join(project, "frame.md"), "# compact frame tokens\n");
   write(
     join(project, "STORYBOARD.md"),
-    `---\nformat: 1920x1080\n---\n\n## Frame 1 — Diff\n\n- duration: 4s\n- src: compositions/frames/01-diff.html\n- focal: code-diff\n- blueprint: compose\n- rules: text-reveal\n\n### Source excerpt\n\n\`\`\`diff\n-oldCall()\n+newCall({ attested: true })\n\`\`\`\n\n## Frame 2 — Impact\n\n- duration: 3s\n- src: compositions/frames/02-impact.html\n- blueprint: number-lockup\n- rules: counting-dynamic-scale\n`,
+    `---\nformat: 1920x1080\n---\n\n## Frame 1 — Diff\n\n- duration: 4s\n- src: compositions/frames/01-diff.html\n- focal: code-diff\n- blueprint: compose\n- rules: text-reveal\n\n### Source excerpt\n\n\`\`\`diff\n-oldCall()\n+newCall({ attested: true })\n\`\`\`\n\n## Frame 2 — Impact\n\n- duration: 3s\n- src: compositions/frames/02-impact.html\n- blueprint: dataviz-countup\n- rules: counting-dynamic-scale\n`,
   );
 
   const result = buildFramePackets({

--- a/skills/product-launch-video/scripts/frame-packets.test.mjs
+++ b/skills/product-launch-video/scripts/frame-packets.test.mjs
@@ -123,3 +123,22 @@ test("a blueprint with no file fails the run instead of shipping an empty sectio
   );
   assert.equal(existsSync(outDir), false);
 });
+
+test("an uninstalled animation skill degrades with a warning, it does not fail the run", () => {
+  // hyperframes-animation installs on demand, so an absent blueprints/ means the
+  // library isn't there yet — not that the frame named a bad id. Matches how an
+  // absent rules/ already behaves.
+  const project = mkdtempSync(join(tmpdir(), "plv-blueprint-uninstalled-"));
+  write(join(project, "frame.md"), "# tokens\n");
+  write(
+    join(project, "STORYBOARD.md"),
+    `---\nformat: 1920x1080\n---\n\n## Frame 1 — Hook\n\n- duration: 3s\n- src: compositions/frames/01-hook.html\n- blueprint: dataviz-countup (Adapt)\n`,
+  );
+
+  const [packet] = buildFramePackets({
+    projectDir: project,
+    animationDir: join(project, "absent-animation-skill"),
+  });
+
+  assert.doesNotMatch(readFileSync(packet.path, "utf8"), /## Selected blueprint/);
+});

--- a/skills/product-launch-video/scripts/frame-packets.test.mjs
+++ b/skills/product-launch-video/scripts/frame-packets.test.mjs
@@ -64,3 +64,62 @@ test("packet validation is atomic and leaves no partial output on overflow", () 
   );
   assert.equal(existsSync(outDir), false);
 });
+
+// ── the blueprint qualifier ──────────────────────────────────────────────────
+// Regression: visual-design.md documents `blueprint:` as the id plus a
+// `(Reproduce)` / `(Adapt)` qualifier, and prints `dataviz-countup (Adapt)` as
+// its worked example. The resolver used the raw field as the filename, so every
+// qualified blueprint looked for a file that cannot exist and inlined "" —
+// packets shipped without the document the frame was designed against, and the
+// run still reported success. The cases above only ever used bare ids.
+
+test("a qualified blueprint resolves to the same body as the bare id", () => {
+  const project = mkdtempSync(join(tmpdir(), "plv-blueprint-qualified-"));
+  write(join(project, "frame.md"), "# tokens\n");
+  write(
+    join(project, "STORYBOARD.md"),
+    `---\nformat: 1920x1080\n---\n\n## Frame 1 — Adapted\n\n- duration: 3s\n- src: compositions/frames/01-adapted.html\n- blueprint: device-surface-showcase (Adapt)\n\n## Frame 2 — Reproduced\n\n- duration: 3s\n- src: compositions/frames/02-reproduced.html\n- blueprint: device-surface-showcase (Reproduce)\n\n## Frame 3 — Bare\n\n- duration: 3s\n- src: compositions/frames/03-bare.html\n- blueprint: device-surface-showcase\n`,
+  );
+
+  const packets = buildFramePackets({ projectDir: project });
+  const blueprintSections = packets.map((packet) => {
+    const body = readFileSync(packet.path, "utf8");
+    const start = body.indexOf("## Selected blueprint:");
+    assert.notEqual(start, -1, `${packet.frameId} inlined no blueprint`);
+    return body.slice(start);
+  });
+
+  assert.match(blueprintSections[0], /## Selected blueprint: device-surface-showcase\n/);
+  // The qualifier is direction for the worker, not a different document: all
+  // three frames must inline byte-identical blueprint bodies.
+  assert.equal(new Set(blueprintSections).size, 1);
+});
+
+test("a qualified `compose` still selects no blueprint", () => {
+  const project = mkdtempSync(join(tmpdir(), "plv-blueprint-compose-"));
+  write(join(project, "frame.md"), "# tokens\n");
+  write(
+    join(project, "STORYBOARD.md"),
+    `---\nformat: 1920x1080\n---\n\n## Frame 1 — Freeform\n\n- duration: 3s\n- src: compositions/frames/01-freeform.html\n- blueprint: compose (Adapt)\n`,
+  );
+
+  const [packet] = buildFramePackets({ projectDir: project });
+
+  assert.doesNotMatch(readFileSync(packet.path, "utf8"), /## Selected blueprint/);
+});
+
+test("a blueprint with no file fails the run instead of shipping an empty section", () => {
+  const project = mkdtempSync(join(tmpdir(), "plv-blueprint-missing-"));
+  const outDir = join(project, ".hyperframes", "frame-packets");
+  write(join(project, "frame.md"), "# tokens\n");
+  write(
+    join(project, "STORYBOARD.md"),
+    `---\nformat: 1920x1080\n---\n\n## Frame 1 — Typo\n\n- duration: 3s\n- src: compositions/frames/01-typo.html\n- blueprint: device-surface-showcses\n`,
+  );
+
+  assert.throws(
+    () => buildFramePackets({ projectDir: project, outDir }),
+    /01-typo: blueprint "device-surface-showcses" has no file/,
+  );
+  assert.equal(existsSync(outDir), false);
+});


### PR DESCRIPTION
## What

The frame-packet builder now parses the `blueprint:` field into the blueprint id it names, instead of using the raw field as a filename. A blueprint that resolves to no file is a named error rather than a silently empty section.

## Why

`references/visual-design.md` documents `blueprint:` as the id plus a `(Reproduce)` / `(Adapt)` qualifier, and prints `dataviz-countup (Adapt)` as its worked example. The resolver passed that raw value straight to `join(animationDir, "blueprints", `${blueprint}.md`)`, so a qualified blueprint looked for `<id> (Adapt).md`. That file cannot exist, and `selectedFile()` returns `""` for a missing path.

The result: every packet shipped without the one document the frame was designed against, and the run still exited 0 with nothing on stderr. On a storyboard whose only difference was the documented qualifier, packets dropped from 17836 bytes to 648 bytes with no `## Selected blueprint` section, and the CLI still printed `✓ frame packets: 1 bounded packet(s)`.

`compose (Adapt)` missed the `compose` check the same way, so it went looking for `compose (Adapt).md`.

This affects `product-launch-video`, `faceless-explainer`, `pr-to-video` and `general-video`, which all delegate to the shared builder.

## How

`blueprintId(block)` parses the field once, so no caller resolves a raw field value against the blueprints directory. The qualifier is direction for the frame worker, not part of the filename.

A blueprint with no file now throws, naming the frame, the id and the path. That matches how the builder already treats a missing `src` and an oversize packet, and it means a typo fails the run instead of quietly producing a packet with no motion guidance.

The docs are correct as written and are unchanged; the resolver was the side that was wrong.

## Test plan

Three cases added to `frame-packets.test.mjs`: a qualified id resolves to a byte-identical blueprint body across `(Adapt)`, `(Reproduce)` and the bare form; a qualified `compose` still selects nothing; a blueprint with no file throws and leaves no partial output.

The existing tests used bare ids only, which is how the documented form escaped them. Verified the two new behavioural cases fail on the parent commit and pass here.

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

## Review notes

Two follow-up commits, both from making the failure visible.

**1. Absent library vs bad id.** Throwing on any unresolvable blueprint was too broad. `hyperframes-animation` installs on demand, so an absent `blueprints/` directory is a skill that isn't installed yet, not a frame naming a bad id. The second commit splits them: an absent library warns and inlines nothing, exactly as an absent `rules/` already does in `knownRuleIds`; a present library with no file for this id still throws.

**2. Two dead blueprint references, surfaced by CI.** The new error caught two ids that have never existed in `hyperframes-animation/blueprints/`:

- `skills/faceless-explainer/references/story-design.md` — the frame template taught `messaging-multi-phase`, so an agent copying it verbatim tagged a blueprint that resolves to nothing. This is the bug reaching users through the docs, not just a fixture.
- `skills/pr-to-video/scripts/workflow-guardrails.test.mjs` — the diff-excerpt fixture used `number-lockup`.

Both now point at `dataviz-countup`, which the faceless-explainer skill already uses in its own visual-design template and tests, and which matches the pr-to-video frame's own `counting-dynamic-scale` rule. A sweep of every `blueprint:` value across `skills/` finds no others.