### PR TITLE
chore: release v0.8.6

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,25 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.6"
+  description="Released - 2026-08-21"
+  tags={["Release", "Audio", "Core", "Skills", "Lint"]}
+>
+Audio now replays reliably after backward seeks, and rendered mixes keep every clip at its authored time.
+Studio keeps nested timelines open, skill updates require confirmation, and a brittle lint error is gone.
+
+## Fixes
+
+- **Audio:** Keep delayed clips at their authored times in rendered mixes, preventing late clips from jumping to the start or disappearing ([c056289d8](https://github.com/heygen-com/hyperframes/commit/c056289d832351dc35256bda8b36188a77bc557a), [#3380](https://github.com/heygen-com/hyperframes/pull/3380)).
+- **Core:** Replay ended audio after backward timeline seeks without repeating tails during ordinary playback ([477e09642](https://github.com/heygen-com/hyperframes/commit/477e09642b6db735866316301d924d0dfdc3cf38), [#3383](https://github.com/heygen-com/hyperframes/pull/3383)).
+- **Skills:** Ask for confirmation before updating installed skills ([efc2e1964](https://github.com/heygen-com/hyperframes/commit/efc2e1964a1c837f748a1c319896998a0e9da211), [#3295](https://github.com/heygen-com/hyperframes/pull/3295)).
+- **Studio:** Keep subcomposition timelines open during playback ([a340ed382](https://github.com/heygen-com/hyperframes/commit/a340ed382aa5d335a3b7e40b6cfb4dfae1870569), [#3382](https://github.com/heygen-com/hyperframes/pull/3382)).
+- **Lint:** Remove the fragile `head_leaked_text` rule that could block correct compositions ([a89780679](https://github.com/heygen-com/hyperframes/commit/a8978067981805bdae72b8f16ca1c57153ec207a), [#3385](https://github.com/heygen-com/hyperframes/pull/3385)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.5...v0.8.6).
+</Update>
+
+<Update
   label="HyperFrames v0.8.5"
   description="Released - 2026-08-20"
   tags={["Release", "Studio", "Lint", "Telemetry"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.6.md
+++ b/releases/v0.8.6.md
@@ -1,0 +1,18 @@
+# HyperFrames v0.8.6
+
+Released on 2026-08-21.
+
+Audio now replays reliably after backward seeks, and rendered mixes keep every clip at its authored time.
+Studio keeps nested timelines open, skill updates require confirmation, and a brittle lint error is gone.
+
+## Fixes
+
+- **Audio:** Keep delayed clips at their authored times in rendered mixes, preventing late clips from jumping to the start or disappearing ([c056289d8](https://github.com/heygen-com/hyperframes/commit/c056289d832351dc35256bda8b36188a77bc557a), [#3380](https://github.com/heygen-com/hyperframes/pull/3380)).
+- **Core:** Replay ended audio after backward timeline seeks without repeating tails during ordinary playback ([477e09642](https://github.com/heygen-com/hyperframes/commit/477e09642b6db735866316301d924d0dfdc3cf38), [#3383](https://github.com/heygen-com/hyperframes/pull/3383)).
+- **Skills:** Ask for confirmation before updating installed skills ([efc2e1964](https://github.com/heygen-com/hyperframes/commit/efc2e1964a1c837f748a1c319896998a0e9da211), [#3295](https://github.com/heygen-com/hyperframes/pull/3295)).
+- **Studio:** Keep subcomposition timelines open during playback ([a340ed382](https://github.com/heygen-com/hyperframes/commit/a340ed382aa5d335a3b7e40b6cfb4dfae1870569), [#3382](https://github.com/heygen-com/hyperframes/pull/3382)).
+- **Lint:** Remove the fragile `head_leaked_text` rule that could block correct compositions ([a89780679](https://github.com/heygen-com/hyperframes/commit/a8978067981805bdae72b8f16ca1c57153ec207a), [#3385](https://github.com/heygen-com/hyperframes/pull/3385)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.5...v0.8.6


### PR DESCRIPTION
## What

Prepare the stable HyperFrames v0.8.6 patch release.

- Bump all 13 publishable packages and three plugin manifests from 0.8.5 to 0.8.6.
- Add reviewed GitHub and docs changelog entries.
- Publish through the protected `release/v*` merge workflow. No stable tag was pushed from this branch.

## Why

This patch ships two user-visible audio correctness fixes: ended dialogue now replays after backward timeline seeks, and delayed render-mix clips stay at their authored times instead of jumping to the start or disappearing.

It also keeps subcomposition timelines open during playback, requires confirmation before skill updates, and removes a brittle lint rule that could block correct compositions.

## Included changes

- #3380 — preserve delayed audio timing in offline mixes
- #3383 — replay ended audio after backward seeks
- #3382 — keep subcomposition timelines open during playback
- #3295 — confirm skill updates before applying them
- #3385 — remove the fragile `head_leaked_text` lint rule

## Validation

- Release workflow tests: 56 passed
- Full monorepo build: passed
- Release-script typecheck: passed
- Packed manifests and clean consumer install: passed across 13 packages, 121 exports, and 116 Node exports
- Changelog formatting, tracked-artifact check, commitlint, and release pre-commit hooks: passed
- Release commit is based on the current `main` head and the local-only `v0.8.6` tag points to the exact release commit

Merging this reviewed PR will create the stable tag at the immutable merge commit, publish npm packages with the `latest` dist-tag, and create the GitHub release.
