### PR TITLE
fix(cli,studio): surface project lint in Studio

### DIFF
--- a/packages/cli/src/commands/publish.test.ts
+++ b/packages/cli/src/commands/publish.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 
 const publishState = vi.hoisted(() => ({ publish: vi.fn() }));
@@ -37,17 +37,16 @@ describe("parseUpdateTarget", () => {
 });
 
 describe("publish default-entry preflight", () => {
-  it("rejects the real fixture before creating or uploading an archive", async () => {
+  async function runEntryMismatch(candidate: string): Promise<string> {
     const project = mkdtempSync(join(tmpdir(), "hf-publish-entry-mismatch-"));
-    const compositions = join(project, "compositions");
-    const authoredProject = join(compositions, "brand");
-    mkdirSync(authoredProject, { recursive: true });
+    const candidatePath = join(project, candidate);
+    mkdirSync(dirname(candidatePath), { recursive: true });
     writeFileSync(
       join(project, "index.html"),
       `<html><body><div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="10"></div></body></html>`,
     );
     writeFileSync(
-      join(authoredProject, "index.html"),
+      candidatePath,
       `<html><body><div data-composition-id="authored" data-width="1920" data-height="1080" data-start="0" data-duration="5"><div class="clip" data-start="0" data-duration="5">Visible</div></div></body></html>`,
     );
     publishState.publish.mockReset();
@@ -69,10 +68,25 @@ describe("publish default-entry preflight", () => {
         publishCommand.run?.({ args: { dir: project, yes: true, proxy: false } } as never),
       ).rejects.toMatchObject({ name: "CliRuntimeError" });
       expect(publishState.publish).not.toHaveBeenCalled();
-      expect(lines.join("\n")).toContain("hyperframes publish <project>/compositions/brand");
+      return lines.join("\n");
     } finally {
       log.mockRestore();
       rmSync(project, { recursive: true, force: true });
     }
+  }
+
+  it("suggests a nested index.html directory with the re-rooting caveat", async () => {
+    const output = await runEntryMismatch("compositions/brand/index.html");
+
+    expect(output).toContain("hyperframes publish <project>/compositions/brand");
+    expect(output).toContain("assets are self-contained under that directory");
+  });
+
+  it("does not suggest a directory for a standalone file that is not index.html", async () => {
+    const output = await runEntryMismatch("compositions/card.html");
+
+    expect(output).toContain("compositions/card.html");
+    expect(output).not.toContain("hyperframes publish <project>/compositions");
+    expect(output).toContain("publish accepts project directories, not individual HTML files");
   });
 });

--- a/packages/cli/src/commands/publish.test.ts
+++ b/packages/cli/src/commands/publish.test.ts
@@ -40,13 +40,14 @@ describe("publish default-entry preflight", () => {
   it("rejects the real fixture before creating or uploading an archive", async () => {
     const project = mkdtempSync(join(tmpdir(), "hf-publish-entry-mismatch-"));
     const compositions = join(project, "compositions");
-    mkdirSync(compositions);
+    const authoredProject = join(compositions, "brand");
+    mkdirSync(authoredProject, { recursive: true });
     writeFileSync(
       join(project, "index.html"),
       `<html><body><div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="10"></div></body></html>`,
     );
     writeFileSync(
-      join(compositions, "index.html"),
+      join(authoredProject, "index.html"),
       `<html><body><div data-composition-id="authored" data-width="1920" data-height="1080" data-start="0" data-duration="5"><div class="clip" data-start="0" data-duration="5">Visible</div></div></body></html>`,
     );
     publishState.publish.mockReset();
@@ -58,13 +59,19 @@ describe("publish default-entry preflight", () => {
       url: "https://hyperframes.dev/p/project-id",
       claimToken: "",
     });
+    const lines: string[] = [];
+    const log = vi.spyOn(console, "log").mockImplementation((...parts: unknown[]) => {
+      lines.push(parts.map(String).join(" "));
+    });
 
     try {
       await expect(
         publishCommand.run?.({ args: { dir: project, yes: true, proxy: false } } as never),
       ).rejects.toMatchObject({ name: "CliRuntimeError" });
       expect(publishState.publish).not.toHaveBeenCalled();
+      expect(lines.join("\n")).toContain("hyperframes publish <project>/compositions/brand");
     } finally {
+      log.mockRestore();
       rmSync(project, { recursive: true, force: true });
     }
   });

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -101,10 +101,10 @@ export default defineCommand({
         console.log(c.error("  Aborting publish because the default index.html entry is blank."));
         if (candidate && posix.basename(candidate) === "index.html") {
           const candidateDir = posix.dirname(candidate);
-          const target = candidateDir === "." ? "<project>" : `<project>/${candidateDir}`;
+          const target = `<project>/${candidateDir}`;
           console.log(
             c.dim(
-              `  Move or mount the authored file, or publish its directory directly: hyperframes publish ${target}`,
+              `  Move or mount the authored file, or publish its directory directly: hyperframes publish ${target}. Only use the directory form when its assets are self-contained under that directory; otherwise mount it from the project root.`,
             ),
           );
         } else if (candidate) {

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -1,4 +1,4 @@
-import { join, relative, resolve } from "node:path";
+import { join, posix, relative, resolve } from "node:path";
 import { failCommand, setCommandExitCode } from "../utils/commandResult.js";
 import { existsSync } from "node:fs";
 import { defineCommand } from "citty";
@@ -6,7 +6,11 @@ import * as clack from "@clack/prompts";
 
 import type { Example } from "./_examples.js";
 import { c } from "../ui/colors.js";
-import { hasDefinitiveEntryMismatch, lintProject } from "../utils/lintProject.js";
+import {
+  definitiveEntryMismatchComposition,
+  hasDefinitiveEntryMismatch,
+  lintProject,
+} from "../utils/lintProject.js";
 import { formatLintFindings } from "../utils/lintFormat.js";
 import {
   buildPublishFileMap,
@@ -93,7 +97,23 @@ export default defineCommand({
         console.log();
       }
       if (hasDefinitiveEntryMismatch(lintResult)) {
+        const candidate = definitiveEntryMismatchComposition(lintResult);
         console.log(c.error("  Aborting publish because the default index.html entry is blank."));
+        if (candidate && posix.basename(candidate) === "index.html") {
+          const candidateDir = posix.dirname(candidate);
+          const target = candidateDir === "." ? "<project>" : `<project>/${candidateDir}`;
+          console.log(
+            c.dim(
+              `  Move or mount the authored file, or publish its directory directly: hyperframes publish ${target}`,
+            ),
+          );
+        } else if (candidate) {
+          console.log(
+            c.dim(
+              `  Move or mount ${candidate} as a project index.html before publishing; publish accepts project directories, not individual HTML files.`,
+            ),
+          );
+        }
         console.log();
         failCommand();
       }

--- a/packages/cli/src/commands/snapshot.test.ts
+++ b/packages/cli/src/commands/snapshot.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 
 const snapshotState = vi.hoisted(() => ({
@@ -85,16 +85,16 @@ describe("transparent snapshot capture", () => {
 });
 
 describe("snapshot lint preflight", () => {
-  it("rejects the real fixture before invoking browser capture", async () => {
+  async function runEntryMismatch(candidate: string): Promise<string> {
     const project = mkdtempSync(join(tmpdir(), "hf-snapshot-entry-mismatch-"));
-    const compositions = join(project, "compositions");
-    mkdirSync(compositions);
+    const candidatePath = join(project, candidate);
+    mkdirSync(dirname(candidatePath), { recursive: true });
     writeFileSync(
       join(project, "index.html"),
       `<html><body><div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="10"></div></body></html>`,
     );
     writeFileSync(
-      join(compositions, "card.html"),
+      candidatePath,
       `<html><body><div data-composition-id="authored" data-width="1920" data-height="1080" data-start="0" data-duration="5"><div class="clip" data-start="0" data-duration="5">Visible</div></div></body></html>`,
     );
     snapshotState.openSettledPage.mockClear();
@@ -110,15 +110,26 @@ describe("snapshot lint preflight", () => {
         name: "CliRuntimeError",
       });
       expect(snapshotState.openSettledPage).not.toHaveBeenCalled();
-      expect(lines.join("\n")).toContain("compositions/card.html");
-      expect(lines.join("\n")).not.toContain("hyperframes snapshot <project>/compositions");
-      expect(lines.join("\n")).toContain(
-        "snapshot accepts project directories, not individual HTML files",
-      );
+      return lines.join("\n");
     } finally {
       log.mockRestore();
       rmSync(project, { recursive: true, force: true });
     }
+  }
+
+  it("does not suggest a directory for a standalone file that is not index.html", async () => {
+    const output = await runEntryMismatch("compositions/card.html");
+
+    expect(output).toContain("compositions/card.html");
+    expect(output).not.toContain("hyperframes snapshot <project>/compositions");
+    expect(output).toContain("snapshot accepts project directories, not individual HTML files");
+  });
+
+  it("suggests the reported index.html directory with the re-rooting caveat", async () => {
+    const output = await runEntryMismatch("compositions/index.html");
+
+    expect(output).toContain("hyperframes snapshot <project>/compositions");
+    expect(output).toContain("assets are self-contained under that directory");
   });
 });
 

--- a/packages/cli/src/commands/snapshot.test.ts
+++ b/packages/cli/src/commands/snapshot.test.ts
@@ -94,7 +94,7 @@ describe("snapshot lint preflight", () => {
       `<html><body><div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="10"></div></body></html>`,
     );
     writeFileSync(
-      join(compositions, "index.html"),
+      join(compositions, "card.html"),
       `<html><body><div data-composition-id="authored" data-width="1920" data-height="1080" data-start="0" data-duration="5"><div class="clip" data-start="0" data-duration="5">Visible</div></div></body></html>`,
     );
     snapshotState.openSettledPage.mockClear();
@@ -110,8 +110,11 @@ describe("snapshot lint preflight", () => {
         name: "CliRuntimeError",
       });
       expect(snapshotState.openSettledPage).not.toHaveBeenCalled();
-      expect(lines.join("\n")).toContain("hyperframes snapshot");
-      expect(lines.join("\n")).toContain("compositions");
+      expect(lines.join("\n")).toContain("compositions/card.html");
+      expect(lines.join("\n")).not.toContain("hyperframes snapshot <project>/compositions");
+      expect(lines.join("\n")).toContain(
+        "snapshot accepts project directories, not individual HTML files",
+      );
     } finally {
       log.mockRestore();
       rmSync(project, { recursive: true, force: true });

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -667,10 +667,10 @@ export default defineCommand({
       console.log(c.error("  Aborting snapshot because the default index.html entry is blank."));
       if (candidate && posix.basename(candidate) === "index.html") {
         const candidateDir = posix.dirname(candidate);
-        const target = candidateDir === "." ? "<project>" : `<project>/${candidateDir}`;
+        const target = `<project>/${candidateDir}`;
         console.log(
           c.dim(
-            `  Move or mount the authored file, or snapshot its directory directly: hyperframes snapshot ${target}`,
+            `  Move or mount the authored file, or snapshot its directory directly: hyperframes snapshot ${target}. Only use the directory form when its assets are self-contained under that directory; otherwise mount it from the project root.`,
           ),
         );
       } else if (candidate) {

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -3,7 +3,7 @@ import { failCommand } from "../utils/commandResult.js";
 import { defineCommand } from "citty";
 import { existsSync, mkdtempSync, readFileSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { resolve, join, relative, isAbsolute, basename } from "node:path";
+import { resolve, join, relative, isAbsolute, basename, posix } from "node:path";
 import {
   DEFAULT_ZOOM_SCALE,
   captureRegionCrop,
@@ -15,7 +15,11 @@ import {
   type ZoomTarget,
 } from "../capture/captureCompositionFrame.js";
 import { resolveProject } from "../utils/project.js";
-import { hasDefinitiveEntryMismatch, lintProject } from "../utils/lintProject.js";
+import {
+  definitiveEntryMismatchComposition,
+  hasDefinitiveEntryMismatch,
+  lintProject,
+} from "../utils/lintProject.js";
 import { formatLintFindings } from "../utils/lintFormat.js";
 import { normalizeErrorMessage } from "../utils/errorMessage.js";
 import { serveStaticProjectHtml } from "../utils/staticProjectServer.js";
@@ -654,17 +658,28 @@ export default defineCommand({
     const project = resolveProject(args.dir);
     const lintResult = await lintProject(project.dir);
     if (hasDefinitiveEntryMismatch(lintResult)) {
+      const candidate = definitiveEntryMismatchComposition(lintResult);
       console.log("");
       for (const line of formatLintFindings(lintResult, { errorsFirst: true })) {
         console.log(line);
       }
       console.log("");
       console.log(c.error("  Aborting snapshot because the default index.html entry is blank."));
-      console.log(
-        c.dim(
-          "  Move or mount the authored file, or snapshot its directory directly: hyperframes snapshot <project>/compositions",
-        ),
-      );
+      if (candidate && posix.basename(candidate) === "index.html") {
+        const candidateDir = posix.dirname(candidate);
+        const target = candidateDir === "." ? "<project>" : `<project>/${candidateDir}`;
+        console.log(
+          c.dim(
+            `  Move or mount the authored file, or snapshot its directory directly: hyperframes snapshot ${target}`,
+          ),
+        );
+      } else if (candidate) {
+        console.log(
+          c.dim(
+            `  Move or mount ${candidate} as a project index.html before snapshotting; snapshot accepts project directories, not individual HTML files.`,
+          ),
+        );
+      }
       console.log("");
       failCommand();
     }

--- a/packages/cli/src/server/studioServer.test.ts
+++ b/packages/cli/src/server/studioServer.test.ts
@@ -88,6 +88,7 @@ describe("Studio project lint endpoint", () => {
   it("surfaces findings that require the complete project graph", async () => {
     const projectDir = tmpProject();
     mkdirSync(join(projectDir, "compositions"));
+    mkdirSync(join(projectDir, "scenes"));
     writeFileSync(
       join(projectDir, "index.html"),
       `<html><body><div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="10"></div></body></html>`,
@@ -96,15 +97,20 @@ describe("Studio project lint endpoint", () => {
       join(projectDir, "compositions", "index.html"),
       `<html><body><div data-composition-id="authored" data-width="1920" data-height="1080" data-start="0" data-duration="5"><div class="clip" data-start="0" data-duration="5">Visible</div></div></body></html>`,
     );
+    writeFileSync(join(projectDir, "scenes", "intro.html"), "<html><body>Intro</body></html>");
     server = createStudioServer({ projectDir, projectName: "demo" });
 
     const response = await server.app.request("http://localhost/api/projects/demo/lint");
-    const payload = (await response.json()) as { findings?: Array<{ code?: string }> };
+    const payload = (await response.json()) as {
+      findings?: Array<{ code?: string; file?: string }>;
+    };
 
     expect(response.status).toBe(200);
     expect(payload.findings).toContainEqual(
       expect.objectContaining({ code: "blank_root_with_standalone_composition" }),
     );
+    expect(payload.findings).toContainEqual(expect.objectContaining({ file: "scenes/intro.html" }));
+    expect(payload.findings?.every((finding) => !finding.file?.startsWith(projectDir))).toBe(true);
   });
 });
 

--- a/packages/cli/src/server/studioServer.test.ts
+++ b/packages/cli/src/server/studioServer.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadHyperframeRuntimeSource } from "@hyperframes/core";
@@ -81,6 +81,30 @@ describe("createStudioServer autoProxy plumbing", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({ browserGpuMode: "software" });
+  });
+});
+
+describe("Studio project lint endpoint", () => {
+  it("surfaces findings that require the complete project graph", async () => {
+    const projectDir = tmpProject();
+    mkdirSync(join(projectDir, "compositions"));
+    writeFileSync(
+      join(projectDir, "index.html"),
+      `<html><body><div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="10"></div></body></html>`,
+    );
+    writeFileSync(
+      join(projectDir, "compositions", "index.html"),
+      `<html><body><div data-composition-id="authored" data-width="1920" data-height="1080" data-start="0" data-duration="5"><div class="clip" data-start="0" data-duration="5">Visible</div></div></body></html>`,
+    );
+    server = createStudioServer({ projectDir, projectName: "demo" });
+
+    const response = await server.app.request("http://localhost/api/projects/demo/lint");
+    const payload = (await response.json()) as { findings?: Array<{ code?: string }> };
+
+    expect(response.status).toBe(200);
+    expect(payload.findings).toContainEqual(
+      expect.objectContaining({ code: "blank_root_with_standalone_composition" }),
+    );
   });
 });
 

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -431,6 +431,11 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
       return await lintHyperframeHtml(html, opts);
     },
 
+    async lintProject(dir: string) {
+      const { lintProject } = await import("@hyperframes/lint");
+      return await lintProject(dir);
+    },
+
     runtimeUrl: "/api/runtime.js",
 
     rendersDir: () => join(projectDir, "renders"),

--- a/packages/cli/src/utils/lintProject.ts
+++ b/packages/cli/src/utils/lintProject.ts
@@ -11,3 +11,13 @@ export function hasDefinitiveEntryMismatch(result: ProjectLintResult): boolean {
     ),
   );
 }
+
+export function definitiveEntryMismatchComposition(result: ProjectLintResult): string | undefined {
+  for (const entry of result.results) {
+    const finding = entry.result.findings.find(
+      (candidate) => candidate.code === "blank_root_with_standalone_composition",
+    );
+    if (finding) return finding.suggestedComposition;
+  }
+  return undefined;
+}

--- a/packages/lint/src/project.test.ts
+++ b/packages/lint/src/project.test.ts
@@ -89,7 +89,9 @@ describe("blank_root_with_standalone_composition", () => {
     expect(finding?.severity).toBe("error");
     expect(finding?.message).toContain("compositions/index.html");
     expect(finding?.message).toContain("index.html");
+    expect(finding?.message).toContain("publish");
     expect(finding?.fixHint).toContain("data-composition-src");
+    expect(finding?.suggestedComposition).toBe("compositions/index.html");
   });
 
   it("treats non-rendering script, style, link, meta, and template children as blank", async () => {
@@ -172,6 +174,24 @@ describe("blank_root_with_standalone_composition", () => {
       .find((item) => item.code === "blank_root_with_standalone_composition");
 
     expect(finding).toBeDefined();
+  });
+
+  it("does not treat a composition that only mounts another composition as standalone", async () => {
+    const project = makeProject(validHtml(), {
+      "wrapper.html": `<!doctype html><html><body>
+  <div data-composition-id="wrapper" data-width="1920" data-height="1080" data-start="0" data-duration="5">
+    <div data-composition-src="compositions/scene.html" data-start="0" data-duration="5"></div>
+  </div>
+</body></html>`,
+      "scene.html": `<template><div data-composition-id="scene"><p>Scene</p></div></template>`,
+    });
+
+    const { results } = await lintProject(project);
+    const finding = results
+      .flatMap((result) => result.result.findings)
+      .find((item) => item.code === "blank_root_with_standalone_composition");
+
+    expect(finding).toBeUndefined();
   });
 });
 

--- a/packages/lint/src/project.ts
+++ b/packages/lint/src/project.ts
@@ -287,10 +287,11 @@ function lintBlankRootWithStandaloneComposition(
     {
       code: "blank_root_with_standalone_composition",
       severity: "error",
-      message: `The default index.html composition has no renderable content, but ${standaloneCandidates.join(", ")} contains a standalone timed composition. Default check, snapshot, preview, and render commands open index.html, so they will capture only its background.`,
+      message: `The default index.html composition has no renderable content, but ${standaloneCandidates.join(", ")} contains a standalone timed composition. Default check, snapshot, preview, render, and publish commands open index.html, so they will capture or publish only its background.`,
       fixHint:
         `Move the authored composition into index.html, or mount it from index.html with data-composition-src and the sub-composition <template> contract. ` +
         `If the separate file is intentional, render it explicitly with --composition ${standaloneCandidates[0]}.`,
+      suggestedComposition: standaloneCandidates[0],
     },
   ];
 }

--- a/packages/lint/src/types.ts
+++ b/packages/lint/src/types.ts
@@ -9,6 +9,8 @@ export type HyperframeLintFinding = {
   elementId?: string;
   fixHint?: string;
   snippet?: string;
+  /** Optional standalone entry that command-specific guidance can act on. */
+  suggestedComposition?: string;
 };
 
 /**

--- a/packages/studio-server/src/routes/lint.test.ts
+++ b/packages/studio-server/src/routes/lint.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -57,5 +57,48 @@ describe("registerLintRoutes — dot-directory exclusion (#1384)", () => {
     const lintedFiles = (payload.findings ?? []).map((f) => f.file);
     expect(lintedFiles).toContain("index.html");
     expect(lintedFiles).not.toContain(".hyperframes/preset.html");
+  });
+
+  it("returns project-level findings instead of re-linting files independently", async () => {
+    const projectDir = createProjectDir();
+    const singleFileLint = vi.fn(async () => ({ findings: [] }));
+    const projectLint = vi.fn(async () => ({
+      results: [
+        {
+          file: "index.html",
+          result: {
+            findings: [
+              {
+                code: "blank_root_with_standalone_composition",
+                severity: "error",
+                message: "The default entry is blank.",
+              },
+            ],
+          },
+        },
+      ],
+    }));
+    const adapter = {
+      ...createAdapter(projectDir),
+      lint: singleFileLint,
+      lintProject: projectLint,
+    };
+    const app = new Hono();
+    registerLintRoutes(app, adapter);
+
+    const response = await app.request("http://localhost/projects/demo/lint");
+    const payload = (await response.json()) as {
+      findings?: Array<{ code?: string; file?: string }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(projectLint).toHaveBeenCalledWith(projectDir);
+    expect(singleFileLint).not.toHaveBeenCalled();
+    expect(payload.findings).toContainEqual(
+      expect.objectContaining({
+        code: "blank_root_with_standalone_composition",
+        file: "index.html",
+      }),
+    );
   });
 });

--- a/packages/studio-server/src/routes/lint.test.ts
+++ b/packages/studio-server/src/routes/lint.test.ts
@@ -72,6 +72,7 @@ describe("registerLintRoutes — dot-directory exclusion (#1384)", () => {
                 code: "blank_root_with_standalone_composition",
                 severity: "error",
                 message: "The default entry is blank.",
+                file: join(projectDir, "index.html"),
               },
             ],
           },
@@ -99,6 +100,50 @@ describe("registerLintRoutes — dot-directory exclusion (#1384)", () => {
         code: "blank_root_with_standalone_composition",
         file: "index.html",
       }),
+    );
+  });
+
+  it("unions project lint with HTML files outside the canonical project graph", async () => {
+    const projectDir = createProjectDir();
+    const scenesDir = join(projectDir, "scenes");
+    mkdirSync(scenesDir);
+    writeFileSync(join(scenesDir, "intro.html"), "<html><body>intro</body></html>");
+    const singleFileLint = vi.fn(async () => ({
+      findings: [
+        {
+          code: "scene_finding",
+          severity: "warning",
+          message: "Scene finding.",
+          file: join(projectDir, "scenes", "intro.html"),
+        },
+      ],
+    }));
+    const projectLint = vi.fn(async () => ({
+      results: [
+        {
+          file: "index.html",
+          result: { findings: [] },
+        },
+      ],
+    }));
+    const app = new Hono();
+    registerLintRoutes(app, {
+      ...createAdapter(projectDir),
+      lint: singleFileLint,
+      lintProject: projectLint,
+    });
+
+    const response = await app.request("http://localhost/projects/demo/lint");
+    const payload = (await response.json()) as {
+      findings?: Array<{ code?: string; file?: string }>;
+    };
+
+    expect(singleFileLint).toHaveBeenCalledTimes(1);
+    expect(singleFileLint).toHaveBeenCalledWith("<html><body>intro</body></html>", {
+      filePath: "scenes/intro.html",
+    });
+    expect(payload.findings).toContainEqual(
+      expect.objectContaining({ code: "scene_finding", file: "scenes/intro.html" }),
     );
   });
 });

--- a/packages/studio-server/src/routes/lint.ts
+++ b/packages/studio-server/src/routes/lint.ts
@@ -9,6 +9,18 @@ export function registerLintRoutes(api: Hono, adapter: StudioApiAdapter): void {
     const project = await adapter.resolveProject(c.req.param("id"));
     if (!project) return c.json({ error: "not found" }, 404);
     try {
+      if (adapter.lintProject) {
+        const result = await adapter.lintProject(project.dir);
+        return c.json({
+          findings: result.results.flatMap((entry) =>
+            entry.result.findings.map((finding) => ({
+              ...finding,
+              file: finding.file ?? entry.file,
+            })),
+          ),
+        });
+      }
+
       const htmlFiles = walkDir(project.dir).filter(
         (f) => f.endsWith(".html") && !isInHiddenOrVendorDir(f),
       );

--- a/packages/studio-server/src/routes/lint.ts
+++ b/packages/studio-server/src/routes/lint.ts
@@ -1,45 +1,63 @@
 import type { Hono } from "hono";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { StudioApiAdapter } from "../types.js";
+import type { LintResult, StudioApiAdapter } from "../types.js";
 import { isInHiddenOrVendorDir, walkDir } from "../helpers/safePath.js";
+
+type LintFinding = LintResult["findings"][number];
+
+async function collectProjectFindings(
+  adapter: StudioApiAdapter,
+  projectDir: string,
+): Promise<{ findings: LintFinding[]; coveredFiles: Set<string> }> {
+  const findings: LintFinding[] = [];
+  const coveredFiles = new Set<string>();
+  if (!adapter.lintProject) return { findings, coveredFiles };
+
+  const result = await adapter.lintProject(projectDir);
+  for (const entry of result.results) {
+    coveredFiles.add(entry.file);
+    for (const finding of entry.result.findings) {
+      findings.push({ ...finding, file: entry.file });
+    }
+  }
+  return { findings, coveredFiles };
+}
+
+async function lintUncoveredHtml(
+  adapter: StudioApiAdapter,
+  projectDir: string,
+  htmlFiles: string[],
+  coveredFiles: Set<string>,
+): Promise<LintFinding[]> {
+  const findings: LintFinding[] = [];
+  for (const file of htmlFiles) {
+    if (coveredFiles.has(file)) continue;
+    const content = readFileSync(join(projectDir, file), "utf-8");
+    const result = await adapter.lint(content, { filePath: file });
+    for (const finding of result?.findings ?? []) {
+      findings.push({ ...finding, file });
+    }
+  }
+  return findings;
+}
 
 export function registerLintRoutes(api: Hono, adapter: StudioApiAdapter): void {
   api.get("/projects/:id/lint", async (c) => {
     const project = await adapter.resolveProject(c.req.param("id"));
     if (!project) return c.json({ error: "not found" }, 404);
     try {
-      if (adapter.lintProject) {
-        const result = await adapter.lintProject(project.dir);
-        return c.json({
-          findings: result.results.flatMap((entry) =>
-            entry.result.findings.map((finding) => ({
-              ...finding,
-              file: finding.file ?? entry.file,
-            })),
-          ),
-        });
-      }
-
       const htmlFiles = walkDir(project.dir).filter(
         (f) => f.endsWith(".html") && !isInHiddenOrVendorDir(f),
       );
-      const allFindings: Array<{
-        severity: string;
-        message: string;
-        file?: string;
-        fixHint?: string;
-      }> = [];
-      for (const file of htmlFiles) {
-        const content = readFileSync(join(project.dir, file), "utf-8");
-        const result = await adapter.lint(content, { filePath: file });
-        if (result?.findings) {
-          for (const f of result.findings) {
-            allFindings.push({ ...f, file });
-          }
-        }
-      }
-      return c.json({ findings: allFindings });
+      const projectLint = await collectProjectFindings(adapter, project.dir);
+      const extraFindings = await lintUncoveredHtml(
+        adapter,
+        project.dir,
+        htmlFiles,
+        projectLint.coveredFiles,
+      );
+      return c.json({ findings: [...projectLint.findings, ...extraFindings] });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return c.json({ error: `Lint failed: ${msg}` }, 500);

--- a/packages/studio-server/src/types.ts
+++ b/packages/studio-server/src/types.ts
@@ -45,11 +45,16 @@ export interface MediaProcessingJobState {
 /** Lint result from the core linter. */
 export interface LintResult {
   findings: Array<{
+    code?: string;
     severity: string;
     message: string;
     file?: string;
     fixHint?: string;
   }>;
+}
+
+export interface ProjectLintResult {
+  results: Array<{ file: string; result: LintResult }>;
 }
 
 export interface StudioSelectionTextField {
@@ -109,6 +114,13 @@ export interface StudioApiAdapter {
 
   /** Lint a single HTML string. */
   lint(html: string, opts?: { filePath?: string }): Promise<LintResult> | LintResult;
+
+  /**
+   * Lint the complete project, including relationships between files. Official
+   * adapters provide this; the single-file method remains as a compatibility
+   * fallback for third-party adapters compiled against older releases.
+   */
+  lintProject?: (projectDir: string) => Promise<ProjectLintResult> | ProjectLintResult;
 
   /** URL to the hyperframe runtime JS (injected into preview HTML). */
   runtimeUrl: string;

--- a/packages/studio/vite.adapter.ts
+++ b/packages/studio/vite.adapter.ts
@@ -210,6 +210,11 @@ export function createViteAdapter(dataDir: string, server: ViteDevServer): Studi
       return await mod.lintHyperframeHtml(html, opts);
     },
 
+    async lintProject(projectDir: string) {
+      const mod = await server.ssrLoadModule("@hyperframes/core/lint");
+      return await mod.lintProject(projectDir);
+    },
+
     runtimeUrl: "/api/runtime.js",
 
     rendersDir: () => resolve(dataDir, "../renders"),


### PR DESCRIPTION
## What

Studio’s Lint modal now reports findings that depend on the whole project graph, including blank default entries, multiple root compositions, missing sub-compositions, and unmounted audio. Snapshot and publish failures also give repair instructions that are valid for the actual standalone entry instead of assuming every project uses `compositions/index.html`.

Follow-up to #3392 and #3391.

## Why

#3392 stopped default CLI commands from rendering or publishing a blank scaffold, but Studio still linted each HTML file independently. The public Studio symptom from #3391 therefore remained diagnosable only from the CLI, and the new command hints could point users at a directory without an `index.html` or at a flag the current command did not support.

## How

The shared Studio endpoint now accepts complete project-lint results. Both official hosts—the embedded CLI server and the Vite development server—provide `lintProject`; the old single-file adapter remains as a compatibility fallback for third-party hosts compiled against earlier releases. Results are re-stamped with project-relative paths for Studio’s file tree, then unioned with single-file lint for HTML outside `index.html` and `compositions/`, preserving the endpoint’s previous coverage.

The blank-entry finding carries its suggested standalone entry as structured metadata. Snapshot and publish derive directory commands only when that entry is an `index.html`; for another filename they explain that the file must be moved or mounted instead of printing a command that cannot resolve. Directory-form guidance also warns that re-rooting is safe only when assets are self-contained. The remaining `data-composition-src` exclusion is pinned so a wrapper that only mounts another composition cannot be mistaken for authored standalone content.

## Test plan

- [x] Unit tests added/updated
  - `@hyperframes/lint`: 501 passed
  - `@hyperframes/studio-server`: 450 passed
  - `@hyperframes/cli`: 2,809 passed / 3 skipped
  - route-level test drives the real embedded Studio API against a two-entry project plus HTML outside the canonical graph
  - mutation checks prove relative path re-stamping, union coverage, both command-hint branches, the official adapter wiring, and the `data-composition-src` exclusion are load-bearing
- [x] Manual testing performed
  - verified the real Studio API response includes `blank_root_with_standalone_composition`
  - verified every returned Studio file path is project-relative and `scenes/intro.html` remains linted
  - verified snapshot does not suggest a directory for `compositions/card.html`
  - verified publish derives `compositions/brand` from `compositions/brand/index.html`
- [x] Documentation updated
  - corrected #3392’s merged description so it no longer claims Studio already had project-level lint coverage
- [x] All affected-package typechecks pass
- [x] Full monorepo production build passes
- [x] Changed-file oxlint, oxfmt, `git diff --check`, Fallow audit, and pre-commit hooks pass

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
