### PR TITLE
fix(engine): treat a sentineled cache entry with no frames as a miss

### DIFF
--- a/packages/engine/src/services/extractionCache.test.ts
+++ b/packages/engine/src/services/extractionCache.test.ts
@@ -227,11 +227,36 @@ describe("lookupCacheEntry / markCacheEntryComplete", () => {
   it("hits after ensureCacheEntryDir + markCacheEntryComplete", () => {
     const first = lookupCacheEntry(tmpRoot, base(sourceFile));
     ensureCacheEntryDir(first.entry);
+    writeFileSync(join(first.entry.dir, "frame_00001.jpg"), "x", "utf-8");
     markCacheEntryComplete(first.entry);
 
     const second = lookupCacheEntry(tmpRoot, base(sourceFile));
     expect(second.hit).toBe(true);
     expect(second.entry.dir).toBe(first.entry.dir);
+  });
+
+  it("treats a sentineled entry with no frames as a miss", () => {
+    const first = lookupCacheEntry(tmpRoot, base(sourceFile));
+    ensureCacheEntryDir(first.entry);
+    writeFileSync(join(first.entry.dir, "frame_00001.jpg"), "x", "utf-8");
+    markCacheEntryComplete(first.entry);
+    expect(lookupCacheEntry(tmpRoot, base(sourceFile)).hit).toBe(true);
+
+    // Any per-file cleanup can empty the directory while leaving the sentinel.
+    // Serving that as a hit rehydrates zero frames, so every later render of
+    // the project fails identically at the coverage gate.
+    rmSync(join(first.entry.dir, "frame_00001.jpg"));
+
+    expect(lookupCacheEntry(tmpRoot, base(sourceFile)).hit).toBe(false);
+  });
+
+  it("counts frames of any format when deciding a hit", () => {
+    const first = lookupCacheEntry(tmpRoot, base(sourceFile));
+    ensureCacheEntryDir(first.entry);
+    writeFileSync(join(first.entry.dir, "frame_00001.png"), "x", "utf-8");
+    markCacheEntryComplete(first.entry);
+
+    expect(lookupCacheEntry(tmpRoot, base(sourceFile)).hit).toBe(true);
   });
 
   it("treats an in-progress dir without the sentinel as a miss", () => {

--- a/packages/engine/src/services/extractionCache.ts
+++ b/packages/engine/src/services/extractionCache.ts
@@ -171,15 +171,37 @@ export function cacheEntryDirName(keyHash: string): string {
 }
 
 /**
+ * Whether a sentineled entry directory still holds at least one frame file.
+ *
+ * The sentinel records that extraction finished, not that the frames survived.
+ * Any per-file cleanup that empties the directory leaves the sentinel behind,
+ * and the entry then rehydrates as a hit with zero frames. Deliberately
+ * format-agnostic: a hit must be usable whatever extension the frames carry.
+ */
+function hasFrameFiles(dir: string): boolean {
+  try {
+    return readdirSync(dir).some((file) => file.startsWith(FRAME_FILENAME_PREFIX));
+  } catch {
+    // Unreadable entry directory: treat as a miss and re-extract.
+    return false;
+  }
+}
+
+/**
  * Look up a cache entry by key input. Returns the resolved entry path plus a
  * `hit` flag. On miss, callers should extract frames into a
  * `partialCacheEntryDir(entry)` directory and publish it with
  * `publishCacheEntry` once extraction succeeds.
+ *
+ * An entry only counts as a hit when it carries the completion sentinel AND
+ * still has frames to serve. Without the second condition an emptied entry
+ * keeps rehydrating with zero frames, so every later render of that project
+ * fails identically at the coverage gate with no user-discoverable fix.
  */
 export function lookupCacheEntry(rootDir: string, input: CacheKeyInput): CacheLookup {
   const keyHash = computeCacheKey(input);
   const dir = join(rootDir, cacheEntryDirName(keyHash));
-  const complete = existsSync(join(dir, COMPLETE_SENTINEL));
+  const complete = existsSync(join(dir, COMPLETE_SENTINEL)) && hasFrameFiles(dir);
   return { entry: { dir, keyHash }, hit: complete };
 }
 


### PR DESCRIPTION
Addresses the cache half of #3372.

### Problem

`lookupCacheEntry` decides a hit purely on the presence of the `.hf-complete` sentinel:

```ts
const complete = existsSync(join(dir, COMPLETE_SENTINEL));
return { entry: { dir, keyHash }, hit: complete };
```

The sentinel records that extraction *finished*, not that the frames survived. `rehydrateCacheEntry` then takes whatever `readdirSync` returns, with no check against `totalFrames`, so an entry whose frames were removed by any per-file cleanup keeps its sentinel and rehydrates as a hit with zero frames.

The clip reaches the coverage gate with no frames, scores `0/expected`, and the render aborts with a message about capture coverage. As the issue notes, this is a plausible explanation for field reports of "happens every time" with no user-discoverable fix: the poison is on disk, not in the composition, so nothing the user changes about the project clears it.

### Fix

An entry counts as a hit only when it carries the sentinel **and** still holds at least one frame file:

```ts
const complete = existsSync(join(dir, COMPLETE_SENTINEL)) && hasFrameFiles(dir);
```

An emptied entry is a miss, so the next render re-extracts and the project recovers by itself.

`hasFrameFiles` matches on `FRAME_FILENAME_PREFIX` only, without the format suffix. A hit has to be usable whatever extension the frames carry, and `lookupCacheEntry` has no format context at that point. An unreadable entry directory also counts as a miss rather than throwing, since re-extracting is always safe.

### Scope

This is deliberately only the second of the three defects in #3372.

I have not touched the primary one, `resolveVideoExtractionPolicy()` defaulting `failureMode` to `"off"`. The issue calls the remedy there a judgement call between flipping the default to `"enforce"` and surfacing the error separately, and that is your decision to make rather than mine to guess at. Nor have I touched the third, clamping media-start against the playable video-stream duration.

Per the issue, the coverage gate is left alone.

Worth noting the two remaining defects are independent of this one: a first render against a video-less tail still fails with the same coverage message. What this change fixes is that the failure no longer becomes permanent for the project.

### Testing

In `extractionCache.test.ts`:

- a sentineled entry whose frame is then removed goes from hit to miss
- a `.png` frame is honoured as well as `.jpg`, covering the format-agnostic count

I also had to amend one existing test. `"hits after ensureCacheEntryDir + markCacheEntryComplete"` created a directory containing only the sentinel and asserted a hit, which is exactly the state this change reclassifies. It now writes a frame file before marking the entry complete, so it still tests that a genuinely complete entry hits. Flagging it explicitly since it is a behaviour change to an existing assertion rather than a new case.

Reverting `extractionCache.ts` while keeping the tests fails the new zero-frame case, so it covers the change rather than restating current behaviour.

`bunx oxlint` and `bunx oxfmt --check` are clean on both files. `extractionCache.test.ts` passes at 33 tests. Across `packages/engine/src/services/` I get 183 passing (up from 181 with the two added) and the same 9 pre-existing failures in `browserManager.test.ts` and `parallelCoordinator-peerAbort.test.ts`, which fail identically on a clean checkout without a workspace build.
