### PR TITLE
fix(studio): give the group row's caret the panel's glyph and size back

### DIFF
--- a/packages/studio/src/components/editor/CanvasContextMenu.test.tsx
+++ b/packages/studio/src/components/editor/CanvasContextMenu.test.tsx
@@ -92,7 +92,7 @@ describe("CanvasContextMenu — handler gating", () => {
 
     // No menu opened at all — no buttons, no dead-end items, no DOM mutation.
     expect(menuButtons()).toHaveLength(0);
-    expect(document.body.querySelector(".fixed.z-50")).toBeNull();
+    expect(document.body.querySelector(".fixed.z-\\[200\\]")).toBeNull();
     expect(el.style.zIndex).toBe("3");
   });
 

--- a/packages/studio/src/components/editor/CanvasContextMenu.tsx
+++ b/packages/studio/src/components/editor/CanvasContextMenu.tsx
@@ -212,7 +212,7 @@ export const CanvasContextMenu = memo(function CanvasContextMenu({
   return createPortal(
     <div
       ref={menuRef}
-      className="fixed z-50 bg-neutral-900 border border-neutral-700 rounded-md shadow-lg py-1 min-w-[180px]"
+      className="fixed z-[200] bg-neutral-900 border border-neutral-700 rounded-md shadow-lg py-1 min-w-[180px]"
       style={{ left: adjustedX, top: adjustedY }}
       onPointerDown={stopBubble}
       onMouseDown={stopBubble}

--- a/packages/studio/src/components/editor/TimelineFxPopover.test.tsx
+++ b/packages/studio/src/components/editor/TimelineFxPopover.test.tsx
@@ -160,7 +160,7 @@ describe("TimelineFxPopover", () => {
     const dialog = withViewportHeight(200, () =>
       dialogOf(mount({ anchorRect: rect(100, 120) }).host),
     );
-    // bottom:32 + maxHeight:160 puts the box at y = 8..40 — a margin on each side.
+    // bottom:32 + maxHeight:160 puts the box at y = 8..168 — a margin on each side.
     expect(dialog.style.bottom).toBe("32px");
     const bottom = Number.parseFloat(dialog.style.bottom);
     const height = Number.parseFloat(dialog.style.maxHeight);

--- a/packages/studio/src/components/editor/TimelineFxPopover.tsx
+++ b/packages/studio/src/components/editor/TimelineFxPopover.tsx
@@ -125,7 +125,7 @@ export function TimelineFxPopover({
       ref={rootRef}
       role="dialog"
       aria-label="Effects"
-      className="z-50 flex flex-col overflow-hidden rounded-md border border-white/10 bg-[#1b1b1f] p-2 shadow-xl"
+      className="z-[200] flex flex-col overflow-hidden rounded-md border border-white/10 bg-[#1b1b1f] p-2 shadow-xl"
       style={clampedStyle(anchorRect)}
       onKeyDown={onKeyDown}
       onPointerDown={(event) => event.stopPropagation()}

--- a/packages/studio/src/player/components/AutomationSelectionMenu.tsx
+++ b/packages/studio/src/player/components/AutomationSelectionMenu.tsx
@@ -41,7 +41,7 @@ export const AutomationSelectionMenu = memo(function AutomationSelectionMenu({
   return createPortal(
     <div
       ref={menuRef}
-      className="hf-automation-menu fixed z-50 min-w-[140px] rounded border border-panel-border-input bg-panel-bg-2 py-1 shadow-lg"
+      className="hf-automation-menu fixed z-[200] min-w-[140px] rounded border border-panel-border-input bg-panel-bg-2 py-1 shadow-lg"
       style={{ left: adjustedX, top: adjustedY }}
     >
       {AUTOMATION_SHAPES.map((shape) => (

--- a/packages/studio/src/player/components/ClipContextMenu.tsx
+++ b/packages/studio/src/player/components/ClipContextMenu.tsx
@@ -48,7 +48,7 @@ export const ClipContextMenu = memo(function ClipContextMenu({
       ref={menuRef}
       role="menu"
       aria-label="Clip actions"
-      className="fixed z-50 bg-neutral-900 border border-neutral-700 rounded-md shadow-lg py-1 min-w-[180px]"
+      className="fixed z-[200] bg-neutral-900 border border-neutral-700 rounded-md shadow-lg py-1 min-w-[180px]"
       style={{ left: adjustedX, top: adjustedY }}
     >
       {splitLabel && (

--- a/packages/studio/src/player/components/KeyframeDiamondContextMenu.tsx
+++ b/packages/studio/src/player/components/KeyframeDiamondContextMenu.tsx
@@ -96,7 +96,7 @@ export function KeyframeDiamondContextMenu({
       ref={menuRef}
       role="menu"
       aria-label="Keyframe actions"
-      className="fixed z-50 bg-neutral-900 border border-neutral-700 rounded-md shadow-lg py-1 min-w-[180px] overflow-y-auto"
+      className="fixed z-[200] bg-neutral-900 border border-neutral-700 rounded-md shadow-lg py-1 min-w-[180px] overflow-y-auto"
       style={{ left: adjustedX, top: adjustedY, maxHeight: `calc(100vh - ${adjustedY + 8}px)` }}
     >
       {onMoveToPlayhead && (

--- a/packages/studio/src/player/components/TimelineFxButton.tsx
+++ b/packages/studio/src/player/components/TimelineFxButton.tsx
@@ -79,7 +79,7 @@ export function TimelineFxButton(props: TimelineFxButtonProps) {
             <div
               role="dialog"
               aria-label="Group these clips to add effects"
-              className="z-50 w-56 rounded-md border border-white/10 bg-[#1b1b1f] p-2.5 text-[11px] text-white/75 shadow-xl"
+              className="z-[200] w-56 rounded-md border border-white/10 bg-[#1b1b1f] p-2.5 text-[11px] text-white/75 shadow-xl"
               style={{ position: "fixed", left: anchorRect.left, top: anchorRect.bottom + 4 }}
               onPointerDown={(event) => event.stopPropagation()}
             >

--- a/packages/studio/src/player/components/TimelineGroupHeader.test.tsx
+++ b/packages/studio/src/player/components/TimelineGroupHeader.test.tsx
@@ -65,7 +65,9 @@ describe("TimelineGroupHeader disclosure caret", () => {
     expect(glyph?.getAttribute("style") ?? "").not.toContain("rotate");
   });
 
-  it("matches the property panel's carets: mono, and not the smaller 11px", () => {
+  it("keeps the caret mono at 13px, not back down at the 11px the row inherits", () => {
+    // Only this component's own className — the panel carets are not read here,
+    // and this does not claim to pin a match against them.
     const className = caret(renderHeader()).className;
     expect(className).toContain("font-mono");
     expect(className).toContain("text-[13px]");

--- a/packages/studio/src/player/components/TimelineGroupHeader.test.tsx
+++ b/packages/studio/src/player/components/TimelineGroupHeader.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TimelineGroupHeader } from "./TimelineGroupHeader";
+import { defaultTimelineTheme } from "./timelineTheme";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function renderHeader(
+  overrides: Partial<React.ComponentProps<typeof TimelineGroupHeader>> = {},
+): HTMLElement {
+  const host = document.createElement("div");
+  document.body.append(host);
+  act(() => {
+    createRoot(host).render(
+      <TimelineGroupHeader
+        label="Voiceover"
+        memberCount={5}
+        isExpanded={false}
+        onToggleExpanded={vi.fn()}
+        laneCount={0}
+        isLaneOpen={false}
+        onToggleLanes={vi.fn()}
+        hidden={false}
+        onToggleHidden={vi.fn()}
+        isSoloed={false}
+        isHalfLitSolo={false}
+        onToggleSolo={vi.fn()}
+        onFxChainChange={vi.fn()}
+        onOpenFxRack={vi.fn()}
+        columnWidth={220}
+        theme={defaultTimelineTheme}
+        {...overrides}
+      />,
+    );
+  });
+  return host;
+}
+
+/** The structural disclosure — the caret, not the `∿` lane toggle. */
+function caret(host: HTMLElement): HTMLButtonElement {
+  const el = Array.from(host.querySelectorAll("button")).find((b) =>
+    b.getAttribute("aria-label")?.includes("tracks"),
+  );
+  if (!el) throw new Error("no disclosure caret");
+  return el as HTMLButtonElement;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("TimelineGroupHeader disclosure caret", () => {
+  // Guards a regression that shipped once: the caret silently reverted to a
+  // smaller, non-mono, rotated glyph unlike the property panel's carets.
+  it("swaps the glyph rather than rotating one", () => {
+    expect(caret(renderHeader({ isExpanded: false })).textContent).toContain("▸");
+    expect(caret(renderHeader({ isExpanded: true })).textContent).toContain("▾");
+  });
+
+  it("does not rotate the glyph", () => {
+    const glyph = caret(renderHeader({ isExpanded: true })).querySelector("span");
+    expect(glyph?.getAttribute("style") ?? "").not.toContain("rotate");
+  });
+
+  it("matches the property panel's carets: mono, and not the smaller 11px", () => {
+    const className = caret(renderHeader()).className;
+    expect(className).toContain("font-mono");
+    expect(className).toContain("text-[13px]");
+    expect(className).not.toContain("text-[11px]");
+  });
+});

--- a/packages/studio/src/player/components/TimelineGroupHeader.tsx
+++ b/packages/studio/src/player/components/TimelineGroupHeader.tsx
@@ -77,7 +77,10 @@ export function TimelineGroupHeader({
         aria-expanded={isExpanded}
         aria-label={`${isExpanded ? "Hide" : "Show"} ${label} tracks`}
         title={`${isExpanded ? "Hide" : "Show"} tracks`}
-        className={`flex h-6 w-6 shrink-0 items-center justify-center rounded border-0 bg-transparent p-0 text-[11px] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#3CE6AC] ${
+        // Mono and a size up, matching the property panel's disclosure carets
+        // (`hf-fx-preset-run-caret`, `propertyPanelFxNodeOpenBody`) — the same
+        // affordance should not be smaller here than it is there.
+        className={`flex h-6 w-6 shrink-0 items-center justify-center rounded border-0 bg-transparent p-0 font-mono text-[13px] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#3CE6AC] ${
           isExpanded ? "text-white" : "text-white/55 hover:text-white"
         }`}
         onPointerDown={(event) => event.stopPropagation()}
@@ -86,9 +89,9 @@ export function TimelineGroupHeader({
           onToggleExpanded();
         }}
       >
-        <span aria-hidden="true" style={{ transform: isExpanded ? "rotate(90deg)" : undefined }}>
-          ▸
-        </span>
+        {/* Swapped, not rotated: both panel carets swap, and a rotated ▸ sits
+            off-centre in its box because the glyph is not square. */}
+        <span aria-hidden="true">{isExpanded ? "▾" : "▸"}</span>
       </button>
       <span aria-hidden="true" className="shrink-0 text-[12px] leading-none text-white/50">
         ▤

--- a/packages/studio/src/player/components/TimelineGroupHeader.tsx
+++ b/packages/studio/src/player/components/TimelineGroupHeader.tsx
@@ -77,9 +77,10 @@ export function TimelineGroupHeader({
         aria-expanded={isExpanded}
         aria-label={`${isExpanded ? "Hide" : "Show"} ${label} tracks`}
         title={`${isExpanded ? "Hide" : "Show"} tracks`}
-        // Mono and a size up, matching the property panel's disclosure carets
-        // (`hf-fx-preset-run-caret`, `propertyPanelFxNodeOpenBody`) — the same
-        // affordance should not be smaller here than it is there.
+        // Mono, like both of the property panel's disclosure carets. The size is
+        // this row's own call and not a match to either of them: the node-body
+        // caret sits under `text-[9px]`, and `hf-fx-preset-run-caret` has no
+        // size rule at all, so there is no measured target to match.
         className={`flex h-6 w-6 shrink-0 items-center justify-center rounded border-0 bg-transparent p-0 font-mono text-[13px] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[#3CE6AC] ${
           isExpanded ? "text-white" : "text-white/55 hover:text-white"
         }`}

--- a/packages/studio/src/player/components/TrackGapContextMenu.tsx
+++ b/packages/studio/src/player/components/TrackGapContextMenu.tsx
@@ -75,7 +75,7 @@ export const TrackGapContextMenu = memo(function TrackGapContextMenu({
   return createPortal(
     <div
       ref={menuRef}
-      className="fixed z-50 bg-neutral-900 border border-neutral-700 rounded-md shadow-lg py-1 min-w-[180px]"
+      className="fixed z-[200] bg-neutral-900 border border-neutral-700 rounded-md shadow-lg py-1 min-w-[180px]"
       style={{ left: adjustedX, top: adjustedY }}
       onPointerLeave={() => onHoverAction(null)}
     >


### PR DESCRIPTION
Stacked on #3414. Part of restoring fixes stranded in the unreviewed #3363 — see #3413 for the full context.

## What

The timeline group row was the only disclosure caret in the studio still drawn as a **rotated, 11px, non-mono** glyph. Both of the property panel's carets swap between `▸` and `▾` in `font-mono`:

- `propertyPanelFxPresetRun.tsx` (`hf-fx-preset-run-caret`) — `collapsed ? "▸" : "▾"`
- `propertyPanelFxNodeOpenBody.tsx` — `details ? "▾" : "▸"`

So the same affordance rendered smaller, and differently, on the row than in the panel it opens. Now mono, a size up, and swapped rather than rotated — a rotated `▸` also sits off-centre in its box because the glyph is not square.

Note the size is the value the original fix chose; `hf-fx-preset-run-caret` has no CSS rule of its own (it inherits), so "13px matches the panel exactly" is not something I measured — the mono + swap consistency is.

## Tests

Three, mounting the header — there was no test file for this component at all, which is how it silently reverted:

- the glyph swaps rather than rotating
- no `rotate` transform on the glyph
- the mono class is present and the smaller `text-[11px]` is gone

Verified all three fail against the previous caret.

## Checks

`tsc --noEmit` clean · new tests 3/3 · `oxlint` / `oxfmt` clean · `fallow audit` no issues · all touched files well under the studio 600-LOC limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)