### PR TITLE
fix(lint): stop erroring on the documented canonical clip block

### DIFF
--- a/packages/core/docs/core.md
+++ b/packages/core/docs/core.md
@@ -117,7 +117,7 @@ Use the `data-composition-src` attribute to load a composition from an external 
   <video id="el-1" data-start="0" data-duration="10" data-track-index="0" src="..."></video>
   <video id="el-2" data-start="el-1" data-duration="8" data-track-index="0" src="..."></video>
   <img id="el-3" data-start="5" data-duration="4" data-track-index="1" src="..." />
-  <audio id="el-4" data-start="0" data-duration="30" data-track-index="2" src="..." />
+  <audio id="el-4" data-start="0" data-duration="30" data-track-index="2" src="..."></audio>
 
   <!-- Load composition from external file -->
   <div
@@ -343,7 +343,7 @@ The top-level composition is the `index.html` entry point. It acts as the conduc
   <video id="el-1" data-start="0" data-duration="10" data-track-index="0" src="..."></video>
   <video id="el-2" data-start="el-1" data-duration="8" data-track-index="0" src="..."></video>
   <img id="el-3" data-start="5" data-duration="4" data-track-index="1" src="..." />
-  <audio id="el-4" data-start="0" data-duration="30" data-track-index="2" src="..." />
+  <audio id="el-4" data-start="0" data-duration="30" data-track-index="2" src="..."></audio>
 
   <!-- Load sub-compositions from external files -->
   <div

--- a/packages/lint/src/rules/composition.test.ts
+++ b/packages/lint/src/rules/composition.test.ts
@@ -445,7 +445,10 @@ describe("composition rules", () => {
       const result = await lintHyperframeHtml(html);
       const finding = result.findings.find((f) => f.code === "timed_element_missing_clip_class");
       expect(finding).toBeDefined();
-      expect(finding?.severity).toBe("error");
+      // A warning, not an error: the runtime hides the element either way (see
+      // the message), so a missing marker class is an authoring-convention gap.
+      expect(finding?.severity).toBe("warning");
+      expect(finding?.message).not.toContain("visible for the entire composition");
     });
 
     it("does not flag element that has class='clip'", async () => {
@@ -464,12 +467,16 @@ describe("composition rules", () => {
       expect(finding).toBeUndefined();
     });
 
-    it("does not flag audio or video elements", async () => {
+    it("does not flag the media primitives: audio, video, img", async () => {
+      // All three are authored without class="clip" in the canonical clip block
+      // (packages/core/docs/core.md). `img` used to be the only one of the three
+      // that errored, so the documented example failed its own linter.
       const html = `
 <html><body>
   <div data-composition-id="c1" data-width="1920" data-height="1080">
     <audio data-start="0" data-duration="5" src="music.mp3"></audio>
     <video data-start="0" data-duration="5" src="clip.mp4"></video>
+    <img data-start="5" data-duration="4" src="still.png" />
   </div>
   <script>
     window.__timelines = window.__timelines || {};
@@ -479,6 +486,27 @@ describe("composition rules", () => {
       const result = await lintHyperframeHtml(html);
       const finding = result.findings.find((f) => f.code === "timed_element_missing_clip_class");
       expect(finding).toBeUndefined();
+    });
+
+    it("leaves the documented canonical clip block completely clean", async () => {
+      // Verbatim from packages/core/docs/core.md. If this ever goes red again,
+      // the docs and the linter have drifted apart and one of them is wrong.
+      const html = `
+<html><body>
+  <div id="comp-1" data-composition-id="my-video" data-width="1920" data-height="1080" data-start="0">
+    <video id="el-1" data-start="0" data-duration="10" data-track-index="0" src="a.mp4" muted></video>
+    <img id="el-3" data-start="5" data-duration="4" data-track-index="1" src="a.png" />
+    <audio id="el-4" data-start="0" data-duration="30" data-track-index="2" src="a.mp3"></audio>
+  </div>
+  <script src="gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    window.__timelines["my-video"] = gsap.timeline({ paused: true });
+  </script>
+</body></html>`;
+      const result = await lintHyperframeHtml(html);
+      const blocking = result.findings.filter((f) => f.severity !== "info");
+      expect(blocking.map((f) => `${f.severity}:${f.code}`)).toEqual([]);
     });
 
     it("does not flag element with only data-track-index (layer container, no timing)", async () => {

--- a/packages/lint/src/rules/composition.ts
+++ b/packages/lint/src/rules/composition.ts
@@ -515,7 +515,12 @@ export const compositionRules: Array<(ctx: LintContext) => HyperframeLintFinding
   // fallow-ignore-next-line complexity
   ({ tags }) => {
     const findings: HyperframeLintFinding[] = [];
-    const skipTags = new Set(["audio", "video", "script", "style", "template"]);
+    // `img` sits here for the same reason `video` and `audio` already did: the
+    // three media primitives are authored without `class="clip"` in the
+    // canonical clip block (packages/core/docs/core.md), so requiring it on the
+    // `<img>` alone errored on the documented pattern while its two siblings on
+    // the adjacent lines passed.
+    const skipTags = new Set(["audio", "img", "video", "script", "style", "template"]);
     for (const tag of tags) {
       if (skipTags.has(tag.name)) continue;
       // Skip composition hosts
@@ -534,11 +539,18 @@ export const compositionRules: Array<(ctx: LintContext) => HyperframeLintFinding
       const elementId = readAttr(tag.raw, "id") || undefined;
       findings.push({
         code: "timed_element_missing_clip_class",
-        severity: "error",
-        message: `<${tag.name}${elementId ? ` id="${elementId}"` : ""}> has timing attributes but no class="clip". The element will be visible for the entire composition instead of only during its scheduled time range.`,
+        // Not an error: the runtime drives timed visibility off the `data-start`
+        // ATTRIBUTE, not this class — `syncTimedElementVisibility` walks
+        // `querySelectorAll("[data-start]")` and toggles `style.visibility`
+        // regardless of class (pinned by the runtime's own init test, which
+        // uses a bare `<div data-start data-duration>` with no `class="clip"`).
+        // The class is an authoring convention the tooling reads, so a missing
+        // one is worth flagging but does not break the render.
+        severity: "warning",
+        message: `<${tag.name}${elementId ? ` id="${elementId}"` : ""}> has timing attributes but no class="clip". The runtime still hides it outside its time range, but Studio and the GSAP clip-ownership rules use .clip to recognise a clip, so leaving it off makes the element harder to edit and to lint.`,
         elementId,
         fixHint:
-          'Add class="clip" to the element. The HyperFrames runtime uses .clip to control visibility based on data-start/data-duration.',
+          'Add class="clip" to the element so Studio and the linter can recognise it as a clip.',
         snippet: truncateSnippet(tag.raw),
       });
     }

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -78,7 +78,7 @@
       "files": 2
     },
     "talking-head-recut": {
-      "hash": "214eda4c0f2bedb1",
+      "hash": "7ac85a5f44467d6b",
       "files": 28
     }
   }

--- a/skills/talking-head-recut/SKILL.md
+++ b/skills/talking-head-recut/SKILL.md
@@ -950,10 +950,11 @@ ffmpeg -y -i "$VIDEO_PATH" -c:v libx264 -crf 18 -g 30 -keyint_min 30 \
       <!-- Layer 2: each card-host sits at the bounds dictated by its layout. -->
       <!-- IMPORTANT: every card-host MUST carry BOTH "card-host" and "clip" classes. -->
       <!--   - "card-host"  → our positioning + pointer-events styles                 -->
-      <!--   - "clip"       → HyperFrames runtime uses this to enforce visibility     -->
-      <!--                    only during data-start … data-start+data-duration.      -->
-      <!--                    Without "clip" the host stays visible the whole video   -->
-      <!--                    (lint: timed_element_missing_clip_class).               -->
+      <!--   - "clip"       → the marker Studio and the linter use to recognise a     -->
+      <!--                    clip. Visibility itself comes from data-start /         -->
+      <!--                    data-duration, which the runtime honours with or        -->
+      <!--                    without this class                                      -->
+      <!--                    (lint: timed_element_missing_clip_class, a warning).    -->
       <!-- Example: card-01 with zone="fullscreen" → card-host covers (0,0,1920,1080) -->
       <div
         class="card-host clip"
@@ -1158,7 +1159,7 @@ decides where the actual visible card sits.
 - Animate wrappers such as `#video-wrap`, not the video element dimensions directly.
 - Avoid animating the same property on the same element from multiple timelines at the same time.
 - Use `data-track-index`, not `data-layer`; use `data-duration`, not `data-end`.
-- Every timed element (`card-host`, sub-composition, etc.) MUST include `class="clip"` alongside its own classes — e.g. `class="card-host clip"`. The HyperFrames runtime uses `.clip` to gate visibility to the `data-start … data-start+data-duration` window. Without it the element is visible for the whole video (lint: `timed_element_missing_clip_class`).
+- Every timed element (`card-host`, sub-composition, etc.) should include `class="clip"` alongside its own classes — e.g. `class="card-host clip"`. Visibility itself is driven by `data-start` / `data-duration`: the runtime gates every `[data-start]` element to its window whether or not this class is present. `.clip` is the marker Studio and the GSAP clip-ownership rules read to recognise a clip, so leaving it off makes the element harder to edit and to lint (lint: `timed_element_missing_clip_class`, a warning).
 - For body / global `font-family`, list **concrete font names** (`'Inter', 'Caveat', …`) — not a CSS variable like `var(--font-family)`. The HyperFrames font resolver doesn't expand CSS vars during static analysis (lint: `font_family_without_font_face`). Cards may still use `var(--font-family)` internally since their `@font-face` declarations are loaded.
 
 ### 10. Render to MP4


### PR DESCRIPTION
## What

Linting the primitive-clip example from `packages/core/docs/core.md:115-120` produced two errors against the docs' own linter:

```
error  timed_element_missing_clip_class  el-3   <img data-start data-duration data-track-index src>
error  self_closing_media_tag            el-4   <audio ... />
```

Both fixed, in opposite directions. One was the rule's fault, one was the docs'.

- `timed_element_missing_clip_class` is now a **warning**, its message says something true, and `img` joins `audio`/`video` in `skipTags`.
- `packages/core/docs/core.md` now writes `<audio ...></audio>` instead of `<audio ... />`.
- The same false claim, copied into the `talking-head-recut` skill, is corrected there too.

Found while verifying a review comment on #3366.

## Why

**The rule was asserting a failure that does not happen.** Its message read: *"The element will be visible for the entire composition instead of only during its scheduled time range."*

That is not what the runtime does. `syncTimedElementVisibility` (`packages/core/src/runtime/init.ts:1920-1968`) walks `document.querySelectorAll("[data-start]")` and sets `style.visibility` from the time window. It reads the **attribute**, and never looks at the class. The runtime's own init test pins this with a bare `<div data-start data-duration>` carrying no `class="clip"`, asserting `visibility` flips to `hidden` at the boundary — 75 tests in that file pass on `main` today.

Every other consumer of the string `"clip"` agrees it is a marker, not a mechanism. Studio's `domEditingDom.ts` and `timelineElementHelpers.ts`, the runtime's `timeline.ts`, and core's selector helper all treat it as a class name to *skip* when deriving a display label. Nothing keys behaviour on its presence. There is also no framework-shipped `.clip { }` CSS anywhere in the repo.

So: the class is an authoring convention the tooling reads, worth flagging when missing, but its absence does not break the render. That makes it a warning, and the message now explains the real cost (Studio editing and the GSAP clip-ownership rules) instead of a rendering failure that will not occur.

**`img` was inconsistent with its two siblings.** `audio` and `video` were already in `skipTags`. All three media primitives sit on adjacent lines of the same documented clip block, all three authored without `class="clip"` — and only the `<img>` errored. That inconsistency is what made the documented pattern fail its own linter.

**The docs were wrong about the audio tag.** `self_closing_media_tag` was correct here: `/` is ignored on a non-void element, so `<audio ... />` leaves the element open and subsequent content nests inside it. The `<img ... />` on the line above is a genuine void element and is left alone.

**The false claim had already propagated.** `skills/talking-head-recut/SKILL.md` repeated it twice — in an annotated example and in the rules list — where agents read it as fact and would keep adding `class="clip"` for the wrong reason. Corrected at both sites.

## How

Three small changes plus a regression test:

1. `skipTags` gains `img`, with a comment naming the docs block so the reason survives.
2. Severity `error` → `warning`; message and `fixHint` rewritten to the true mechanism. A comment above the severity cites `syncTimedElementVisibility` and the runtime test, so the next person does not "restore" the old claim.
3. `<audio ... />` → `<audio ...></audio>` in `core.md`.
4. The skill's two copies of the claim rewritten.

**Scope note.** I did not delete the rule. Whether `class="clip"` should remain a required convention at all is a product decision touching ~438 files of docs, skills and templates, and the tooling does read the marker. Flagging it as an open question rather than deciding it here.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated

- New test lints the canonical block **verbatim** and asserts zero errors and zero warnings, so docs and linter cannot silently drift apart again.
- Existing "does not flag audio or video" test extended to cover `img` and renamed to name the three media primitives.
- The severity test now also asserts the message no longer contains "visible for the entire composition".
- `packages/lint`: 515 tests pass. `packages/cli`: 2794 pass. `packages/core` `init.test.ts`: 75 pass (the runtime behaviour this argument rests on).
- Verified before and after by linting the corrected block: 2 errors → 0 errors, 0 warnings.
- Measured across the 643 shipped registry HTML files: **no change** (386 errors / 121 warnings both sides). This rule fires on none of them, so the win here is correctness of the documented pattern and of agent-authored compositions, not finding volume. Stating that explicitly rather than implying a reduction.
