### PR TITLE
chore: release v0.8.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,20 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.10"
+  description="Released - 2026-08-22"
+  tags={["Release", "Studio"]}
+>
+When a render fails to reach the Studio server, the error now says why. Before, every cause showed the same message, so a failure you could repeat every time still gave you nothing to act on.
+
+## Fixes
+
+- **Studio:** Name the cause when a render request fails ([7a024cf68](https://github.com/heygen-com/hyperframes/commit/7a024cf68ee64b13ad6d7694b19efb252c0ce699), [#3424](https://github.com/heygen-com/hyperframes/pull/3424)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.9...v0.8.10).
+</Update>
+
+<Update
   label="HyperFrames v0.8.9"
   description="Released - 2026-08-22"
   tags={["Release", "Audio", "Studio", "Skills"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.10.md
+++ b/releases/v0.8.10.md
@@ -1,0 +1,13 @@
+# HyperFrames v0.8.10
+
+Released on 2026-08-22.
+
+When a render fails to reach the Studio server, the error now says why. Before, every cause showed the same message, so a failure you could repeat every time still gave you nothing to act on.
+
+## Fixes
+
+- **Studio:** Name the cause when a render request fails ([7a024cf68](https://github.com/heygen-com/hyperframes/commit/7a024cf68ee64b13ad6d7694b19efb252c0ce699), [#3424](https://github.com/heygen-com/hyperframes/pull/3424)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.9...v0.8.10


### PR DESCRIPTION
Stable release. **Merging this PR publishes** — the workflow checks out the merge SHA, creates the `v0.8.10` tag there, publishes the npm packages, and cuts the GitHub release using `releases/v0.8.10.md` as its body.

I stopped at opening the PR deliberately: the publish is the irreversible step and the process puts it behind a human merge. The local tag was **not** pushed.

## What ships

One commit since `v0.8.9`:

- **Studio: name the cause when a render request fails** ([#3424](https://github.com/heygen-com/hyperframes/pull/3424))

Studio's render POST caught its error without binding it, so every transport failure — a dead server, a DNS error, an aborted request, a server that died mid-render — surfaced as one sentence. That string also travels into the feedback report, so failures that reproduce every time still arrived with nothing to act on. The cause is now named alongside the existing CLI guidance.

That is the whole release. It is small on purpose: the observability is worth shipping ahead of the other fixes in flight.

## One thing to know before merging

The pre-commit `largefiles` hook refused this commit:

```
ERROR: large binaries are being committed to git instead of LFS.
       (limit: 500 KB - override per-commit with HF_MAX_NONLFS_KB)
  - docs/changelog.mdx (503 KB)
```

I used the hook's own documented escape (`HF_MAX_NONLFS_KB=1024`), not `--no-verify`, so the
check still ran and still reported. Why that is the right call rather than a bypass:

**The file is fine.** 514 KB across 5237 lines is 170 release entries at ~3 KB each. No
embedded blob, longest line 717 characters. It is exactly what 170 releases of notes weigh.

**The check misclassifies it.** `scripts/check-large-files.sh` exists to catch *binaries*
committed straight into the pack instead of LFS - that is its comment, its error message and
its name. But it has no binary detection: it exempts symlinks, `registry/*` and LFS-tracked
paths, then judges everything else on `wc -c` alone. A line-diffable markdown source trips a
binary guard that never checks for binaries.

**Its suggested fix would be wrong here.** The error tells you to add an LFS pattern. A
changelog is text that belongs in git history and diffs line-by-line; routing it through LFS
to satisfy a binary rule would be the wrong trade.

So the fix belongs in the check (exempt text, or at least `.md`/`.mdx`), not in the
changelog. Until then every release trips it, because the file only grows. Splitting the
changelog may still be worth doing for docs rendering - 170 entries on one page is a lot -
but that is a separate argument from this hook.

## Not in this release

- [#3425](https://github.com/heygen-com/hyperframes/pull/3425) (unwritable font cache aborting a render) was still in CI when this was cut.
