### PR TITLE
chore: release v0.8.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,38 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.4"
+  description="Released - 2026-08-19"
+  tags={["Release", "CLI", "Studio", "Producer"]}
+>
+A new `normalize-audio` command matches one clip's loudness to another, and the volume fader now tells the truth about the gain it writes.
+Previews keep running in the background in every launch mode, and pressing Delete in Studio now removes the whole selection.
+
+## Features
+
+- **CLI:** Add normalize-audio to match one clip's loudness to another ([b3c43e248](https://github.com/heygen-com/hyperframes/commit/b3c43e24804e632ef2437e2ebd6789094ced2569), [#3306](https://github.com/heygen-com/hyperframes/pull/3306)).
+- **CLI:** Run a managed background preview in every launch mode ([9da422fd7](https://github.com/heygen-com/hyperframes/commit/9da422fd7f75b0d5fe7f7f2defd889239bb82fe6), [#3310](https://github.com/heygen-com/hyperframes/pull/3310)).
+- **CLI:** Give every preview lifecycle op one JSON document ([0e3c5f6be](https://github.com/heygen-com/hyperframes/commit/0e3c5f6bef4760d863309e997619bb1db99f5530), [#3309](https://github.com/heygen-com/hyperframes/pull/3309)).
+
+## Fixes
+
+- **CLI:** Zip the publish archive to the same bytes every time ([d464f60b9](https://github.com/heygen-com/hyperframes/commit/d464f60b9600485cd97c537338e25b7f77f9ca90), [#3358](https://github.com/heygen-com/hyperframes/pull/3358)).
+- **Studio:** Make the volume fader tell the truth about the gain it writes ([228eabd43](https://github.com/heygen-com/hyperframes/commit/228eabd43fa6164dc1296e4615bae33dcca98696), [#3305](https://github.com/heygen-com/hyperframes/pull/3305)).
+- **Producer:** Give inlined media a document-unique render id ([634df5a5a](https://github.com/heygen-com/hyperframes/commit/634df5a5af7aad3e529035d62d324aca1512df35), [#3342](https://github.com/heygen-com/hyperframes/pull/3342)).
+- **Studio:** Make Delete remove the whole canvas selection ([ec0b23f3c](https://github.com/heygen-com/hyperframes/commit/ec0b23f3cec98ea9bb4b61d54ad18bb48ee1c721), [#3339](https://github.com/heygen-com/hyperframes/pull/3339)).
+- **Audio:** Raise the authoring gain ceiling and carry it through the probes ([e282ff15c](https://github.com/heygen-com/hyperframes/commit/e282ff15cc8b8ef519d514c7741e6b27cfd92aae), [#3333](https://github.com/heygen-com/hyperframes/pull/3333)).
+- **CLI:** Keep a live preview's ownership record and stop past a bad one ([74149e249](https://github.com/heygen-com/hyperframes/commit/74149e249ac5a2e7a88d15f241d12ec58db01283), [#3308](https://github.com/heygen-com/hyperframes/pull/3308)).
+- **Producer:** Clamp embedded video/audio windows to the scene ([b31dde35b](https://github.com/heygen-com/hyperframes/commit/b31dde35b13a3c23c677ba3b648d01a7d735f5be), [#3332](https://github.com/heygen-com/hyperframes/pull/3332)).
+- **CLI:** Signal only processes the OS says own the port ([c1c70f44b](https://github.com/heygen-com/hyperframes/commit/c1c70f44bd9d43e22e80449d1b084d6e4d8ae034), [#3307](https://github.com/heygen-com/hyperframes/pull/3307)).
+
+## Internal
+
+- Bound the ffmpeg apt fetch so a stalled mirror costs a retry, not the job ([7e96e60fe](https://github.com/heygen-com/hyperframes/commit/7e96e60fe228548fe4813aa5e9917bbde9a50feb), [#3356](https://github.com/heygen-com/hyperframes/pull/3356)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.3...v0.8.4).
+</Update>
+
+<Update
   label="HyperFrames v0.8.3"
   description="Released - 2026-08-18"
   tags={["Release"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.4.md
+++ b/releases/v0.8.4.md
@@ -1,0 +1,31 @@
+# HyperFrames v0.8.4
+
+Released on 2026-08-19.
+
+A new `normalize-audio` command matches one clip's loudness to another, and the volume fader now tells the truth about the gain it writes.
+Previews keep running in the background in every launch mode, and pressing Delete in Studio now removes the whole selection.
+
+## Features
+
+- **CLI:** Add normalize-audio to match one clip's loudness to another ([b3c43e248](https://github.com/heygen-com/hyperframes/commit/b3c43e24804e632ef2437e2ebd6789094ced2569), [#3306](https://github.com/heygen-com/hyperframes/pull/3306)).
+- **CLI:** Run a managed background preview in every launch mode ([9da422fd7](https://github.com/heygen-com/hyperframes/commit/9da422fd7f75b0d5fe7f7f2defd889239bb82fe6), [#3310](https://github.com/heygen-com/hyperframes/pull/3310)).
+- **CLI:** Give every preview lifecycle op one JSON document ([0e3c5f6be](https://github.com/heygen-com/hyperframes/commit/0e3c5f6bef4760d863309e997619bb1db99f5530), [#3309](https://github.com/heygen-com/hyperframes/pull/3309)).
+
+## Fixes
+
+- **CLI:** Zip the publish archive to the same bytes every time ([d464f60b9](https://github.com/heygen-com/hyperframes/commit/d464f60b9600485cd97c537338e25b7f77f9ca90), [#3358](https://github.com/heygen-com/hyperframes/pull/3358)).
+- **Studio:** Make the volume fader tell the truth about the gain it writes ([228eabd43](https://github.com/heygen-com/hyperframes/commit/228eabd43fa6164dc1296e4615bae33dcca98696), [#3305](https://github.com/heygen-com/hyperframes/pull/3305)).
+- **Producer:** Give inlined media a document-unique render id ([634df5a5a](https://github.com/heygen-com/hyperframes/commit/634df5a5af7aad3e529035d62d324aca1512df35), [#3342](https://github.com/heygen-com/hyperframes/pull/3342)).
+- **Studio:** Make Delete remove the whole canvas selection ([ec0b23f3c](https://github.com/heygen-com/hyperframes/commit/ec0b23f3cec98ea9bb4b61d54ad18bb48ee1c721), [#3339](https://github.com/heygen-com/hyperframes/pull/3339)).
+- **Audio:** Raise the authoring gain ceiling and carry it through the probes ([e282ff15c](https://github.com/heygen-com/hyperframes/commit/e282ff15cc8b8ef519d514c7741e6b27cfd92aae), [#3333](https://github.com/heygen-com/hyperframes/pull/3333)).
+- **CLI:** Keep a live preview's ownership record and stop past a bad one ([74149e249](https://github.com/heygen-com/hyperframes/commit/74149e249ac5a2e7a88d15f241d12ec58db01283), [#3308](https://github.com/heygen-com/hyperframes/pull/3308)).
+- **Producer:** Clamp embedded video/audio windows to the scene ([b31dde35b](https://github.com/heygen-com/hyperframes/commit/b31dde35b13a3c23c677ba3b648d01a7d735f5be), [#3332](https://github.com/heygen-com/hyperframes/pull/3332)).
+- **CLI:** Signal only processes the OS says own the port ([c1c70f44b](https://github.com/heygen-com/hyperframes/commit/c1c70f44bd9d43e22e80449d1b084d6e4d8ae034), [#3307](https://github.com/heygen-com/hyperframes/pull/3307)).
+
+## Internal
+
+- Bound the ffmpeg apt fetch so a stalled mirror costs a retry, not the job ([7e96e60fe](https://github.com/heygen-com/hyperframes/commit/7e96e60fe228548fe4813aa5e9917bbde9a50feb), [#3356](https://github.com/heygen-com/hyperframes/pull/3356)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.3...v0.8.4


### PR DESCRIPTION
Stable release **v0.8.4**, covering the 12 commits since `v0.8.3`.

> Merging this PR publishes. The workflow checks out the merge SHA, creates the `v0.8.4` tag there, publishes to npm, and cuts the GitHub release. The local tag was deliberately **not** pushed — `publish.yml` only produces a stable release from a merged `release/v*` PR, and a tag push can only ever produce a prerelease.

## Summary as it will read

> A new `normalize-audio` command matches one clip's loudness to another, and the volume fader now tells the truth about the gain it writes.
>
> Previews keep running in the background in every launch mode, and pressing Delete in Studio now removes the whole selection.

## What's in it

**Features** — `normalize-audio` (#3306), managed background preview in every launch mode (#3310), one JSON document per preview lifecycle op (#3309).

**Fixes** — deterministic publish archive (#3358), volume fader precision (#3305), document-unique render id for inlined media (#3342), Delete removing the whole canvas selection (#3339), the 12 dB authoring gain ceiling carried through the probes (#3333), preview ownership records (#3308), embedded media windows clamped to the scene (#3332), signalling only OS-owned ports (#3307).

**Internal** — the ffmpeg apt fetch bounded at the connection (#3356).

## Version choice

Patch, not minor, despite three `feat` commits. That matches this repo rather than a generic reading of semver: `v0.8.3` was itself a patch bump containing a `feat`.

## Worth a reviewer's eye

Two things in here change bytes or behaviour beyond their own package, and I'd rather point at them than have them found later:

- **#3358 changes every publish archive's digest, once.** That is the fix working — a project used to zip to a new digest every two seconds because adm-zip stamped entries with the wall clock. Anything caching a digest for an unchanged project sees one change on this release.
- **#3356 touches CI for the whole repo.** It went through two shapes; the second is the one measured (`Producer: integration` 20m18s failing → 2m29s passing). @jrusso1020 raised the original report and hasn't reviewed the final shape.