### PR TITLE
fix(lint): stop duplicate_composition_id firing on repeated sub-composition mounts

### DIFF
--- a/packages/lint/src/rules/composition.test.ts
+++ b/packages/lint/src/rules/composition.test.ts
@@ -315,6 +315,50 @@ describe("composition rules", () => {
       expect(finding).toBeUndefined();
     });
 
+    it("does not flag one sub-composition mounted repeatedly with per-instance values", async () => {
+      // Regression: sub-compositions.md "Per-Instance Variables" documents
+      // mounting one source several times with different data-variable-values.
+      // That necessarily repeats the id, and the runtime rewrites repeated
+      // mounts to `id__hf1`/`id__hf2` so they coexist. Flagging it made the
+      // documented pattern an error with no correct way to satisfy it.
+      const html = `<!DOCTYPE html>
+<html>
+<body>
+  <div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="6" data-no-timeline>
+    <div data-composition-id="word" data-composition-src="compositions/word-caption.html" data-variable-values='{"text":"one"}' data-start="0" data-duration="2"></div>
+    <div data-composition-id="word" data-composition-src="compositions/word-caption.html" data-variable-values='{"text":"two"}' data-start="2" data-duration="2"></div>
+    <div data-composition-id="word" data-composition-src="compositions/word-caption.html" data-variable-values='{"text":"three"}' data-start="4" data-duration="2"></div>
+  </div>
+</body>
+</html>`;
+
+      const result = await lintHyperframeHtml(html);
+      expect(result.findings.find((f) => f.code === "duplicate_composition_id")).toBeUndefined();
+    });
+
+    it("still flags a real collision between a root and a non-mount element", async () => {
+      // The guard that keeps the exemption honest: skipping mounts must not
+      // blind the rule to the meta-versus-root collision it exists for, even
+      // when a legitimately repeated mount is present in the same file.
+      const html = `<!DOCTYPE html>
+<html>
+<head>
+  <meta name="composition-id" data-composition-id="main">
+</head>
+<body>
+  <div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="4" data-no-timeline>
+    <div data-composition-id="word" data-composition-src="compositions/word-caption.html" data-start="0" data-duration="2"></div>
+    <div data-composition-id="word" data-composition-src="compositions/word-caption.html" data-start="2" data-duration="2"></div>
+  </div>
+</body>
+</html>`;
+
+      const result = await lintHyperframeHtml(html);
+      const finding = result.findings.find((f) => f.code === "duplicate_composition_id");
+      expect(finding).toBeDefined();
+      expect(finding?.message).toContain("main");
+    });
+
     it("ignores composition ids inside inert template content", async () => {
       const html = `<!DOCTYPE html>
 <html><body>

--- a/packages/lint/src/rules/composition.ts
+++ b/packages/lint/src/rules/composition.ts
@@ -262,6 +262,16 @@ export const compositionRules: Array<(ctx: LintContext) => HyperframeLintFinding
     const tagsByCompositionId = new Map<string, string[]>();
     for (const tag of tags) {
       if (isInsideInertTemplate(tag, tags)) continue;
+      // A `data-composition-src` element is a MOUNT of a sub-composition, not a
+      // composition root, and sub-compositions.md documents mounting one source
+      // repeatedly with different `data-variable-values` to get per-instance
+      // variations. Those mounts legitimately share an id: the runtime rewrites
+      // repeated ones to `id__hf1`, `id__hf2` so they coexist. Counting them
+      // here made the documented pattern an error with no correct way to
+      // satisfy it. The collision this rule exists for -- a <meta> tag carrying
+      // the root's id, per its own fixHint -- is unaffected, since that tag has
+      // no `data-composition-src`.
+      if (readAttr(tag.raw, "data-composition-src")) continue;
       const compositionId = readDecodedAttr(tag.raw, "data-composition-id");
       if (!compositionId || compositionId.trim().length === 0) continue;
 


### PR DESCRIPTION
## What

Exempt sub-composition **mounts** from `duplicate_composition_id`.

Closes #3403.

## Why

`sub-compositions.md:220` documents mounting one sub-composition several times with different
`data-variable-values`:

> The host can render the same sub-composition multiple times with different
> `data-variable-values` to produce per-instance variations.

Doing that necessarily repeats `data-composition-id`, so the rule reported our own documented
pattern as an **error** and blocked `check`, with no correct way to satisfy it.

Everything else in the pipeline handles the pattern. The reporter confirmed render, validate,
inspect and snapshot all behave, and the runtime deliberately rewrites repeated mounts to
`id__hf1`, `id__hf2` so they can coexist.

## How

The rule bucketed every element carrying `data-composition-id` and flagged any bucket of two
or more. It had **no reference to `data-composition-src`**, so it could not tell a composition
*root* — where the id must be unique — from a *mount*, where repetition is the documented way
to get per-instance variations.

Mounts are now skipped, the same way the rule already skips tags inside an inert `<template>`.

The collision the rule exists for is untouched. Its own fixHint names the case:

> especially a `<meta>` tag carrying the same data-composition-id as the root `<div>`

That `<meta>` has no `data-composition-src`, so it is still counted.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

### Before / after on the documented pattern

A blank project with one `word-caption.html` sub-composition mounted three times, each with a
different `data-variable-values` — copied from the docs.

**Before** (published 0.8.6):

```
✗ [index.html] duplicate_composition_id: Composition id "word-caption" is used by 3
  elements. Each data-composition-id value must be unique within a composition file.
◇  1 error(s), 3 warning(s)
```

**After** (this branch):

```
◇  0 error(s), 3 warning(s)
```

The three warnings are identical either side. That is the point of showing them: the fix
removes one specific false positive rather than quieting the file.

### Regression tests

Two, and the second is the one that keeps the exemption honest:

- `does not flag one sub-composition mounted repeatedly with per-instance values` — the
  documented pattern must be clean.
- `still flags a real collision between a root and a non-mount element` — a `<meta>` sharing
  the root's id must still error **even when a legitimately repeated mount sits in the same
  file**, so the exemption cannot be widened into blindness.

Verified the first fails without the fix:

```
$ # mount exemption removed
Tests  1 failed | 134 passed (135)
$ # restored
Tests  465 passed (465)   (all rule suites)
```

### Other checks

- `vitest packages/lint/src/rules` — 465 passed, 9 files
- `oxlint` + `oxfmt` on both touched files — clean
- Pre-commit hooks (fallow, typecheck, commitlint) — green

## Note on severity

This was an `error`, so a user following our documentation got a failing gate. It is the
second lint rule recently found blocking a legitimate documented pattern at `error` severity,
after `head_leaked_text` (#3385). Might be worth a separate look at how error-versus-warning
is decided in this ruleset — the cost of a false positive at `error` is a blocked pipeline.
