### PR TITLE
test(engine): budget the ffmpeg audio-level tests, and make a stall say why

### DIFF
--- a/packages/engine/src/services/audioMixer.level.test.ts
+++ b/packages/engine/src/services/audioMixer.level.test.ts
@@ -55,110 +55,140 @@ function firstAudibleSeconds(path: string): number {
   throw new Error(`No audible sample found in ${path}`);
 }
 
-describe.skipIf(!HAS_FFMPEG)("processCompositionAudio levels", () => {
-  afterEach(() => {
-    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
-  });
+/**
+ * These two tests drive real ffmpeg, and the file ran on vitest's 5s default:
+ * `places a delayed track on its authored start` takes ~137ms locally and still
+ * hit that cap on the windows runner, failing an unrelated PR. 60s is what the
+ * rest of the ffmpeg-driven engine tests use. Applied to the suite rather than
+ * each test so the budget has one home.
+ *
+ * Headroom alone would only delay an undiagnosable failure, so the ffmpeg
+ * process timeout is capped well under it too. Its production default is 5
+ * minutes — far above any test budget — so a stalled mix could only ever
+ * surface as a bare "Test timed out", with no stderr and no failing stage.
+ */
+const FFMPEG_TEST_TIMEOUT_MS = 60_000;
+const TEST_FFMPEG_TIMEOUT_MS = 20_000;
 
-  it("preserves the level of a mono source in the stereo mix", async () => {
-    const projectDir = mkdtempSync(join(tmpdir(), "hf-mono-level-"));
-    const workDir = mkdtempSync(join(tmpdir(), "hf-mono-work-"));
-    tempDirs.push(projectDir, workDir);
-    const sourcePath = join(projectDir, "voice.wav");
-    const outputPath = join(projectDir, "audio.aac");
-    const setup = spawnSync(
-      getFfmpegBinary(),
-      [
-        "-nostdin",
-        "-v",
-        "error",
-        "-f",
-        "lavfi",
-        "-i",
-        "sine=frequency=1000:duration=1:sample_rate=48000",
-        "-ac",
-        "1",
-        "-c:a",
-        "pcm_s16le",
-        sourcePath,
-      ],
-      { encoding: "utf-8" },
-    );
-    expect(setup.status, setup.stderr).toBe(0);
+/** Assert the mix succeeded, reporting `failures` rather than a bare `false`. */
+function expectMixed(result: { success: boolean; failures?: unknown }): void {
+  if (!result.success) {
+    throw new Error(`mix failed: ${JSON.stringify(result.failures ?? result, null, 2)}`);
+  }
+}
 
-    const result = await processCompositionAudio(
-      [
-        {
-          id: "voice",
-          src: "voice.wav",
-          start: 0,
-          end: 1,
-          mediaStart: 0,
-          layer: 0,
-          volume: 1,
-          type: "audio",
-        },
-      ],
-      projectDir,
-      workDir,
-      outputPath,
-      1,
-    );
+describe.skipIf(!HAS_FFMPEG)(
+  "processCompositionAudio levels",
+  () => {
+    afterEach(() => {
+      for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+    });
 
-    expect(result.success).toBe(true);
-    expect(meanVolumeDb(outputPath) - meanVolumeDb(sourcePath)).toBeGreaterThan(-0.3);
-  });
+    it("preserves the level of a mono source in the stereo mix", async () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "hf-mono-level-"));
+      const workDir = mkdtempSync(join(tmpdir(), "hf-mono-work-"));
+      tempDirs.push(projectDir, workDir);
+      const sourcePath = join(projectDir, "voice.wav");
+      const outputPath = join(projectDir, "audio.aac");
+      const setup = spawnSync(
+        getFfmpegBinary(),
+        [
+          "-nostdin",
+          "-v",
+          "error",
+          "-f",
+          "lavfi",
+          "-i",
+          "sine=frequency=1000:duration=1:sample_rate=48000",
+          "-ac",
+          "1",
+          "-c:a",
+          "pcm_s16le",
+          sourcePath,
+        ],
+        { encoding: "utf-8" },
+      );
+      expect(setup.status, setup.stderr).toBe(0);
 
-  it("places a delayed track on its authored start, not one AAC frame later", async () => {
-    // The mix is AAC-encoded, and AAC encoders emit ~1024 priming samples. A
-    // raw ADTS container has nowhere to record that delay, so it decodes as
-    // real leading silence and drags the whole track 21.33 ms late against a
-    // frame-accurate video. MIXED_AUDIO_FILENAME picks a container that stores
-    // the delay as an edit list instead; this asserts the artifact we actually
-    // ship lands on time.
-    const projectDir = mkdtempSync(join(tmpdir(), "hf-onset-"));
-    const workDir = mkdtempSync(join(tmpdir(), "hf-onset-work-"));
-    tempDirs.push(projectDir, workDir);
-    const sourcePath = join(projectDir, "tone.wav");
-    const outputPath = join(projectDir, MIXED_AUDIO_FILENAME);
-    const setup = spawnSync(
-      getFfmpegBinary(),
-      [
-        "-nostdin",
-        "-v",
-        "error",
-        "-f",
-        "lavfi",
-        "-i",
-        "sine=frequency=1000:duration=1:sample_rate=48000",
-        "-c:a",
-        "pcm_s16le",
-        sourcePath,
-      ],
-      { encoding: "utf-8" },
-    );
-    expect(setup.status, setup.stderr).toBe(0);
+      const result = await processCompositionAudio(
+        [
+          {
+            id: "voice",
+            src: "voice.wav",
+            start: 0,
+            end: 1,
+            mediaStart: 0,
+            layer: 0,
+            volume: 1,
+            type: "audio",
+          },
+        ],
+        projectDir,
+        workDir,
+        outputPath,
+        1,
+        undefined,
+        { ffmpegProcessTimeout: TEST_FFMPEG_TIMEOUT_MS },
+      );
 
-    const result = await processCompositionAudio(
-      [
-        {
-          id: "tone",
-          src: "tone.wav",
-          start: 2,
-          end: 3,
-          mediaStart: 0,
-          layer: 0,
-          volume: 1,
-          type: "audio",
-        },
-      ],
-      projectDir,
-      workDir,
-      outputPath,
-      4,
-    );
+      expectMixed(result);
+      expect(meanVolumeDb(outputPath) - meanVolumeDb(sourcePath)).toBeGreaterThan(-0.3);
+    });
 
-    expect(result.success).toBe(true);
-    expect(firstAudibleSeconds(outputPath)).toBeCloseTo(2, 2);
-  });
-});
+    it("places a delayed track on its authored start, not one AAC frame later", async () => {
+      // The mix is AAC-encoded, and AAC encoders emit ~1024 priming samples. A
+      // raw ADTS container has nowhere to record that delay, so it decodes as
+      // real leading silence and drags the whole track 21.33 ms late against a
+      // frame-accurate video. MIXED_AUDIO_FILENAME picks a container that stores
+      // the delay as an edit list instead; this asserts the artifact we actually
+      // ship lands on time.
+      const projectDir = mkdtempSync(join(tmpdir(), "hf-onset-"));
+      const workDir = mkdtempSync(join(tmpdir(), "hf-onset-work-"));
+      tempDirs.push(projectDir, workDir);
+      const sourcePath = join(projectDir, "tone.wav");
+      const outputPath = join(projectDir, MIXED_AUDIO_FILENAME);
+      const setup = spawnSync(
+        getFfmpegBinary(),
+        [
+          "-nostdin",
+          "-v",
+          "error",
+          "-f",
+          "lavfi",
+          "-i",
+          "sine=frequency=1000:duration=1:sample_rate=48000",
+          "-c:a",
+          "pcm_s16le",
+          sourcePath,
+        ],
+        { encoding: "utf-8" },
+      );
+      expect(setup.status, setup.stderr).toBe(0);
+
+      const result = await processCompositionAudio(
+        [
+          {
+            id: "tone",
+            src: "tone.wav",
+            start: 2,
+            end: 3,
+            mediaStart: 0,
+            layer: 0,
+            volume: 1,
+            type: "audio",
+          },
+        ],
+        projectDir,
+        workDir,
+        outputPath,
+        4,
+        undefined,
+        { ffmpegProcessTimeout: TEST_FFMPEG_TIMEOUT_MS },
+      );
+
+      expectMixed(result);
+      expect(firstAudibleSeconds(outputPath)).toBeCloseTo(2, 2);
+    });
+  },
+  FFMPEG_TEST_TIMEOUT_MS,
+);


### PR DESCRIPTION
> Review this with whitespace ignored (`?w=1`) — adding the third argument to `describe`
> reindents the whole suite body, so the real change is **34 / 4**, not 131 / 101.

## What

Gives the two real-ffmpeg tests in `audioMixer.level.test.ts` a budget they were never
given, and makes a stalled mix report which stage stalled.

## Why

`places a delayed track on its authored start, not one AAC frame later` timed out on
`windows-latest` and failed an unrelated PR — the second ffmpeg audio test to do that this
week.

The previous fix raised the budget in `audioMixer.grouping.test.ts`, which was the file the
symptom named. **That was the wrong scope.** Auditing every ffmpeg-driven engine test:

| file | explicit timeouts |
|---|---|
| `videoFrameExtractor.test.ts` | 30s / 60s |
| `audioMixer.grouping.test.ts` | 60s (raised last week) |
| `audioMixer.level.test.ts` | **none — vitest's 5s default** |
| `audioMixer.test.ts` | none, but its suites are pure parsing (0–3ms) |

`audioMixer.grouping.test.ts` was the only audio suite with explicit timeouts at all. The
one that just failed runs a full mix on a 5 second default.

For scale: the failing test takes **~137ms locally**. So the runner is not 36x slower — but
5s was never a number anyone chose for a full ffmpeg mix, it is just what vitest does when
nobody says.

## How

- `FFMPEG_TEST_TIMEOUT_MS = 60_000` on the **suite**, not each test, so the budget has one
  home. Scoped to the `describe.skipIf(!HAS_FFMPEG)` block deliberately: the sibling
  parsing suites are pure and should keep failing fast at 5s, where a hang is a real bug.
- `ffmpegProcessTimeout: 20_000` passed through the `config` parameter
  `processCompositionAudio` already accepts. No production signature or behaviour change.
- An `expectMixed()` helper replaces `expect(result.success).toBe(true)`, throwing the
  recorded `failures` instead of collapsing to `expected false to be true`.

## Test plan

Engine package green: **1610 passed / 3 skipped** across 67 files.

Both claims verified rather than asserted.

**The budget applies.** Temporarily inserting a 6s sleep — which the 5s default would kill:

```
✓ places a delayed track on its authored start, not one AAC frame later  7204ms
Tests  2 passed (2)
```

**A stall reports why.** Forcing `TEST_FFMPEG_TIMEOUT_MS` to `1`:

```
→ mix failed: [
  {
    "stage": "prepare",
    "reason": "ffmpeg_timeout",
    "owner": "system",
    "retryable": true,
```

versus the bare `Test timed out in 5000ms` that CI reported.

## Not covered

- This still does not explain **why** these mixes stall on Windows and not locally. I could
  not reproduce a hang on macOS. If it is a genuine hang rather than runner contention, a
  bigger budget will not fix it — but the next occurrence will name the stage instead of
  saying nothing, which is what has been missing to diagnose it.
- `audioMixer.test.ts` is left on the default deliberately. Its suites are parsing tests
  that run in single-digit milliseconds; giving them 60s would hide a real hang.
