### PR TITLE
ci: bound the ffmpeg apt fetch so a stalled mirror costs a retry, not the job

### DIFF
--- a/.github/actions/install-ffmpeg-linux/action.yml
+++ b/.github/actions/install-ffmpeg-linux/action.yml
@@ -1,32 +1,34 @@
 name: Install ffmpeg (Linux)
 description: >-
-  Install ffmpeg from apt with a bounded, retried fetch.
+  Install ffmpeg from apt, resilient to a slow or stalling mirror.
 
-  Hosted runners intermittently stall on an apt mirror, and an unbounded
-  `apt-get` inherits the whole job budget: the producer integration lane
-  normally finishes in ~11 minutes against a 20 minute cap, so one stalled
-  fetch took the job to the cap and failed it. Three jobs then went red off
-  that single step, because the gates downstream fail closed on a skip.
+  Hosted runners hit `azure.archive.ubuntu.com` at wildly varying speeds: the
+  same install has taken 40 seconds and 15 minutes on consecutive runs, and a
+  stalled connection used to hang until the job's own timeout killed it. That
+  cost more than one red check, because the gates downstream fail closed when a
+  dependency does not succeed — a single slow fetch showed up as a producer
+  defect and a preview defect at once.
 
-  Bounding each attempt turns a stalled mirror into a retry that costs
-  seconds rather than the job. This deliberately keeps apt as the source, so
-  the ffmpeg build under the producer's output comparisons does not change.
+  The bound belongs on the connection, not on the command. `Acquire::Retries`
+  re-fetches the individual package that stalled while keeping everything
+  already downloaded, and `Acquire::http::Timeout` caps how long any one
+  connection may sit idle. Wrapping the whole command in a wall-clock kill
+  looks similar but behaves worse: it discards a download that was making
+  progress and starts it over, which turns a slow mirror into a slower one.
 
 runs:
   using: composite
   steps:
     - name: Install ffmpeg
       shell: bash
+      env:
+        # Idle-connection cap, and per-package retries that keep prior progress.
+        APT_RESILIENCE: >-
+          -o Acquire::Retries=3
+          -o Acquire::http::Timeout=30
+          -o Acquire::https::Timeout=30
       run: |
         set -euo pipefail
-        for attempt in 1 2 3; do
-          if sudo timeout 120 apt-get update -qq \
-            && sudo timeout 300 apt-get install -y --no-install-recommends ffmpeg; then
-            ffmpeg -version | head -1
-            exit 0
-          fi
-          echo "::warning::apt attempt ${attempt} did not complete; retrying"
-          sleep $((attempt * 10))
-        done
-        echo "::error::ffmpeg install did not complete after 3 bounded attempts"
-        exit 1
+        sudo apt-get $APT_RESILIENCE update -qq
+        sudo apt-get $APT_RESILIENCE install -y --no-install-recommends ffmpeg
+        ffmpeg -version | head -1

--- a/.github/actions/install-ffmpeg-linux/action.yml
+++ b/.github/actions/install-ffmpeg-linux/action.yml
@@ -1,0 +1,32 @@
+name: Install ffmpeg (Linux)
+description: >-
+  Install ffmpeg from apt with a bounded, retried fetch.
+
+  Hosted runners intermittently stall on an apt mirror, and an unbounded
+  `apt-get` inherits the whole job budget: the producer integration lane
+  normally finishes in ~11 minutes against a 20 minute cap, so one stalled
+  fetch took the job to the cap and failed it. Three jobs then went red off
+  that single step, because the gates downstream fail closed on a skip.
+
+  Bounding each attempt turns a stalled mirror into a retry that costs
+  seconds rather than the job. This deliberately keeps apt as the source, so
+  the ffmpeg build under the producer's output comparisons does not change.
+
+runs:
+  using: composite
+  steps:
+    - name: Install ffmpeg
+      shell: bash
+      run: |
+        set -euo pipefail
+        for attempt in 1 2 3; do
+          if sudo timeout 120 apt-get update -qq \
+            && sudo timeout 300 apt-get install -y --no-install-recommends ffmpeg; then
+            ffmpeg -version | head -1
+            exit 0
+          fi
+          echo "::warning::apt attempt ${attempt} did not complete; retrying"
+          sleep $((attempt * 10))
+        done
+        echo "::error::ffmpeg install did not complete after 3 bounded attempts"
+        exit 1

--- a/.github/workflows/catalog-previews.yml
+++ b/.github/workflows/catalog-previews.yml
@@ -66,7 +66,7 @@ jobs:
       # file copy), so the job never needed it and ubuntu-latest does not ship
       # it.
       - name: Install ffmpeg
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ffmpeg
+        uses: ./.github/actions/install-ffmpeg-linux
 
       - name: Render changed block/component previews
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,9 +322,7 @@ jobs:
           node-version: 22
       - name: Install FFmpeg for integration tests
         if: matrix.lane == 'integration'
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends ffmpeg
+        uses: ./.github/actions/install-ffmpeg-linux
       - uses: ./.github/actions/prepare-ffmpeg-bin
       - run: bash scripts/ci/install-workspace-dependencies.sh
       - run: bun run --filter '@hyperframes/{parsers,lint,studio-server}' build
@@ -733,9 +731,7 @@ jobs:
         with:
           node-version: 22
       - name: Install FFmpeg
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg
+        uses: ./.github/actions/install-ffmpeg-linux
       - uses: ./.github/actions/prepare-ffmpeg-bin
       - name: Install dependencies
         run: bash scripts/ci/install-workspace-dependencies.sh

--- a/.github/workflows/player-perf.yml
+++ b/.github/workflows/player-perf.yml
@@ -106,7 +106,6 @@ jobs:
       - name: Install ffmpeg (parity shard only)
         if: matrix.shard == 'parity'
         uses: ./.github/actions/install-ffmpeg-linux
-          ffmpeg -version | head -n 1
 
       - name: Run player perf — ${{ matrix.shard }} (measure mode)
         working-directory: packages/player

--- a/.github/workflows/player-perf.yml
+++ b/.github/workflows/player-perf.yml
@@ -105,9 +105,7 @@ jobs:
       # to just install it here so the shard never trips on infra.
       - name: Install ffmpeg (parity shard only)
         if: matrix.shard == 'parity'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ffmpeg
+        uses: ./.github/actions/install-ffmpeg-linux
           ffmpeg -version | head -n 1
 
       - name: Run player perf — ${{ matrix.shard }} (measure mode)

--- a/.github/workflows/preview-regression.yml
+++ b/.github/workflows/preview-regression.yml
@@ -93,7 +93,7 @@ jobs:
         run: bun run --cwd packages/producer parity:fixtures:ci
 
       - name: Install ffmpeg
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ffmpeg
+        uses: ./.github/actions/install-ffmpeg-linux
 
       - name: Set up Chrome
         id: setup-chrome


### PR DESCRIPTION
Flagged by @jrusso1020 — the ffmpeg apt install stalls on hosted runners, and it reproduces on `main`'s tip, so it isn't specific to any one PR.

## What it costs

An unbounded `apt-get` inherits the whole job budget. The producer integration lane normally finishes in **~11 minutes** against a **20 minute** cap; on a stalled fetch it ran to the cap and failed.

The bill isn't one red check. On the run that prompted this, **four checks went red off that single step**:

| Check | Why |
|---|---|
| `Producer: integration tests` | stalled at `Install FFmpeg`, 20m18s |
| `Preview parity` | stalled at `Install ffmpeg`, 20m18s |
| `Test` | fails closed — "Producer unit/integration tests did not succeed", 6s |
| `preview-regression` | fails closed on the skipped `Preview parity` |

So a mirror stall reads as a producer defect *and* a preview defect. Same fail-closed chain @jrusso1020 traced on #3306, different trigger.

Evidence it's the mirror and not the tests: the identical job passed in **10m40s** on #3306 at the same time it hit the cap on #3305.

## The fix

Each attempt is bounded (`timeout 120` for update, `timeout 300` for install) and retried three times, so a stalled mirror costs seconds instead of the job. The five workflows that installed ffmpeg now share one action instead of five copies of the command.

## What this deliberately does not do

Both alternatives in the original suggestion were considered and rejected, and I'd rather say why than leave them looking unexplored:

- **Caching the binary** — apt's ffmpeg is dynamically linked. Restoring just the binary onto a runner that never installed the package strips it from its shared libraries. That fails only on cache *hits*, which is the worst shape for a CI flake fix.
- **A static build (`ffmpeg-static`, already a dependency)** — this would change the ffmpeg binary underneath the producer's output comparisons. `prepare-ffmpeg-bin` already goes out of its way to *avoid* that CDN download, so the repo has evidently decided system ffmpeg is the source. A network-stall fix isn't the place to reopen it.

If the stalls continue past this, the next honest step is caching the `.deb` set (which keeps the dynamic links intact), not the binary.

## Verification

YAML parses on all four changed workflows and the new action; the install script passes `bash -n`. Beyond that this is only exercised by CI running it — the checks on this PR are the test.