### PR TITLE
fix(studio): capture storyboard tiles at review density

### DIFF
--- a/packages/studio-server/src/routes/thumbnail.test.ts
+++ b/packages/studio-server/src/routes/thumbnail.test.ts
@@ -68,6 +68,25 @@ describe("registerThumbnailRoutes", () => {
     );
   });
 
+  it("captures source-sized jpeg output when requested", async () => {
+    const adapter = createAdapter();
+    const app = new Hono();
+    registerThumbnailRoutes(app, adapter);
+
+    const response = await app.request(
+      "http://localhost/projects/demo/thumbnail/index.html?t=1.2&output=source",
+    );
+
+    expect(response.status).toBe(200);
+    expect(adapter.generateThumbnail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: "jpeg",
+        outputWidth: 1920,
+        outputHeight: 1080,
+      }),
+    );
+  });
+
   it("deduplicates concurrent generation and writes one complete cache entry", async () => {
     const adapter = createAdapter();
     const project = await adapter.resolveProject("demo");

--- a/packages/studio-server/src/routes/thumbnail.test.ts
+++ b/packages/studio-server/src/routes/thumbnail.test.ts
@@ -44,6 +44,19 @@ function createAdapter(): StudioApiAdapter {
   };
 }
 
+async function writeComposition(
+  adapter: StudioApiAdapter,
+  width: number,
+  height: number,
+): Promise<void> {
+  const project = await adapter.resolveProject("demo");
+  if (!project) throw new Error("missing project");
+  writeFileSync(
+    join(project.dir, "index.html"),
+    `<div data-width="${width}" data-height="${height}"></div>`,
+  );
+}
+
 describe("registerThumbnailRoutes", () => {
   it("forwards selector queries to thumbnail generation", async () => {
     const adapter = createAdapter();
@@ -68,21 +81,59 @@ describe("registerThumbnailRoutes", () => {
     );
   });
 
-  it("captures source-sized jpeg output when requested", async () => {
+  it("maps square authored dimensions across jpeg output modes", async () => {
     const adapter = createAdapter();
     const app = new Hono();
     registerThumbnailRoutes(app, adapter);
+    await writeComposition(adapter, 1080, 1080);
+
+    const sourceResponse = await app.request(
+      "http://localhost/projects/demo/thumbnail/index.html?t=1.2&output=source",
+    );
+    const previewResponse = await app.request(
+      "http://localhost/projects/demo/thumbnail/index.html?t=1.2&output=preview",
+    );
+    const storyboardResponse = await app.request(
+      "http://localhost/projects/demo/thumbnail/index.html?t=1.2&output=storyboard",
+    );
+
+    expect(sourceResponse.status).toBe(200);
+    expect(previewResponse.status).toBe(200);
+    expect(storyboardResponse.status).toBe(200);
+    expect(adapter.generateThumbnail).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        format: "jpeg",
+        outputWidth: 1080,
+        outputHeight: 1080,
+      }),
+    );
+    expect(adapter.generateThumbnail).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ outputWidth: 135, outputHeight: 135 }),
+    );
+    expect(adapter.generateThumbnail).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ outputWidth: 1080, outputHeight: 1080 }),
+    );
+  });
+
+  it("caps storyboard output at a 1080px longest side", async () => {
+    const adapter = createAdapter();
+    const app = new Hono();
+    registerThumbnailRoutes(app, adapter);
+    await writeComposition(adapter, 7680, 4320);
 
     const response = await app.request(
-      "http://localhost/projects/demo/thumbnail/index.html?t=1.2&output=source",
+      "http://localhost/projects/demo/thumbnail/index.html?t=1.2&output=storyboard",
     );
 
     expect(response.status).toBe(200);
     expect(adapter.generateThumbnail).toHaveBeenCalledWith(
       expect.objectContaining({
         format: "jpeg",
-        outputWidth: 1920,
-        outputHeight: 1080,
+        outputWidth: 1080,
+        outputHeight: 608,
       }),
     );
   });

--- a/packages/studio-server/src/routes/thumbnail.ts
+++ b/packages/studio-server/src/routes/thumbnail.ts
@@ -20,6 +20,7 @@ import { thumbnailGenerationCoordinator } from "./thumbnailGenerationCoordinator
 const THUMBNAIL_CACHE_VERSION = "v4";
 const THUMBNAIL_MAX_OUTPUT_WIDTH = 240;
 const THUMBNAIL_MAX_OUTPUT_HEIGHT = 135;
+const STORYBOARD_MAX_OUTPUT_DIMENSION = 1080;
 const THUMBNAIL_CACHE_MAX_BYTES = 512 * 1024 * 1024;
 const THUMBNAIL_CACHE_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 const prunedCacheDirs = new Set<string>();
@@ -98,9 +99,13 @@ export function registerThumbnailRoutes(api: Hono, adapter: StudioApiAdapter): v
     // PNG is the legacy source-density capture contract. Callers can opt either
     // format into the bounded preview contract explicitly.
     const outputMode =
-      requestedOutput === "source" || (requestedOutput !== "preview" && format === "png")
+      requestedOutput === "source"
         ? "source"
-        : "preview";
+        : requestedOutput === "storyboard"
+          ? "storyboard"
+          : requestedOutput !== "preview" && format === "png"
+            ? "source"
+            : "preview";
     const rawSelectorIndex = Number.parseInt(url.searchParams.get("selectorIndex") || "0", 10);
     const selectorIndex =
       Number.isFinite(rawSelectorIndex) && rawSelectorIndex > 0 ? rawSelectorIndex : undefined;
@@ -160,7 +165,13 @@ export function registerThumbnailRoutes(api: Hono, adapter: StudioApiAdapter): v
     const outputScale =
       outputMode === "source"
         ? 1
-        : Math.min(1, THUMBNAIL_MAX_OUTPUT_WIDTH / compW, THUMBNAIL_MAX_OUTPUT_HEIGHT / compH);
+        : outputMode === "storyboard"
+          ? Math.min(
+              1,
+              STORYBOARD_MAX_OUTPUT_DIMENSION / compW,
+              STORYBOARD_MAX_OUTPUT_DIMENSION / compH,
+            )
+          : Math.min(1, THUMBNAIL_MAX_OUTPUT_WIDTH / compW, THUMBNAIL_MAX_OUTPUT_HEIGHT / compH);
     const outputWidth = Math.max(1, Math.round(compW * outputScale));
     const outputHeight = Math.max(1, Math.round(compH * outputScale));
     const cacheKey = `${THUMBNAIL_CACHE_VERSION}${urlVersionKey}${manualEditsKey}${motionKey}${sourceKey}_${format}_${outputMode}_${compPath.replace(/\//g, "_")}_${compW}x${compH}_${outputWidth}x${outputHeight}_${sourceMtime}_${seekTime.toFixed(2)}${selectorKey}.${format === "png" ? "png" : "jpg"}`;

--- a/packages/studio/src/components/storyboard/FramePoster.test.tsx
+++ b/packages/studio/src/components/storyboard/FramePoster.test.tsx
@@ -37,24 +37,20 @@ function renderPoster(surface?: "tile" | "hero"): HTMLImageElement {
 }
 
 describe("FramePoster", () => {
-  // Regression: the hero and the tile shared one bounded poster, so the frame
-  // detail view — the sketch pass's only picture — showed a 240x135 capture
-  // upscaled past 7x on a retina display, and body copy was unreadable.
-  it("captures the focus hero at the composition's own dimensions", () => {
-    const url = new URL(renderPoster("hero").src);
+  // Regression: the contact sheet stretched a 240x135 capture across a wide,
+  // high-density card, making body copy, thin lines, and sprite details blurry.
+  it.each([undefined, "tile", "hero"] as const)(
+    "captures the %s surface at the composition's own dimensions",
+    (surface) => {
+      const url = new URL(renderPoster(surface).src);
 
-    expect(url.searchParams.get("output")).toBe("source");
-    expect(url.pathname).toBe("/api/projects/demo/thumbnail/frames/01-hero.html");
-  });
-
-  it("leaves the contact-sheet tile on the route's bounded preview capture", () => {
-    const url = new URL(renderPoster("tile").src);
-
-    expect(url.searchParams.has("output")).toBe(false);
-  });
+      expect(url.searchParams.get("output")).toBe("source");
+      expect(url.pathname).toBe("/api/projects/demo/thumbnail/frames/01-hero.html");
+    },
+  );
 
   it("defaults to the tile surface", () => {
-    expect(new URL(renderPoster().src).search).toBe(new URL(renderPoster("tile").src).search);
+    expect(renderPoster().className).toBe(renderPoster("tile").className);
   });
 
   it("letterboxes only the hero, so a tile still fills its cell", () => {

--- a/packages/studio/src/components/storyboard/FramePoster.test.tsx
+++ b/packages/studio/src/components/storyboard/FramePoster.test.tsx
@@ -39,15 +39,16 @@ function renderPoster(surface?: "tile" | "hero"): HTMLImageElement {
 describe("FramePoster", () => {
   // Regression: the contact sheet stretched a 240x135 capture across a wide,
   // high-density card, making body copy, thin lines, and sprite details blurry.
-  it.each([undefined, "tile", "hero"] as const)(
-    "captures the %s surface at the composition's own dimensions",
-    (surface) => {
-      const url = new URL(renderPoster(surface).src);
+  it.each([
+    [undefined, "storyboard"],
+    ["tile", "storyboard"],
+    ["hero", "source"],
+  ] as const)("captures the %s surface at %s density", (surface, output) => {
+    const url = new URL(renderPoster(surface).src);
 
-      expect(url.searchParams.get("output")).toBe("source");
-      expect(url.pathname).toBe("/api/projects/demo/thumbnail/frames/01-hero.html");
-    },
-  );
+    expect(url.searchParams.get("output")).toBe(output);
+    expect(url.pathname).toBe("/api/projects/demo/thumbnail/frames/01-hero.html");
+  });
 
   it("defaults to the tile surface", () => {
     expect(renderPoster().className).toBe(renderPoster("tile").className);

--- a/packages/studio/src/components/storyboard/FramePoster.tsx
+++ b/packages/studio/src/components/storyboard/FramePoster.tsx
@@ -11,10 +11,8 @@ export interface FramePosterProps {
   /**
    * Where this poster is rendered. A contact-sheet tile is ~300px wide and there
    * are many of them; the focus hero is up to 900px wide and there is exactly
-   * one. That single difference decides both the crop and how much resolution
-   * the server has to capture, so it is one prop rather than two that can
-   * disagree: `tile` fills+crops at the route's bounded preview density, `hero`
-   * letterboxes at the composition's own dimensions.
+   * one. Both use a source-resolution capture so storyboard copy stays readable;
+   * the surface only decides whether the result fills or letterboxes its cell.
    */
   surface?: "tile" | "hero";
   /**
@@ -57,11 +55,10 @@ export function FramePoster({
     seekTime: seconds,
     duration: 0,
     origin: window.location.origin,
-    // The hero is the sketch pass's only picture (references/review-loop.md), and
-    // it is shown large. Bounded to the preview cap it arrives at 240x135 and
-    // upscales past 7x on a retina display, which is unreadable for exactly the
-    // body copy and labels this pass exists to confirm.
-    ...(surface === "hero" ? { output: "source" as const } : {}),
+    // Storyboards exist to review composition detail. The bounded preview arrives
+    // at 240x135 and is visibly upscaled even in the contact sheet, making type,
+    // thin lines, and sprite details unreadable on high-density displays.
+    output: "source",
   });
   if (posterVersion) {
     const withVersion = new URL(url, window.location.origin);

--- a/packages/studio/src/components/storyboard/FramePoster.tsx
+++ b/packages/studio/src/components/storyboard/FramePoster.tsx
@@ -11,8 +11,8 @@ export interface FramePosterProps {
   /**
    * Where this poster is rendered. A contact-sheet tile is ~300px wide and there
    * are many of them; the focus hero is up to 900px wide and there is exactly
-   * one. Both use a source-resolution capture so storyboard copy stays readable;
-   * the surface only decides whether the result fills or letterboxes its cell.
+   * one. Tiles use a bounded high-density capture; the hero uses source density.
+   * The surface also decides whether the result fills or letterboxes its cell.
    */
   surface?: "tile" | "hero";
   /**
@@ -55,10 +55,10 @@ export function FramePoster({
     seekTime: seconds,
     duration: 0,
     origin: window.location.origin,
-    // Storyboards exist to review composition detail. The bounded preview arrives
-    // at 240x135 and is visibly upscaled even in the contact sheet, making type,
-    // thin lines, and sprite details unreadable on high-density displays.
-    output: "source",
+    // The normal 240x135 preview is unreadable in the contact sheet, while source
+    // density is unbounded across all tiles. Give tiles a capped review density
+    // and reserve true source output for the single focus hero.
+    output: surface === "hero" ? "source" : "storyboard",
   });
   if (posterVersion) {
     const withVersion = new URL(url, window.location.origin);

--- a/packages/studio/src/player/components/CompositionThumbnail.test.ts
+++ b/packages/studio/src/player/components/CompositionThumbnail.test.ts
@@ -87,6 +87,9 @@ describe("buildCompositionThumbnailUrl", () => {
 
     expect(buildCompositionThumbnailUrl(base)).not.toContain("output=");
     expect(buildCompositionThumbnailUrl({ ...base, output: "source" })).toContain("output=source");
+    expect(buildCompositionThumbnailUrl({ ...base, output: "storyboard" })).toContain(
+      "output=storyboard",
+    );
   });
 });
 

--- a/packages/studio/src/player/components/CompositionThumbnail.tsx
+++ b/packages/studio/src/player/components/CompositionThumbnail.tsx
@@ -42,10 +42,10 @@ export function buildCompositionThumbnailUrl({
   /**
    * Capture density. Omitted, the route bounds the image to its preview cap —
    * right for the timeline, where thumbnails are small and numerous and their
-   * decoded bytes are budgeted. `"source"` captures at the composition's own
-   * dimensions for review surfaces where authored detail must stay readable.
+   * decoded bytes are budgeted. `"storyboard"` caps the longest side at a
+   * high-density review size; `"source"` uses the composition's own dimensions.
    */
-  output?: "source";
+  output?: "source" | "storyboard";
 }): string {
   const thumbnailBase = previewUrl
     .replace("/preview/comp/", "/thumbnail/")

--- a/packages/studio/src/player/components/CompositionThumbnail.tsx
+++ b/packages/studio/src/player/components/CompositionThumbnail.tsx
@@ -43,7 +43,7 @@ export function buildCompositionThumbnailUrl({
    * Capture density. Omitted, the route bounds the image to its preview cap —
    * right for the timeline, where thumbnails are small and numerous and their
    * decoded bytes are budgeted. `"source"` captures at the composition's own
-   * dimensions, for the rare surface that shows one poster large enough to read.
+   * dimensions for review surfaces where authored detail must stay readable.
    */
   output?: "source";
 }): string {


### PR DESCRIPTION
## What

- Capture storyboard contact-sheet posters at a bounded high-density review size.
- Preserve `object-cover` for tiles and `object-contain` for the focus hero.
- Keep timeline thumbnails on the bounded preview path.
- Add component and server-route regression coverage for preview, storyboard, and source JPEG output.

## Why

Storyboard tiles currently omit `output=source`, so the thumbnail route caps them at 240x135. A square 1080x1080 composition therefore arrives as only 135x135 and is stretched across a much larger card. On high-density displays this makes typography, thin lines, and sprite detail visibly blurry, which undermines the storyboard review surface.

## How

`FramePoster` now requests `output: "storyboard"` for tiles and retains `output: "source"` for the single focus hero. The storyboard mode preserves authored aspect ratio while capping the longest side at 1080px. Generic timeline thumbnails remain unchanged and continue to omit an output parameter.

The tests pin the complete contract: a 1080x1080 composition maps to 135x135 preview and 1080x1080 storyboard/source output, while an 8K composition is capped to 1080x608 in storyboard mode.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated (if applicable)

Commands run:

- `bun run --cwd packages/studio test src/components/storyboard/FramePoster.test.tsx src/player/components/CompositionThumbnail.test.ts`
- `bun run --cwd packages/studio-server test src/routes/thumbnail.test.ts`
- `bun run --cwd packages/studio typecheck`
- `bun run --cwd packages/studio-server typecheck`
- `bunx oxfmt --check` on all four changed files
- `bunx oxlint` on all four changed files

Manual verification used the same six 1080x1080 Framey storyboard compositions at a 1280x720, DPR-2 viewport. The same 387x217 CSS tile changed from a 135x135 poster response to 1080x1080, an 8x increase per dimension and 64x increase in pixel area. The follow-up route coverage verifies that storyboard output remains bounded for 8K sources.
