### PR TITLE
fix(registry): make the tabs active label follow the sliding indicator

### DIFF
--- a/registry/components/tabs-slide-indicator/demo.html
+++ b/registry/components/tabs-slide-indicator/demo.html
@@ -54,6 +54,8 @@
         background: #18181b;
         transform: translateX(var(--hf-tab-x));
         box-shadow: 0 12px 26px rgba(0, 0, 0, 0.18);
+        overflow: hidden;
+        z-index: 2;
       }
       .hf-transition-tabs-slide-indicator button {
         position: relative;
@@ -61,10 +63,19 @@
         height: 36px;
         border: 0;
         background: transparent;
-        color: #71717a;
+        color: #6b6b73;
         font-weight: 600;
       }
-      .hf-transition-tabs-slide-indicator button:nth-of-type(2) {
+      .hf-transition-tabs-slide-indicator .indicator-labels {
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: grid;
+        grid-template-columns: repeat(3, 86px);
+        transform: translateX(calc(var(--hf-tab-x) * -1));
+        pointer-events: none;
+      }
+      .hf-transition-tabs-slide-indicator .indicator-labels button {
         color: #fff;
       }
     </style>
@@ -88,7 +99,12 @@
     { "id": "labels", "type": "string", "role": "content", "label": "Labels", "description": "The tab names, separated by commas. Two or more names rebuild the row.", "default": "Plan,Debug,Ask" }
   ]'
         >
-          <span class="indicator"></span><button>Plan</button><button>Debug</button
+          <span class="indicator"
+            ><span class="indicator-labels" aria-hidden="true"
+              ><button tabindex="-1">Plan</button><button tabindex="-1">Debug</button
+              ><button tabindex="-1">Ask</button></span
+            ></span
+          ><button>Plan</button><button>Debug</button
           ><button>Ask</button>
         </div>
       </div>
@@ -117,6 +133,17 @@
             return Object.prototype.hasOwnProperty.call(table, value) ? value : fallback;
           }
 
+          // The mirrored copy is decorative: it repeats a label the row
+          // already carries, so it stays out of the tab order.
+          function makeTab(text, mirrored) {
+            var button = document.createElement("button");
+            button.textContent = text;
+            if (mirrored) {
+              button.tabIndex = -1;
+            }
+            return button;
+          }
+
           var accent = accents[pick(accents, vars.accent, "ink")];
           var width = widths[pick(widths, vars.width, "standard")];
           var radius = shapes[pick(shapes, vars.shape, "pill")];
@@ -140,14 +167,18 @@
             roots[i].style.setProperty("--hf-tab-radius", radius);
             // A single tab has nowhere to slide to, so it is left as authored.
             if (labels.length > 1) {
+              // Every label exists twice: once in the row and once in the
+              // clipped copy the pill carries, so both are rebuilt together.
+              var mirror = roots[i].querySelector(".indicator-labels");
               var old = roots[i].querySelectorAll("button");
               for (var j = 0; j < old.length; j += 1) {
                 old[j].parentNode.removeChild(old[j]);
               }
               for (var k = 0; k < labels.length; k += 1) {
-                var button = document.createElement("button");
-                button.textContent = labels[k];
-                roots[i].appendChild(button);
+                roots[i].appendChild(makeTab(labels[k], false));
+                if (mirror) {
+                  mirror.appendChild(makeTab(labels[k], true));
+                }
               }
               roots[i].style.setProperty("--hf-tab-count", String(labels.length));
             }
@@ -190,6 +221,8 @@
         background: var(--hf-tab-fill, #18181b);
         transform: translateX(calc(var(--hf-tab-x) * var(--hf-tab-step, 1)));
         box-shadow: 0 12px 26px rgba(0, 0, 0, 0.18);
+        overflow: hidden;
+        z-index: 2;
       }
       .hf-transition-tabs-slide-indicator button {
         position: relative;
@@ -197,10 +230,19 @@
         height: 36px;
         border: 0;
         background: transparent;
-        color: #71717a;
+        color: #6b6b73;
         font-weight: 850;
       }
-      .hf-transition-tabs-slide-indicator button:nth-of-type(2) {
+      .hf-transition-tabs-slide-indicator .indicator-labels {
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: grid;
+        grid-template-columns: repeat(var(--hf-tab-count, 3), var(--hf-tab-width, 86px));
+        transform: translateX(calc(var(--hf-tab-x) * var(--hf-tab-step, 1) * -1));
+        pointer-events: none;
+      }
+      .hf-transition-tabs-slide-indicator .indicator-labels button {
         color: #fff;
       }
     </style>

--- a/registry/components/tabs-slide-indicator/tabs-slide-indicator.html
+++ b/registry/components/tabs-slide-indicator/tabs-slide-indicator.html
@@ -39,7 +39,12 @@
     { "id": "labels", "type": "string", "role": "content", "label": "Labels", "description": "The tab names, separated by commas. Two or more names rebuild the row.", "default": "Plan,Debug,Ask" }
   ]'
 >
-  <span class="indicator"></span><button>Plan</button><button>Debug</button><button>Ask</button>
+  <span class="indicator"
+    ><span class="indicator-labels" aria-hidden="true"
+      ><button tabindex="-1">Plan</button><button tabindex="-1">Debug</button
+      ><button tabindex="-1">Ask</button></span
+    ></span
+  ><button>Plan</button><button>Debug</button><button>Ask</button>
 </div>
 
 <style>
@@ -64,6 +69,8 @@
     background: var(--hf-tab-fill, #18181b);
     transform: translateX(calc(var(--hf-tab-x) * var(--hf-tab-step, 1)));
     box-shadow: 0 12px 26px rgba(0, 0, 0, 0.18);
+    overflow: hidden;
+    z-index: 2;
   }
   .hf-transition-tabs-slide-indicator button {
     position: relative;
@@ -71,10 +78,23 @@
     height: 36px;
     border: 0;
     background: transparent;
-    color: #71717a;
+    color: #6b6b73;
     font-weight: 850;
   }
-  .hf-transition-tabs-slide-indicator button:nth-of-type(2) {
+  /* The pill carries a clipped copy of the label row. Countering the pill's
+     own translate keeps that copy aligned with the buttons underneath at
+     every frame, so the white label is exactly the part of the row the pill
+     covers - it follows the indicator instead of being pinned to one tab. */
+  .hf-transition-tabs-slide-indicator .indicator-labels {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: grid;
+    grid-template-columns: repeat(var(--hf-tab-count, 3), var(--hf-tab-width, 86px));
+    transform: translateX(calc(var(--hf-tab-x) * var(--hf-tab-step, 1) * -1));
+    pointer-events: none;
+  }
+  .hf-transition-tabs-slide-indicator .indicator-labels button {
     color: #fff;
   }
 </style>
@@ -104,6 +124,17 @@
       return Object.prototype.hasOwnProperty.call(table, value) ? value : fallback;
     }
 
+    // The mirrored copy is decorative: it repeats a label the row already
+    // carries, so it stays out of the tab order.
+    function makeTab(text, mirrored) {
+      var button = document.createElement("button");
+      button.textContent = text;
+      if (mirrored) {
+        button.tabIndex = -1;
+      }
+      return button;
+    }
+
     var accent = accents[pick(accents, vars.accent, "ink")];
     var width = widths[pick(widths, vars.width, "standard")];
     var radius = shapes[pick(shapes, vars.shape, "pill")];
@@ -127,14 +158,18 @@
       roots[i].style.setProperty("--hf-tab-radius", radius);
       // A single tab has nowhere to slide to, so it is left as authored.
       if (labels.length > 1) {
+        // Every label exists twice: once in the row and once in the clipped
+        // copy the pill carries, so both have to be rebuilt together.
+        var mirror = roots[i].querySelector(".indicator-labels");
         var old = roots[i].querySelectorAll("button");
         for (var j = 0; j < old.length; j += 1) {
           old[j].parentNode.removeChild(old[j]);
         }
         for (var k = 0; k < labels.length; k += 1) {
-          var button = document.createElement("button");
-          button.textContent = labels[k];
-          roots[i].appendChild(button);
+          roots[i].appendChild(makeTab(labels[k], false));
+          if (mirror) {
+            mirror.appendChild(makeTab(labels[k], true));
+          }
         }
         roots[i].style.setProperty("--hf-tab-count", String(labels.length));
       }


### PR DESCRIPTION
Fixes #3266

### Problem

The component pinned its active colour to a fixed tab:

```css
.hf-transition-tabs-slide-indicator button:nth-of-type(2) {
  color: #fff;
}
```

The pill starts under the *first* tab, so before the slide "Plan" was gray on the dark pill and "Debug" was white on the light track. The two only agreed once the pill arrived at "Debug".

The inactive gray `#71717a` also measured **4.40:1** against the `#f4f4f5` track, just under the 4.5:1 AA requirement.

### Fix

The pill now carries a clipped copy of the label row:

```html
<span class="indicator"
  ><span class="indicator-labels" aria-hidden="true"
    ><button tabindex="-1">Plan</button>...</span
  ></span
><button>Plan</button>...
```

`.indicator` gets `overflow: hidden`, and the copy counters the pill's own translate:

```css
transform: translateX(calc(var(--hf-tab-x) * var(--hf-tab-step, 1) * -1));
```

That keeps the copy aligned with the buttons underneath at every frame, so the white text is exactly the part of the row the pill covers. It crosses over mid-slide instead of being pinned to one tab, and it is driven by the same `--hf-tab-x` the timeline already animates, so it stays deterministic under seek. The documented timeline recipe is unchanged.

Inactive gray is now `#6b6b73`, **4.80:1**.

### One consequence worth flagging

`.indicator` needed `z-index: 2` to sit above the `z-index: 1` buttons, because its `transform` makes it a stacking context and the label copy cannot otherwise paint above the row. The copy has to live inside `.indicator` since that is the element the timeline sets `--hf-tab-x` on, and inheritance only goes downward.

So the pill's `box-shadow` now paints over the track rather than behind the labels. I think this reads correctly, a raised pill casting onto what is below it, but it is a visual change beyond the reported bug and easy to revert if you would rather not have it. The alternative I considered was animating `left` instead of `transform`, which keeps the old layering exactly but trades a composited property for a layout one.

### Verification

Measured in the browser against the demo, at several points of the slide:

| `--hf-tab-x` | pill position | white label | copy-to-row drift |
| --- | --- | --- | --- |
| `0px` | tab 1 | Plan | 0.00px |
| `43px` | mid-slide | Plan + Debug, split at the pill edge | 0.00px |
| `86px` | tab 2 | Debug | 0.00px |

`elementFromPoint` at each label centre confirms the pill's subtree is topmost exactly where the pill sits and the gray row elsewhere.

Contrast computed with the WCAG relative-luminance formula: `#71717a` 4.397:1, `#6b6b73` 4.805:1, white on the `#18181b` pill 17.72:1.

The `labels` variable rebuilds both rows, checked with four labels: 4 row buttons, 4 copies, 0.00px drift, copies at `tabIndex -1`. The copy is `aria-hidden` and `pointer-events: none` so it adds nothing to the accessibility tree or the tab order.

`node scripts/lint-registry-items.mjs` passes at 372 items, 0 errors. Both `demo.html` and the installable snippet carry the same change, including the demo's duplicated head style block.
