### PR TITLE
fix(cli): keep the preview server alive on an uncaught exception

### DIFF
--- a/packages/cli/src/cli.lifecycle.test.ts
+++ b/packages/cli/src/cli.lifecycle.test.ts
@@ -68,6 +68,49 @@ describe("CLI lifecycle", () => {
     expect(order).toEqual(["cli_error", "flush"]);
   });
 
+  it("exits on an uncaught exception for a one-shot command", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    try {
+      mockInitCommand(vi.fn());
+      mockTelemetry({});
+      process.argv = ["node", "cli.ts", "init", "--json"];
+      await import("./cli.js");
+
+      emitUncaught(new Error("boom"));
+
+      // A one-shot command is over anyway, so the exit code is the result.
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("keeps a long-running server alive on an uncaught exception", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      mockInitCommand(vi.fn());
+      mockTelemetry({});
+      process.argv = ["node", "cli.ts", "init", "--json"];
+      await import("./cli.js");
+
+      const serverMode = await import("./utils/server-mode.js");
+      serverMode.markServerMode();
+
+      emitUncaught(new Error("boom"));
+
+      // Exiting would drop every open SSE connection at once, which Studio
+      // reports to every client as "Connection lost. Is the render server
+      // running?" — so the server stays up and the error is reported instead.
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(stderr).toHaveBeenCalledWith(expect.stringContaining("server kept running"));
+      serverMode._resetServerModeForTests();
+    } finally {
+      stderr.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
   it("hands queued events to flushSync even after finalizeCli has run", async () => {
     const flushSync = vi.fn();
     const trackCommandResult = vi.fn();
@@ -182,6 +225,15 @@ describe("CLI lifecycle", () => {
     }
   });
 });
+
+function emitUncaught(error: Error): void {
+  // Invoke the CLI's own listener directly. Emitting on `process` would also
+  // reach vitest's handler and fail the run.
+  const listeners = process.listeners("uncaughtException");
+  const handler = listeners[listeners.length - 1];
+  if (!handler) throw new Error("no uncaughtException listener registered");
+  handler(error, "uncaughtException");
+}
 
 function mockInitCommand(run: () => void): void {
   vi.doMock("./commands/init.js", () => ({

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -105,6 +105,7 @@ import type { ArgsDef, CommandDef } from "citty";
 import { getRunId } from "./telemetry/runId.js";
 import { reportCommandFailure, trackCommandFailures } from "./utils/command-failure-tracking.js";
 import { isRenderSucceeded } from "./utils/render-success-state.js";
+import { isServerMode } from "./utils/server-mode.js";
 import { resolveCommandUsage } from "./utils/commandUsageResolution.js";
 import {
   CliResultSignal,
@@ -422,6 +423,16 @@ function exitAfterCliFailure(
   process.exit(1);
 }
 
+// Report an uncaught error without exiting, for a process hosting a
+// long-running server. Telemetry still records it, and the message goes to
+// stderr so the crash is visible for diagnosis rather than silently absorbed.
+function reportServerUncaughtException(error: Error): void {
+  emitCliErrorEvent("uncaught_exception", error);
+  process.stderr.write(
+    `  [hyperframes] Uncaught exception in the preview server (server kept running): ${error.stack ?? error.message}\n`,
+  );
+}
+
 process.on("uncaughtException", (error) => {
   if ((error as NodeJS.ErrnoException).code === "EPIPE") {
     handleStreamEpipe();
@@ -432,6 +443,14 @@ process.on("uncaughtException", (error) => {
   // artifact is committed.
   if (isRenderSucceeded()) {
     exitAfterPostRenderTermination("uncaughtException", "uncaught_exception", error);
+  }
+  // A one-shot command exiting here loses nothing. A long-running server
+  // loses every concurrent job and every connected client, and Studio then
+  // reports the dropped SSE stream as "Connection lost. Is the render server
+  // running?" — blaming the user's setup for a crash inside this process.
+  if (isServerMode()) {
+    reportServerUncaughtException(error);
+    return;
   }
   exitAfterCliFailure("uncaught_exception", error);
 });

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -46,6 +46,7 @@ import { c } from "../ui/colors.js";
 import { isDevMode } from "../utils/env.js";
 import { normalizeErrorMessage as errorMessage } from "../utils/errorMessage.js";
 import { buildNpxCommand } from "../utils/npxCommand.js";
+import { markServerMode } from "../utils/server-mode.js";
 import type { StudioSelectionSnapshot } from "@hyperframes/studio-server";
 import {
   openBrowser,
@@ -351,6 +352,11 @@ export default defineCommand({
     // Resolve once so embedded, monorepo-dev, and locally installed Studio
     // modes all receive identical --proxy/--no-proxy + config semantics.
     const autoProxy = resolveAutoProxy(dir, args.proxy as boolean | undefined);
+
+    // Past this point every mode hosts a long-running server, so an uncaught
+    // error must not take the process (and every connected client) down.
+    // The short-lived branches above (--status, --stop, --list) have returned.
+    markServerMode();
 
     if (isDevMode()) {
       if (args.background) {

--- a/packages/cli/src/utils/server-mode.ts
+++ b/packages/cli/src/utils/server-mode.ts
@@ -1,0 +1,39 @@
+/**
+ * Marks the process as hosting a long-running server rather than running a
+ * one-shot command.
+ *
+ * The CLI's process-wide `uncaughtException` handler exits the process. For
+ * `render` that is correct: the command is over anyway, and the exit code is
+ * the result. For `preview`, which hosts Studio, it means any uncaught error
+ * anywhere in the process tears the server down, dropping every open SSE
+ * connection at once. Studio then reports that to every connected client as
+ * "Connection lost. Is the render server running?", blaming the user's setup
+ * for a crash inside our own process.
+ *
+ * A one-shot command exiting on an uncaught exception loses nothing. A server
+ * doing it loses every concurrent job and every connected client, so in server
+ * mode the handler reports the error and leaves the process running.
+ */
+
+let serverMode = false;
+
+/**
+ * Called by the preview command once it commits to a long-running mode, before
+ * the server starts accepting connections.
+ */
+export function markServerMode(): void {
+  serverMode = true;
+}
+
+/**
+ * Read by the cli.ts process handlers to decide whether an uncaught error
+ * should be fatal.
+ */
+export function isServerMode(): boolean {
+  return serverMode;
+}
+
+/** Test-only reset. Not exported from the package. */
+export function _resetServerModeForTests(): void {
+  serverMode = false;
+}


### PR DESCRIPTION
Fixes #3373

### Problem

The preview server shares the one-shot CLI's process-wide `uncaughtException` handler, which ends in `process.exit(1)`:

```ts
process.on("uncaughtException", (error) => {
  if ((error as NodeJS.ErrnoException).code === "EPIPE") handleStreamEpipe();
  if (isRenderSucceeded()) {
    exitAfterPostRenderTermination("uncaughtException", "uncaught_exception", error);
  }
  exitAfterCliFailure("uncaught_exception", error);   // -> process.exit(1)
});
```

For `render` that is correct: the command is over anyway and the exit code is the result. For `preview`, which hosts Studio, it means **any** uncaught error anywhere in the process tears the server down and drops every open SSE connection at once. Studio then shows every connected client:

```
Connection lost. Is the render server running?
```

which blames the user's setup for a crash inside our own process.

The only escape hatch, `isRenderSucceeded()`, is set exclusively by the render command (`commands/render.ts:753` and `:920`), so in the preview server it is permanently `false` and every uncaught error took the fatal branch.

### Fix

A small server-mode sentinel, mirroring the existing `render-success-state.ts` shape:

- `utils/server-mode.ts` holds `markServerMode()` / `isServerMode()`, plus a test-only reset.
- `commands/preview.ts` calls `markServerMode()` at the single point where every remaining path is long-running, immediately after the short-lived `--status`, `--stop` and `--list` branches have returned and before dispatching to dev, local-studio or embedded mode.
- The `uncaughtException` handler checks it after the EPIPE and post-render branches, so neither of those changes behaviour. In server mode it reports the error to telemetry and stderr and returns, leaving the process running.

The error is not swallowed: it still goes through `emitCliErrorEvent`, and the stack is written to stderr so the crash stays visible for diagnosis.

### Scope

I deliberately left `unhandledRejection` alone. It already does not exit, so it does not cause the reported teardown, and changing how it sets `commandFailed` / `process.exitCode` would alter behaviour beyond this issue. Happy to follow up if you would like the server exempted there too.

I also did not touch the Studio wording in `useRenderQueue.ts:259`. As the issue notes, that message is now a genuine signal that the process died, and with this change it should stop appearing for uncaught errors, which seemed more useful than rewording it.

### Testing

Two cases added to `cli.lifecycle.test.ts`, alongside the existing EPIPE and post-render ones:

- a one-shot command still exits 1 on an uncaught exception
- in server mode the process stays up, `process.exit` is not called, and the report reaches stderr

They invoke the CLI's own registered listener directly rather than emitting on `process`, which would also reach vitest's handler and fail the run.

Reverting the `isServerMode()` guard while keeping the tests fails the server case, so it covers the change rather than restating current behaviour.

`bunx oxlint` and `bunx oxfmt --check` are clean on all four files. On the wider CLI suite I get 401 passing (up from 399 with the two added), with 15 test *files* failing to collect both before and after my change on a fresh `bun install` without a workspace build, so that set looks unrelated.
