### PR TITLE
feat(cli): send the frame-cache health counters to render_complete

### DIFF
--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -1558,6 +1558,10 @@ function trackRenderMetrics(
     extractPhase3Ms: extract?.extractMs,
     extractCacheHits: extract?.cacheHits,
     extractCacheMisses: extract?.cacheMisses,
+    extractCachePublishFailures: extract?.cachePublishFailures,
+    extractCacheGcEvictions: extract?.cacheGcEvictions,
+    extractCacheGcBytesFreed: extract?.cacheGcBytesFreed,
+    extractCacheAgedPartialsCleared: extract?.cacheAgedPartialsCleared,
     ...renderJobObservabilityTelemetryPayload(job),
     ...getMemorySnapshot(),
   });

--- a/packages/cli/src/server/studioRenderTelemetry.test.ts
+++ b/packages/cli/src/server/studioRenderTelemetry.test.ts
@@ -109,10 +109,12 @@ const fullPerf: RenderPerfSummary = {
     extractMs: 60,
     cacheHits: 3,
     cacheMisses: 4,
-    cachePublishFailures: 0,
-    cacheGcEvictions: 0,
-    cacheGcBytesFreed: 0,
-    cacheAgedPartialsCleared: 0,
+    // Distinct non-zero values: all-zeros cannot tell a correct mapping from
+    // one that crossed two fields.
+    cachePublishFailures: 5,
+    cacheGcEvictions: 6,
+    cacheGcBytesFreed: 7,
+    cacheAgedPartialsCleared: 8,
   },
   tmpPeakBytes: 1024,
   captureAvgMs: 13,
@@ -184,6 +186,10 @@ describe("studioRenderTelemetry", () => {
       expect(p.extractPhase3Ms).toBe(60);
       expect(p.extractCacheHits).toBe(3);
       expect(p.extractCacheMisses).toBe(4);
+      expect(p.extractCachePublishFailures).toBe(5);
+      expect(p.extractCacheGcEvictions).toBe(6);
+      expect(p.extractCacheGcBytesFreed).toBe(7);
+      expect(p.extractCacheAgedPartialsCleared).toBe(8);
       // observability aggregate
       expect(p.observabilityRenderJobId).toBe("render-123");
       expect(p.observabilityCompositionHash).toBe("abc123");

--- a/packages/cli/src/server/studioRenderTelemetry.ts
+++ b/packages/cli/src/server/studioRenderTelemetry.ts
@@ -74,6 +74,10 @@ function extractPayload(
     extractPhase3Ms: extract.extractMs,
     extractCacheHits: extract.cacheHits,
     extractCacheMisses: extract.cacheMisses,
+    extractCachePublishFailures: extract.cachePublishFailures,
+    extractCacheGcEvictions: extract.cacheGcEvictions,
+    extractCacheGcBytesFreed: extract.cacheGcBytesFreed,
+    extractCacheAgedPartialsCleared: extract.cacheAgedPartialsCleared,
   };
 }
 

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -275,6 +275,17 @@ export function trackRenderComplete(
     extractPhase3Ms?: number;
     extractCacheHits?: number;
     extractCacheMisses?: number;
+    /**
+     * Frame-cache health. `cachePublishFailures` is the one to alert on: the
+     * render still succeeded from the partial dir, so nothing surfaces, but
+     * every later render re-extracts — warm renders going cold with no signal.
+     * The GC counters give it a denominator (was the entry evicted, or did the
+     * publish fail?).
+     */
+    extractCachePublishFailures?: number;
+    extractCacheGcEvictions?: number;
+    extractCacheGcBytesFreed?: number;
+    extractCacheAgedPartialsCleared?: number;
     // Attribute this event to a specific user (e.g. the browser user who
     // triggered a studio render); defaults to the install anonymousId.
     distinctId?: string;
@@ -368,6 +379,10 @@ export function trackRenderComplete(
       extract_phase3_ms: props.extractPhase3Ms,
       extract_cache_hits: props.extractCacheHits,
       extract_cache_misses: props.extractCacheMisses,
+      extract_cache_publish_failures: props.extractCachePublishFailures,
+      extract_cache_gc_evictions: props.extractCacheGcEvictions,
+      extract_cache_gc_bytes_freed: props.extractCacheGcBytesFreed,
+      extract_cache_aged_partials_cleared: props.extractCacheAgedPartialsCleared,
     },
     props.distinctId,
   );


### PR DESCRIPTION
Follow-up flagged in the #1915 review: `ExtractionPhaseBreakdown` collects four frame-cache counters that `extractPayload` never forwarded, so they reached `RenderPerfSummary` and stopped there.

- `extract_cache_publish_failures` — the one to alert on. A failed atomic publish still lets the render succeed from the partial dir, so nothing surfaces, but every later render re-extracts. Its docstring calls it "the first signal that warm renders are silently going cold"; until now that signal had no consumer.
- `extract_cache_gc_evictions`, `extract_cache_gc_bytes_freed`, `extract_cache_aged_partials_cleared` — the denominator: evicted on purpose, or failed to publish.

Both writers map them (`render.ts` for CLI renders, `studioRenderTelemetry.ts` for studio ones). The mapping test asserts all four with distinct non-zero values, so a crossed pair cannot pass — the fixture previously had them all at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)