### PR TITLE
fix(core): bind native window methods in the scoped sub-composition proxy

### DIFF
--- a/packages/core/src/compiler/compositionScoping.test.ts
+++ b/packages/core/src/compiler/compositionScoping.test.ts
@@ -169,6 +169,40 @@ body { margin: 0; }
     expect(fakeWindow.__captured).toEqual({ title: "Pro", price: "$29" });
   });
 
+  it("hands native window methods back bound to the real window", () => {
+    // Regression: the scoped `window` proxy returned natives UNBOUND, so `this`
+    // at call time was the Proxy itself and Chrome rejected it with
+    // "Illegal invocation" — breaking window.addEventListener, setTimeout,
+    // matchMedia, getComputedStyle and requestAnimationFrame in every
+    // sub-composition, including the window.addEventListener("hf-seek", ...)
+    // form the Three.js and TypeGPU adapters document. The sibling document
+    // and gsap proxies in this file always bound; this one did not.
+    const { document } = parseHTML(`<div data-composition-id="scene"></div>`);
+    const fakeWindow: Record<string, unknown> = { document, __timelines: {} };
+    let boundToWindow = false;
+    // Method shorthand, not `function () {}`: like a real native method it has
+    // no `.prototype`, which is the property the proxy uses to tell a method
+    // apart from a class. Stands in for the native brand check, which throws
+    // when the method is invoked with anything else as `this`.
+    const natives = {
+      addEventListener(this: unknown) {
+        if (this !== fakeWindow) throw new TypeError("Illegal invocation");
+        boundToWindow = true;
+      },
+    };
+    fakeWindow.addEventListener = natives.addEventListener;
+
+    const wrapped = wrapScopedCompositionScript(
+      `window.addEventListener("hf-seek", function () {});`,
+      "scene",
+    );
+    new Function("window", wrapped)(fakeWindow);
+
+    // Asserted on the call landing, not on throwing: the wrapper's error
+    // boundary swallows the TypeError, which is why this shipped unnoticed.
+    expect(boundToWindow).toBe(true);
+  });
+
   it("preserves non-getVariables members on window.__hyperframes (only getVariables is rescoped)", () => {
     const { document } = parseHTML(`<div data-composition-id="card-1"></div>`);
     let fitCalled = false;

--- a/packages/core/src/compiler/compositionScoping.ts
+++ b/packages/core/src/compiler/compositionScoping.ts
@@ -485,7 +485,22 @@ export function wrapScopedCompositionScript(
           // (__hfScopedHyperframes is a hoisted var assigned below, before any
           // sub-comp script -- the only code that reads this -- runs.)
           if (prop === "__hyperframes") return __hfScopedHyperframes;
-          return Reflect.get(target, prop, target);
+          // Native window methods must stay bound to the real window. Handed
+          // back unbound, "this" at call time is this Proxy and Chrome rejects
+          // it with "Illegal invocation", which broke window.addEventListener,
+          // setTimeout, matchMedia and getComputedStyle inside every
+          // sub-composition -- including the window.addEventListener("hf-seek",
+          // ...) form the Three.js and TypeGPU adapters document. The sibling
+          // document and gsap proxies here already bind.
+          //
+          // Only bind non-constructors. Function.prototype.bind drops static
+          // members, so binding a class exposed on window (window.Texts and
+          // friends) would silently strip its statics. Built-in methods have
+          // no .prototype; classes and constructor functions do.
+          var value = Reflect.get(target, prop, target);
+          return typeof value === "function" && value.prototype === undefined
+            ? value.bind(target)
+            : value;
         },
         set: function(target, prop, value, receiver) {
           if (prop === "__timelines") {


### PR DESCRIPTION
## What

Bind native `window` methods in the scoped sub-composition proxy, so they stay attached to
the real window instead of the Proxy.

Closes #3376.

## Why

`wrapScopedCompositionScript` runs every sub-composition script with `window` shadowed by a
Proxy. Its `get` trap returned natives **unbound**, so `this` at call time was the Proxy and
Chrome rejected it with `TypeError: Illegal invocation`.

That broke `window.addEventListener`, `setTimeout`, `matchMedia` and `getComputedStyle`
inside **every** sub-composition — including the `window.addEventListener("hf-seek", …)`
form that `skills/hyperframes-animation/adapters/three.md:51` and `adapters/typegpu.md`
document as *the* way to drive a scene.

The two sibling proxies in the same file already do this. `document` (line 436) and `gsap`
(line 579) are identical code plus `.bind(target)`. The window proxy was the outlier.

Root compositions are never wrapped, which is why identical code worked standalone and
failed the moment it was mounted.

## How

One narrowed bind in the window proxy's `get` trap:

```js
var value = Reflect.get(target, prop, target);
return typeof value === "function" && value.prototype === undefined
  ? value.bind(target)
  : value;
```

**The `value.prototype === undefined` guard is load-bearing.** My first attempt bound every
function and broke the existing test `preserves static methods on classes exposed through
window` — `Function.prototype.bind` drops static members, so binding a class exposed on
`window` silently strips its statics. Built-in methods have no `.prototype`; classes and
constructor functions do.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

### Regression test

Added `hands native window methods back bound to the real window` to
`compositionScoping.test.ts`. It stands in for the native brand check with an object
**method shorthand** (like a real native it has no `.prototype`) that throws when invoked
with the wrong `this`.

It asserts on the call landing rather than on throwing, because the wrapper's error boundary
swallows the `TypeError` — which is exactly why this shipped unnoticed.

Verified the test fails without the fix:

```
$ git checkout -- compositionScoping.ts && vitest -t "hands native window methods"
FAIL  composition scoping > hands native window methods back bound to the real window
Tests  1 failed | 49 skipped (50)

$ # fix restored
Tests  50 passed (50)
```

### End-to-end, before vs after

Same project both times, built on the repo's own `packages/producer/tests/sub-comp-t0`
fixture, with a sub-composition whose script uses the documented
`window.addEventListener("hf-seek", …)` to move a marker as time advances. Rendered with the
local CLI at draft quality.

**Before** — the listener never registers, so the marker sits at its authored position for
the whole clip:

```
[Browser:ERROR] [Compiler] Composition script failed hook TypeError: Illegal invocation
[Browser:ERROR] [Compiler] Composition script failed hook TypeError: Illegal invocation
[Browser:ERROR] [Compiler] Composition script failed hook TypeError: Illegal invocation
```

| frame | marker x |
|---|---|
| t=0.3s | ~25px |
| t=1.6s | ~25px (unmoved) |

**After** — no error, and the marker tracks time:

```
220.3 KB · 6.0s video · rendered in 3.2s
```

| frame | marker x |
|---|---|
| t=0.3s | ~75px |
| t=1.6s | ~305px |

Frames captured at both timestamps; the side-by-side comparison image is attached in the
first comment.

### Other checks

- `vitest packages/core/src/compiler/compositionScoping.test.ts` — 50 passed
- `oxlint` + `oxfmt` on both touched files — clean
- Pre-commit hooks (fallow, typecheck, commitlint) — green
- `vitest packages/core/src/compiler/` shows 16 failures in `compositionAssembly`,
  `htmlBundler`, `htmlCompiler` and `timingCompiler`. **These are pre-existing** — identical
  counts with my change reverted and restored, and they are module-load errors in files this
  PR does not touch.

## Not covered

The second defect described in #3376 — `inlineSubCompositions.ts` stripping `type="module"`
on the render path where `compositionLoader.ts:552` preserves it — is a separate seam and is
left for its own PR. The issue stays open for it.
