### PR TITLE
docs: say one paused ROOT timeline, not "timelines must be paused"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ skills/                 → AI agent skill definitions
 - **Package manager**: bun (not pnpm, not npm for workspace operations)
 - **Commit format**: Conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`)
 - **TypeScript**: Avoid `any` and `as T` assertions. Prefer type guards and narrowing.
-- **Compositions**: HTML files with `data-*` attributes. Clips need `class="clip"`. GSAP timelines must be paused and registered on `window.__timelines`.
+- **Compositions**: HTML files with `data-*` attributes. Clips need `class="clip"`. Each composition registers **exactly one** paused GSAP timeline on `window.__timelines`. Don't nest your own paused sub-timelines into it: a paused child never advances when the root is seeked, so the render comes out blank.
 - **Frame Adapters**: Animation runtimes plug in via the seek-by-frame adapter pattern. GSAP is the primary adapter.
 - **Deterministic rendering**: No `Date.now()`, no unseeded `Math.random()`, no render-time network fetches.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ skills/                 → AI agent skill definitions
 - **Package manager**: bun (not pnpm, not npm for workspace operations)
 - **Commit format**: Conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`)
 - **TypeScript**: Avoid `any` and `as T` assertions. Prefer type guards and narrowing.
-- **Compositions**: HTML files with `data-*` attributes. Clips need `class="clip"`. GSAP timelines must be paused and registered on `window.__timelines`.
+- **Compositions**: HTML files with `data-*` attributes. Clips need `class="clip"`. Each composition registers **exactly one** paused GSAP timeline on `window.__timelines`. Don't nest your own paused sub-timelines into it: a paused child never advances when the root is seeked, so the render comes out blank.
 - **Frame Adapters**: Animation runtimes plug in via the seek-by-frame adapter pattern. GSAP is the primary adapter.
 - **Deterministic rendering**: No `Date.now()`, no unseeded `Math.random()`, no render-time network fetches.
 

--- a/packages/cli/src/templates/_shared/AGENTS.md
+++ b/packages/cli/src/templates/_shared/AGENTS.md
@@ -90,11 +90,15 @@ Fix all errors before presenting the result. Warnings should be reviewed before 
 
 1. Every timed element needs `data-start`, `data-duration`, and `data-track-index`
 2. Elements with timing **MUST** have `class="clip"` — the framework uses this for visibility control
-3. Timelines must be paused and registered on `window.__timelines`:
+3. Register **exactly one** paused timeline per composition on `window.__timelines`:
    ```js
    window.__timelines = window.__timelines || {};
    window.__timelines["composition-id"] = gsap.timeline({ paused: true });
    ```
+   Only that registered timeline is paused. Don't build scene timelines as
+   `gsap.timeline({ paused: true })` and `.add()` them into it — a paused child
+   never advances when the root is seeked, so every frame renders the t=0 state
+   and the video comes out blank with no warning from lint, check or validate.
 4. Videos use `muted` with a separate `<audio>` element for the audio track
 5. Sub-compositions use `data-composition-src="compositions/file.html"` to reference other HTML files
 6. Only deterministic logic — no `Date.now()`, no `Math.random()`, no network fetches

--- a/packages/cli/src/templates/_shared/CLAUDE.md
+++ b/packages/cli/src/templates/_shared/CLAUDE.md
@@ -90,11 +90,15 @@ Fix all errors before presenting the result. Warnings should be reviewed before 
 
 1. Every timed element needs `data-start`, `data-duration`, and `data-track-index`
 2. Elements with timing **MUST** have `class="clip"` — the framework uses this for visibility control
-3. Timelines must be paused and registered on `window.__timelines`:
+3. Register **exactly one** paused timeline per composition on `window.__timelines`:
    ```js
    window.__timelines = window.__timelines || {};
    window.__timelines["composition-id"] = gsap.timeline({ paused: true });
    ```
+   Only that registered timeline is paused. Don't build scene timelines as
+   `gsap.timeline({ paused: true })` and `.add()` them into it — a paused child
+   never advances when the root is seeked, so every frame renders the t=0 state
+   and the video comes out blank with no warning from lint, check or validate.
 4. Videos use `muted` with a separate `<audio>` element for the audio track
 5. Sub-compositions use `data-composition-src="compositions/file.html"` to reference other HTML files
 6. Only deterministic logic — no `Date.now()`, no `Math.random()`, no network fetches


### PR DESCRIPTION
## What

The four compressed copies of the timeline contract now say what the skill says: **one**
paused timeline, the registered root, and don't nest your own paused sub-timelines into it.

## Why

`skills/hyperframes-core/SKILL.md` has always been correct:

> Each composition registers **exactly one** `gsap.timeline({ paused: true })` ... Don't
> manually nest sub-timelines into the host.

Every compressed copy dropped both halves:

> GSAP timelines must be paused and registered on `window.__timelines`.

Plural, no cap, no warning against nesting. An author following *that* writes a paused
timeline per scene and combines them with `.add()` — exactly the shape that renders black,
because a paused child never advances when the root is seeked. Every frame is the t=0 state,
and `lint`, `check` and `validate` all pass, none of them looking at pixels.

This is the drift the skill-catalog sync rule exists to prevent: a compressed copy asserting
something the skill does not.

## How

Four surfaces, all previously carrying the same sentence:

- `CLAUDE.md`
- `AGENTS.md`
- `packages/cli/src/templates/_shared/CLAUDE.md`
- `packages/cli/src/templates/_shared/AGENTS.md`

The two template files are written into every `hyperframes init` project and must stay
byte-identical — verified with `diff -q` after the edit.

## Relationship to #3427

[#3427](https://github.com/heygen-com/hyperframes/pull/3427) makes the runtime repair this
shape, so nobody following the old wording is stuck. This PR stops it being authored in the
first place. Either alone is a partial fix: the runtime one leaves the misleading guidance in
place, and this one leaves every existing composition broken.

## Not covered

- `docs/` prose is untouched; a grep for the old sentence across `docs/`, `README.md` and
  `docs/guides/` returns nothing, so these four were the whole set.
- No lint rule. #3427's runtime repair cannot be evaded, so a static rule would only
  duplicate it for the subset it can see.
