### PR TITLE
fix(skills): make the carve CLI work against the published core, and honour its own group invariant

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -26,8 +26,8 @@
       "files": 121
     },
     "hyperframes-audio": {
-      "hash": "819ab4e70d0f1cc9",
-      "files": 6
+      "hash": "5be0b86606a24f4a",
+      "files": 7
     },
     "hyperframes-cli": {
       "hash": "3fa884269c43d7df",

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -26,7 +26,7 @@
       "files": 121
     },
     "hyperframes-audio": {
-      "hash": "a5c5b62882ddad63",
+      "hash": "5564aeda7725f455",
       "files": 7
     },
     "hyperframes-cli": {

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -26,7 +26,7 @@
       "files": 121
     },
     "hyperframes-audio": {
-      "hash": "5be0b86606a24f4a",
+      "hash": "0b5e0ac8d731e1d2",
       "files": 7
     },
     "hyperframes-cli": {

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -26,7 +26,7 @@
       "files": 121
     },
     "hyperframes-audio": {
-      "hash": "0b5e0ac8d731e1d2",
+      "hash": "a5c5b62882ddad63",
       "files": 7
     },
     "hyperframes-cli": {

--- a/skills/hyperframes-audio/SKILL.md
+++ b/skills/hyperframes-audio/SKILL.md
@@ -261,15 +261,33 @@ A `sources` list naming two or more plain clip ids instead of a group is caught
 by the `audio_carve_ungrouped_sources` lint rule — it still works, but it is the
 version that silently rots when a clip is added.
 
-**The bed must not be a member of the group it carves against.** A group id in
-`sources` resolves to every current member on every analysis, so a bed inside
-that group is handed itself as a voice and carved against its own content —
-which is the "never carve a track against itself" rule arriving one re-analysis
-later, after a first pass that looked correct. Give the bed its own group
-(`music`) and the narration its own (`voiceover`). `carve.mjs` refuses to write
-the group form when it detects this and records clip ids instead, so the lint
-rule points at the arrangement rather than the CLI quietly producing a
-self-carve.
+**Keep the carve group a voice group: no bed, no SFX, no music.** A group id in
+`sources` resolves to every _current_ member on _every_ analysis, so the group
+you name is the group you get later — not the tracks that were measured when it
+was written. Two ways that bites:
+
+- **The bed in its own source group.** It is handed to itself as a voice and
+  carved against its own content — the "never carve a track against itself" rule
+  arriving one re-analysis later.
+- **An SFX or music clip in the voice group.** It enters the sidechain on the
+  next analysis and the bed starts ducking under a whoosh, even though the run
+  that wrote the attribute never measured it.
+
+Both are invisible at the moment the carve is written: the analysis sums the
+voices it detected and never round-trips through group resolution, so the first
+pass is genuinely correct and only the next one is wrong. So give each role its
+own group — `music` for the bed, `voiceover` for the narration, `sfx` for the
+hits — and keep the group named in `sources` holding nothing but voices.
+
+`carve.mjs` refuses to write the group form when it sees either case, records
+clip ids, and says on stderr which member blocked it. The
+`audio_carve_ungrouped_sources` rule then points at the arrangement instead of
+the CLI quietly persisting a wider carve than it measured.
+
+A voice that this run left out is **not** one of these cases and does not block
+the group form: `carve.mjs` only analyses voices that overlap the bed, and
+picking up a clip that plays later without an edit to `sources` is the whole
+reason to name the group.
 
 **One knob.** `strength` is 0..1 and derives everything: how deep to cut, how
 many bands, how wide, how far to favour intelligibility over raw voice energy,

--- a/skills/hyperframes-audio/SKILL.md
+++ b/skills/hyperframes-audio/SKILL.md
@@ -261,6 +261,16 @@ A `sources` list naming two or more plain clip ids instead of a group is caught
 by the `audio_carve_ungrouped_sources` lint rule — it still works, but it is the
 version that silently rots when a clip is added.
 
+**The bed must not be a member of the group it carves against.** A group id in
+`sources` resolves to every current member on every analysis, so a bed inside
+that group is handed itself as a voice and carved against its own content —
+which is the "never carve a track against itself" rule arriving one re-analysis
+later, after a first pass that looked correct. Give the bed its own group
+(`music`) and the narration its own (`voiceover`). `carve.mjs` refuses to write
+the group form when it detects this and records clip ids instead, so the lint
+rule points at the arrangement rather than the CLI quietly producing a
+self-carve.
+
 **One knob.** `strength` is 0..1 and derives everything: how deep to cut, how
 many bands, how wide, how far to favour intelligibility over raw voice energy,
 how far the level may drop, how far under the voice to aim. Those six move

--- a/skills/hyperframes-audio/scripts/carve.mjs
+++ b/skills/hyperframes-audio/scripts/carve.mjs
@@ -26,7 +26,7 @@
 
 import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -81,7 +81,7 @@ function fail(message, code = 1) {
  * the skill was installed — a sibling of the composition is what has the
  * dependency.
  */
-async function loadCore(fromDir) {
+export async function loadCore(fromDir) {
   const require = createRequire(pathToFileURL(resolve(fromDir, "package.json")));
 
   /*
@@ -142,7 +142,7 @@ async function loadCore(fromDir) {
 }
 
 /**
- * The `sources` a carve should record for these voices.
+ * The `sources` a carve should record for these voices, on this bed.
  *
  * SKILL.md states the invariant: "A carve against more than one clip id is
  * wrong. Group the clips and carve against the group." Naming the group lets
@@ -155,12 +155,38 @@ async function loadCore(fromDir) {
  * skill's invariant and tripped its own lint rule on every run. When every
  * voice shares one group, record the group. Mixed or ungrouped voices keep
  * their ids, and the lint rule then correctly tells the author to group them.
+ *
+ * The bed has to be part of the decision, because the group form resolves
+ * LATER and wider than it looks. If the bed is itself a member of the voices'
+ * group, `resolveCarveSourceIds` expands that id to every current member on the
+ * next analysis — including the bed — and the bed ends up carved against
+ * itself, which SKILL.md calls a bug rather than a mix choice. This run cannot
+ * see it: `main()` sums the voice list it detected and never round-trips
+ * through group resolution, so the first pass is correct and only the next
+ * re-analysis in Studio is wrong. So decline the group form there and fall back
+ * to clip ids, which is exactly the case `audio_carve_ungrouped_sources` exists
+ * to put in front of the author.
+ *
+ * Only an `<audio>` bed can trip it: group membership is audio-only
+ * (`audioGroupOf`), so `data-audio-group` on a `<video>` bed is ignored by core
+ * and expanding a group can never pull it in.
  */
-export function carveSources(voices) {
+export function carveSources(voices, bed) {
+  const group = sharedVoiceGroup(voices);
+  return group && !bedInVoiceGroup(voices, bed) ? [group] : voices.map((v) => v.id);
+}
+
+/** The one group every voice belongs to, or null if they do not share exactly one. */
+function sharedVoiceGroup(voices) {
   const groups = voices.map((v) => attrOf(v.tag, "data-audio-group"));
   const first = groups[0];
-  const allShareOneGroup = Boolean(first) && groups.every((g) => g === first);
-  return allShareOneGroup ? [first] : voices.map((v) => v.id);
+  return Boolean(first) && groups.every((g) => g === first) ? first : null;
+}
+
+/** The case above: naming this group would put the bed in its own source list. */
+export function bedInVoiceGroup(voices, bed) {
+  const group = sharedVoiceGroup(voices);
+  return Boolean(group) && bed?.kind === "audio" && attrOf(bed.tag, "data-audio-group") === group;
 }
 
 /** Mono float PCM for one media file, via ffmpeg. */
@@ -414,7 +440,16 @@ async function main() {
     : [];
   const lanes = [...carriedLanes, ...carvedLanes];
 
-  const settings = { enabled: true, sources: carveSources(voices), strength: args.strength };
+  const settings = { enabled: true, sources: carveSources(voices, bedEl), strength: args.strength };
+  // Say why the group form was declined, or the lint rule tells the author to
+  // group clips they have already grouped.
+  if (bedInVoiceGroup(voices, bedEl)) {
+    process.stderr.write(
+      `note   bed ${bedEl.id} is in group "${attrOf(bedTag, "data-audio-group")}" with the voices,\n` +
+        `       so sources are clip ids: naming that group would carve the bed\n` +
+        `       against itself on the next analysis. Move the bed to its own group.\n`,
+    );
+  }
   const written =
     ` data-fx-carve="${escapeAttr(JSON.stringify(settings))}"` +
     ` data-fx-chain="${escapeAttr(fxApi.serializeAudioFxChain(chain))}"` +
@@ -451,6 +486,19 @@ async function main() {
 
 // Only run as a CLI. Guarded so the pure helpers above can be unit-tested by
 // importing this module (`skills/**/*.test.mjs`, run by `bun run test:skills`).
-if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+//
+// realpath both sides: on macOS /tmp → /private/tmp, and node resolves the main
+// module's symlinks in import.meta.url while argv[1] keeps the invoked spelling —
+// a raw compare silently skips main() when invoked through any symlinked path.
+function isMainModule(importMetaUrl) {
+  if (!process.argv[1]) return false;
+  try {
+    return pathToFileURL(realpathSync(process.argv[1])).href === importMetaUrl;
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule(import.meta.url)) {
   await main();
 }

--- a/skills/hyperframes-audio/scripts/carve.mjs
+++ b/skills/hyperframes-audio/scripts/carve.mjs
@@ -171,9 +171,9 @@ export async function loadCore(fromDir) {
  * (`audioGroupOf`), so `data-audio-group` on a `<video>` bed is ignored by core
  * and expanding a group can never pull it in.
  */
-export function carveSources(voices, bed) {
+export function carveSources(voices, bed, members = []) {
   const group = sharedVoiceGroup(voices);
-  return group && !bedInVoiceGroup(voices, bed) ? [group] : voices.map((v) => v.id);
+  return group && !groupSourceRefusal(voices, bed, members) ? [group] : voices.map((v) => v.id);
 }
 
 /** The one group every voice belongs to, or null if they do not share exactly one. */
@@ -183,10 +183,49 @@ function sharedVoiceGroup(voices) {
   return Boolean(first) && groups.every((g) => g === first) ? first : null;
 }
 
-/** The case above: naming this group would put the bed in its own source list. */
-export function bedInVoiceGroup(voices, bed) {
+/**
+ * Why naming the voices' shared group would persist something this run did not
+ * analyse — or null when the group is safe to name.
+ *
+ * `members` is every `<audio>` in the composition as `{id, group, nameKind}`,
+ * with `nameKind` from core's `classifyAudioName`, so this and Studio's picker
+ * classify the same way.
+ *
+ * Two refusals, and both exist because the group form resolves LATER and WIDER
+ * than the analysis: `resolveCarveSourceIds` expands a group id to every current
+ * member on every analysis, and `resolveCarveVoices` keeps any audio member with
+ * a src. `main()` meanwhile sums the voice list `detectTracks` returned, so the
+ * first pass looks correct however wrong the persisted attribute is.
+ *
+ *   `bed`   — the bed is a member, so it would be handed to itself as a voice
+ *             and carved against its own content.
+ *   `mixed` — a member classified music or sfx is not a voice this run measured,
+ *             so it would enter the sidechain on the next analysis and duck the
+ *             bed under a whoosh.
+ *
+ * Deliberately NOT a refusal: a member classified `voice` or `unknown` that this
+ * run left out. That is the group form working as designed — `detectTracks` only
+ * takes voices that overlap the bed, and picking up a clip that starts playing
+ * later without an edit to `sources` is the whole reason SKILL.md says to name
+ * the group. Refusing there would collapse the group form into clip ids for
+ * every ordinary narration sequence.
+ */
+export function groupSourceRefusal(voices, bed, members = []) {
   const group = sharedVoiceGroup(voices);
-  return Boolean(group) && bed?.kind === "audio" && attrOf(bed.tag, "data-audio-group") === group;
+  if (!group) return null;
+  if (bed?.kind === "audio" && attrOf(bed.tag, "data-audio-group") === group) {
+    return { group, reason: "bed", ids: [bed.id] };
+  }
+  const analysed = new Set(voices.map((v) => v.id));
+  const strays = members
+    .filter(
+      (m) =>
+        m.group === group &&
+        !analysed.has(m.id) &&
+        (m.nameKind === "music" || m.nameKind === "sfx"),
+    )
+    .map((m) => m.id);
+  return strays.length > 0 ? { group, reason: "mixed", ids: strays } : null;
 }
 
 /** Mono float PCM for one media file, via ffmpeg. */
@@ -320,7 +359,7 @@ function detectTracks(html, given, classify, overlaps) {
         `  name one with --voice`,
     );
   }
-  return { bed, voices: usable };
+  return { bed, voices: usable, all };
 }
 
 const startOf = (tag) => {
@@ -335,12 +374,21 @@ async function main() {
   const { carve: carveApi, fx: fxApi } = await loadCore(args.core ? resolve(args.core) : compDir);
 
   const html = readFileSync(compPath, "utf-8");
-  const { bed: bedEl, voices } = detectTracks(
-    html,
-    args,
-    carveApi.classifyAudioName,
-    carveApi.clipsOverlap,
-  );
+  const {
+    bed: bedEl,
+    voices,
+    all: media,
+  } = detectTracks(html, args, carveApi.classifyAudioName, carveApi.clipsOverlap);
+  // Group membership + name classification for every audio track, so the source
+  // decision can see what the group will resolve to later and not just what this
+  // run analysed.
+  const members = media
+    .filter((el) => el.kind === "audio")
+    .map((el) => ({
+      id: el.id,
+      group: attrOf(el.tag, "data-audio-group"),
+      nameKind: carveApi.classifyAudioName(el.id, unescapeAttr(attrOf(el.tag, "src") ?? "")),
+    }));
   const bedTag = bedEl.tag;
   const bedSrc = attrOf(bedTag, "src");
   process.stdout.write(
@@ -440,14 +488,24 @@ async function main() {
     : [];
   const lanes = [...carriedLanes, ...carvedLanes];
 
-  const settings = { enabled: true, sources: carveSources(voices, bedEl), strength: args.strength };
+  const settings = {
+    enabled: true,
+    sources: carveSources(voices, bedEl, members),
+    strength: args.strength,
+  };
   // Say why the group form was declined, or the lint rule tells the author to
   // group clips they have already grouped.
-  if (bedInVoiceGroup(voices, bedEl)) {
+  const refusal = groupSourceRefusal(voices, bedEl, members);
+  if (refusal) {
     process.stderr.write(
-      `note   bed ${bedEl.id} is in group "${attrOf(bedTag, "data-audio-group")}" with the voices,\n` +
-        `       so sources are clip ids: naming that group would carve the bed\n` +
-        `       against itself on the next analysis. Move the bed to its own group.\n`,
+      refusal.reason === "bed"
+        ? `note   bed ${bedEl.id} is in group "${refusal.group}" with the voices, so\n` +
+            `       sources are clip ids: naming that group would carve the bed\n` +
+            `       against itself on the next analysis. Move the bed to its own group.\n`
+        : `note   group "${refusal.group}" also holds ${refusal.ids.join(", ")}, which this run\n` +
+            `       did not analyse (music/sfx by name), so sources are clip ids: naming\n` +
+            `       the group would pull them into the sidechain on the next analysis.\n` +
+            `       Move them out of the voice group.\n`,
     );
   }
   const written =

--- a/skills/hyperframes-audio/scripts/carve.mjs
+++ b/skills/hyperframes-audio/scripts/carve.mjs
@@ -171,7 +171,7 @@ export async function loadCore(fromDir) {
  * (`audioGroupOf`), so `data-audio-group` on a `<video>` bed is ignored by core
  * and expanding a group can never pull it in.
  */
-export function carveSources(voices, bed, members = []) {
+export function carveSources(voices, bed, members) {
   const group = sharedVoiceGroup(voices);
   return group && !groupSourceRefusal(voices, bed, members) ? [group] : voices.map((v) => v.id);
 }
@@ -190,6 +190,13 @@ function sharedVoiceGroup(voices) {
  * `members` is every `<audio>` in the composition as `{id, group, nameKind}`,
  * with `nameKind` from core's `classifyAudioName`, so this and Studio's picker
  * classify the same way.
+ *
+ * Required, deliberately not defaulting to `[]`. With an empty list the `mixed`
+ * refusal below cannot fire, so a call that forgot the argument would return the
+ * group form and restore the exact behaviour this function exists to prevent —
+ * silently, because the first CLI pass is correct either way and only a later
+ * Studio re-analysis is wrong. A missing argument throws on `members.filter`
+ * instead.
  *
  * Two refusals, and both exist because the group form resolves LATER and WIDER
  * than the analysis: `resolveCarveSourceIds` expands a group id to every current
@@ -210,7 +217,7 @@ function sharedVoiceGroup(voices) {
  * the group. Refusing there would collapse the group form into clip ids for
  * every ordinary narration sequence.
  */
-export function groupSourceRefusal(voices, bed, members = []) {
+export function groupSourceRefusal(voices, bed, members) {
   const group = sharedVoiceGroup(voices);
   if (!group) return null;
   if (bed?.kind === "audio" && attrOf(bed.tag, "data-audio-group") === group) {

--- a/skills/hyperframes-audio/scripts/carve.mjs
+++ b/skills/hyperframes-audio/scripts/carve.mjs
@@ -83,10 +83,49 @@ function fail(message, code = 1) {
  */
 async function loadCore(fromDir) {
   const require = createRequire(pathToFileURL(resolve(fromDir, "package.json")));
-  const load = (subpath) => {
-    const file = require.resolve(`@hyperframes/core/${subpath}`);
-    return import(pathToFileURL(file).href);
+
+  /*
+   * Two constraints at once, and satisfying either alone is broken:
+   *
+   *   1. Anchored at the PROJECT, not at this script. This file lives wherever
+   *      the skill was installed, which has no @hyperframes/core; the
+   *      composition's project is what holds the dependency. So a bare
+   *      `import("@hyperframes/core/audio-carve")` from here cannot work — bare
+   *      specifiers resolve relative to the importing module.
+   *   2. Honouring the package's export CONDITIONS. `require.resolve` asks for
+   *      "require"/"node". The workspace manifest declares `node`, so this
+   *      resolved fine inside the monorepo — but the PUBLISHED manifest carries
+   *      only `import` + `types`, so every consumer of the released package got
+   *      ERR_PACKAGE_PATH_NOT_EXPORTED for a package that ships the file. That
+   *      is the audience this skill is shipped to, so the script was broken
+   *      everywhere except where it was developed.
+   *
+   * Keep the project anchor; fall back to the package's declared `import`
+   * target when no require-resolvable condition exists.
+   */
+  const load = async (subpath) => {
+    const spec = `@hyperframes/core/${subpath}`;
+    try {
+      return await import(pathToFileURL(require.resolve(spec)).href);
+    } catch (error) {
+      if (error?.code !== "ERR_PACKAGE_PATH_NOT_EXPORTED") throw error;
+      // `./package.json` is exported by every manifest, so this always resolves
+      // and gives us the package root without guessing at node_modules layout.
+      const pkgPath = require.resolve("@hyperframes/core/package.json");
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      const entry = pkg.exports?.[`./${subpath}`];
+      const target = typeof entry === "string" ? entry : (entry?.import ?? entry?.default ?? null);
+      if (!target) {
+        fail(
+          `@hyperframes/core does not export ./${subpath}\n` +
+            `  found at: ${pkgPath} (version ${pkg.version})\n` +
+            `  update it:  npm i -D @hyperframes/core`,
+        );
+      }
+      return import(pathToFileURL(resolve(dirname(pkgPath), target)).href);
+    }
   };
+
   try {
     return {
       carve: await load("audio-carve"),
@@ -94,13 +133,34 @@ async function loadCore(fromDir) {
     };
   } catch (error) {
     fail(
-      `cannot resolve @hyperframes/core from ${fromDir}\n` +
-        `  install or update it:  npm i -D @hyperframes/core\n` +
-        `  (the audio-carve export needs a version that ships the carve analysis)\n` +
+      `cannot load @hyperframes/core from ${fromDir}\n` +
+        `  is it installed there?  npm i -D @hyperframes/core\n` +
         `  or point at one:   --core <dir containing node_modules/@hyperframes/core>\n` +
-        `  (${error.message})`,
+        `  (${error.code ?? "error"}: ${error.message.split("\n")[0]})`,
     );
   }
+}
+
+/**
+ * The `sources` a carve should record for these voices.
+ *
+ * SKILL.md states the invariant: "A carve against more than one clip id is
+ * wrong. Group the clips and carve against the group." Naming the group lets
+ * `resolveCarveSourceIds` resolve membership at analysis time, so a voice added
+ * later is covered without editing `sources` — whereas a list of clip ids rots
+ * silently the moment a fourth narration clip appears. The lint rule
+ * `audio_carve_ungrouped_sources` enforces exactly this.
+ *
+ * This script was writing clip ids unconditionally, so it violated its own
+ * skill's invariant and tripped its own lint rule on every run. When every
+ * voice shares one group, record the group. Mixed or ungrouped voices keep
+ * their ids, and the lint rule then correctly tells the author to group them.
+ */
+export function carveSources(voices) {
+  const groups = voices.map((v) => attrOf(v.tag, "data-audio-group"));
+  const first = groups[0];
+  const allShareOneGroup = Boolean(first) && groups.every((g) => g === first);
+  return allShareOneGroup ? [first] : voices.map((v) => v.id);
 }
 
 /** Mono float PCM for one media file, via ffmpeg. */
@@ -354,7 +414,7 @@ async function main() {
     : [];
   const lanes = [...carriedLanes, ...carvedLanes];
 
-  const settings = { enabled: true, sources: voices.map((v) => v.id), strength: args.strength };
+  const settings = { enabled: true, sources: carveSources(voices), strength: args.strength };
   const written =
     ` data-fx-carve="${escapeAttr(JSON.stringify(settings))}"` +
     ` data-fx-chain="${escapeAttr(fxApi.serializeAudioFxChain(chain))}"` +
@@ -389,4 +449,8 @@ async function main() {
   process.stdout.write(`wrote ${args.comp} (id="${bedEl.id}")\n`);
 }
 
-await main();
+// Only run as a CLI. Guarded so the pure helpers above can be unit-tested by
+// importing this module (`skills/**/*.test.mjs`, run by `bun run test:skills`).
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  await main();
+}

--- a/skills/hyperframes-audio/scripts/carve.test.mjs
+++ b/skills/hyperframes-audio/scripts/carve.test.mjs
@@ -5,7 +5,7 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { carveSources, loadCore } from "./carve.mjs";
+import { carveSources, groupSourceRefusal, loadCore } from "./carve.mjs";
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -13,6 +13,11 @@ const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 function voice(id, group) {
   const attr = group === undefined ? "" : ` data-audio-group="${group}"`;
   return { id, tag: `<audio id="${id}"${attr} src="${id}.wav"></audio>` };
+}
+
+/** An audio member as `main` describes it for the source decision. */
+function member(id, group, nameKind) {
+  return { id, group, nameKind };
 }
 
 /** A bed as `mediaElements` yields it: `kind` is what decides group membership. */
@@ -88,6 +93,75 @@ test("a VIDEO bed is immune — group membership is audio-only", () => {
   // can never pull this bed in and declining would be a false positive.
   const voices = [voice("vo1", "mix"), voice("vo2", "mix")];
   assert.deepEqual(carveSources(voices, bed("clip", "mix", "video")), ["mix"]);
+});
+
+test("an sfx member of the voices' group blocks the group form", () => {
+  // The group resolves wider than the analysis: `resolveCarveSourceIds` expands
+  // it to every current member and `resolveCarveVoices` keeps any audio with a
+  // src, so an sfx clip sharing the voice group enters the sidechain on the next
+  // analysis and ducks the bed under a whoosh. This run cannot see it — it sums
+  // the voices `detectTracks` returned, which correctly excluded the sfx.
+  const voices = [voice("vo1", "voiceover"), voice("vo2", "voiceover")];
+  const members = [
+    member("vo1", "voiceover", "voice"),
+    member("vo2", "voiceover", "voice"),
+    member("whoosh", "voiceover", "sfx"),
+    member("bgm", "music", "music"),
+  ];
+  assert.deepEqual(carveSources(voices, bed("bgm", "music"), members), ["vo1", "vo2"]);
+});
+
+test("a music member of the voices' group blocks it too", () => {
+  const voices = [voice("vo1", "voiceover")];
+  const members = [member("vo1", "voiceover", "voice"), member("pad", "voiceover", "music")];
+  assert.deepEqual(carveSources(voices, bed("bgm", "music"), members), ["vo1"]);
+});
+
+test("a voice member this run did NOT analyse keeps the group form", () => {
+  // The designed case, and the one a membership check must not break: a voice
+  // that does not overlap the bed is left out of the analysis on purpose, and
+  // covering it on a later analysis without editing `sources` is the entire
+  // reason SKILL.md says to name the group. Refusing here would collapse the
+  // group form into clip ids for every ordinary narration sequence.
+  const voices = [voice("vo1", "voiceover"), voice("vo2", "voiceover")];
+  const members = [
+    member("vo1", "voiceover", "voice"),
+    member("vo2", "voiceover", "voice"),
+    member("vo-outro", "voiceover", "voice"),
+  ];
+  assert.deepEqual(carveSources(voices, bed("bgm", "music"), members), ["voiceover"]);
+});
+
+test("an unclassifiable member keeps the group form", () => {
+  // `unknown` is what `detectTracks` itself treats as a possible voice, so it is
+  // not evidence of a non-voice member — loose in the safe direction, same as
+  // detection.
+  const voices = [voice("vo1", "voiceover")];
+  const members = [member("vo1", "voiceover", "voice"), member("track7", "voiceover", "unknown")];
+  assert.deepEqual(carveSources(voices, bed("bgm", "music"), members), ["voiceover"]);
+});
+
+test("an sfx member of a DIFFERENT group is irrelevant", () => {
+  const voices = [voice("vo1", "voiceover")];
+  const members = [member("vo1", "voiceover", "voice"), member("whoosh", "sfx", "sfx")];
+  assert.deepEqual(carveSources(voices, bed("bgm", "music"), members), ["voiceover"]);
+});
+
+test("groupSourceRefusal names which member blocked the group, and why", () => {
+  // The stderr note is built from this, so it has to carry the ids: "sources are
+  // clip ids" plus `audio_carve_ungrouped_sources` reads as nonsense to an author
+  // who did group their clips.
+  const voices = [voice("vo1", "voiceover"), voice("vo2", "voiceover")];
+  assert.deepEqual(
+    groupSourceRefusal(voices, bed("bgm", "music"), [member("whoosh", "voiceover", "sfx")]),
+    { group: "voiceover", reason: "mixed", ids: ["whoosh"] },
+  );
+  assert.deepEqual(groupSourceRefusal(voices, bed("bgm", "voiceover"), []), {
+    group: "voiceover",
+    reason: "bed",
+    ids: ["bgm"],
+  });
+  assert.equal(groupSourceRefusal(voices, bed("bgm", "music"), []), null);
 });
 
 test("the CLI still runs when invoked through a symlinked path", () => {

--- a/skills/hyperframes-audio/scripts/carve.test.mjs
+++ b/skills/hyperframes-audio/scripts/carve.test.mjs
@@ -1,11 +1,33 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { carveSources } from "./carve.mjs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { carveSources, loadCore } from "./carve.mjs";
+
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 
 /** A voice as `detectTracks` yields it: an id plus its raw opening tag. */
 function voice(id, group) {
   const attr = group === undefined ? "" : ` data-audio-group="${group}"`;
   return { id, tag: `<audio id="${id}"${attr} src="${id}.wav"></audio>` };
+}
+
+/** A bed as `mediaElements` yields it: `kind` is what decides group membership. */
+function bed(id, group, kind = "audio") {
+  const attr = group === undefined ? "" : ` data-audio-group="${group}"`;
+  return { id, kind, tag: `<${kind} id="${id}"${attr} src="${id}.mp3"></${kind}>` };
+}
+
+async function inTempDir(run) {
+  const dir = mkdtempSync(join(tmpdir(), "carve-test-"));
+  try {
+    return await run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 test("voices sharing one group carve against the group, not their ids", () => {
@@ -40,4 +62,83 @@ test("a partially grouped set keeps its ids", () => {
 
 test("an empty group attribute is not a group", () => {
   assert.deepEqual(carveSources([voice("vo1", ""), voice("vo2", "")]), ["vo1", "vo2"]);
+});
+
+test("a bed inside the voices' group keeps clip ids, so it is never its own source", () => {
+  // `resolveCarveSourceIds` expands a group to every CURRENT member, and it gets
+  // no host element to exclude — so naming a group the bed belongs to puts the
+  // bed in its own voice list on the next analysis, and it is carved against
+  // itself. This run cannot see it (main sums the detected voices directly), so
+  // the check has to happen here.
+  const voices = [voice("vo1", "mix"), voice("vo2", "mix")];
+  assert.deepEqual(carveSources(voices, bed("bgm", "mix")), ["vo1", "vo2"]);
+});
+
+test("a bed in a DIFFERENT group leaves the group form alone", () => {
+  const voices = [voice("vo1", "voiceover"), voice("vo2", "voiceover")];
+  assert.deepEqual(carveSources(voices, bed("bgm", "music")), ["voiceover"]);
+});
+
+test("an ungrouped bed leaves the group form alone", () => {
+  assert.deepEqual(carveSources([voice("vo1", "voiceover")], bed("bgm")), ["voiceover"]);
+});
+
+test("a VIDEO bed is immune — group membership is audio-only", () => {
+  // `data-audio-group` on a <video> is ignored by core, so expanding the group
+  // can never pull this bed in and declining would be a false positive.
+  const voices = [voice("vo1", "mix"), voice("vo2", "mix")];
+  assert.deepEqual(carveSources(voices, bed("clip", "mix", "video")), ["mix"]);
+});
+
+test("the CLI still runs when invoked through a symlinked path", () => {
+  // argv[1] keeps the invoked spelling while import.meta.url is the realpath, so
+  // a raw compare in the entry guard skips main() and the CLI exits 0 having
+  // written nothing. macOS /tmp -> /private/tmp reaches this with no symlink of
+  // one's own; so does any skill install placed behind a link.
+  return inTempDir((dir) => {
+    const link = join(dir, "scripts-link");
+    symlinkSync(SCRIPTS_DIR, link, "junction");
+    let status = 0;
+    let stderr = "";
+    try {
+      execFileSync(process.execPath, [join(link, "carve.mjs")], { encoding: "utf-8" });
+    } catch (error) {
+      status = error.status;
+      stderr = String(error.stderr);
+    }
+    // Reaching parseArgs is the proof main() ran at all: no args is an error, and
+    // the broken guard's symptom is a silent exit 0 with no output.
+    assert.equal(status, 1, `expected the usage error, got status ${status}`);
+    assert.match(stderr, /--comp is required/);
+  });
+});
+
+test("loadCore honours an import-only export map, as the published core has", () => {
+  // The published manifest carries only `import` + `types` for these subpaths, so
+  // `require.resolve` cannot resolve them at all and the fallback has to read the
+  // export map itself. A fixture pins that without depending on npm.
+  return inTempDir(async (dir) => {
+    const pkgDir = join(dir, "node_modules", "@hyperframes", "core");
+    mkdirSync(join(pkgDir, "dist"), { recursive: true });
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "fixture-project" }));
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "@hyperframes/core",
+        version: "0.0.0-fixture",
+        type: "module",
+        exports: {
+          "./package.json": "./package.json",
+          "./audio-carve": { import: "./dist/audioCarve.js" },
+          "./audio-fx": { import: "./dist/audioFx.js" },
+        },
+      }),
+    );
+    writeFileSync(join(pkgDir, "dist", "audioCarve.js"), 'export const marker = "carve";\n');
+    writeFileSync(join(pkgDir, "dist", "audioFx.js"), 'export const marker = "fx";\n');
+
+    const core = await loadCore(dir);
+    assert.equal(core.carve.marker, "carve");
+    assert.equal(core.fx.marker, "fx");
+  });
 });

--- a/skills/hyperframes-audio/scripts/carve.test.mjs
+++ b/skills/hyperframes-audio/scripts/carve.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { carveSources } from "./carve.mjs";
+
+/** A voice as `detectTracks` yields it: an id plus its raw opening tag. */
+function voice(id, group) {
+  const attr = group === undefined ? "" : ` data-audio-group="${group}"`;
+  return { id, tag: `<audio id="${id}"${attr} src="${id}.wav"></audio>` };
+}
+
+test("voices sharing one group carve against the group, not their ids", () => {
+  // SKILL.md's invariant: "A carve against more than one clip id is wrong.
+  // Group the clips and carve against the group." Naming the group lets
+  // membership resolve at analysis time, so a voice added later is covered.
+  const voices = [voice("vo1", "voiceover"), voice("vo2", "voiceover"), voice("vo3", "voiceover")];
+  assert.deepEqual(carveSources(voices), ["voiceover"]);
+});
+
+test("a single grouped voice still records the group", () => {
+  assert.deepEqual(carveSources([voice("vo1", "voiceover")]), ["voiceover"]);
+});
+
+test("ungrouped voices keep their ids, so the lint rule can still say so", () => {
+  // Not silently inventing a group: `audio_carve_ungrouped_sources` is the
+  // right signal here, and it needs the ids to fire on.
+  assert.deepEqual(carveSources([voice("vo1"), voice("vo2")]), ["vo1", "vo2"]);
+});
+
+test("voices in DIFFERENT groups keep their ids", () => {
+  // One carve cannot name two groups, and picking either would silently drop
+  // the other's members from the analysis.
+  const voices = [voice("vo1", "narration"), voice("vo2", "interview")];
+  assert.deepEqual(carveSources(voices), ["vo1", "vo2"]);
+});
+
+test("a partially grouped set keeps its ids", () => {
+  const voices = [voice("vo1", "voiceover"), voice("vo2")];
+  assert.deepEqual(carveSources(voices), ["vo1", "vo2"]);
+});
+
+test("an empty group attribute is not a group", () => {
+  assert.deepEqual(carveSources([voice("vo1", ""), voice("vo2", "")]), ["vo1", "vo2"]);
+});

--- a/skills/hyperframes-audio/scripts/carve.test.mjs
+++ b/skills/hyperframes-audio/scripts/carve.test.mjs
@@ -40,34 +40,43 @@ test("voices sharing one group carve against the group, not their ids", () => {
   // Group the clips and carve against the group." Naming the group lets
   // membership resolve at analysis time, so a voice added later is covered.
   const voices = [voice("vo1", "voiceover"), voice("vo2", "voiceover"), voice("vo3", "voiceover")];
-  assert.deepEqual(carveSources(voices), ["voiceover"]);
+  assert.deepEqual(carveSources(voices, undefined, []), ["voiceover"]);
 });
 
 test("a single grouped voice still records the group", () => {
-  assert.deepEqual(carveSources([voice("vo1", "voiceover")]), ["voiceover"]);
+  assert.deepEqual(carveSources([voice("vo1", "voiceover")], undefined, []), ["voiceover"]);
 });
 
 test("ungrouped voices keep their ids, so the lint rule can still say so", () => {
   // Not silently inventing a group: `audio_carve_ungrouped_sources` is the
   // right signal here, and it needs the ids to fire on.
-  assert.deepEqual(carveSources([voice("vo1"), voice("vo2")]), ["vo1", "vo2"]);
+  assert.deepEqual(carveSources([voice("vo1"), voice("vo2")], undefined, []), ["vo1", "vo2"]);
 });
 
 test("voices in DIFFERENT groups keep their ids", () => {
   // One carve cannot name two groups, and picking either would silently drop
   // the other's members from the analysis.
   const voices = [voice("vo1", "narration"), voice("vo2", "interview")];
-  assert.deepEqual(carveSources(voices), ["vo1", "vo2"]);
+  assert.deepEqual(carveSources(voices, undefined, []), ["vo1", "vo2"]);
 });
 
 test("a partially grouped set keeps its ids", () => {
   const voices = [voice("vo1", "voiceover"), voice("vo2")];
-  assert.deepEqual(carveSources(voices), ["vo1", "vo2"]);
+  assert.deepEqual(carveSources(voices, undefined, []), ["vo1", "vo2"]);
 });
 
 test("an empty group attribute is not a group", () => {
-  assert.deepEqual(carveSources([voice("vo1", ""), voice("vo2", "")]), ["vo1", "vo2"]);
+  assert.deepEqual(carveSources([voice("vo1", ""), voice("vo2", "")], undefined, []), [
+    "vo1",
+    "vo2",
+  ]);
 });
+
+// The nine cases above pass `[]` explicitly because they predate the membership
+// check and are about the bed and the group attributes alone. `members` is a
+// required argument: with `[]` the `mixed` refusal cannot fire, so a default
+// would let a call that forgot it return the group form and silently undo the
+// widening fix — see the wiring test at the bottom of this file.
 
 test("a bed inside the voices' group keeps clip ids, so it is never its own source", () => {
   // `resolveCarveSourceIds` expands a group to every CURRENT member, and it gets
@@ -76,23 +85,23 @@ test("a bed inside the voices' group keeps clip ids, so it is never its own sour
   // itself. This run cannot see it (main sums the detected voices directly), so
   // the check has to happen here.
   const voices = [voice("vo1", "mix"), voice("vo2", "mix")];
-  assert.deepEqual(carveSources(voices, bed("bgm", "mix")), ["vo1", "vo2"]);
+  assert.deepEqual(carveSources(voices, bed("bgm", "mix"), []), ["vo1", "vo2"]);
 });
 
 test("a bed in a DIFFERENT group leaves the group form alone", () => {
   const voices = [voice("vo1", "voiceover"), voice("vo2", "voiceover")];
-  assert.deepEqual(carveSources(voices, bed("bgm", "music")), ["voiceover"]);
+  assert.deepEqual(carveSources(voices, bed("bgm", "music"), []), ["voiceover"]);
 });
 
 test("an ungrouped bed leaves the group form alone", () => {
-  assert.deepEqual(carveSources([voice("vo1", "voiceover")], bed("bgm")), ["voiceover"]);
+  assert.deepEqual(carveSources([voice("vo1", "voiceover")], bed("bgm"), []), ["voiceover"]);
 });
 
 test("a VIDEO bed is immune — group membership is audio-only", () => {
   // `data-audio-group` on a <video> is ignored by core, so expanding the group
   // can never pull this bed in and declining would be a false positive.
   const voices = [voice("vo1", "mix"), voice("vo2", "mix")];
-  assert.deepEqual(carveSources(voices, bed("clip", "mix", "video")), ["mix"]);
+  assert.deepEqual(carveSources(voices, bed("clip", "mix", "video"), []), ["mix"]);
 });
 
 test("an sfx member of the voices' group blocks the group form", () => {
@@ -215,4 +224,16 @@ test("loadCore honours an import-only export map, as the published core has", ()
     assert.equal(core.carve.marker, "carve");
     assert.equal(core.fx.marker, "fx");
   });
+});
+
+test("members is required, so dropping it cannot silently restore the group form", () => {
+  // The gap this closes: `main()` is the only code that BUILDS `members`, and no
+  // test runs `main()` (the symlink test stops at the usage error, a real run
+  // needs ffmpeg). With `members = []` defaulted, a refactor that dropped the
+  // third argument would return the group form again with the whole suite green
+  // — the same signature as the bug itself: first pass correct, persisted
+  // attribute wrong, nothing red. Omitting it now throws instead.
+  const voices = [voice("vo1", "voiceover"), voice("vo2", "voiceover")];
+  assert.throws(() => carveSources(voices, bed("bgm", "music")), TypeError);
+  assert.throws(() => groupSourceRefusal(voices, bed("bgm", "music")), TypeError);
 });


### PR DESCRIPTION
Found by using the shipped audio-groups/carve feature end to end on a real project (a HyperFrames video built against published `hyperframes@0.8.8`) rather than from inside this repo. Independent of #3413/#3414/#3415 — different files, no shared surface, so it is based on `main` rather than stacked.

## 1. The CLI could not load core at all — for everyone except us

`loadCore` resolved `./audio-carve` and `./audio-fx` with `require.resolve`. Reproduced both ways:

```
# inside this monorepo
require.resolve('@hyperframes/core/audio-carve') -> OK

# against the published package, in a real project
require.resolve('@hyperframes/core/audio-carve') -> ERR_PACKAGE_PATH_NOT_EXPORTED
import('@hyperframes/core/audio-carve')          -> OK, 12 exports
```

The workspace manifest declares a `node` condition, which `require.resolve` matches. The **published** manifest does not:

| | `./audio-carve` |
| --- | --- |
| `packages/core/package.json` `exports` | `{bun, node: ./dist/audioCarve.js, import, types}` |
| `packages/core/package.json` `publishConfig.exports` | `{import: ./dist/audioCarve.js, types}` |

So the script worked in development and failed for the audience it ships to. Its error text made this worse by naming a remedy that cannot work:

> `cannot resolve @hyperframes/core … install or update it: npm i -D @hyperframes/core (the audio-carve export needs a version that ships the carve analysis)`

No install adds a condition the manifest never declares. This cost a full delivery cycle downstream — the carve was recorded as "blocked by a tool defect" and the piece shipped with coarse volume ducking instead.

**Fix:** keep the project anchor (this script lives wherever the skill was installed, so a bare `import(spec)` would resolve against the *skill* directory and find nothing), and fall back to the manifest's declared `import` target when no require-resolvable condition exists. Error message now describes what actually happened.

## 2. It violated the invariant its own SKILL.md sets

`skills/hyperframes-audio/SKILL.md` is unambiguous:

> **A carve against more than one clip id is wrong. Group the clips and carve against the group.** This is an invariant, not a tip.

The script wrote `sources: voices.map((v) => v.id)` unconditionally. So every run against grouped voices emitted output that trips this repo's own `audio_carve_ungrouped_sources` lint rule, and — the reason the invariant exists — a voice added to the group later plays outside the carve's awareness and the bed silently fails to duck under it.

Now: when every detected voice shares one group, record the group. Mixed groups, partial grouping, or no grouping keep the clip ids, so the lint rule still fires on exactly the case it is meant to catch rather than being papered over.

Verified end to end against a real 26-element composition on published core:

- grouped voices → `data-fx-carve.sources = ["voiceover"]`, and `hyperframes check` passes clean
- same composition with the group attributes stripped → `["vo1","vo2","vo3","vo4","vo5"]`

## Notes

`main()` moves behind the standard entry guard so the pure helper can be imported by a test. `node carve.mjs …` is unaffected — re-verified against a real composition after the change.

**Not addressed here, deliberately:** the root cause of (1) is that `publishConfig.exports` omits `node`/`require` for *every* subpath of `@hyperframes/core` (generated by `scripts/package-subpaths.mjs` — `publishedExport()` emits only `{import, types}`, and because the descriptor is read back from the published map the omission is self-perpetuating). That breaks any require-resolving consumer of any published subpath, which is the same class as the known `@hyperframes/sdk` ESM-only issue. It is a packaging-policy change with repo-wide blast radius and belongs in its own PR with a maintainer decision — happy to open it.

## Checks

`node --test` carve suite 6/6 · full `test:skills` **512 passed / 0 failed** · `oxlint` 0/0 · `oxfmt --check` clean · `lint:skills` clean · `check:skill-mirror` OK · `check:tracked-artifacts` OK · `fallow audit --base origin/main` no issues · `skills-manifest.json` regenerated for the changed skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)