### PR TITLE
fix(cli): stop a caught post-render throw reporting a valid render as failed

### DIFF
--- a/packages/cli/src/cli.lifecycle.test.ts
+++ b/packages/cli/src/cli.lifecycle.test.ts
@@ -165,6 +165,57 @@ describe("CLI lifecycle", () => {
     }
   });
 
+  it("does not let a post-validation throw doom a render whose artifact is on disk", async () => {
+    // The gap the field reports land in: a teardown step throws AFTER the
+    // artifact validated, the command wrapper catches it, and the result
+    // carries exitCode 1. The uncaughtException / unhandledRejection handlers
+    // both consult isRenderSucceeded(), but a caught throw never reaches them,
+    // so nothing sanitized the code and a valid MP4 was reported as a failure.
+    const trackCommandResult = vi.fn();
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    try {
+      const successState = await import("./utils/render-success-state.js");
+      mockInitCommand(() => {
+        successState.markRenderSucceeded();
+        throw new Error("post-render teardown blew up");
+      });
+      mockTelemetry({ trackCommandResult });
+
+      process.argv = ["node", "cli.ts", "init", "--json"];
+      await import("./cli.js");
+
+      expect(process.exitCode).toBe(0);
+      expect(trackCommandResult).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, exitCode: 0 }),
+      );
+      successState._resetRenderSuccessForTests();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("still exits non-zero when a command throws and no render ever validated", async () => {
+    // The guard on the sanitizer above: it must key off a validated artifact,
+    // not merely off the command having finished. Without this, every caught
+    // throw would silently become exit 0.
+    const trackCommandResult = vi.fn();
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    try {
+      mockInitCommand(() => {
+        throw new Error("genuine failure");
+      });
+      mockTelemetry({ trackCommandResult });
+
+      process.argv = ["node", "cli.ts", "init", "--json"];
+      await import("./cli.js");
+
+      expect(process.exitCode).not.toBe(0);
+      expect(trackCommandResult).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
   it("still scores an EPIPE before the artifact is validated as a failure", async () => {
     const trackCommandResult = vi.fn();
     const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -283,12 +283,21 @@ let finalized = false;
 async function finalizeCli(result: CommandResult): Promise<void> {
   if (finalized) return;
   finalized = true;
-  commandFailed ||= result.exitCode !== 0;
+  // Once the artifact has validated and been committed to disk, the run
+  // delivered — anything recorded as a failure after that is teardown noise.
+  // The uncaughtException / unhandledRejection handlers already consult
+  // isRenderSucceeded(), but a post-render throw that the command wrapper
+  // CATCHES never reaches them: it becomes an ordinary non-zero
+  // CommandResult, and a valid render is reported as a failure. Sanitizing
+  // here, once, is what those handlers cannot cover, and it keeps the exit
+  // code and the telemetry record from disagreeing about the same run.
+  const exitCode = isRenderSucceeded() ? 0 : result.exitCode;
+  commandFailed ||= exitCode !== 0;
   await telemetryReady.catch(() => {});
   _trackCommandResult?.({
     command,
-    success: result.exitCode === 0 && commandSucceededForTelemetry(),
-    exitCode: result.exitCode,
+    success: exitCode === 0 && commandSucceededForTelemetry(),
+    exitCode,
     durationMs: Date.now() - commandStart,
     runId,
   });
@@ -298,7 +307,7 @@ async function finalizeCli(result: CommandResult): Promise<void> {
     _printStalePinNotice?.();
     _printSkillsUpdateNotice?.();
   }
-  process.exitCode = result.exitCode;
+  process.exitCode = exitCode;
 }
 
 registerRootExitRequester((exitCode) => {


### PR DESCRIPTION
## What

A render that produced and validated its artifact could still exit `1`. `finalizeCli` now
sanitizes the exit code once a render has validated, so a caught teardown throw cannot
report a good render as a failure.

## Why

From the field on 0.8.7: the MP4 was on disk, an independent `ffprobe` and a full decode
both passed, and the CLI exited `1` immediately after logging `artifact validated`.

This shape is already known — `render-success-state.ts` exists solely for it and documents
three earlier cases — so the sentinel was in place. The gap is **which paths read it**:

| path | consults `isRenderSucceeded()` |
|---|---|
| `uncaughtException` handler | yes |
| `unhandledRejection` handler | yes |
| a throw the command wrapper **catches** | **no** |

A caught post-render throw never reaches either handler. It becomes an ordinary non-zero
`CommandResult`, and `finalizeCli` wrote that straight to `process.exitCode`.

That left a run disagreeing with itself. `commandSucceededForTelemetry()` already lets a
validated render override a failure, so telemetry recorded the run as a success while the
shell saw exit `1`.

## How

One line of policy in `finalizeCli`, where every command result funnels through:

```ts
const exitCode = isRenderSucceeded() ? 0 : result.exitCode;
```

used for `commandFailed`, the telemetry record, and `process.exitCode`, so the three cannot
disagree.

Deliberately **not** wrapping the individual teardown steps. Which step threw does not
matter; that the artifact is committed does. Wrapping N call sites would leave the N+1th
unguarded, which is how this reached the field in the first place. The throw is still
printed, so it stays visible for diagnosis without being fatal.

## Test plan

Reproduced as a failing test before fixing, and **on macOS** — this is not Windows-specific,
the field reports are one instance of it.

**Before:**

```
× CLI lifecycle > does not let a post-validation throw doom a render whose artifact is on disk
  → expected 1 to be +0
```

**After:** 8 passed in `cli.lifecycle.test.ts`, and the full CLI package is green at
2812 passed / 3 skipped across 193 files.

Two tests, one per side of the invariant:

- a command that marks the render validated and then throws now exits `0`, and reports
  `success: true, exitCode: 0` to telemetry;
- a command that throws with **no** validated render still exits non-zero and reports
  `success: false` — the guard that stops the sanitizer swallowing genuine failures.

## Not covered

- The reporter also saw orphan `chrome-headless-shell` trees from earlier interrupted runs.
  That is a separate cleanup problem and is untouched here; this PR only stops a delivered
  render being scored as failed.
- I did not identify which specific teardown step threw on their machine. The fix is
  deliberately independent of that — it holds for any of them — but it does mean the
  underlying throw is still occurring and will now surface as a printed warning rather than
  a failed exit.
