### PR TITLE
chore: release v0.8.11

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,25 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.11"
+  description="Released - 2026-08-23"
+  tags={["Release", "Engine", "Studio", "Sdk"]}
+>
+Caption-heavy transparent renders can now reuse unchanged frames without missing mounted clip boundaries. Studio's grouping dialog also stays within the window on short screens.
+
+## Fixes
+
+- **Engine:** Keep static-frame dedup active across dense caption changes while preserving mounted clip boundaries and safe verification fallbacks ([65b2299db](https://github.com/heygen-com/hyperframes/commit/65b2299db284ece3232de26ed7afbe0360e097bd), [#3438](https://github.com/heygen-com/hyperframes/pull/3438)).
+- **Studio:** Stop the grouping dialog opening off the bottom of the window ([dd0626a55](https://github.com/heygen-com/hyperframes/commit/dd0626a55a0d0f24cae1b00bd2c95c0ebfa7a573), [#3421](https://github.com/heygen-com/hyperframes/pull/3421)).
+
+## Internal
+
+- **Sdk:** Render-faithfulness test for serialize() bake contract (WS-F) ([f11b60854](https://github.com/heygen-com/hyperframes/commit/f11b60854a3ab1490bee8aef14086c8b245a3376), [#1575](https://github.com/heygen-com/hyperframes/pull/1575)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.10...v0.8.11).
+</Update>
+
+<Update
   label="HyperFrames v0.8.10"
   description="Released - 2026-08-22"
   tags={["Release", "Studio"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.11.md
+++ b/releases/v0.8.11.md
@@ -1,0 +1,18 @@
+# HyperFrames v0.8.11
+
+Released on 2026-08-23.
+
+Caption-heavy transparent renders can now reuse unchanged frames without missing mounted clip boundaries. Studio's grouping dialog also stays within the window on short screens.
+
+## Fixes
+
+- **Engine:** Keep static-frame dedup active across dense caption changes while preserving mounted clip boundaries and safe verification fallbacks ([65b2299db](https://github.com/heygen-com/hyperframes/commit/65b2299db284ece3232de26ed7afbe0360e097bd), [#3438](https://github.com/heygen-com/hyperframes/pull/3438)).
+- **Studio:** Stop the grouping dialog opening off the bottom of the window ([dd0626a55](https://github.com/heygen-com/hyperframes/commit/dd0626a55a0d0f24cae1b00bd2c95c0ebfa7a573), [#3421](https://github.com/heygen-com/hyperframes/pull/3421)).
+
+## Internal
+
+- **Sdk:** Render-faithfulness test for serialize() bake contract (WS-F) ([f11b60854](https://github.com/heygen-com/hyperframes/commit/f11b60854a3ab1490bee8aef14086c8b245a3376), [#1575](https://github.com/heygen-com/hyperframes/pull/1575)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.10...v0.8.11


### PR DESCRIPTION
## What

Prepare the reviewed stable `v0.8.11` release across all 13 npm packages and three agent-plugin manifests.

## Why

Ship the static-frame dedup correctness/performance fix from #3438 and the Studio grouping-dialog viewport fix from #3421 to the stable `latest` channel.

## How

- Bump publishable packages and plugin manifests from `0.8.10` to `0.8.11`.
- Add reviewed GitHub release notes at `releases/v0.8.11.md`.
- Add the matching user-facing docs changelog entry.
- Keep the local release tag unpushed; the immutable merged-PR publish workflow will create the canonical tag at the squash merge SHA.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated (if applicable)

- `bun run test:scripts`: 184 Node tests + 42 catalog Vitest tests passed.
- `bun run build`: all workspaces built successfully.
- `bun run verify:packed-manifests`: all 13 published workspaces verified publish-safe.
- #3438 exact-head CI and the real 939-frame transparent render were green before merge.