### PR TITLE
Fix Windows console window for chrome-headless-shell

### DIFF
--- a/packages/cli/src/beats/headlessAnalyzer.ts
+++ b/packages/cli/src/beats/headlessAnalyzer.ts
@@ -140,6 +140,8 @@ export async function analyzeBeatsHeadless(audioBytes: Buffer): Promise<Headless
   const browser = await ensureBrowser();
   const chrome: Browser = await puppeteer.default.launch({
     headless: true,
+      // @ts-ignore -- windowsHide not in PuppeteerLaunchOptions but forwarded to spawn on Windows (see #3430)
+      windowsHide: true,
     executablePath: browser.executablePath,
     args: ["--no-sandbox", "--disable-dev-shm-usage", "--autoplay-policy=no-user-gesture-required"],
   });

--- a/packages/cli/src/capture/captureCompositionFrame.ts
+++ b/packages/cli/src/capture/captureCompositionFrame.ts
@@ -182,6 +182,8 @@ export async function openSettledCompositionPage(
   try {
     chromeBrowser = await puppeteer.default.launch({
       headless: true,
+      // @ts-ignore -- windowsHide not in PuppeteerLaunchOptions but forwarded to spawn on Windows (see #3430)
+      windowsHide: true,
       executablePath: browser.executablePath,
       args: buildChromeArgs(
         { ...viewport, captureMode: "screenshot" },

--- a/packages/cli/src/capture/index.ts
+++ b/packages/cli/src/capture/index.ts
@@ -128,6 +128,8 @@ export async function captureWebsite(
   const puppeteer = await import("puppeteer-core");
   const chromeBrowser = await puppeteer.default.launch({
     headless: true,
+      // @ts-ignore -- windowsHide not in PuppeteerLaunchOptions but forwarded to spawn on Windows (see #3430)
+      windowsHide: true,
     executablePath: browser.executablePath,
     protocolTimeout: captureProtocolTimeoutMs(timeout, budgetMs),
     args: [

--- a/packages/cli/src/commands/layout.ts
+++ b/packages/cli/src/commands/layout.ts
@@ -223,6 +223,8 @@ async function runLayoutAudit(
     assertWebGpuRequirement(html, requestedGpuMode, resolvedGpuMode);
     chromeBrowser = await puppeteer.default.launch({
       headless: true,
+      // @ts-ignore -- windowsHide not in PuppeteerLaunchOptions but forwarded to spawn on Windows (see #3430)
+      windowsHide: true,
       executablePath: browser.executablePath,
       args: buildChromeArgs(
         { width: 1920, height: 1080, captureMode: "screenshot" },

--- a/packages/cli/src/commands/motionShot.ts
+++ b/packages/cli/src/commands/motionShot.ts
@@ -293,6 +293,8 @@ async function openCompositionPage(
   assertWebGpuRequirement(html, requestedGpuMode, resolvedGpuMode);
   const browser = await puppeteer.default.launch({
     headless: true,
+      // @ts-ignore -- windowsHide not in PuppeteerLaunchOptions but forwarded to spawn on Windows (see #3430)
+      windowsHide: true,
     executablePath,
     args: buildChromeArgs(
       { ...size, captureMode: "screenshot" },

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -428,6 +428,8 @@ async function validateInBrowser(
     assertWebGpuRequirement(html, requestedGpuMode, resolvedGpuMode);
     const chromeBrowser = await puppeteer.default.launch({
       headless: true,
+      // @ts-ignore -- windowsHide not in PuppeteerLaunchOptions but forwarded to spawn on Windows (see #3430)
+      windowsHide: true,
       executablePath: browser.executablePath,
       args: buildChromeArgs(
         { ...viewport, captureMode: "screenshot" },

--- a/packages/engine/src/services/browserManager.ts
+++ b/packages/engine/src/services/browserManager.ts
@@ -77,7 +77,11 @@ async function probeHardwareWebGlInfo(
       defaultViewport: { width: 64, height: 64 },
       executablePath: options.executablePath,
       timeout: options.browserTimeout,
-    });
+      // Prevent visible console window on Windows for console-subsystem
+      // chrome-headless-shell.exe (see #3430).
+      // @ts-ignore -- windowsHide not in PuppeteerLaunchOptions but forwarded to spawn on Windows (see #3430)
+      windowsHide: true,
+    } as any);
     const page = await probeBrowser.newPage();
     return await page.evaluate(() => {
       const unavailable = { hasWebGL: false, vendor: "", renderer: "" };
@@ -701,7 +705,11 @@ async function launchBrowser(
       executablePath: fingerprint.executablePath,
       timeout: fingerprint.browserTimeoutMs,
       protocolTimeout: fingerprint.protocolTimeoutMs,
-    });
+      // Prevent visible console window on Windows for console-subsystem
+      // chrome-headless-shell.exe (see #3430).
+      // @ts-ignore -- windowsHide not in PuppeteerLaunchOptions but forwarded to spawn on Windows (see #3430)
+      windowsHide: true,
+    } as any);
 
     const browserVersion = await browser.version().catch(() => "unknown");
     const gpuFlags = fingerprint.args.filter(

--- a/packages/producer/src/parity-harness.ts
+++ b/packages/producer/src/parity-harness.ts
@@ -314,6 +314,8 @@ async function run(): Promise<void> {
   const browser = await puppeteer.launch({
     ...browserTarget,
     headless: true,
+      // @ts-ignore -- windowsHide not in PuppeteerLaunchOptions but forwarded to spawn on Windows (see #3430)
+      windowsHide: true,
     defaultViewport: {
       width: options.width,
       height: options.height,

--- a/packages/studio/vite.browser.ts
+++ b/packages/studio/vite.browser.ts
@@ -103,6 +103,8 @@ async function getSharedBrowser(): Promise<import("puppeteer-core").Browser | nu
     if (!executablePath) return null;
     browser = await puppeteer.default.launch({
       headless: true,
+      // @ts-ignore -- windowsHide not in PuppeteerLaunchOptions but forwarded to spawn on Windows (see #3430)
+      windowsHide: true,
       executablePath,
       args: [
         "--no-sandbox",


### PR DESCRIPTION
Fixes #3430

### Problem

On Windows, every `npx hyperframes render` flashed a visible CMD/console window for each shot (78 windows for 78 shots). `chrome-headless-shell.exe` is a console-subsystem binary, so Node's `child_process.spawn` shows a console window unless `windowsHide: true` (`CREATE_NO_WINDOW`) is set. `puppeteer-core`'s `launch` spawns the browser without `windowsHide` by default, so the window was visible on every launch, even from GUI apps with no terminal.

### Change

Add `windowsHide: true` to all `puppeteer.launch` sites so the browser is launched hidden on Windows:

- `packages/engine/src/services/browserManager.ts` (pooled browser for `hyperframes render`)
- `packages/cli/src/capture/*`, `packages/cli/src/beats/headlessAnalyzer.ts`, `packages/cli/src/commands/*`, `packages/studio/vite.browser.ts`, `packages/producer/src/parity-harness.ts`

On non-Windows platforms `windowsHide` is ignored.

### Validation

- `git diff --check` clean
- Change is isolated to `puppeteer.launch` options; existing `chrome-headless-shell` path resolution and launch-arg tests expected to be unaffected
