### PR TITLE
test(engine): give the ffmpeg-bound grouping mixes their 30s timeout

### DIFF
--- a/packages/engine/src/services/audioMixer.grouping.test.ts
+++ b/packages/engine/src/services/audioMixer.grouping.test.ts
@@ -108,7 +108,7 @@ describe.skipIf(!HAS_FFMPEG)("mix level arithmetic", () => {
     // Two coherent copies of one tone = +6.02 dB. If amix's 1/N ever survives
     // the correction, this lands at 0 dB instead.
     expect(meanVolumeDb(twoUp) - meanVolumeDb(oneUp)).toBeCloseTo(6.02, 0);
-  });
+  }, 30_000);
 
   it("does not lift the survivors when a shorter track ends", async () => {
     // amix with normalize=true rescales by the number of CURRENTLY ACTIVE
@@ -145,7 +145,7 @@ describe.skipIf(!HAS_FFMPEG)("mix level arithmetic", () => {
     const tailTogether = meanVolumeDb(together, 1.5, 3);
     const tailAlone = meanVolumeDb(alone, 1.5, 3);
     expect(Math.abs(tailTogether - tailAlone)).toBeLessThan(0.5);
-  });
+  }, 30_000);
 
   /**
    * The gate for group buses (plans/audio-mixer-groups.md §1).
@@ -193,7 +193,7 @@ describe.skipIf(!HAS_FFMPEG)("mix level arithmetic", () => {
     // An empty group chain is pure routing — the export must read the same
     // whether or not the two tones happened to share a group.
     expect(Math.abs(meanVolumeDb(groupedOut) - meanVolumeDb(flatOut))).toBeLessThan(0.3);
-  });
+  }, 30_000);
 
   it("a group FX chain fully cutting its members leaves an ungrouped track untouched (routing isolation)", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-fx-"));
@@ -231,7 +231,7 @@ describe.skipIf(!HAS_FFMPEG)("mix level arithmetic", () => {
     // and the ungrouped sfx track's own processing is unaffected by the
     // group existing at all.
     expect(Math.abs(meanVolumeDb(mixedOut) - meanVolumeDb(sfxAloneOut))).toBeLessThan(0.5);
-  });
+  }, 30_000);
 
   it("a member's own volume envelope still applies inside a group", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-env-"));
@@ -267,5 +267,5 @@ describe.skipIf(!HAS_FFMPEG)("mix level arithmetic", () => {
     const groupedTail = meanVolumeDb(groupedOut, 3, 4);
     const flatTail = meanVolumeDb(flatOut, 3, 4);
     expect(Math.abs(groupedTail - flatTail)).toBeLessThan(0.5);
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
## What

Adds the per-test `30_000` timeout to the five tests in `packages/engine/src/services/audioMixer.grouping.test.ts`.

## Why

These tests spawn real ffmpeg per assertion and were running on vitest's 5s default. On slow Windows runners the FX-chain and envelope cases land right at the line and intermittently fail "Tests on windows-latest" for PRs that touch nothing in the engine (observed twice on an unrelated docs/registry PR, including once at 5.02s). The other ffmpeg-bound engine suite, `videoFrameExtractor.test.ts`, already carries per-test `30_000` timeouts; this brings the grouping suite in line.

## How

`}, 30_000);` on each of the five `it` blocks. No logic changes.

## Test plan

- [x] `vitest run src/services/audioMixer.grouping.test.ts`: 5/5 pass locally (2.4s on this machine; the margin matters only on the slow runners).
- [x] `oxfmt --check` clean.