### PR TITLE
chore: release v0.8.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,34 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.8"
+  description="Released - 2026-08-22"
+  tags={["Release", "Audio", "CLI", "Engine"]}
+>
+The audio effects rack, track groups, mute and solo are on for everyone.
+They shipped across twelve releases behind a flag at zero percent, so this is
+the first release where you can reach them.
+
+## Features
+
+- **Audio:** Open the audio FX, group and mute features to everyone ([0e9a4f371](https://github.com/heygen-com/hyperframes/commit/0e9a4f371d4cff4e853640ea87caf76814af5278), [#3401](https://github.com/heygen-com/hyperframes/pull/3401)).
+
+## Fixes
+
+- **CLI:** Stop a caught post-render throw reporting a valid render as failed ([ea95b7d44](https://github.com/heygen-com/hyperframes/commit/ea95b7d44e6de95a514931026d6c01be7f9c01a0), [#3409](https://github.com/heygen-com/hyperframes/pull/3409)).
+- **Lint:** Surface unloadable media variable defaults, stop reading data-var-src ids as paths ([41edbfb2c](https://github.com/heygen-com/hyperframes/commit/41edbfb2ce5a8beb1c9d9de2a3eb09195a369a4b), [#3406](https://github.com/heygen-com/hyperframes/pull/3406)).
+- **Studio:** Invalidate the preview signature off the watcher that sees project writes ([5842dd8df](https://github.com/heygen-com/hyperframes/commit/5842dd8df4c7fca3ed895e4bc047299c9274ed14), [#3364](https://github.com/heygen-com/hyperframes/pull/3364)).
+- **Lint:** Stop duplicate_composition_id firing on repeated sub-composition mounts ([09a5ef709](https://github.com/heygen-com/hyperframes/commit/09a5ef70925f8a67276df0166ff1e1a6eca5db6f), [#3404](https://github.com/heygen-com/hyperframes/pull/3404)).
+- **Producer:** Anchor local-font embedding to its url() occurrence ([e1191edba](https://github.com/heygen-com/hyperframes/commit/e1191edba6d8ec44e3d79624cc92ef32fe99805d), [#3405](https://github.com/heygen-com/hyperframes/pull/3405)).
+
+## Internal
+
+- **Engine:** Give the audio grouping mixes room, and make a stall say why ([9c73e64a0](https://github.com/heygen-com/hyperframes/commit/9c73e64a07635fe02922ec2f0f3bc0b37ef6483d), [#3408](https://github.com/heygen-com/hyperframes/pull/3408)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.7...v0.8.8).
+</Update>
+
+<Update
   label="HyperFrames v0.8.7"
   description="Released - 2026-08-21"
   tags={["Release", "Lint", "Catalog", "Core"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.8.md
+++ b/releases/v0.8.8.md
@@ -1,0 +1,27 @@
+# HyperFrames v0.8.8
+
+Released on 2026-08-22.
+
+The audio effects rack, track groups, mute and solo are on for everyone.
+They shipped across twelve releases behind a flag at zero percent, so this is
+the first release where you can reach them.
+
+## Features
+
+- **Audio:** Open the audio FX, group and mute features to everyone ([0e9a4f371](https://github.com/heygen-com/hyperframes/commit/0e9a4f371d4cff4e853640ea87caf76814af5278), [#3401](https://github.com/heygen-com/hyperframes/pull/3401)).
+
+## Fixes
+
+- **CLI:** Stop a caught post-render throw reporting a valid render as failed ([ea95b7d44](https://github.com/heygen-com/hyperframes/commit/ea95b7d44e6de95a514931026d6c01be7f9c01a0), [#3409](https://github.com/heygen-com/hyperframes/pull/3409)).
+- **Lint:** Surface unloadable media variable defaults, stop reading data-var-src ids as paths ([41edbfb2c](https://github.com/heygen-com/hyperframes/commit/41edbfb2ce5a8beb1c9d9de2a3eb09195a369a4b), [#3406](https://github.com/heygen-com/hyperframes/pull/3406)).
+- **Studio:** Invalidate the preview signature off the watcher that sees project writes ([5842dd8df](https://github.com/heygen-com/hyperframes/commit/5842dd8df4c7fca3ed895e4bc047299c9274ed14), [#3364](https://github.com/heygen-com/hyperframes/pull/3364)).
+- **Lint:** Stop duplicate_composition_id firing on repeated sub-composition mounts ([09a5ef709](https://github.com/heygen-com/hyperframes/commit/09a5ef70925f8a67276df0166ff1e1a6eca5db6f), [#3404](https://github.com/heygen-com/hyperframes/pull/3404)).
+- **Producer:** Anchor local-font embedding to its url() occurrence ([e1191edba](https://github.com/heygen-com/hyperframes/commit/e1191edba6d8ec44e3d79624cc92ef32fe99805d), [#3405](https://github.com/heygen-com/hyperframes/pull/3405)).
+
+## Internal
+
+- **Engine:** Give the audio grouping mixes room, and make a stall say why ([9c73e64a0](https://github.com/heygen-com/hyperframes/commit/9c73e64a07635fe02922ec2f0f3bc0b37ef6483d), [#3408](https://github.com/heygen-com/hyperframes/pull/3408)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.7...v0.8.8


### PR DESCRIPTION
Release v0.8.8. Cut from `main` at `0e9a4f371` (#3401).

## What's in it

**The audio suite is on for everyone.** The effects rack, track groups, mute and solo shipped across twelve PRs behind three canaries at zero percent, so this is the first release where anyone can reach them. #3401 retired the canaries and the five gates they fed.

Plus five fixes and one internal change — full list in `releases/v0.8.8.md`.

## Mechanics

`bun run release:prepare 0.8.8`, notes reviewed, then `--no-tag` for this PR per CONTRIBUTING's release-PR path. 13 packages and 3 plugin manifests to 0.8.8 (fixed versioning). `bun install` leaves the lockfile unchanged; the release-script tests pass (33).

**One thing worth knowing for next time:** the first draft spanned `v0.7.109...v0.8.8` — eight releases of history — because this worktree had no `v0.8.*` tags, so the drafter fell back to the newest tag it could see. `git fetch --tags` then redrafting gave the correct `v0.8.7...v0.8.8` range. Worth a `git fetch --tags` before `release:prepare` in a fresh worktree.

## After merge

Tag the squashed commit on `main` and push the tag to trigger the publish workflow:

```
git tag v0.8.8 <merge-sha> && git push origin v0.8.8
```

Specific tag, not `--tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)