### PR TITLE
chore: release v0.8.9

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,53 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.9"
+  description="Released - 2026-08-22"
+  tags={["Release", "Audio", "Studio", "Skills"]}
+>
+The last release turned the audio effects rack on for everyone. This one fixes
+what people hit first when they used it, and documents the whole system.
+
+## Features
+
+- **Engine:** Renders no longer finish with the drawElement self-check silently
+  switched off. That check compares frames with ffmpeg's `psnr` filter, and an
+  ffmpeg built without it made every comparison fail quietly. HyperFrames now
+  tests for the filter once at startup and captures by screenshot instead when it
+  is missing ([073b098e2](https://github.com/heygen-com/hyperframes/commit/073b098e21aa006571b60c446711c6dff57a2eac), [#3418](https://github.com/heygen-com/hyperframes/pull/3418)).
+
+## Fixes
+
+- **Studio:** The effects preset list on a timeline track no longer runs off the
+  top or bottom of the window. It fits the space it opens into and scrolls, so
+  every preset and both footer buttons stay reachable ([277fe0fa2](https://github.com/heygen-com/hyperframes/commit/277fe0fa221756480928605d71590ead55cbfb64), [#3413](https://github.com/heygen-com/hyperframes/pull/3413)).
+- **Studio:** The timeline's popovers and menus can no longer be painted behind
+  other parts of the app. Every panel that floats above the timeline now sits on
+  the same layer as the rest of the studio's popovers ([8612cfd40](https://github.com/heygen-com/hyperframes/commit/8612cfd40fcfd2d4dae6bff6b9b9ac940c7e7bbd), [#3414](https://github.com/heygen-com/hyperframes/pull/3414)).
+- **Studio:** The expand arrow on an audio group row is back to the size and
+  shape the properties panel uses, instead of a smaller rotated one ([c59402389](https://github.com/heygen-com/hyperframes/commit/c59402389555ef2fca455e504fa40c5773354cf3), [#3415](https://github.com/heygen-com/hyperframes/pull/3415)).
+- **Skills:** The voiceover carve command now runs in your own project. It could
+  not load HyperFrames from a published install at all, and the error it printed
+  suggested reinstalling, which never helped. It also records the voice group
+  rather than a list of clip ids, so a narration clip added later is covered
+  without editing the carve ([f0cc9b1a3](https://github.com/heygen-com/hyperframes/commit/f0cc9b1a3441522797cfe06dc3892ac2065c7bf2), [#3416](https://github.com/heygen-com/hyperframes/pull/3416)).
+- **Producer, CLI:** A render that cannot find its manifest now lists every path
+  it looked in, instead of naming one ([718bf5ef3](https://github.com/heygen-com/hyperframes/commit/718bf5ef32d4e521f686ea6ebe64545a6a2647ed), [#3387](https://github.com/heygen-com/hyperframes/pull/3387)).
+
+## Docs & Examples
+
+- **Audio:** The audio effects system is documented. There are new pages for
+  [mixing and presets](/studio/audio-effects), the [voiceover
+  carve](/studio/voiceover-carve), [groups, mute and
+  solo](/studio/audio-groups), and [automation
+  lanes](/studio/audio-automation), plus a [full
+  reference](/reference/audio-effects) covering every effect, parameter range,
+  preset, and attribute ([0eca7b1e0](https://github.com/heygen-com/hyperframes/commit/0eca7b1e0aef831bbab1265395f942378468afc0), [#3420](https://github.com/heygen-com/hyperframes/pull/3420)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.8...v0.8.9).
+</Update>
+
+<Update
   label="HyperFrames v0.8.8"
   description="Released - 2026-08-22"
   tags={["Release", "Audio", "CLI", "Engine"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.9.md
+++ b/releases/v0.8.9.md
@@ -1,0 +1,43 @@
+# HyperFrames v0.8.9
+
+Released on 2026-08-22.
+
+The last release turned the audio effects rack on for everyone. This one fixes
+what people hit first when they used it, and documents the whole system.
+
+## Features
+
+- **Engine:** Renders no longer finish with the drawElement self-check silently
+  switched off. That check compares frames with ffmpeg's `psnr` filter, and an
+  ffmpeg built without it made every comparison fail quietly. HyperFrames now
+  tests for the filter once at startup and captures by screenshot instead when it
+  is missing ([073b098e2](https://github.com/heygen-com/hyperframes/commit/073b098e21aa006571b60c446711c6dff57a2eac), [#3418](https://github.com/heygen-com/hyperframes/pull/3418)).
+
+## Fixes
+
+- **Studio:** The effects preset list on a timeline track no longer runs off the
+  top or bottom of the window. It fits the space it opens into and scrolls, so
+  every preset and both footer buttons stay reachable ([277fe0fa2](https://github.com/heygen-com/hyperframes/commit/277fe0fa221756480928605d71590ead55cbfb64), [#3413](https://github.com/heygen-com/hyperframes/pull/3413)).
+- **Studio:** The timeline's popovers and menus can no longer be painted behind
+  other parts of the app. Every panel that floats above the timeline now sits on
+  the same layer as the rest of the studio's popovers ([8612cfd40](https://github.com/heygen-com/hyperframes/commit/8612cfd40fcfd2d4dae6bff6b9b9ac940c7e7bbd), [#3414](https://github.com/heygen-com/hyperframes/pull/3414)).
+- **Studio:** The expand arrow on an audio group row is back to the size and
+  shape the properties panel uses, instead of a smaller rotated one ([c59402389](https://github.com/heygen-com/hyperframes/commit/c59402389555ef2fca455e504fa40c5773354cf3), [#3415](https://github.com/heygen-com/hyperframes/pull/3415)).
+- **Skills:** The voiceover carve command now runs in your own project. It could
+  not load HyperFrames from a published install at all, and the error it printed
+  suggested reinstalling, which never helped. It also records the voice group
+  rather than a list of clip ids, so a narration clip added later is covered
+  without editing the carve ([f0cc9b1a3](https://github.com/heygen-com/hyperframes/commit/f0cc9b1a3441522797cfe06dc3892ac2065c7bf2), [#3416](https://github.com/heygen-com/hyperframes/pull/3416)).
+- **Producer, CLI:** A render that cannot find its manifest now lists every path
+  it looked in, instead of naming one ([718bf5ef3](https://github.com/heygen-com/hyperframes/commit/718bf5ef32d4e521f686ea6ebe64545a6a2647ed), [#3387](https://github.com/heygen-com/hyperframes/pull/3387)).
+
+## Docs & Examples
+
+- **Audio:** The audio effects system is documented. There are new pages for
+  mixing and presets, the voiceover carve, groups and mute and solo, and
+  automation lanes, plus a full reference covering every effect, parameter range,
+  preset, and attribute ([0eca7b1e0](https://github.com/heygen-com/hyperframes/commit/0eca7b1e0aef831bbab1265395f942378468afc0), [#3420](https://github.com/heygen-com/hyperframes/pull/3420)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.8...v0.8.9


### PR DESCRIPTION
Stable release. **Merging this PR publishes** — the workflow checks out the merge SHA, verifies it, creates the `v0.8.9` tag there, publishes the npm packages, and cuts the GitHub release using `releases/v0.8.9.md` as its body.

I stopped at opening the PR deliberately: the publish is the irreversible step and the process puts it behind a human merge.

## What ships

Seven commits since `v0.8.8`, all already reviewed and merged to `main`.

| | Change |
| --- | --- |
| Feature | #3418 — renders no longer finish with the drawElement self-check silently switched off |
| Fix | #3413 — the timeline effects preset list stays on screen and scrolls |
| Fix | #3414 — the timeline's popovers can no longer be painted behind other chrome |
| Fix | #3415 — the audio group row's expand arrow matches the panel's again |
| Fix | #3416 — the voiceover carve command runs against a published install, and records the voice group |
| Fix | #3387 — a missing-manifest error lists every path it tried |
| Docs | #3420 — the audio effects system is documented |

Release notes are rewritten for users rather than left as commit subjects, per `docs/contributing/changelog-process.mdx`. `releases/v0.8.9.md` and the `docs/changelog.mdx` `<Update>` entry are in sync.

## Version

`0.8.9`, a patch bump, consistent with `v0.8.8` — which also carried a Features section. Say so and I will redo it as `0.9.0` if the psnr preflight is considered feature-weight enough to deserve a minor.

## Checks run locally

- `bun run verify:packed-manifests` — 122 packed exports resolved, 117 executed, clean packed-consumer install, Node execution, TypeScript/Vite resolution, and CLI startup all verified.
- `validate-release-channel` simulated with the merged-PR inputs (`VERSION=0.8.9 DIST_TAG=latest EVENT_NAME=pull_request PR_HEAD_REF=release/v0.8.9`) — validated for `latest`.
- `mint validate` and `mint broken-links` — the new changelog entry renders and its links to the new audio pages resolve.
- All 14 publishable packages plus the three plugin manifests are at `0.8.9`.
- Local `v0.8.9` tag was **not** pushed.

## One thing to decide, separately from this release

The release commit needed `HF_MAX_NONLFS_KB=600` to get past the `largefiles` pre-commit hook. `docs/changelog.mdx` has grown to **502 KB** and the guard's default limit is 500 KB, so **every future release trips this**.

The guard is explicitly aimed at binaries — its own header names ONNX models and MP4s — and `changelog.mdx` is text that Mintlify has to read, so routing it through LFS would break the docs site. It needs one of: archiving older entries to a second page, exempting that path in the hook, or raising the default. That is a maintenance decision rather than something to slip into a release commit, so I have left it and am flagging it here.

Not in this release: #3421, which is open and unreviewed.