### PR TITLE
fix(cli): keep phrase-level CJK and Thai transcripts as separate cues

### DIFF
--- a/packages/cli/src/whisper/normalize.test.ts
+++ b/packages/cli/src/whisper/normalize.test.ts
@@ -317,6 +317,16 @@ Render video. Built for agents.
     expect(cues).toHaveLength(2);
   });
 
+  it("treats entries at the length threshold as phrases", () => {
+    // Four characters is the boundary: at or above it the entries are read as
+    // phrase-level cues, below it as word-level tokens.
+    const cues = wordsToCues([
+      { text: "你好世界", start: 0, end: 2 },
+      { text: "谢谢大家", start: 2, end: 4 },
+    ]);
+    expect(cues).toHaveLength(2);
+  });
+
   it("still groups word-level CJK tokens into cues", () => {
     // The mirror of the case above: short per-token entries are word-level
     // whisper output and must still be joined.

--- a/packages/cli/src/whisper/normalize.test.ts
+++ b/packages/cli/src/whisper/normalize.test.ts
@@ -292,6 +292,43 @@ Render video. Built for agents.
     expect(cues).toEqual([{ text: "你好世界", start: 0, end: 1 }]);
   });
 
+  it("keeps phrase-level CJK entries as separate cues", () => {
+    // Chinese has no inter-word spaces, so the whitespace test cannot see
+    // that these are phrases; they used to collapse into one cue spanning
+    // the whole transcript.
+    const cues = wordsToCues([
+      { text: "这是第一个句子", start: 0, end: 2 },
+      { text: "这是第二个句子", start: 2, end: 4 },
+      { text: "这是第三个句子", start: 4, end: 6 },
+    ]);
+    expect(cues).toHaveLength(3);
+    expect(cues[0]).toEqual({
+      text: "这是第一个句子",
+      start: 0,
+      end: 2,
+    });
+  });
+
+  it("keeps phrase-level Thai entries as separate cues", () => {
+    const cues = wordsToCues([
+      { text: "สวัสดีครับ", start: 0, end: 2 },
+      { text: "ยินดีต้อนรับ", start: 2, end: 4 },
+    ]);
+    expect(cues).toHaveLength(2);
+  });
+
+  it("still groups word-level CJK tokens into cues", () => {
+    // The mirror of the case above: short per-token entries are word-level
+    // whisper output and must still be joined.
+    const cues = wordsToCues([
+      { text: "你", start: 0, end: 0.3 },
+      { text: "好", start: 0.3, end: 0.6 },
+      { text: "世", start: 0.6, end: 0.9 },
+      { text: "界", start: 0.9, end: 1.2 },
+    ]);
+    expect(cues).toEqual([{ text: "你好世界", start: 0, end: 1.2 }]);
+  });
+
   it("preserves single-word cue boundaries when preGrouped", () => {
     // Phrase-level cues without internal whitespace (one-word or CJK captions)
     // must not merge — auto-detection can't see them, so the caller forces it.

--- a/packages/cli/src/whisper/normalize.ts
+++ b/packages/cli/src/whisper/normalize.ts
@@ -356,6 +356,47 @@ function entriesToCues(words: Word[]): Cue[] {
 // inter-word spaces.
 const CJK_CHAR = /[　-〿぀-ヿ㐀-䶿一-鿿豈-﫿＀-￯]/;
 
+// Scripts written without inter-word spaces: the CJK ranges above plus Thai,
+// Lao, Myanmar and Khmer. Used only to decide whether entries are already
+// phrase-level — the whitespace test below cannot answer that for these
+// scripts. Hangul is excluded for the same reason as in CJK_CHAR.
+const SPACELESS_SCRIPT_CHAR = /[฀-๿຀-໿က-႟ក-៿　-〿぀-ヿ㐀-䶿一-鿿豈-﫿＀-￯]/;
+
+// Whisper emits word-level tokens for spaceless scripts one or two characters
+// at a time, while a phrase-level cue runs to several times that. Four is
+// comfortably above the token case and below any real caption.
+const SPACELESS_PHRASE_MIN_CHARS = 4;
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length === 0) return 0;
+  if (sorted.length % 2 === 1) return sorted[mid] ?? 0;
+  return ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2;
+}
+
+/**
+ * Whether the entries are already grouped into phrases.
+ *
+ * Any entry containing internal whitespace is a multi-word phrase, which
+ * settles it for space-separated scripts. Chinese, Japanese, Thai and the
+ * other spaceless scripts never satisfy that test, so their phrase-level
+ * transcripts used to be re-grouped into a single cue covering the whole
+ * clip. For those, fall back to entry length instead.
+ *
+ * The median, rather than `some` or `every`, keeps one long token from
+ * declaring word-level input pre-grouped and a couple of short cues (a bare
+ * yes or no) from declaring a real transcript word-level.
+ */
+function inferPreGrouped(words: Word[]): boolean {
+  if (words.some((w) => /\s/.test(w.text.trim()))) return true;
+
+  const spaceless = words.filter((w) => SPACELESS_SCRIPT_CHAR.test(w.text));
+  if (spaceless.length === 0) return false;
+
+  return median(spaceless.map((w) => w.text.trim().length)) >= SPACELESS_PHRASE_MIN_CHARS;
+}
+
 /** Join two adjacent tokens, omitting the space across a CJK boundary. */
 function joinTokens(left: string, right: string): string {
   const a = left.at(-1) ?? "";
@@ -367,10 +408,10 @@ function joinTokens(left: string, right: string): string {
 export function wordsToCues(words: Word[], opts: WordsToCuesOptions = {}): Cue[] {
   // Phrase-level transcripts (imported .srt/.vtt cues) must keep their existing
   // cue boundaries — re-grouping would merge distinct captions and lose timing.
-  // The caller can force this via `preGrouped`; otherwise infer it from the data
-  // (any entry containing internal whitespace is a multi-word phrase, so the
-  // whole transcript is phrase-level rather than word-level whisper output).
-  const preGrouped = opts.preGrouped ?? words.some((w) => /\s/.test(w.text.trim()));
+  // The caller can force this via `preGrouped`; otherwise infer it from the
+  // data — internal whitespace for space-separated scripts, entry length for
+  // the scripts that have no inter-word spaces to look for.
+  const preGrouped = opts.preGrouped ?? inferPreGrouped(words);
   if (preGrouped) return entriesToCues(words);
 
   const maxChars = opts.maxChars ?? 42;


### PR DESCRIPTION
Fixes #3353

### Problem

`wordsToCues` decided whether its input was already grouped into phrases by testing for internal whitespace:

```ts
const preGrouped = opts.preGrouped ?? words.some((w) => /\s/.test(w.text.trim()));
```

Chinese, Japanese and Thai do not put spaces between words, so for those scripts the test is always false. Phrase-level entries were treated as individual words and re-grouped into one cue covering the whole transcript. Three Chinese phrases produced one cue; the same three phrases in English produced three.

The failure was silent, which is what made it expensive: as the issue records, two projects hit it and each built their own pipeline rather than finding `--preserve-cues`.

### Approach

The issue lists three options. I took the second, keeping the whitespace test and adding a codepoint check alongside it, but with the length signal from the first, because a codepoint check on its own is not enough to decide the question.

Whether entries are pre-grouped is really "does an entry hold more than one token". Whitespace answers that for space-separated scripts. For spaceless scripts nothing in the codepoints answers it: word-level whisper output and phrase-level cues are both unbroken runs of Han characters. Treating every CJK transcript as pre-grouped would emit one cue per token and break the normal `transcribe` path, which the existing `"joins CJK word-level tokens without inserting spaces"` test covers.

So for spaceless scripts the fallback is entry length. Whisper emits word-level tokens for those scripts one or two characters at a time, while a phrase-level cue runs to several times that, and four sits comfortably between.

The median is used rather than `some` or `every`: `some` would let one long token declare word-level input pre-grouped, and `every` would let a couple of short cues (a bare yes or no) declare a real transcript word-level.

I did not take option 1 wholesale. Replacing the whitespace test with a duration heuristic for *all* scripts would put every existing English transcript through a new classifier, and this change deliberately leaves space-separated input on exactly the path it is on today.

Detection also covers Thai, Lao, Myanmar and Khmer, which have the same problem. I left `joinTokens` and its `CJK_CHAR` alone: widening the separator rule is a real change to output for those scripts and belongs in its own PR.

### Testing

Added to `normalize.test.ts`:

- three phrase-level Chinese entries produce three cues with their original timings, the issue's repro
- two phrase-level Thai entries produce two cues
- four short word-level CJK tokens still group into one cue, the regression guard for the case above

The existing `"joins CJK word-level tokens without inserting spaces"` test passes unchanged: its tokens have a median length of 1, well under the threshold.

Reverting the `inferPreGrouped` call while keeping the tests fails the CJK and Thai cases, so they cover the change rather than restating current behaviour.

`bunx vitest run packages/cli/src/whisper/` passes at 106 tests with no pre-existing failures, and `bunx oxlint` / `bunx oxfmt --check` are clean on both files.
