### PR TITLE
fix(engine): hide ffmpeg console windows on Windows

### DIFF
--- a/packages/engine/src/services/streamingEncoder.ts
+++ b/packages/engine/src/services/streamingEncoder.ts
@@ -457,6 +457,8 @@ export async function spawnStreamingEncoder(
 
   const ffmpeg: ChildProcess = spawn(getFfmpegBinary(), args, {
     stdio: ["pipe", "pipe", "pipe"],
+    // See runFfmpeg.ts: keeps a console window off the user's desktop on Windows.
+    windowsHide: true,
   });
   trackChildProcess(ffmpeg);
 

--- a/packages/engine/src/utils/ffprobe.ts
+++ b/packages/engine/src/utils/ffprobe.ts
@@ -69,6 +69,8 @@ async function runFfprobe(
     // Nothing is ever written to the child's stdin; leaving it as a pipe is
     // what lets a stdin-reading invocation block indefinitely.
     stdio: ["ignore", "pipe", "pipe"],
+    // See runFfmpeg.ts: keeps a console window off the user's desktop on Windows.
+    windowsHide: true,
   });
   trackChildProcess(proc);
   // Decoded through StringDecoder rather than per-chunk toString(): a

--- a/packages/engine/src/utils/gpuEncoder.ts
+++ b/packages/engine/src/utils/gpuEncoder.ts
@@ -64,6 +64,8 @@ export async function selectUsableGpuEncoder(
 export async function detectGpuEncoder(): Promise<GpuEncoder> {
   const ffmpeg = spawn(getFfmpegBinary(), ["-encoders"], {
     stdio: ["pipe", "pipe", "pipe"],
+    // See runFfmpeg.ts: keeps a console window off the user's desktop on Windows.
+    windowsHide: true,
   });
   trackChildProcess(ffmpeg);
   let stdout = "";
@@ -146,6 +148,7 @@ export function getProbeArgs(encoder: ConcreteGpuEncoder): string[] {
 async function canUseGpuEncoder(encoder: ConcreteGpuEncoder): Promise<boolean> {
   const ffmpeg = spawn(getFfmpegBinary(), getProbeArgs(encoder), {
     stdio: ["ignore", "ignore", "pipe"],
+    windowsHide: true,
   });
   trackChildProcess(ffmpeg);
   const outcome = await new ManagedChildProcess(ffmpeg, {

--- a/packages/engine/src/utils/runFfmpeg.ts
+++ b/packages/engine/src/utils/runFfmpeg.ts
@@ -92,7 +92,11 @@ export function formatFfmpegError(
 
 export async function runFfmpeg(args: string[], opts?: RunFfmpegOptions): Promise<RunFfmpegResult> {
   const timeout = opts?.timeout ?? DEFAULT_TIMEOUT;
-  const ffmpeg = spawn(getFfmpegBinary(), args);
+  // windowsHide: ffmpeg/ffprobe are console-subsystem binaries, so without
+  // this Node opens a visible console window per spawn on Windows. A render
+  // shells out dozens of times across parallel workers, which flashes a burst
+  // of windows across the user's desktop. No-op on macOS and Linux.
+  const ffmpeg = spawn(getFfmpegBinary(), args, { windowsHide: true });
   trackChildProcess(ffmpeg);
   const managed = new ManagedChildProcess(ffmpeg, {
     signal: opts?.signal,

--- a/packages/engine/src/utils/runFfmpeg.windowsHide.test.ts
+++ b/packages/engine/src/utils/runFfmpeg.windowsHide.test.ts
@@ -1,0 +1,40 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+
+// Hoisted so the mock factory below can reach it without a top-level variable.
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+
+vi.mock("node:child_process", () => ({ spawn: spawnMock }));
+vi.mock("child_process", () => ({ spawn: spawnMock }));
+
+/** Minimal stand-in for the ChildProcess runFfmpeg awaits. */
+function fakeFfmpeg() {
+  const proc = new EventEmitter() as EventEmitter & Record<string, unknown>;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = { write: vi.fn(), end: vi.fn() };
+  proc.kill = vi.fn();
+  proc.pid = 4242;
+  queueMicrotask(() => proc.emit("close", 0, null));
+  return proc;
+}
+
+describe("runFfmpeg spawn options", () => {
+  it("hides the console window so Windows renders do not flash terminals", async () => {
+    // Regression for the Windows popup report: ffmpeg is a console-subsystem
+    // binary, and Node defaults `windowsHide` to false, so every spawn opened a
+    // visible window. A render shells out dozens of times across parallel
+    // workers, which produced a burst of windows on the user's desktop.
+    // Asserted on the options actually handed to spawn rather than on the
+    // source text, so a future call site that drops the flag is caught by
+    // behaviour.
+    spawnMock.mockImplementation(() => fakeFfmpeg());
+
+    const { runFfmpeg } = await import("./runFfmpeg.js");
+    await runFfmpeg(["-version"]);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const options = spawnMock.mock.calls[0]?.[2] as { windowsHide?: boolean } | undefined;
+    expect(options?.windowsHide).toBe(true);
+  });
+});

--- a/packages/producer/src/services/audioExtractor.ts
+++ b/packages/producer/src/services/audioExtractor.ts
@@ -88,7 +88,8 @@ export function parseAudioElements(html: string): AudioElement[] {
  */
 function runFFmpeg(args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
-    const ffmpeg = spawn(getFfmpegBinary(), args);
+    // See runFfmpeg.ts: keeps a console window off the user's desktop on Windows.
+    const ffmpeg = spawn(getFfmpegBinary(), args, { windowsHide: true });
     trackChildProcess(ffmpeg);
     let stderr = "";
 

--- a/packages/producer/src/services/distributed/shared.ts
+++ b/packages/producer/src/services/distributed/shared.ts
@@ -333,7 +333,11 @@ let cachedFfmpegVersion: string | null = null;
  */
 export async function readFfmpegVersion(): Promise<string> {
   if (cachedFfmpegVersion !== null) return cachedFfmpegVersion;
-  const { stdout } = await execFile("ffmpeg", ["-version"], { maxBuffer: 1024 * 1024 });
+  const { stdout } = await execFile("ffmpeg", ["-version"], {
+    maxBuffer: 1024 * 1024,
+    // See runFfmpeg.ts: keeps a console window off the user's desktop on Windows.
+    windowsHide: true,
+  });
   const firstLine = stdout.split(/\r?\n/)[0]?.trim() ?? "";
   if (!firstLine) {
     throw new Error("ffmpeg -version returned empty output");


### PR DESCRIPTION
## What

Pass `windowsHide: true` at every production ffmpeg/ffprobe spawn site.

Closes #3379.

## Why

`ffmpeg` and `ffprobe` are console-subsystem binaries, and Node's `child_process.spawn`
defaults `windowsHide` to `false`. Every spawn therefore opens a visible console window on
Windows. A render shells out dozens of times across parallel workers, so the reporter saw a
burst of windows appear and disappear across their desktop, ~11 at once with 6 capture
workers.

Cosmetic, but it is the first impression of a render on Windows.

## How

The report named two call sites. **Seven production sites share the cause**, so all seven
are fixed rather than the two mentioned:

| file | site |
|---|---|
| `engine/src/utils/runFfmpeg.ts` | the shared runner, used across the pipeline |
| `engine/src/utils/gpuEncoder.ts` | `-encoders` probe |
| `engine/src/utils/gpuEncoder.ts` | per-encoder probe |
| `engine/src/utils/ffprobe.ts` | metadata probe |
| `engine/src/services/streamingEncoder.ts` | streaming encode |
| `producer/src/services/audioExtractor.ts` | audio extraction |
| `producer/src/services/distributed/shared.ts` | `ffmpeg -version` check |

`windowsHide` is a no-op on macOS and Linux, so it is applied unconditionally.

Left alone deliberately: `parity-harness.ts`, `regression-harness.ts` and
`mediaTypeTestFixtures.ts` all spawn ffmpeg too, but they are dev-only tooling that never
runs on a user's desktop. Changing them would widen the diff without changing the reported
behaviour.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

### Regression test

`runFfmpeg.windowsHide.test.ts` mocks `child_process` and asserts on the options object
actually handed to `spawn`:

```ts
const options = spawnMock.mock.calls[0]?.[2] as { windowsHide?: boolean } | undefined;
expect(options?.windowsHide).toBe(true);
```

Asserted on behaviour rather than on source text, so a future call site that drops the flag
is caught by what it does, not by how it is written.

Verified it fails without the fix:

```
$ # windowsHide removed from runFfmpeg
FAIL  runFfmpeg.windowsHide.test.ts > hides the console window so Windows renders do not flash terminals
$ # restored
Tests  1 passed (1)
```

### Other checks

- `vitest packages/engine/src/utils/` — 651 passed, 20 files
- `oxlint` + `oxfmt` on all 7 touched files — clean
- Pre-commit hooks (fallow, typecheck, commitlint) — green

## Before / after

I do not have a Windows machine, so I cannot capture the desktop screenshots this one
really wants. The observable change is at the spawn boundary, and that is what the test
pins:

```
before   spawn(getFfmpegBinary(), args)                          -> console window per call
after    spawn(getFfmpegBinary(), args, { windowsHide: true })   -> no window
```

The reporter's repro repo is linked in #3379 and is the right way to confirm the desktop
behaviour on a real Windows box before merge.
