### PR TITLE
fix(studio): stop the grouping dialog opening off the bottom of the window

### DIFF
--- a/packages/studio/src/player/components/TimelineFxButton.test.tsx
+++ b/packages/studio/src/player/components/TimelineFxButton.test.tsx
@@ -68,6 +68,37 @@ describe("TimelineFxButton", () => {
     expect(document.querySelector('[role="dialog"]')).toBeTruthy();
   });
 
+  // The reported symptom was "the grouping button did nothing". The dialog WAS
+  // opening — it positioned at `anchorRect.bottom + 4` with no flip and no
+  // clamp, and this button lives in a track header at the bottom of the studio
+  // window, so it opened past the viewport edge. The test below it passed
+  // throughout: happy-dom reports an all-zero rect for an unlaid-out button,
+  // which lands the dialog at top:4 — on screen, and nothing like the app.
+  it("flips the group dialog above the anchor when there is no room below", () => {
+    const host = mount(<TimelineFxButton variant="group-pointer" onGroupClips={vi.fn()} />);
+    const fx = byTextButton(host, "FX");
+    // A track header near the bottom edge of the (1024x768) window.
+    fx!.getBoundingClientRect = () =>
+      ({ left: 300, top: 760, right: 320, bottom: 776, width: 20, height: 16 }) as DOMRect;
+    act(() => fx?.click());
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+    expect(dialog).toBeTruthy();
+    // Above the anchor, and fully inside the viewport: 644 + 112 === 756.
+    expect(dialog.style.top).toBe("644px");
+  });
+
+  it("keeps the group dialog inside the right edge of the window", () => {
+    const host = mount(<TimelineFxButton variant="group-pointer" onGroupClips={vi.fn()} />);
+    const fx = byTextButton(host, "FX");
+    // Hard against the right edge: 224px wide + a 12px margin has to fit.
+    fx!.getBoundingClientRect = () =>
+      ({ left: 1010, top: 100, right: 1024, bottom: 116, width: 14, height: 16 }) as DOMRect;
+    act(() => fx?.click());
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+    expect(dialog.style.left).toBe("788px");
+    expect(dialog.style.top).toBe("120px");
+  });
+
   it("group-pointer variant offers Group instead of a popover", () => {
     const onGroupClips = vi.fn();
     const host = mount(<TimelineFxButton variant="group-pointer" onGroupClips={onGroupClips} />);

--- a/packages/studio/src/player/components/TimelineFxButton.tsx
+++ b/packages/studio/src/player/components/TimelineFxButton.tsx
@@ -18,6 +18,24 @@ import {
 } from "@hyperframes/core/audio-fx";
 import type { HfAudioNameKind } from "@hyperframes/core/audio-carve";
 import { TimelineFxPopover } from "../../components/editor/TimelineFxPopover.js";
+import { resolveFloatingPanelPosition } from "../../components/editor/floatingPanel.js";
+
+// Estimated, like FORMAT_PANEL_SIZE in RenderQueue: `w-56` is exact, and only
+// the flip decision uses the height — the clamp keeps the dialog on screen
+// either way.
+const GROUP_DIALOG_SIZE = { width: 224, height: 112 };
+
+/** Where the grouping dialog goes: flipped above the anchor when there is no
+ *  room below, and clamped so neither edge leaves the viewport. */
+function groupDialogPosition(anchorRect: DOMRect): { left: number; top: number } {
+  const { left, top } = resolveFloatingPanelPosition(
+    anchorRect,
+    { width: window.innerWidth, height: window.innerHeight },
+    GROUP_DIALOG_SIZE,
+    { offset: 4 },
+  );
+  return { left, top };
+}
 
 function parseFxChainOrEmpty(raw: string | undefined): HfAudioFxChain {
   if (!raw) return { version: 1, nodes: [] };
@@ -80,7 +98,12 @@ export function TimelineFxButton(props: TimelineFxButtonProps) {
               role="dialog"
               aria-label="Group these clips to add effects"
               className="z-[200] w-56 rounded-md border border-white/10 bg-[#1b1b1f] p-2.5 text-[11px] text-white/75 shadow-xl"
-              style={{ position: "fixed", left: anchorRect.left, top: anchorRect.bottom + 4 }}
+              // Was `top: anchorRect.bottom + 4` with no flip and no clamp. This
+              // button lives in a track header at the BOTTOM of the studio
+              // window, so the dialog opened past the viewport edge and the
+              // click read as doing nothing at all. Same helper the other body
+              // portals position with.
+              style={{ position: "fixed", ...groupDialogPosition(anchorRect) }}
               onPointerDown={(event) => event.stopPropagation()}
             >
               <p>Group these clips to add effects to all of them.</p>


### PR DESCRIPTION
Supersedes #3417, which was written on top of #3413–#3415 and went stale when those merged. Rebuilt on current `main` and — more importantly — rebuilt on **main's own** `resolveFloatingPanelPosition` rather than the second, parallel helper I had written. Please close #3417 in favour of this.

## The bug

Reported as **"the grouping button didn't work — I clicked it and nothing happened."**

The dialog was opening. It positioned itself raw:

```jsx
style={{ position: "fixed", left: anchorRect.left, top: anchorRect.bottom + 4 }}
```

No flip, no clamp. This button lives in a **track header at the bottom of the studio window**, so `anchorRect.bottom + 4` puts the dialog past the viewport edge. It was the last floating surface in the timeline with no viewport handling at all — the FX popover beside it got its cap in #3413, and every portal got its tier in #3414.

## The fix

It now goes through `resolveFloatingPanelPosition` — the helper `RenderQueue` and `propertyPanelColor` already position with — so it flips above the anchor when there is no room below and clamps so neither edge leaves the viewport.

`GROUP_DIALOG_SIZE` is a declared estimate in the same style as `FORMAT_PANEL_SIZE` and `COLOR_PICKER_SIZE`: `w-56` is exact, only the flip decision reads the height, and the clamp keeps the dialog on screen either way.

Measured in the test: an anchor at `top: 760` in a 768px-tall window previously produced `top: 780px` — 12px below the bottom edge. It now lands at `top: 644px`, fully inside the viewport (644 + 112 = 756, against a 756 limit).

## Why it shipped

The existing `group-pointer` test passes **with or without** the fix. happy-dom reports an all-zero rect for an unlaid-out button, so the dialog landed at `top: 4px` — on screen, and nothing like the real app. A geometry test that never sets a geometry proves nothing.

The two new tests set a realistic anchor: one at the bottom edge, one hard against the right edge. Both verified to fail against the raw positioning and pass with the helper.

## Deliberately not included

A toast for the grouping write's silent `elements.length < 2` bail. The path is real in code — the button renders on `clipCount > 1` while the write bails on *resolved* count — but I could not reach it from the UI: the offer only appears on a track with 2+ ungrouped clips, and sub-composition audio arrives as separate single-clip rows, so the button never renders there. Adding a message for a branch I cannot demonstrate, plus the file split it would force to stay under the 600-line studio cap, is not justified by the evidence I have.

Also worth recording from chasing this: I reproduced the environment on both the dev build and published `0.8.8` and **could not reproduce a failing write**. Clicking the real button groups the clips and updates the timeline. My first "reproduction" was my own test error — a text-match click that hit the paragraph rather than the button.

## Checks

`tsc --noEmit` clean · full studio suite **4380 passed / 0 failed** · `oxlint` 0/0 · `oxfmt --check` clean · `fallow audit --base origin/main` no issues (its one duplication finding is inherited) · both touched files well under the 600-line limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)