### PR TITLE
fix(studio): stop unrelated preview setup from disabling playback shortcuts

### DIFF
--- a/packages/studio/src/player/hooks/usePlaybackKeyboard.ts
+++ b/packages/studio/src/player/hooks/usePlaybackKeyboard.ts
@@ -9,6 +9,7 @@
 import { useRef, useCallback } from "react";
 import { useCaptionStore } from "../../captions/store";
 import { shouldIgnorePlaybackShortcutEvent, SHUTTLE_SPEEDS } from "../lib/playbackShortcuts";
+import { describeTarget, traceShortcut } from "../lib/shortcutDebug";
 import { canvasNudgeKeysClaimed } from "../../utils/canvasNudgeGate";
 import { usePlayerStore } from "../store/playerStore";
 import { stepFrameTime, STUDIO_PREVIEW_FPS } from "../lib/time";
@@ -81,7 +82,14 @@ export function usePlaybackKeyboard({
 
   const handlePlaybackKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (e.defaultPrevented) return;
+      if (e.defaultPrevented) {
+        traceShortcut("key already claimed (defaultPrevented)", {
+          code: e.code,
+          target: describeTarget(e.target),
+        });
+        return;
+      }
+      traceShortcut("key seen", { code: e.code, target: describeTarget(e.target) });
       const captionState = useCaptionStore.getState();
       if (
         shouldIgnorePlaybackShortcutEvent(e, {
@@ -89,12 +97,19 @@ export function usePlaybackKeyboard({
           selectedCaptionSegmentCount: captionState.selectedSegmentIds.size,
         })
       ) {
+        traceShortcut("key ignored by guard", {
+          code: e.code,
+          target: describeTarget(e.target),
+          modifiers: { meta: e.metaKey, ctrl: e.ctrlKey, alt: e.altKey },
+          captionEditMode: captionState.isEditMode,
+        });
         return;
       }
       const key = e.key.toLowerCase();
       pressedKeysRef.current.add(key);
       if (e.code === "Space") {
         e.preventDefault();
+        traceShortcut("space -> togglePlay");
         togglePlay();
         return;
       }
@@ -194,10 +209,17 @@ export function usePlaybackKeyboard({
     try {
       iframeWin = iframeRef.current?.contentWindow ?? null;
       iframeDoc = iframeRef.current?.contentDocument ?? null;
-    } catch {
+    } catch (error) {
+      // Reading across the boundary threw: the preview is on another origin.
+      traceShortcut("attach ABORTED: preview unreachable", { error: String(error) });
       return;
     }
-    if (!iframeWin && !iframeDoc) return;
+    if (!iframeWin && !iframeDoc) {
+      // Called before the iframe has a document — shortcuts stay unbound until
+      // the next load fires this again.
+      traceShortcut("attach ABORTED: no preview window or document");
+      return;
+    }
 
     const handleIframeKeyDown = (e: KeyboardEvent) => playbackKeyDownRef.current(e);
     const handleIframeKeyUp = (e: KeyboardEvent) => playbackKeyUpRef.current(e);
@@ -209,6 +231,10 @@ export function usePlaybackKeyboard({
     }
     iframeDoc?.addEventListener("keydown", handleIframeKeyDown, true);
     iframeDoc?.addEventListener("keyup", handleIframeKeyUp, true);
+    traceShortcut("attached to preview", {
+      window: Boolean(iframeWin),
+      document: Boolean(iframeDoc),
+    });
     iframeShortcutCleanupRef.current = () => {
       try {
         iframeWin?.removeEventListener("keydown", handleIframeKeyDown, true);

--- a/packages/studio/src/player/hooks/useTimelineSyncCallbacks.test.ts
+++ b/packages/studio/src/player/hooks/useTimelineSyncCallbacks.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from "vitest";
 import {
+  runPreviewSetupSteps,
   resolveReloadSeekTime,
   resolveTimelineTotalDuration,
   revealIframe,
@@ -215,5 +216,83 @@ describe("resolveTimelineTotalDuration", () => {
         authoredRootDurationSeconds,
       }),
     ).toBe(44.5);
+  });
+});
+
+describe("runPreviewSetupSteps", () => {
+  function steps(overrides: Partial<Record<string, () => void>> = {}) {
+    const ran: string[] = [];
+    const errors: string[] = [];
+    const make = (name: string) => () => {
+      ran.push(name);
+      overrides[name]?.();
+    };
+    return {
+      ran,
+      errors,
+      args: {
+        attachShortcuts: make("shortcuts"),
+        normalizeViewport: make("viewport"),
+        healCompositionIds: make("composition-ids"),
+        onError: (step: string) => errors.push(step),
+      },
+    };
+  }
+
+  it("THE BUG: a throwing viewport pass used to cost the user every shortcut", () => {
+    // These ran as one sequence inside a silent catch, with the shortcuts last.
+    // A composition that made either DOM pass throw left space, J/K/L and the
+    // arrows dead while the transport buttons kept working, because those are
+    // React handlers on the parent document.
+    const s = steps({
+      viewport: () => {
+        throw new Error("unusual composition");
+      },
+    });
+
+    runPreviewSetupSteps(s.args);
+
+    expect(s.ran).toContain("shortcuts");
+    expect(s.errors).toEqual(["viewport"]);
+  });
+
+  it("attaches shortcuts before anything that can break them", () => {
+    const s = steps();
+    runPreviewSetupSteps(s.args);
+    expect(s.ran[0]).toBe("shortcuts");
+  });
+
+  it("runs every remaining step after one throws", () => {
+    const s = steps({
+      shortcuts: () => {
+        throw new Error("no preview window");
+      },
+    });
+
+    runPreviewSetupSteps(s.args);
+
+    expect(s.ran).toEqual(["shortcuts", "viewport", "composition-ids"]);
+    expect(s.errors).toEqual(["shortcuts"]);
+  });
+
+  it("reports a failure rather than swallowing it", () => {
+    const seen: unknown[] = [];
+    runPreviewSetupSteps({
+      attachShortcuts: () => {
+        throw new Error("boom");
+      },
+      normalizeViewport: () => {},
+      healCompositionIds: () => {},
+      onError: (_step, error) => seen.push(error),
+    });
+
+    expect(seen).toHaveLength(1);
+    expect((seen[0] as Error).message).toBe("boom");
+  });
+
+  it("stays quiet when every step succeeds", () => {
+    const s = steps();
+    runPreviewSetupSteps(s.args);
+    expect(s.errors).toEqual([]);
   });
 });

--- a/packages/studio/src/player/hooks/useTimelineSyncCallbacks.ts
+++ b/packages/studio/src/player/hooks/useTimelineSyncCallbacks.ts
@@ -59,6 +59,42 @@ interface UseTimelineSyncCallbacksParams {
  * playhead (the clamp below is the one sanctioned move — content shrank past it).
  */
 /**
+ * Run the per-load preview setup, one step at a time, keyboard first.
+ *
+ * The steps are independent, but they used to run as one sequence inside a
+ * `catch {}` that swallowed everything. Attaching the preview's keyboard
+ * listeners was last, so a throw from either DOM pass before it — which an
+ * unusual composition can cause — silently cost the user every playback
+ * shortcut. The transport buttons kept working, because those are React
+ * handlers on the parent document, so the failure presented as "space is
+ * broken" rather than as an error anyone could see.
+ *
+ * Isolating each step means one failure can no longer disable the others, and
+ * ordering the shortcuts first means input works even if the rest of the setup
+ * is having a bad day. `onError` exists so a genuine failure leaves a trace
+ * instead of vanishing.
+ */
+export function runPreviewSetupSteps(steps: {
+  attachShortcuts: () => void;
+  normalizeViewport: () => void;
+  healCompositionIds: () => void;
+  onError?: (step: string, error: unknown) => void;
+}): void {
+  const ordered: [string, () => void][] = [
+    ["shortcuts", steps.attachShortcuts],
+    ["viewport", steps.normalizeViewport],
+    ["composition-ids", steps.healCompositionIds],
+  ];
+  for (const [name, run] of ordered) {
+    try {
+      run();
+    } catch (error) {
+      steps.onError?.(name, error);
+    }
+  }
+}
+
+/**
  * Undo the `visibility: hidden` that refreshPlayer sets across a full reload.
  * Safe to call when the iframe was never hidden (idempotent no-op). Every reload
  * completion + failure path funnels through here so the preview can never get
@@ -351,9 +387,13 @@ export function useTimelineSyncCallbacks({
       const doc = iframe?.contentDocument;
       const iframeWin = iframe?.contentWindow as IframeWindow | null;
       if (doc && iframeWin) {
-        normalizePreviewViewport(doc, iframeWin);
-        autoHealMissingCompositionIds(doc);
-        attachIframeShortcutListeners();
+        runPreviewSetupSteps({
+          attachShortcuts: attachIframeShortcutListeners,
+          normalizeViewport: () => normalizePreviewViewport(doc, iframeWin),
+          healCompositionIds: () => autoHealMissingCompositionIds(doc),
+          onError: (step, error) =>
+            console.warn(`[studio] preview setup step "${step}" failed:`, error),
+        });
       }
 
       const manifest = iframeWin?.__clipManifest;

--- a/packages/studio/src/player/hooks/useTimelineSyncCallbacks.ts
+++ b/packages/studio/src/player/hooks/useTimelineSyncCallbacks.ts
@@ -28,6 +28,7 @@ import {
   buildMissingCompositionElements,
 } from "../lib/timelineIframeHelpers";
 import { acceptedRuntimeMessageFps, inspectStudioRuntimeMessage } from "../lib/runtimeProtocol";
+import { traceShortcut } from "../lib/shortcutDebug";
 
 interface UseTimelineSyncCallbacksParams {
   iframeRef: React.RefObject<HTMLIFrameElement | null>;
@@ -88,7 +89,9 @@ export function runPreviewSetupSteps(steps: {
   for (const [name, run] of ordered) {
     try {
       run();
+      traceShortcut(`preview setup: ${name} ok`);
     } catch (error) {
+      traceShortcut(`preview setup: ${name} THREW`, { error: String(error) });
       steps.onError?.(name, error);
     }
   }

--- a/packages/studio/src/player/lib/shortcutDebug.test.ts
+++ b/packages/studio/src/player/lib/shortcutDebug.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { describeTarget, shortcutDebugEnabled, traceShortcut } from "./shortcutDebug";
+
+interface DebugWindow {
+  __hfDebugShortcuts?: boolean;
+}
+
+afterEach(() => {
+  delete (window as unknown as DebugWindow).__hfDebugShortcuts;
+  vi.restoreAllMocks();
+});
+
+describe("shortcutDebugEnabled", () => {
+  it("is off unless asked for", () => {
+    // The keyboard path runs on every keystroke, so silence is the only
+    // acceptable default.
+    expect(shortcutDebugEnabled()).toBe(false);
+  });
+
+  it("turns on from the console", () => {
+    (window as unknown as DebugWindow).__hfDebugShortcuts = true;
+    expect(shortcutDebugEnabled()).toBe(true);
+  });
+});
+
+describe("traceShortcut", () => {
+  it("writes nothing while disabled", () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    traceShortcut("key seen", { code: "Space" });
+    expect(info).not.toHaveBeenCalled();
+  });
+
+  it("prefixes every line so a user can filter and paste them back", () => {
+    (window as unknown as DebugWindow).__hfDebugShortcuts = true;
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    traceShortcut("key seen", { code: "Space" });
+
+    expect(info).toHaveBeenCalledWith("[studio:shortcuts] key seen", { code: "Space" });
+  });
+});
+
+describe("describeTarget", () => {
+  it("names an element without dumping the node", () => {
+    const el = document.createElement("canvas");
+    el.id = "stage";
+    el.className = "preview big";
+    expect(describeTarget(el)).toBe("canvas#stage.preview");
+  });
+
+  it("survives a target that is not an element", () => {
+    expect(describeTarget(null)).toBe("none");
+    expect(describeTarget(new EventTarget())).toBe("non-element");
+  });
+});

--- a/packages/studio/src/player/lib/shortcutDebug.ts
+++ b/packages/studio/src/player/lib/shortcutDebug.ts
@@ -1,0 +1,52 @@
+/**
+ * Opt-in tracing for the preview keyboard path.
+ *
+ * Playback shortcuts fail in a way that leaves nothing behind: the listeners
+ * live on the preview iframe, they are attached during a load whose errors were
+ * historically swallowed, and the transport buttons keep working either way. So
+ * "space doesn't work" arrives with no console output and no way to tell whether
+ * the key was never seen, was seen and ignored, or was seen and handled while
+ * playback failed for some other reason.
+ *
+ * This makes each of those three distinguishable, and stays silent unless asked
+ * for — the path runs on every keystroke, so it cannot log by default.
+ *
+ * Turn it on with either:
+ *   window.__hfDebugShortcuts = true
+ *   ?debugShortcuts   (anywhere in the URL, including after the route hash)
+ */
+
+const FLAG = "debugShortcuts";
+
+interface DebugWindow {
+  __hfDebugShortcuts?: boolean;
+}
+
+export function shortcutDebugEnabled(): boolean {
+  try {
+    if (typeof window === "undefined") return false;
+    if ((window as unknown as DebugWindow).__hfDebugShortcuts === true) return true;
+    // Studio routes on the hash, so the query can sit either side of it.
+    return window.location.href.includes(FLAG);
+  } catch {
+    return false;
+  }
+}
+
+/** One line per event, prefixed so a user can paste `[studio:shortcuts]` back. */
+export function traceShortcut(event: string, detail?: Record<string, unknown>): void {
+  if (!shortcutDebugEnabled()) return;
+  if (detail === undefined) console.info(`[studio:shortcuts] ${event}`);
+  else console.info(`[studio:shortcuts] ${event}`, detail);
+}
+
+/** A target described well enough to recognise, without dumping the node. */
+export function describeTarget(target: EventTarget | null): string {
+  if (!target || typeof target !== "object") return "none";
+  const el = target as Partial<Element> & { tagName?: string; id?: string };
+  if (!el.tagName) return "non-element";
+  const id = el.id ? `#${el.id}` : "";
+  const cls =
+    typeof el.className === "string" && el.className ? `.${el.className.split(/\s+/)[0]}` : "";
+  return `${el.tagName.toLowerCase()}${id}${cls}`;
+}


### PR DESCRIPTION
## What

Playback keyboard shortcuts (space, J/K/L, arrows) could silently stop working for a composition while the transport buttons kept working on that same composition.

The preview's key listeners were attached third inside a `try` with an empty `catch {}`:

```ts
normalizePreviewViewport(doc, iframeWin);
autoHealMissingCompositionIds(doc);
attachIframeShortcutListeners();
```

Both calls above it touch the preview document, and a composition can make either throw. When one does, the shortcuts are never attached and the error is discarded.

Each step now runs independently, keyboard first, with failures reported instead of swallowed.

## Why

Reported as "space doesn't work" on one composition, where clicking Play still worked.

That split is the diagnosis. The transport buttons are React handlers on the parent document, so they are unaffected. The shortcuts are listeners attached to the preview iframe during load. Anything that stops that attachment takes the keyboard with it and leaves the buttons alone — which presents as a broken key rather than a broken load, with nothing in the console.

Ordering matters as much as isolation here: input handling should survive the rest of the preview setup having a bad day, not the other way round.

## How

Extracted the sequence into `runPreviewSetupSteps`, which runs each step in its own `try` and reports failures through an `onError` callback. Shortcuts go first.

Extracting it is also what makes the behaviour testable — the hook itself has too many dependencies to drive directly, which is why this had no coverage before.

The empty `catch {}` around the wider block is left as-is; narrowing that is a bigger change than this fix warrants.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed

Three of the five new tests fail against the old sequence and pass against the new one:

```
× THE BUG: a throwing viewport pass used to cost the user every shortcut
× attaches shortcuts before anything that can break them
× runs every remaining step after one throws
```

- `bunx vitest run src/player` — 1310 passed, 99 files
- `bunx tsc --noEmit` — clean
- oxlint + oxfmt clean

**Not claimed:** the exact call that throws on the reporting composition was not isolated. The symptom was reproduced and the mechanism is proven by the tests; this removes the class rather than one instance of it. If the underlying throw is still there, it will now show up as a warning naming the step instead of vanishing.