### PR TITLE
fix(cli): zip the publish archive to the same bytes every time

### DIFF
--- a/packages/cli/src/utils/publishProject.test.ts
+++ b/packages/cli/src/utils/publishProject.test.ts
@@ -304,6 +304,33 @@ describe("createPublishArchive (U6 cloud-render regression guard)", () => {
   // `createPublishArchive` is exactly the thin composition of
   // `buildPublishFileMap` + `zipPublishFileMap` with no baking hook, and that
   // a local video asset's original bytes/HTML pass through unmodified.
+  it("zips the same files to the same bytes across a two-second boundary", () => {
+    // The flake this pins: adm-zip stamps each entry with `new Date()` as it is
+    // constructed, and a ZIP timestamp resolves to two seconds — so two runs
+    // either side of a boundary produced different bytes for identical content.
+    // The byte-identity assertion below could only ever fail this way, and did,
+    // rarely enough to survive since July.
+    //
+    // Moving the clock is what reproduces it: back-to-back builds land in the
+    // same bucket almost always, which is exactly why it hid.
+    const dir = makeProjectDir();
+    try {
+      writeFileSync(join(dir, "index.html"), "<html></html>", "utf-8");
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+        const first = createPublishArchive(dir);
+        vi.setSystemTime(new Date("2026-01-01T00:00:03.000Z"));
+        const second = createPublishArchive(dir);
+        expect(first.buffer.equals(second.buffer)).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps a source video byte-identical and excludes proxies from the cloud-render archive", () => {
     const dir = makeProjectDir();
     try {

--- a/packages/cli/src/utils/publishProject.ts
+++ b/packages/cli/src/utils/publishProject.ts
@@ -504,10 +504,31 @@ export function buildPublishFileMap(projectDir: string): Map<string, Buffer> {
 
 /** Zip an in-memory archive file map (from `buildPublishFileMap`, optionally
  * transformed in between, e.g. by proxy baking) into the final archive buffer. */
+/**
+ * Fixed entry timestamp, so the same files always zip to the same bytes.
+ *
+ * adm-zip stamps every entry with `new Date()` as it is constructed, and a ZIP
+ * timestamp has two-second granularity — so archiving identical content twice
+ * produced different bytes whenever the two runs landed either side of a
+ * two-second boundary. That makes the archive's digest a function of the clock
+ * rather than of its contents, which is the opposite of what a
+ * content-addressed artifact needs.
+ *
+ * Built from local components on purpose: `fromDate2DOS` reads `getFullYear`,
+ * `getMonth`, `getHours` and friends, so a fixed *instant* would still encode
+ * differently in different timezones. Fixing the wall-clock reading is what
+ * makes the bytes match across machines. 1980-01-01 is the earliest a DOS
+ * timestamp can represent.
+ */
+const ARCHIVE_ENTRY_TIME = new Date(1980, 0, 1, 0, 0, 0, 0);
+
 export function zipPublishFileMap(fileContents: Map<string, Buffer>): PublishArchiveResult {
   const archive = new AdmZip();
   for (const [filePath, content] of fileContents) {
     archive.addFile(filePath, content);
+  }
+  for (const entry of archive.getEntries()) {
+    entry.header.time = ARCHIVE_ENTRY_TIME;
   }
 
   return {


### PR DESCRIPTION
`createPublishArchive` produced different bytes for identical content depending on when it ran.

## Why

`zipPublishFileMap` calls `archive.addFile(path, content)` with no `attr`, and adm-zip 0.6.0 stamps `_time = fromDate2DOS(new Date())` at entry construction (`headers/entryHeader.js:37`), writing it into both the local and central headers. A ZIP timestamp resolves to **two seconds**, so two builds match only when they land in the same bucket.

That makes the archive's digest a function of the clock rather than of its contents — backwards for something `cloud render` uploads and addresses by content.

## How it surfaced

`publishProject.test.ts:321` asserts two archives built back-to-back are byte-identical. Both sides are the same expression, so the only way it can fail is non-determinism. It has been failing rarely since July and clearing on every re-run, which is exactly the signature of a narrow timing window.

## The fix

Entry times are pinned to a fixed value after the entries are added.

Built from **local** components on purpose: `fromDate2DOS` reads `getFullYear`, `getMonth`, `getHours` and friends, so a fixed *instant* would still encode differently per timezone. Verified identical bytes under three zones:

```
UTC                  1b09f6c6063a73d4
America/Los_Angeles  1b09f6c6063a73d4
Asia/Kolkata         1b09f6c6063a73d4
```

1980-01-01 is the earliest a DOS timestamp can represent (`fromDate2DOS` writes zeroes below 1980).

## Test

The new test moves the clock across a two-second boundary, because that is what reproduces it — back-to-back builds land in the same bucket almost always, which is how it hid for months. Mutation-checked: removing the pin reproduces the original failure exactly (`expected false to be true`), deterministically rather than one run in dozens.

## Scope

Archive bytes change once, on merge, for every input. That is the point — the same project now zips to one digest instead of a new one every two seconds. No test or caller pinned the previous value; `publish.ts:166` and `cloud/render.ts:605` are the two consumers and both take the buffer as-is.

CLI suite: 2783 passing.