### PR TITLE
fix(audio): rebuild timestamps between apad and atrim so FFmpeg 7+ keeps every mixed clip

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -218,6 +218,7 @@ export {
   parseAudioElements,
   processCompositionAudio,
 } from "./services/audioMixer.js";
+export { buildPadToDurationFilter } from "./services/audioPadFilter.js";
 export { cloneCaptureWarning, cloneCaptureWarnings } from "./services/captureWarning.js";
 export type {
   AudioElement,

--- a/packages/engine/src/services/audioMixer.padTimestamps.integration.test.ts
+++ b/packages/engine/src/services/audioMixer.padTimestamps.integration.test.ts
@@ -74,7 +74,11 @@ function rmsDb(path: string, atSeconds: number): number {
   const match = /RMS level dB:\s*(\S+)/.exec(overall);
   if (!match) throw new Error(`astats reported no RMS level for ${path} at ${atSeconds}s`);
   const raw = match[1]!;
-  return raw.endsWith("inf") ? (raw.startsWith("-") ? -Infinity : Infinity) : Number.parseFloat(raw);
+  return raw.endsWith("inf")
+    ? raw.startsWith("-")
+      ? -Infinity
+      : Infinity
+    : Number.parseFloat(raw);
 }
 
 describe.skipIf(!hasFfmpeg)("mixed audio branch padding", () => {

--- a/packages/engine/src/services/audioMixer.padTimestamps.integration.test.ts
+++ b/packages/engine/src/services/audioMixer.padTimestamps.integration.test.ts
@@ -1,0 +1,139 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { processCompositionAudio } from "./audioMixer.js";
+import type { AudioElement } from "./audioMixer.types.js";
+
+/**
+ * Real-FFmpeg regression test for the pad/trim branch template.
+ *
+ * `apad,atrim=0:<total>` — an indefinite pad bounded by a downstream trim —
+ * behaves on FFmpeg 4.2.7 and misbehaves on 7.0.2 and newer: audio leaks to
+ * `t=0` from three mixed branches onward, and from four branches onward the
+ * branch with the largest `adelay` disappears from the mix. Nothing errors;
+ * the render succeeds with wrong audio, which is why only an output
+ * measurement catches it.
+ *
+ * Three or fewer clips is not enough — the dropped-branch half of the bug does
+ * not appear until four. This mixes five.
+ */
+
+const dirs: string[] = [];
+afterEach(() => dirs.splice(0).forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+
+const hasFfmpeg = (() => {
+  try {
+    execFileSync("ffmpeg", ["-version"], { stdio: "ignore" });
+    execFileSync("ffprobe", ["-version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+const TOTAL_SECONDS = 43.3;
+
+/** start (s), source duration (s), tone frequency (Hz) */
+const CLIPS = [
+  { start: 0.3, duration: 7.01, frequency: 400 },
+  { start: 19.6, duration: 0.4, frequency: 1000 },
+  { start: 20.6, duration: 0.4, frequency: 1200 },
+  { start: 30.0, duration: 0.4, frequency: 1500 },
+  { start: 40.0, duration: 0.4, frequency: 1800 },
+] as const;
+
+/**
+ * Mean RMS in dB over a 250ms window starting at `atSeconds`. Digital silence
+ * reports `-inf`, which is the signal for "this branch is not in the mix".
+ */
+function rmsDb(path: string, atSeconds: number): number {
+  const probe = spawnSync(
+    "ffmpeg",
+    [
+      "-hide_banner",
+      "-v",
+      "info",
+      "-ss",
+      atSeconds.toFixed(3),
+      "-t",
+      "0.25",
+      "-i",
+      path,
+      "-af",
+      "astats=metadata=1",
+      "-f",
+      "null",
+      "-",
+    ],
+    { encoding: "utf8" },
+  );
+  const stderr = probe.stderr ?? "";
+  const overall = stderr.slice(stderr.lastIndexOf("Overall"));
+  const match = /RMS level dB:\s*(\S+)/.exec(overall);
+  if (!match) throw new Error(`astats reported no RMS level for ${path} at ${atSeconds}s`);
+  const raw = match[1]!;
+  return raw.endsWith("inf") ? (raw.startsWith("-") ? -Infinity : Infinity) : Number.parseFloat(raw);
+}
+
+describe.skipIf(!hasFfmpeg)("mixed audio branch padding", () => {
+  it("keeps t=0 silent and lands all five staggered clips at their offsets", async () => {
+    const baseDir = mkdtempSync(join(tmpdir(), "hf-padts-base-"));
+    const workDir = mkdtempSync(join(tmpdir(), "hf-padts-work-"));
+    dirs.push(baseDir, workDir);
+
+    const elements: AudioElement[] = CLIPS.map((clip, i) => {
+      const src = `clip-${i}.wav`;
+      execFileSync("ffmpeg", [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "lavfi",
+        "-i",
+        `sine=frequency=${clip.frequency}:duration=${clip.duration}`,
+        "-ar",
+        "44100",
+        "-ac",
+        "2",
+        "-y",
+        join(baseDir, src),
+      ]);
+      return {
+        id: `clip-${i}`,
+        src,
+        start: clip.start,
+        end: clip.start + clip.duration,
+        mediaStart: 0,
+        layer: 0,
+        volume: 1,
+        type: "audio",
+      };
+    });
+
+    const outputPath = join(baseDir, "out.m4a");
+    const result = await processCompositionAudio(
+      elements,
+      baseDir,
+      workDir,
+      outputPath,
+      TOTAL_SECONDS,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+    expect(result.tracksProcessed).toBe(CLIPS.length);
+
+    // The earliest clip starts at 0.3s, so the head of the mix is silence.
+    // The bug puts every clip's audio here at once, ~-29 dB.
+    expect(rmsDb(outputPath, 0)).toBeLessThan(-60);
+
+    // Every clip is audible at its own offset. `-Infinity` here means the
+    // branch is missing from the mix entirely, which is the second half of
+    // the bug and only shows from four branches onward.
+    for (const clip of CLIPS) {
+      expect(rmsDb(outputPath, clip.start + 0.02)).toBeGreaterThan(-45);
+    }
+  }, 120_000);
+});

--- a/packages/engine/src/services/audioMixer.test.ts
+++ b/packages/engine/src/services/audioMixer.test.ts
@@ -296,7 +296,7 @@ describe("processCompositionAudio", () => {
 
     expect(filter).toContain("volume=0");
     expect(filter).toContain("[mixed]volume=1[out]");
-    expect(filter).toContain("apad,atrim=0:2");
+    expect(filter).toContain("apad,asetpts=N/SR/TB,atrim=0:2");
     expect(filter).not.toContain("whole_dur");
     expect(filter).not.toContain("normalize=");
     expect(filter).not.toContain("weights=");
@@ -464,7 +464,7 @@ describe("processCompositionAudio", () => {
     // 2 s clip + the 1.9 s tail 0.6 + size * 2.6 generates.
     expect(filter).toContain("atrim=0:3.9,");
     // And still cut at the composition's end, so a tail cannot extend the video.
-    expect(filter).toContain("apad,atrim=0:8");
+    expect(filter).toContain("apad,asetpts=N/SR/TB,atrim=0:8");
   });
 
   it("hands the volume envelope to the FX pass instead of ducking the file after it", async () => {
@@ -1076,6 +1076,9 @@ describe("processCompositionAudio", () => {
     // indefinite `apad` to cap the padded stream at composition duration.
     expect((filter?.match(/atrim=/g) ?? []).length).toBe(trackCount * 2);
     expect((filter?.match(/apad,/g) ?? []).length).toBe(trackCount);
+    // The timestamp rebuild between the two is what keeps that cap correct on
+    // FFmpeg 7+; without it the last-delayed track is dropped from the mix.
+    expect((filter?.match(/apad,asetpts=N\/SR\/TB,atrim=/g) ?? []).length).toBe(trackCount);
   });
 
   it("retries with the current file-valued filter option when a nightly removes the legacy alias", async () => {

--- a/packages/engine/src/services/audioMixer.ts
+++ b/packages/engine/src/services/audioMixer.ts
@@ -31,6 +31,7 @@ import type {
   MixResult,
 } from "./audioMixer.types.js";
 import { applyVolumeEnvelopeToWav } from "./audioVolumeEnvelope.js";
+import { buildPadToDurationFilter } from "./audioPadFilter.js";
 import { HF_AUDIO_FX_ATTR, parseAudioFxChain } from "@hyperframes/core/audio-fx";
 import {
   HF_AUDIO_AUTOMATION_ATTR,
@@ -703,7 +704,7 @@ async function mixAudioTracks(
       const trimDuration = track.end - track.start + (track.tailSeconds ?? 0);
       const volumeFilter = buildVolumeExpression(track, ignoreAutomation);
       filterParts.push(
-        `[${i}:a]atrim=0:${formatFilterNumber(trimDuration)},${volumeFilter},adelay=${delayMs}|${delayMs},apad,atrim=0:${formatFilterNumber(totalDuration)}[a${i}]`,
+        `[${i}:a]atrim=0:${formatFilterNumber(trimDuration)},${volumeFilter},adelay=${delayMs}|${delayMs},${buildPadToDurationFilter(formatFilterNumber(totalDuration))}[a${i}]`,
       );
     });
 

--- a/packages/engine/src/services/audioPadFilter.test.ts
+++ b/packages/engine/src/services/audioPadFilter.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildPadToDurationFilter } from "./audioPadFilter.js";
+
+describe("buildPadToDurationFilter", () => {
+  it("pads indefinitely, rebuilds timestamps, then bounds at the target", () => {
+    expect(buildPadToDurationFilter("43.3")).toBe("apad,asetpts=N/SR/TB,atrim=0:43.3");
+  });
+
+  it("keeps off `whole_dur`, which the bundled Windows FFmpeg builds reject", () => {
+    expect(buildPadToDurationFilter("5.000000")).not.toContain("whole_dur");
+  });
+
+  it("uses the caller's number formatting verbatim", () => {
+    // Each call site formats seconds differently (fixed-6 in the producer,
+    // trimmed in the mixer). The helper must not normalize either away.
+    expect(buildPadToDurationFilter("5.000000")).toContain("atrim=0:5.000000");
+    expect(buildPadToDurationFilter("5")).toContain("atrim=0:5");
+  });
+
+  it("places asetpts between apad and atrim, which is the whole fix", () => {
+    // `atrim` reading an indefinite `apad`'s timestamps directly is what drops
+    // and misplaces mixed clips on FFmpeg 7+. Order is the behaviour here, so
+    // pin it rather than only pinning membership.
+    const chain = buildPadToDurationFilter("8").split(",");
+    expect(chain).toEqual(["apad", "asetpts=N/SR/TB", "atrim=0:8"]);
+  });
+});

--- a/packages/engine/src/services/audioPadFilter.ts
+++ b/packages/engine/src/services/audioPadFilter.ts
@@ -1,0 +1,37 @@
+/**
+ * Pad-to-duration filter chain, shared by every audio path that has to hold a
+ * stream to the composition's length.
+ *
+ * Three call sites build this chain — the engine mixer, the producer's audio
+ * extractor, and the producer's pad/trim step — and before this module they
+ * each rebuilt the string by hand, so a fix in one did not reach the others.
+ *
+ * ## Why the chain is three filters and not one
+ *
+ * `apad` with no duration pads indefinitely; the trailing `atrim` is what
+ * bounds it. That pairing is deliberate: `apad=whole_dur=<seconds>` says the
+ * same thing in one filter, but the bundled Windows FFmpeg builds reject the
+ * option outright (`Error applying option 'whole_dur': Option not found`), and
+ * it does not bound a branch that is already *longer* than the target — an FX
+ * tail that overruns the composition survives `whole_dur` and is cut by
+ * `atrim`.
+ *
+ * On FFmpeg 7 and newer, however, `atrim` reading `apad`'s output timestamps
+ * directly is what broke the mix: audio leaked to `t=0` from three mixed
+ * branches onward, and from four branches onward the branch with the largest
+ * `adelay` vanished from the output entirely. Nothing errored.
+ *
+ * `asetpts=N/SR/TB` between them rebuilds each frame's timestamp from the
+ * running sample count, so `atrim` sees a monotonic sample-accurate timeline
+ * instead of whatever the release propagates through an indefinite `apad`.
+ * Measured against FFmpeg 7.0.2, the output is then sample-for-sample what
+ * `apad=whole_dur` produces — without giving up the `atrim` bound or the
+ * Windows builds.
+ *
+ * @param seconds Target duration, already formatted for a filter string by the
+ *   caller. Each call site has its own number formatting and this helper must
+ *   not silently change it.
+ */
+export function buildPadToDurationFilter(seconds: string): string {
+  return `apad,asetpts=N/SR/TB,atrim=0:${seconds}`;
+}

--- a/packages/producer/src/services/audioExtractor.ts
+++ b/packages/producer/src/services/audioExtractor.ts
@@ -9,7 +9,7 @@
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, rmSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { getFfmpegBinary, trackChildProcess } from "@hyperframes/engine";
+import { buildPadToDurationFilter, getFfmpegBinary, trackChildProcess } from "@hyperframes/engine";
 
 export interface AudioElement {
   id: string;
@@ -207,7 +207,7 @@ async function mixTracks(
     const trimDuration = track.duration > 0 ? track.duration : totalDuration;
 
     filterParts.push(
-      `[${i}:a]atrim=0:${trimDuration},volume=${track.volume},adelay=${delayMs}|${delayMs},apad,atrim=0:${totalDuration}[a${i}]`,
+      `[${i}:a]atrim=0:${trimDuration},volume=${track.volume},adelay=${delayMs}|${delayMs},${buildPadToDurationFilter(String(totalDuration))}[a${i}]`,
     );
   });
 

--- a/packages/producer/src/services/render/audioPadTrim.test.ts
+++ b/packages/producer/src/services/render/audioPadTrim.test.ts
@@ -30,7 +30,7 @@ describe("buildPadTrimAudioArgs", () => {
     expect(plan.steps).toHaveLength(1);
     const args = plan.steps[0]!.args;
     expect(args[args.indexOf("-i") + 1]).toBe("/tmp/in.aac");
-    expect(args[args.indexOf("-af") + 1]).toBe("apad,atrim=0:5.000000");
+    expect(args[args.indexOf("-af") + 1]).toBe("apad,asetpts=N/SR/TB,atrim=0:5.000000");
     expect(args.join(" ")).not.toContain("whole_dur");
     expect(args[args.indexOf("-t") + 1]).toBe("5.000000");
     expect(args[args.indexOf("-c:a") + 1]).toBe("aac");
@@ -105,7 +105,7 @@ describe("buildPadTrimAudioArgs", () => {
     expect(winPlan.operation).toBe("pad");
     const args = winPlan.steps[0]!.args;
     expect(args).toContain("-af");
-    expect(args[args.indexOf("-af") + 1]).toBe("apad,atrim=0:5.000000");
+    expect(args[args.indexOf("-af") + 1]).toBe("apad,asetpts=N/SR/TB,atrim=0:5.000000");
     expect(args.join(" ")).not.toContain("whole_dur");
   });
 });

--- a/packages/producer/src/services/render/audioPadTrim.ts
+++ b/packages/producer/src/services/render/audioPadTrim.ts
@@ -22,6 +22,7 @@
 import { spawn } from "node:child_process";
 import { rmSync } from "node:fs";
 import {
+  buildPadToDurationFilter,
   extractAudioMetadata,
   formatFfmpegError,
   getFfprobeBinary,
@@ -109,10 +110,11 @@ export interface PadTrimAudioPlan {
  * sequence that materializes it. Exported separately so unit tests can pin
  * every branch without spawning ffmpeg.
  *
- *   - `sourceDuration < targetDuration` → pad with `apad` to the exact target
- *     and re-encode AAC. This decodes and re-encodes the already mixed audio;
- *     an earlier concat-copy shape avoided that but could not produce a
- *     portable result on the bundled Windows FFmpeg builds.
+ *   - `sourceDuration < targetDuration` → pad to the exact target with the
+ *     shared `buildPadToDurationFilter` chain and re-encode AAC. This decodes
+ *     and re-encodes the already mixed audio; an earlier concat-copy shape
+ *     avoided that but could not produce a portable result on the bundled
+ *     Windows FFmpeg builds.
  *   - `sourceDuration > targetDuration` → filter to the exact target and
  *     re-encode AAC so packet padding cannot outlast the video.
  *   - `|Δ| < AUDIO_DURATION_TOLERANCE_SECONDS` → no-op `copy`, but we still
@@ -143,7 +145,7 @@ export function buildPadTrimAudioPlan(
             "-i",
             audioPath,
             "-af",
-            `apad,atrim=0:${targetSec}`,
+            buildPadToDurationFilter(targetSec),
             "-t",
             targetSec,
             "-c:a",


### PR DESCRIPTION
## What

`apad,atrim=0:<total>` — an indefinite pad bounded by a downstream trim — is replaced everywhere with `apad,asetpts=N/SR/TB,atrim=0:<total>`, and the three call sites that rebuilt that chain by hand now share one helper.

Closes #3344.

## Why

I reproduced the issue's script against `ffmpeg 7.0.2-static` on this machine and got the reported numbers back byte for byte:

```
n=3 buggy  t=0.00s:  -24.973295   c0@19.6s: -31.019831   c1@20.6s: -30.104231
n=4 buggy  t=0.00s:  -30.168587   c0@19.6s: -28.521118   c1@20.6s: -27.606027   c3@30.0s:       -inf
n=5 buggy  t=0.00s:  -29.413305   c0@19.6s: -29.081774   c1@20.6s: -28.166525   c3@30.0s: -27.338586   c4@40.0s:       -inf
```

## How

**The suggested fix is `apad=whole_dur=<total>`, and I did not take it — twice over.**

1. This repo has already decided against `whole_dur` and pinned the decision in three assertions and an error-classification test: *"Bundled Windows FFmpeg builds reject `apad=whole_dur`"* (`audioPadTrim.test.ts:96`), and `audioMixer.test.ts` carries a case whose stderr fixture is literally `Error applying option 'whole_dur': Option not found`. Swapping it in would fix Linux 7.x by breaking the builds that comment is about.

2. `whole_dur` also drops a bound the current chain provides. `audioMixer.ts` deliberately lets an FX tail run past its clip and relies on the trailing `atrim` to stop it at the composition's end. With the same six branches (one delayed 42 s with a 5 s tail against a 43.3 s composition) and `-t` removed so the graph speaks for itself:

   | branch template | output duration |
   | --- | --- |
   | `apad,atrim=0:43.3` (current) | 43.300000 |
   | `apad=whole_dur=43.3` | **46.999977** |
   | `apad,asetpts=N/SR/TB,atrim=0:43.3` | 43.300000 |

   Today `-t totalDuration` hides that at both mix call sites. It is still a bound quietly moving from the filter graph to the muxer.

**What actually goes wrong is narrower than "`apad` + `atrim`".** Any `atrim` reading `apad`'s output timestamps directly is affected — I tried `atrim=end=`, reordering, and `asetpts` after the trim, and all three still drop clip 4. Rebuilding the timestamps from the running sample count *between* the two is what fixes it, and the result is then identical to `whole_dur` at every clip count I measured (2, 3, 4, 5, 6) while keeping both the `atrim` bound and the Windows builds:

```
n=5 CURRENT       t0: -29.413305 c0: -29.081774 c1: -28.166525 c2: -23.356880 c3: -27.338586 c4:       -inf
n=5 whole_dur     t0:       -inf c0: -31.019831 c1: -30.103960 c2: -24.084179 c3: -29.276778 c4: -28.521531
n=5 asetpts FIX   t0:       -inf c0: -31.019831 c1: -30.103960 c2: -24.084179 c3: -29.276778 c4: -28.521531
```

**One place, not three.** `buildPadToDurationFilter` lives in `packages/engine/src/services/audioPadFilter.ts` and is exported from `@hyperframes/engine`; `audioMixer.ts`, `audioExtractor.ts` and `audioPadTrim.ts` all call it. It takes an already-formatted seconds string on purpose — the three sites format numbers differently (`Number(v.toFixed(6)).toString()`, raw `String()`, fixed-6) and the helper must not silently change any of them.

**One thing the issue lists that I could not reproduce as broken:** `audioPadTrim.ts:145` is a single-input `-af` pad with no `adelay`, and on 7.0.2 the old and new chains produce identical output (both 43.300000 s, same RMS at every probe point). It is changed anyway, because it is the same fragile template and the point of the helper is that the next divergence cannot happen. Worth knowing when weighing the risk of that hunk.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

**New — `audioPadFilter.test.ts` (4 tests).** Pins the chain and its *order*, since order is the behaviour here, and keeps the `whole_dur` prohibition asserted.

**New — `audioMixer.padTimestamps.integration.test.ts`.** The regression test the issue asks for: five clips at staggered offsets through the real `processCompositionAudio` and real FFmpeg, asserting `t=0` is silent and every clip is audible at its own offset. It follows this repo's `describe.skipIf(!hasFfmpeg)` convention, so it is a no-op where FFmpeg is absent.

I checked it fails without the fix rather than assuming it: reverting only the helper's return value to `apad,atrim=0:${seconds}` gives

```
AssertionError: expected -24.898801 to be less than -60
  at audioMixer.padTimestamps.integration.test.ts:130
```

Three or fewer clips passes on a broken build, which is why it mixes five.

**Existing assertions updated** in `audioMixer.test.ts` (3) and `audioPadTrim.test.ts` (2). The two `not.toContain("whole_dur")` assertions are untouched and still pass — that is the point.

**Suites** (`bun`, node v24.8.0, ffmpeg 7.0.2-static on PATH). I ran each one on a stashed pristine tree first and diffed the failure *set*:

| | before | after |
| --- | --- | --- |
| `@hyperframes/engine` | 5 failed, 1590 passed | 5 failed, **1595** passed |
| `@hyperframes/producer` | 1 failed, 594 passed | 1 failed, 594 passed |

The failure sets are identical, and all six are environmental on this box rather than from this change — four in `ffprobe.test.ts` on the checked-in HDR PNG fixture (`PNG input is structurally incomplete`, from a shallow clone without LFS) and two on the `unindexed negative-base MPEG-TS` fixture. `bunx oxlint` and `bunx oxfmt --check` are clean on all nine files; `typecheck` exits 0 for both packages.

**Not run:** the producer integration lane and any browser/render end-to-end. `audioExtractor.ts`'s `mixTracks` has no test of its own before or after this change, so that hunk rests on being the same template as the mixer's rather than on a test.

**Disclosure:** written with AI assistance. CONTRIBUTING says there is no need to disclose, but I would rather you know. Every measurement above was run rather than predicted, and I can explain any part of it.