### PR TITLE
fix(cli): give the Windows browser-path hint its PowerShell form too

### DIFF
--- a/packages/cli/src/browser/windowsCrash.test.ts
+++ b/packages/cli/src/browser/windowsCrash.test.ts
@@ -64,4 +64,23 @@ describe("windowsChromeCrashRemediation", () => {
       ),
     ).toBeUndefined();
   });
+
+  // The hint only ever renders on win32, so on CI (Linux) the string itself is
+  // otherwise unasserted. Both shell forms have to be there: `set` is cmd.exe,
+  // and in PowerShell it resolves to the Set-Variable alias — a shell variable
+  // that never reaches the child process, so a PowerShell user would follow the
+  // hint exactly and see no change.
+  it("names both the cmd.exe and the PowerShell way to set the env var", () => {
+    const original = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    try {
+      const hint = windowsChromeCrashRemediation(
+        "Failed to launch the browser process! Code: 3221225595",
+      );
+      expect(hint).toContain('set HYPERFRAMES_BROWSER_PATH="C:\\Program Files');
+      expect(hint).toContain('$env:HYPERFRAMES_BROWSER_PATH = "C:\\Program Files');
+    } finally {
+      Object.defineProperty(process, "platform", { value: original, configurable: true });
+    }
+  });
 });

--- a/packages/cli/src/browser/windowsCrash.ts
+++ b/packages/cli/src/browser/windowsCrash.ts
@@ -45,6 +45,13 @@ export function windowsChromeCrashRemediation(errorMessage: string): string | un
     "",
     '  set HYPERFRAMES_BROWSER_PATH="C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"',
     "",
+    // `set` is cmd.exe syntax. In PowerShell it resolves to the Set-Variable
+    // alias, which makes a shell variable rather than an environment one — it
+    // never reaches the child process, so the hint would look followed and
+    // change nothing.
+    "  PowerShell:",
+    '  $env:HYPERFRAMES_BROWSER_PATH = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"',
+    "",
     "Then re-run your command. Any Chrome build works for the screenshot capture path; install a real chrome-headless-shell later if you need the perf-optimized BeginFrame path.",
   ].join("\n");
 }


### PR DESCRIPTION
Nit raised in the #2481 review, which merged before this landed — so it comes as its own PR.

The hint prints `set HYPERFRAMES_BROWSER_PATH="C:\Program Files\..."`, which is cmd.exe syntax. In PowerShell `set` resolves to the `Set-Variable` alias: it creates a shell variable, not an environment one, so it never reaches the spawned browser. A PowerShell user follows the hint exactly and sees the same `STATUS_STACK_BUFFER_OVERRUN` crash. Both forms are now printed.

The hint only renders on win32, so its text was unasserted on Linux CI — a case that pins `process.platform` for the call now checks both forms are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)