### PR TITLE
chore: release v0.8.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,36 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.5"
+  description="Released - 2026-08-20"
+  tags={["Release", "Studio", "Lint", "Telemetry"]}
+>
+Lint is quieter and more accurate. Seven rules that fired on correct compositions are gone, so you waste fewer edits chasing errors that were never real.
+The clip example in the docs also stopped failing its own linter.
+
+## Features
+
+- **Telemetry:** Measure which lint rules fire, cost, and fail to converge ([f822200fb8](https://github.com/heygen-com/hyperframes/commit/f822200fb8f437b73985f43837c195f5e7312289), [#3367](https://github.com/heygen-com/hyperframes/pull/3367)).
+- **Skills:** Anchored-connector rule + source-traceable visuals doctrine ([a6a9e2f89e](https://github.com/heygen-com/hyperframes/commit/a6a9e2f89e509424a64a1dcd976aabfd54b60d02), [#3354](https://github.com/heygen-com/hyperframes/pull/3354)).
+
+## Fixes
+
+- **Studio:** Capture storyboard tiles at review density ([b4d5abd7b2](https://github.com/heygen-com/hyperframes/commit/b4d5abd7b2cdc419906153ca75d99bd813adf614), [#3371](https://github.com/heygen-com/hyperframes/pull/3371)).
+- **Lint:** Stop erroring on the documented canonical clip block ([2be5a03b80](https://github.com/heygen-com/hyperframes/commit/2be5a03b800e0b17ee36e99167c99edc383065ce), [#3374](https://github.com/heygen-com/hyperframes/pull/3374)).
+- **Skills:** Resolve the blueprint id from a qualified `blueprint:` field ([d1482b0129](https://github.com/heygen-com/hyperframes/commit/d1482b012926d7118fa39e53ef8974328e84cc9e), [#3337](https://github.com/heygen-com/hyperframes/pull/3337)).
+- **Skills:** Stage SVGs that capture wrote into capture/assets/svgs/ ([c66c9a4c76](https://github.com/heygen-com/hyperframes/commit/c66c9a4c76ff0681cadc8007a8e02744bbcdab10), [#3336](https://github.com/heygen-com/hyperframes/pull/3336)).
+- **Core:** Keep authored gain above unity off el.volume in the sandbox bridge ([9140c0eaa1](https://github.com/heygen-com/hyperframes/commit/9140c0eaa1b332de7ca061af040611f5b1c64419), [#3349](https://github.com/heygen-com/hyperframes/pull/3349)).
+- **Producer:** Seek once per step when discovering video visibility ([d09145faab](https://github.com/heygen-com/hyperframes/commit/d09145faabfd3078c29969fbcf293067d50275ac), [#3233](https://github.com/heygen-com/hyperframes/pull/3233)).
+- **Studio:** Capture the storyboard frame hero at full resolution ([f0e637375f](https://github.com/heygen-com/hyperframes/commit/f0e637375f2c43b22192f1ad8c3aef1b5d010e8a), [#3338](https://github.com/heygen-com/hyperframes/pull/3338)).
+
+## Internal
+
+- **Lint:** Drop seven rules that fire on correct compositions ([83ceaeb902](https://github.com/heygen-com/hyperframes/commit/83ceaeb902f07ffc4bed976ca3bdd501eb60aa55), [#3366](https://github.com/heygen-com/hyperframes/pull/3366)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.4...v0.8.5).
+</Update>
+
+<Update
   label="HyperFrames v0.8.4"
   description="Released - 2026-08-19"
   tags={["Release", "CLI", "Studio", "Producer"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.5.md
+++ b/releases/v0.8.5.md
@@ -1,0 +1,29 @@
+# HyperFrames v0.8.5
+
+Released on 2026-08-20.
+
+Lint is quieter and more accurate. Seven rules that fired on correct compositions are gone, so you waste fewer edits chasing errors that were never real.
+The clip example in the docs also stopped failing its own linter.
+
+## Features
+
+- **Telemetry:** Measure which lint rules fire, cost, and fail to converge ([f822200fb8](https://github.com/heygen-com/hyperframes/commit/f822200fb8f437b73985f43837c195f5e7312289), [#3367](https://github.com/heygen-com/hyperframes/pull/3367)).
+- **Skills:** Anchored-connector rule + source-traceable visuals doctrine ([a6a9e2f89e](https://github.com/heygen-com/hyperframes/commit/a6a9e2f89e509424a64a1dcd976aabfd54b60d02), [#3354](https://github.com/heygen-com/hyperframes/pull/3354)).
+
+## Fixes
+
+- **Studio:** Capture storyboard tiles at review density ([b4d5abd7b2](https://github.com/heygen-com/hyperframes/commit/b4d5abd7b2cdc419906153ca75d99bd813adf614), [#3371](https://github.com/heygen-com/hyperframes/pull/3371)).
+- **Lint:** Stop erroring on the documented canonical clip block ([2be5a03b80](https://github.com/heygen-com/hyperframes/commit/2be5a03b800e0b17ee36e99167c99edc383065ce), [#3374](https://github.com/heygen-com/hyperframes/pull/3374)).
+- **Skills:** Resolve the blueprint id from a qualified `blueprint:` field ([d1482b0129](https://github.com/heygen-com/hyperframes/commit/d1482b012926d7118fa39e53ef8974328e84cc9e), [#3337](https://github.com/heygen-com/hyperframes/pull/3337)).
+- **Skills:** Stage SVGs that capture wrote into capture/assets/svgs/ ([c66c9a4c76](https://github.com/heygen-com/hyperframes/commit/c66c9a4c76ff0681cadc8007a8e02744bbcdab10), [#3336](https://github.com/heygen-com/hyperframes/pull/3336)).
+- **Core:** Keep authored gain above unity off el.volume in the sandbox bridge ([9140c0eaa1](https://github.com/heygen-com/hyperframes/commit/9140c0eaa1b332de7ca061af040611f5b1c64419), [#3349](https://github.com/heygen-com/hyperframes/pull/3349)).
+- **Producer:** Seek once per step when discovering video visibility ([d09145faab](https://github.com/heygen-com/hyperframes/commit/d09145faabfd3078c29969fbcf293067d50275ac), [#3233](https://github.com/heygen-com/hyperframes/pull/3233)).
+- **Studio:** Capture the storyboard frame hero at full resolution ([f0e637375f](https://github.com/heygen-com/hyperframes/commit/f0e637375f2c43b22192f1ad8c3aef1b5d010e8a), [#3338](https://github.com/heygen-com/hyperframes/pull/3338)).
+
+## Internal
+
+- **Lint:** Drop seven rules that fire on correct compositions ([83ceaeb902](https://github.com/heygen-com/hyperframes/commit/83ceaeb902f07ffc4bed976ca3bdd501eb60aa55), [#3366](https://github.com/heygen-com/hyperframes/pull/3366)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.4...v0.8.5


### PR DESCRIPTION
# HyperFrames v0.8.5

Released on 2026-08-20.

Lint is quieter and more accurate. Seven rules that fired on correct compositions are gone, so you waste fewer edits chasing errors that were never real.
The clip example in the docs also stopped failing its own linter.

## Features

- **Telemetry:** Measure which lint rules fire, cost, and fail to converge ([f822200fb8](https://github.com/heygen-com/hyperframes/commit/f822200fb8f437b73985f43837c195f5e7312289), [#3367](https://github.com/heygen-com/hyperframes/pull/3367)).
- **Skills:** Anchored-connector rule + source-traceable visuals doctrine ([a6a9e2f89e](https://github.com/heygen-com/hyperframes/commit/a6a9e2f89e509424a64a1dcd976aabfd54b60d02), [#3354](https://github.com/heygen-com/hyperframes/pull/3354)).

## Fixes

- **Studio:** Capture storyboard tiles at review density ([b4d5abd7b2](https://github.com/heygen-com/hyperframes/commit/b4d5abd7b2cdc419906153ca75d99bd813adf614), [#3371](https://github.com/heygen-com/hyperframes/pull/3371)).
- **Lint:** Stop erroring on the documented canonical clip block ([2be5a03b80](https://github.com/heygen-com/hyperframes/commit/2be5a03b800e0b17ee36e99167c99edc383065ce), [#3374](https://github.com/heygen-com/hyperframes/pull/3374)).
- **Skills:** Resolve the blueprint id from a qualified `blueprint:` field ([d1482b0129](https://github.com/heygen-com/hyperframes/commit/d1482b012926d7118fa39e53ef8974328e84cc9e), [#3337](https://github.com/heygen-com/hyperframes/pull/3337)).
- **Skills:** Stage SVGs that capture wrote into capture/assets/svgs/ ([c66c9a4c76](https://github.com/heygen-com/hyperframes/commit/c66c9a4c76ff0681cadc8007a8e02744bbcdab10), [#3336](https://github.com/heygen-com/hyperframes/pull/3336)).
- **Core:** Keep authored gain above unity off el.volume in the sandbox bridge ([9140c0eaa1](https://github.com/heygen-com/hyperframes/commit/9140c0eaa1b332de7ca061af040611f5b1c64419), [#3349](https://github.com/heygen-com/hyperframes/pull/3349)).
- **Producer:** Seek once per step when discovering video visibility ([d09145faab](https://github.com/heygen-com/hyperframes/commit/d09145faabfd3078c29969fbcf293067d50275ac), [#3233](https://github.com/heygen-com/hyperframes/pull/3233)).
- **Studio:** Capture the storyboard frame hero at full resolution ([f0e637375f](https://github.com/heygen-com/hyperframes/commit/f0e637375f2c43b22192f1ad8c3aef1b5d010e8a), [#3338](https://github.com/heygen-com/hyperframes/pull/3338)).

## Internal

- **Lint:** Drop seven rules that fire on correct compositions ([83ceaeb902](https://github.com/heygen-com/hyperframes/commit/83ceaeb902f07ffc4bed976ca3bdd501eb60aa55), [#3366](https://github.com/heygen-com/hyperframes/pull/3366)).

## Full changelog

https://github.com/heygen-com/hyperframes/compare/v0.8.4...v0.8.5
