### PR TITLE
fix(lint): quote a combined scale+translate declaration once

### DIFF
--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -480,6 +480,32 @@ describe("GSAP rules", () => {
     expect(finding?.selector).toBe("#hero");
   });
 
+  it("quotes a combined scale+translate declaration once", async () => {
+    const html = `
+<html><body>
+  <div id="root" data-composition-id="c1" data-width="1920" data-height="1080">
+    <div class="scene-1"></div>
+  </div>
+  <style>
+    .scene-1 { transform: scale(1.08) translate3d(1.5%, 0, 0); }
+  </style>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.to(".scene-1", { duration: 1, x: 100, scale: 1.2 });
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "gsap_css_transform_conflict");
+    expect(finding).toBeDefined();
+    // One declaration matches both the translate and the scale selector map,
+    // so the two lookups return the same text and it must not be repeated.
+    const transform = "scale(1.08) translate3d(1.5%, 0, 0)";
+    expect(finding?.message.split(transform)).toHaveLength(2);
+    expect(finding?.fixHint?.split(transform)).toHaveLength(2);
+  });
+
   it("does NOT warn when tl.to targets element without CSS transform", async () => {
     const html = `
 <html><body>

--- a/packages/lint/src/rules/gsap.ts
+++ b/packages/lint/src/rules/gsap.ts
@@ -1332,7 +1332,10 @@ export const gsapRules: LintRule<LintContext>[] = [
           scaleProps.length > 0 ? matchCssTransform(sel, cssScaleSelectors) : undefined;
         if (!cssFromTranslate && !cssFromScale) continue;
         const existing = conflicts.get(sel) ?? {
-          cssTransform: [cssFromTranslate, cssFromScale].filter(Boolean).join(" "),
+          // A single declaration such as `transform: scale(...) translate3d(...)`
+          // matches both selector maps, so the two lookups return the same text.
+          // Dedupe before joining, or the message quotes it twice.
+          cssTransform: [...new Set([cssFromTranslate, cssFromScale].filter(Boolean))].join(" "),
           props: new Set<string>(),
           raw: call.raw,
         };


### PR DESCRIPTION
Fixes #3263

### Problem

`gsap_css_transform_conflict` looks the selector up in the translate map and the scale map separately, then joins whatever both return:

```ts
const cssFromTranslate = translateProps.length > 0 ? matchCssTransform(sel, cssTranslateSelectors) : undefined;
const cssFromScale     = scaleProps.length     > 0 ? matchCssTransform(sel, cssScaleSelectors)     : undefined;
// ...
cssTransform: [cssFromTranslate, cssFromScale].filter(Boolean).join(" "),
```

When a **single** declaration contains both functions, such as `transform: scale(1.08) translate3d(1.5%, 0, 0)`, it matches both selector maps. The two lookups then return the identical string and the join concatenates it with itself:

```
".scene-1" has CSS `transform: scale(1.08) translate3d(1.5%, 0, 0) scale(1.08) translate3d(1.5%, 0, 0)`
and a GSAP tween animates x/scale. ...
```

The same doubling appeared in `fixHint`, which told the user to remove the doubled text from their CSS.

### Fix

Dedupe the two lookups before joining:

```diff
-cssTransform: [cssFromTranslate, cssFromScale].filter(Boolean).join(" "),
+cssTransform: [...new Set([cssFromTranslate, cssFromScale].filter(Boolean))].join(" "),
```

The case this join exists for, a selector carrying translate and scale in two *separate* declarations, is untouched: those lookups return different strings, so the Set keeps both and they still join with a space.

Output for the issue's repro is now:

```
".scene-1" has CSS `transform: scale(1.08) translate3d(1.5%, 0, 0)` and a GSAP tween animates x/scale. ...
```

### Testing

Added a case to `gsap.test.ts` using the composition from the issue, asserting the declaration appears exactly once in both `message` and `fixHint`.

Reverting the source line while keeping the test fails it, so it covers the change rather than restating current behaviour.

`bunx vitest run packages/lint/src` passes at 518 tests across 14 files with no pre-existing failures, and `bunx oxlint` / `bunx oxfmt --check` are clean on both files.

Note for anyone reproducing: `packages/lint` tests need `bun run --filter '@hyperframes/parsers' build` first, otherwise the suite fails to collect on the `@hyperframes/parsers/color-grading-contract` subpath import in `rules/media.ts`.
