### PR TITLE
fix(audio): renumber timestamps between apad and atrim in mixed branches

### DIFF
--- a/packages/engine/src/services/audioMixer.test.ts
+++ b/packages/engine/src/services/audioMixer.test.ts
@@ -296,7 +296,7 @@ describe("processCompositionAudio", () => {
 
     expect(filter).toContain("volume=0");
     expect(filter).toContain("[mixed]volume=1[out]");
-    expect(filter).toContain("apad,atrim=0:2");
+    expect(filter).toContain("apad,asetpts=N/SR/TB,atrim=0:2");
     expect(filter).not.toContain("whole_dur");
     expect(filter).not.toContain("normalize=");
     expect(filter).not.toContain("weights=");
@@ -464,7 +464,7 @@ describe("processCompositionAudio", () => {
     // 2 s clip + the 1.9 s tail 0.6 + size * 2.6 generates.
     expect(filter).toContain("atrim=0:3.9,");
     // And still cut at the composition's end, so a tail cannot extend the video.
-    expect(filter).toContain("apad,atrim=0:8");
+    expect(filter).toContain("apad,asetpts=N/SR/TB,atrim=0:8");
   });
 
   it("hands the volume envelope to the FX pass instead of ducking the file after it", async () => {
@@ -1076,6 +1076,60 @@ describe("processCompositionAudio", () => {
     // indefinite `apad` to cap the padded stream at composition duration.
     expect((filter?.match(/atrim=/g) ?? []).length).toBe(trackCount * 2);
     expect((filter?.match(/apad,/g) ?? []).length).toBe(trackCount);
+  });
+
+  it("renumbers timestamps between apad and atrim on every mixed branch", async () => {
+    // Regression: `apad` then `atrim` is the portable pad-to-length shape --
+    // #2769 moved off `apad=whole_dur=` because some builds reject that option.
+    // But on FFmpeg 5.x-8.0.x the padded samples carry timestamps `atrim`
+    // misreads, so a delayed branch sounds at t=0 and, past three branches, the
+    // last one vanishes from the mix. `asetpts=N/SR/TB` between the two rebuilds
+    // the timestamps from the sample count and costs no portability, since all
+    // three filters exist in every build we support.
+    const baseDir = mkdtempSync(join(tmpdir(), "hf-audio-base-"));
+    const workDir = mkdtempSync(join(tmpdir(), "hf-audio-work-"));
+    tempDirs.push(baseDir, workDir);
+    writeFileSync(join(baseDir, "a.wav"), "stub");
+    writeFileSync(join(baseDir, "b.wav"), "stub");
+
+    // Two branches, the second delayed: the shape that misplaced audio.
+    await processCompositionAudio(
+      [
+        {
+          id: "a",
+          src: "a.wav",
+          start: 0,
+          end: 1,
+          mediaStart: 0,
+          layer: 0,
+          volume: 1,
+          type: "audio",
+        },
+        {
+          id: "b",
+          src: "b.wav",
+          start: 4,
+          end: 5,
+          mediaStart: 0,
+          layer: 1,
+          volume: 1,
+          type: "audio",
+        },
+      ],
+      baseDir,
+      workDir,
+      join(baseDir, "out.m4a"),
+      8,
+    );
+
+    const filter = capturedFilterScripts.at(-1) ?? "";
+    const branches = filter.match(/apad[^;]*/g) ?? [];
+    expect(branches).toHaveLength(2);
+    for (const branch of branches) {
+      expect(branch).toMatch(/^apad,asetpts=N\/SR\/TB,atrim=0:/);
+    }
+    // The portability constraint #2769 established still holds.
+    expect(filter).not.toContain("whole_dur");
   });
 
   it("retries with the current file-valued filter option when a nightly removes the legacy alias", async () => {

--- a/packages/engine/src/services/audioMixer.ts
+++ b/packages/engine/src/services/audioMixer.ts
@@ -709,8 +709,19 @@ async function mixAudioTracks(
       // can run over what follows but never past the end of the video.
       const trimDuration = track.end - track.start + (track.tailSeconds ?? 0);
       const volumeFilter = buildVolumeExpression(track, ignoreAutomation);
+      // `apad` then `atrim` is the portable pad-to-length shape: PR #2769 moved
+      // off `apad=whole_dur=` because some FFmpeg builds reject that option
+      // outright ("Error applying option 'whole_dur': Option not found").
+      // But on FFmpeg 5.x through 8.0.x the samples `apad` appends carry
+      // timestamps the following `atrim` misreads, so a delayed branch lands at
+      // t=0 and, once four or more branches are mixed, the last one disappears
+      // entirely. `asetpts=N/SR/TB` renumbers the padded stream from the sample
+      // count before the trim reads it, which fixes the misplacement while
+      // keeping the filter set every build supports. Verified correct on 4.2.7,
+      // 7.0.2, an 8.x nightly and 8.1.1; the un-reset form is wrong on the
+      // middle two.
       filterParts.push(
-        `[${i}:a]atrim=0:${formatFilterNumber(trimDuration)},${volumeFilter},adelay=${delayMs}|${delayMs},apad,atrim=0:${formatFilterNumber(totalDuration)}[a${i}]`,
+        `[${i}:a]atrim=0:${formatFilterNumber(trimDuration)},${volumeFilter},adelay=${delayMs}|${delayMs},apad,asetpts=N/SR/TB,atrim=0:${formatFilterNumber(totalDuration)}[a${i}]`,
       );
     });
 

--- a/packages/producer/src/services/audioExtractor.ts
+++ b/packages/producer/src/services/audioExtractor.ts
@@ -211,8 +211,9 @@ async function mixTracks(
     const delayMs = Math.round(track.start * 1000);
     const trimDuration = track.duration > 0 ? track.duration : totalDuration;
 
+    // See audioMixer.ts for why asetpts sits between apad and atrim.
     filterParts.push(
-      `[${i}:a]atrim=0:${trimDuration},volume=${track.volume},adelay=${delayMs}|${delayMs},apad,atrim=0:${totalDuration}[a${i}]`,
+      `[${i}:a]atrim=0:${trimDuration},volume=${track.volume},adelay=${delayMs}|${delayMs},apad,asetpts=N/SR/TB,atrim=0:${totalDuration}[a${i}]`,
     );
   });
 


### PR DESCRIPTION
## What

Insert `asetpts=N/SR/TB` between `apad` and `atrim` on every mixed audio branch.

Closes #3344.

## Why

Each mixed track is built as `atrim → volume → adelay → apad → atrim`. On FFmpeg 5.x
through 8.0.x the samples `apad` appends carry timestamps the following `atrim` misreads,
so a delayed branch sounds at **t=0** instead of at its offset and, once four or more
branches are mixed, the **last one disappears from the output entirely**.

Nothing errors. The render succeeds and the mp4 has wrong audio.

Three independent reports, including one traced from the composition side: *"the first
`<audio>` element whose `data-start` is > 0 and comes after a time gap gets scheduled at
render time 0"*. That reporter thought composition **size** was the trigger and could not
reproduce it small — size was a proxy for branch count, which is why it needs four.

## How

**Not** by reverting to `apad=whole_dur=`. #2769 deliberately moved off that form because
some builds reject the option outright:

```
Error applying option 'whole_dur': Option not found
```

`asetpts=N/SR/TB` rebuilds the timestamps from the sample count before the trim reads them.
It uses only filters every build ships, so it fixes the misplacement without giving up the
portability #2769 bought. The existing `expect(filter).not.toContain("whole_dur")` guard
still passes unchanged.

`audioPadTrim.ts` pads with the same `apad,atrim` pair but has no `adelay`, and is correct
on every version tested, so it is left alone rather than changed on suspicion.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

### Measured across four FFmpeg builds

Five clips at staggered delays, mixed to 43.3s. `t=0.0s` must be silent (the earliest clip
starts at 0.3s) and every clip must sound at its own offset. `-inf` at a clip's offset means
that clip is absent from the mix.

**Current form, `apad,atrim=0:TOTAL`:**

| build | t=0.0s | c4 @ 40.0s |
|---|---|---|
| 4.2.7 | `-inf` ✅ | `-30.1` ✅ |
| **7.0.2** | **`-31.0`** ❌ | **`-inf`** ❌ |
| **8.x nightly** | **`-31.0`** ❌ | **`-inf`** ❌ |
| 8.1.1 | `-inf` ✅ | `-30.1` ✅ |

**This PR, `apad,asetpts=N/SR/TB,atrim=0:TOTAL`:**

| build | t=0.0s | c4 @ 40.0s |
|---|---|---|
| 4.2.7 | `-inf` ✅ | `-30.1` ✅ |
| 7.0.2 | `-inf` ✅ | `-30.1` ✅ |
| 8.x nightly | `-inf` ✅ | `-30.1` ✅ |
| 8.1.1 | `-inf` ✅ | `-30.1` ✅ |

Two other candidates were tested and rejected: `apad,atrim,asetpts` (asetpts *after* the
trim) is still broken on 7.0.2, and `apad=pad_dur=` works but is a relative duration, so it
says something different from what the code means.

### Regression test

`renumbers timestamps between apad and atrim on every mixed branch` asserts every branch
matches `/^apad,asetpts=N\/SR\/TB,atrim=0:/` and re-asserts the `whole_dur` portability
constraint. Verified it fails without the fix:

```
$ # asetpts removed
FAIL  audioMixer.test.ts > renumbers timestamps between apad and atrim on every mixed branch
$ # restored
Tests  59 passed (59)
```

Two existing assertions that pinned the literal `apad,atrim=0:N` string were updated to the
new shape.

### Other checks

- `vitest packages/engine/src/services/audioMixer.test.ts` — 59 passed
- `oxlint` + `oxfmt` on all three touched files — clean
- Pre-commit hooks (fallow, typecheck, commitlint) — green

## Worth knowing

The bug appears to have been fixed upstream somewhere between 8.0.x and 8.1.1, which is why
it is invisible on a current toolchain. It still matters, because we do not control which
FFmpeg a user has, and 7.x is common.
