### PR TITLE
docs: drop --full-depth from skills install commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ Open-source video rendering framework: write HTML, render video.
 This repo ships AI agent skills via [vercel-labs/skills](https://github.com/vercel-labs/skills). Install them before writing compositions — they encode framework-specific patterns that generic docs don't cover. **Default to the core set** — the `/hyperframes` router installs each creation workflow on demand; install everything only when the user explicitly asks for the full set.
 
 ```bash
-npx hyperframes skills update                        # default: installs/refreshes the core set — workflows install on demand
-npx skills add heygen-com/hyperframes --full-depth   # interactive picker (terminal only — non-interactive without --skill installs everything)
+npx hyperframes skills update           # default: installs/refreshes the core set — workflows install on demand
+npx skills add heygen-com/hyperframes   # interactive picker (terminal only — non-interactive without --skill installs everything)
 ```
 
 **Creation workflows** route through one entry skill — read `/hyperframes` first: it orients you to the whole surface, confirms the brief up front (the intent layer), and maps "make me a…" intent — usually a video, but also a navigable deck (`/slideshow`) or a composition port (`/remotion-to-hyperframes`) — to a concrete workflow. Consult it before invoking a specific workflow:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,13 +7,13 @@ Open-source video rendering framework: write HTML, render video.
 This repo ships 20 AI agent skills via [vercel-labs/skills](https://github.com/vercel-labs/skills). Install them before writing compositions — they encode framework-specific patterns that generic docs don't cover. **Default to the core set**: the `/hyperframes` router installs each creation workflow on demand; install all 20 only when the user explicitly asks for the full set.
 
 ```bash
-npx hyperframes skills update                                   # default: installs/refreshes the core set — workflows install on demand
-npx skills add heygen-com/hyperframes --full-depth              # interactive picker (terminal only — non-interactive without --skill installs all 20)
-npx skills add heygen-com/hyperframes --all --full-depth        # all 20 at once — only on explicit request
-npx skills add heygen-com/hyperframes --skill <name> --full-depth  # just one (bare name, no leading slash)
+npx hyperframes skills update                         # default: installs/refreshes the core set — workflows install on demand
+npx skills add heygen-com/hyperframes                 # interactive picker (terminal only — non-interactive without --skill installs all 20)
+npx skills add heygen-com/hyperframes --all           # all 20 at once — only on explicit request
+npx skills add heygen-com/hyperframes --skill <name>  # just one (bare name, no leading slash)
 ```
 
-Keep `--full-depth`: it installs the current `main`. Without it, `skills add` fetches the skills.sh registry blob, which lags `main` by hours (you'd get a stale skill). `hyperframes skills update` already uses full-depth.
+`skills add` resolves the skills.sh registry blob, which can lag `main` by hours, so a freshly added skill may be a little behind. `npx hyperframes skills update` installs from the current `main`; prefer it when freshness matters.
 
 **`/hyperframes` is the entry skill — read it first.** It's the capability map for the domain skills below, the intent layer that confirms every creation brief up front, AND the intent router for the creation workflows. The full README skills section mirrors this list; keep them in sync (see "Skill catalog maintenance" below).
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ HyperFrames is an open-source framework for turning HTML, CSS, media, and seekab
 Install the HyperFrames skills, then describe the video you want:
 
 ```bash
-npx skills add heygen-com/hyperframes --full-depth
+npx skills add heygen-com/hyperframes
 ```
 
 > The picker opens with nothing pre-selected — the **Core Skills** group is all you need: the `/hyperframes` router installs each creation workflow on demand. Agents and non-interactive runs should use `npx hyperframes skills update` instead — it installs exactly the core set, whereas a non-interactive `skills add` without `--skill` installs all 20.
 >
-> `--full-depth` does a full clone of the repo's current `main`. Without it, `skills add` fetches the skills.sh registry blob, which lags `main` by hours — you'd get an older copy of a skill. (`hyperframes skills update` already installs full-depth.)
+> `skills add` resolves the skills.sh registry blob, which can lag `main` by hours. `npx hyperframes skills update` installs from the current `main`, so reach for it when you need the newest copy of a skill.
 
 Try a prompt like:
 
@@ -55,7 +55,7 @@ The skills teach agents the HyperFrames production loop: plan the video, write v
 
 HyperFrames ships 20 skills agents load on demand. Read `/hyperframes` first — it's the router and capability map; it picks a workflow for any "make me a…" request — video, deck, or composition port — and points to the domain skills below.
 
-Default to the **core set** — the router installs each creation workflow on demand. `npx hyperframes skills update` installs exactly that from anywhere; the interactive picker (`npx skills add heygen-com/hyperframes --full-depth`) lists it as the "Core Skills" group, nothing pre-selected. The picker is interactive-only — a non-interactive or agent run without `--skill` installs all 20. Use `npx skills add heygen-com/hyperframes --all --full-depth` to install all 20 deliberately (skips the picker), or `npx skills add heygen-com/hyperframes --skill <name> --full-depth` for just one (bare name, no leading `/`). Keep `--full-depth` — it installs the current `main`; without it `skills add` fetches the skills.sh blob, which lags by hours.
+Default to the **core set** — the router installs each creation workflow on demand. `npx hyperframes skills update` installs exactly that from anywhere; the interactive picker (`npx skills add heygen-com/hyperframes`) lists it as the "Core Skills" group, nothing pre-selected. The picker is interactive-only — a non-interactive or agent run without `--skill` installs all 20. Use `npx skills add heygen-com/hyperframes --all` to install all 20 deliberately (skips the picker), or `npx skills add heygen-com/hyperframes --skill <name>` for just one (bare name, no leading `/`).
 
 Installs stay lean after that: `npx hyperframes init` keeps the **core set** fresh (the router, the `hyperframes-*` domain skills, and `media-use` — plus whatever is already installed; `/figma` stays on demand) and never expands a partial install; the creation workflows install **on demand** — the router runs `npx hyperframes skills update <workflow>` before entering one. Nothing re-pulls the full set behind your back.
 

--- a/docs/guides/hyperframes-vs-remotion.mdx
+++ b/docs/guides/hyperframes-vs-remotion.mdx
@@ -142,7 +142,7 @@ And Apache 2.0 means no seat count and no license review.
 There is a real migration path, not a promise. Install the skill:
 
 ```bash
-npx skills add heygen-com/hyperframes --skill remotion-to-hyperframes --full-depth
+npx skills add heygen-com/hyperframes --skill remotion-to-hyperframes
 ```
 
 Then ask your agent to port the composition. It maps `useCurrentFrame` and

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -23,7 +23,7 @@ framework's rules.
 Run the interactive installer:
 
 ```bash
-npx skills add heygen-com/hyperframes --full-depth
+npx skills add heygen-com/hyperframes
 ```
 
 Select **Core Skills**. The `/hyperframes` router installs a specialized creation workflow when the request needs one, so you do not need the full catalog up front.
@@ -57,7 +57,7 @@ npx hyperframes skills update pr-to-video
 Install the skills from the root of the project you open in Antigravity:
 
 ```bash
-npx skills add heygen-com/hyperframes --full-depth
+npx skills add heygen-com/hyperframes
 ```
 
 Select **Core Skills** and **Antigravity**. This uses Antigravity's supported
@@ -113,13 +113,13 @@ You can invoke a workflow directly when you already know it is the right one, bu
 Install the complete set deliberately with:
 
 ```bash
-npx skills add heygen-com/hyperframes --all --full-depth
+npx skills add heygen-com/hyperframes --all
 ```
 
 Or install one named skill:
 
 ```bash
-npx skills add heygen-com/hyperframes --skill hyperframes-animation --full-depth
+npx skills add heygen-com/hyperframes --skill hyperframes-animation
 ```
 
 Use the full set for an environment that must work across many HyperFrames tasks without fetching later. For a normal project, the core set is smaller and easier to keep current.

--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -1172,7 +1172,7 @@ variable.
 If you called the upstream command directly instead, set it yourself:
 
 ```bash
-GIT_CLONE_PROTECTION_ACTIVE=0 npx skills add heygen-com/hyperframes --full-depth
+GIT_CLONE_PROTECTION_ACTIVE=0 npx skills add heygen-com/hyperframes
 ```
 
 ### `figma` and `events`

--- a/docs/prompting/overview.mdx
+++ b/docs/prompting/overview.mdx
@@ -37,7 +37,7 @@ The guide is one arc, novice to advanced. Each level is what you can do once you
 Install the skills in your project (or globally for your agent):
 
 ```bash
-npx skills add heygen-com/hyperframes --full-depth
+npx skills add heygen-com/hyperframes
 ```
 
 The installer shows a picker. Select the **core skills** below — every project needs them. In Claude Code, restart the session after installing; the skills register as **slash commands**. Start at `/hyperframes`: it orients you to the whole surface and routes "make me a video" requests to the right workflow.
@@ -72,7 +72,7 @@ The installer shows a picker. Select the **core skills** below — every project
 | `/figma`                 | A Figma file / frame / URL → imported assets, brand tokens, and reconstructed motion |
 
 <Tip>
-  To skip the picker and install everything (core + every workflow) in one shot, run `npx skills add heygen-com/hyperframes --all --full-depth`. And start HyperFrames prompts with `/hyperframes` (or invoke the skill another way for non-Claude agents) — it loads the routing + composition context explicitly so the agent picks the right workflow and gets the rules right the first time.
+  To skip the picker and install everything (core + every workflow) in one shot, run `npx skills add heygen-com/hyperframes --all`. And start HyperFrames prompts with `/hyperframes` (or invoke the skill another way for non-Claude agents) — it loads the routing + composition context explicitly so the agent picks the right workflow and gets the rules right the first time.
 </Tip>
 
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -42,10 +42,10 @@ below is the same thing done by hand, if you would rather see each step.
 Run this in your project folder:
 
 ```bash
-npx skills add heygen-com/hyperframes --full-depth
+npx skills add heygen-com/hyperframes
 ```
 
-Choose **Core Skills** in the picker. Keep `--full-depth` so the installer uses the current repository version. Then open or restart your coding agent in that folder.
+Choose **Core Skills** in the picker. Then open or restart your coding agent in that folder.
 
 ## 2. Ask for the video
 


### PR DESCRIPTION
## What

Removes `--full-depth` from every `npx skills add` command we document, and drops the prose that told readers to keep the flag.

Files: `README.md`, `CLAUDE.md`, `AGENTS.md`, `docs/quickstart.mdx`, `docs/prompting/overview.mdx`, `docs/guides/skills.mdx`, `docs/guides/hyperframes-vs-remotion.mdx`, `docs/packages/cli.mdx`.

## Why

Not every user's `skills` CLI supports `--full-depth`, so the documented command fails for them. A copy-pasteable install command that errors is worse than an install that is occasionally a few hours behind `main`.

## How

Flag removed from the commands; bash comment columns re-aligned in `CLAUDE.md` and `AGENTS.md`. Where the docs explained why to keep the flag, the freshness note now points at `npx hyperframes skills update`, which installs from the current `main`.

The CLI itself is unchanged: `packages/cli/src/commands/skills.ts` still passes `--full-depth` to the `skills` version it spawns via `npx`, so `hyperframes skills update` keeps its freshness guarantee.

## Test plan

Docs-only change, no runnable behavior.

- `grep -rn "full-depth"` across `README.md`, `CLAUDE.md`, `AGENTS.md`, and `docs/` returns nothing.
- Remaining `--full-depth` references are confined to `packages/cli/src/commands/skills.ts` and its test, which are intentionally untouched.

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [x] Documentation updated (if applicable)
