### PR TITLE
fix(studio): make audio-group edits transactional

### DIFF
--- a/packages/core/src/audio/audioFxWorklets.test.ts
+++ b/packages/core/src/audio/audioFxWorklets.test.ts
@@ -136,23 +136,125 @@ describe("the worklet processors themselves", () => {
       return crossings / ((s.length - start) / SR);
     }
 
-    it("at semitones: 0, mix: 1 reproduces the input, delayed by exactly one grain/2", async () => {
+    // This assertion used to be that the output equalled the input DELAYED by
+    // grain/2 — the measurement was right and was written down as the contract.
+    // But the grain delay is there to shift pitch, and at semitones: 0 nothing
+    // is being shifted: the node degenerated into a pure 50 ms delay of the
+    // signal, plus a head of silence while the ring filled, under a label that
+    // reads "Unchanged pitch".
+    it("at semitones: 0, mix: 1 passes the input through untouched", async () => {
       const HfPitchshift = (await loadProcessors()).get("hf-pitchshift");
       if (!HfPitchshift) throw new Error("hf-pitchshift not registered");
       const p = new HfPitchshift({ processorOptions: { semitones: 0, mix: 1 } });
       const input = sine(440, 0.5);
       const output = run(p, input);
-      const grain = Math.round(SR * 0.1);
-      // readTap reads from `write - 1`, i.e. one sample behind the one just
-      // written in this same iteration — so the effective delay is one sample
-      // more than the nominal grain/2.
-      const delay = grain / 2 + 1;
-      // Skip the first grain while the ring buffer is still filling.
       let maxErr = 0;
-      for (let i = grain * 2; i < input.length; i++) {
-        maxErr = Math.max(maxErr, Math.abs((output[i] ?? 0) - (input[i - delay] ?? 0)));
+      for (let i = 0; i < input.length; i++) {
+        maxErr = Math.max(maxErr, Math.abs((output[i] ?? 0) - (input[i] ?? 0)));
       }
       expect(maxErr).toBeLessThan(1e-6);
+    });
+
+    it("mix: 0 passes the input through untouched too", async () => {
+      const HfPitchshift = (await loadProcessors()).get("hf-pitchshift");
+      if (!HfPitchshift) throw new Error("hf-pitchshift not registered");
+      const p = new HfPitchshift({ processorOptions: { semitones: 7, mix: 0 } });
+      const input = sine(440, 0.25);
+      const output = run(p, input);
+      let maxErr = 0;
+      for (let i = 0; i < input.length; i++) {
+        maxErr = Math.max(maxErr, Math.abs((output[i] ?? 0) - (input[i] ?? 0)));
+      }
+      expect(maxErr).toBeLessThan(1e-6);
+    });
+
+    /** Largest sample-to-sample step — a splice between the dry and the
+     *  ~50 ms-delayed wet path shows up here as a discontinuity. */
+    function maxStep(s: Float32Array, from: number, to: number): number {
+      let worst = 0;
+      for (let i = from + 1; i < to; i++) {
+        worst = Math.max(worst, Math.abs((s[i] ?? 0) - (s[i - 1] ?? 0)));
+      }
+      return worst;
+    }
+
+    // Dragging the semitones slider off zero mid-playback swaps the output from
+    // x[t] to x[t-50ms]. Switched hard that is an audible click; the wet amount
+    // is ramped instead. A 440 Hz sine steps ~0.057 per sample at its steepest,
+    // so anything near the signal's own peak is a splice, not the waveform.
+    it("does not click when the shift moves off zero mid-signal", async () => {
+      const HfPitchshift = (await loadProcessors()).get("hf-pitchshift");
+      if (!HfPitchshift) throw new Error("hf-pitchshift not registered");
+      const p = new HfPitchshift({ processorOptions: { semitones: 0, mix: 1 } });
+      run(p, sine(440, 0.3)); // settled dry, ring warm
+      p.p = { ...p.p, semitones: 7 };
+      const output = run(p, sine(440, 0.3));
+      expect(maxStep(output, 0, output.length)).toBeLessThan(0.2);
+    });
+
+    it("does not click on the way back to zero either", async () => {
+      const HfPitchshift = (await loadProcessors()).get("hf-pitchshift");
+      if (!HfPitchshift) throw new Error("hf-pitchshift not registered");
+      const p = new HfPitchshift({ processorOptions: { semitones: 7, mix: 1 } });
+      run(p, sine(440, 0.3));
+      p.p = { ...p.p, semitones: 0 };
+      const output = run(p, sine(440, 0.3));
+      expect(maxStep(output, 0, output.length)).toBeLessThan(0.2);
+    });
+
+    // ...and having ramped back down it must reach TRUE bypass, not sit on a
+    // permanently latched wet path. The render builds a fresh node from the
+    // saved attribute and bypasses at semitones 0; a preview that stayed wet
+    // would carry a 50 ms delay the export does not have.
+    it("returns to true bypass after being shifted and set back to zero", async () => {
+      const HfPitchshift = (await loadProcessors()).get("hf-pitchshift");
+      if (!HfPitchshift) throw new Error("hf-pitchshift not registered");
+      const p = new HfPitchshift({ processorOptions: { semitones: 7, mix: 1 } });
+      run(p, sine(440, 0.3));
+      p.p = { ...p.p, semitones: 0 };
+      run(p, sine(440, 0.3)); // ramp down settles here
+
+      const input = sine(440, 0.3);
+      const output = run(p, input);
+      let maxErr = 0;
+      for (let i = 0; i < input.length; i++) {
+        maxErr = Math.max(maxErr, Math.abs((output[i] ?? 0) - (input[i] ?? 0)));
+      }
+      expect(maxErr).toBeLessThan(1e-6);
+    });
+
+    // A node parked at mix 0 has shifted nothing, so it must not have spent
+    // anything that stops the zero-shift bypass engaging later.
+    it("is transparent at zero after sitting mixed fully out", async () => {
+      const HfPitchshift = (await loadProcessors()).get("hf-pitchshift");
+      if (!HfPitchshift) throw new Error("hf-pitchshift not registered");
+      const p = new HfPitchshift({ processorOptions: { semitones: 7, mix: 0 } });
+      run(p, sine(440, 0.3));
+
+      p.p = { ...p.p, semitones: 0, mix: 1 };
+      const input = sine(440, 0.3);
+      const output = run(p, input);
+      let maxErr = 0;
+      for (let i = 0; i < input.length; i++) {
+        maxErr = Math.max(maxErr, Math.abs((output[i] ?? 0) - (input[i] ?? 0)));
+      }
+      expect(maxErr).toBeLessThan(1e-6);
+    });
+
+    // The ring starts empty, so the taps read zeros for the first grain. That
+    // used to come out of the head of every clip as silence; it ramps the wet
+    // path in instead, which is unshifted audio rather than no audio.
+    it("does not open with silence while the grain buffer fills", async () => {
+      const HfPitchshift = (await loadProcessors()).get("hf-pitchshift");
+      if (!HfPitchshift) throw new Error("hf-pitchshift not registered");
+      const p = new HfPitchshift({ processorOptions: { semitones: 7, mix: 1 } });
+      const input = sine(440, 0.5);
+      const output = run(p, input);
+      // Peak over the first 20 ms — well inside the old dead zone.
+      let peak = 0;
+      for (let i = 0; i < Math.round(SR * 0.02); i++)
+        peak = Math.max(peak, Math.abs(output[i] ?? 0));
+      expect(peak).toBeGreaterThan(0.5);
     });
 
     it("at semitones: 12, doubles the fundamental (one octave up)", async () => {

--- a/packages/core/src/audio/audioFxWorklets.ts
+++ b/packages/core/src/audio/audioFxWorklets.ts
@@ -253,6 +253,21 @@ class HfPitchshift extends AudioWorkletProcessor {
     this.buf = [];
     this.write = 0;
     this.phase = 0;
+    // Samples written so far, capped at one grain. The taps read up to a grain
+    // behind the write head, so until this fills they would read the ring's
+    // zeros — the head of every clip came out attenuated or silent.
+    this.filled = 0;
+    // How much of the wet (pitch-shifted) path is currently in the output, and
+    // where it is heading. Crossing between dry and wet is a ~50 ms jump in the
+    // signal, so it is RAMPED rather than switched: a hard swap either way is a
+    // click. Ramping in both directions is also what lets a node return to true
+    // bypass at semitones 0 — a one-way latch left preview stuck with the delay
+    // that the render, building a fresh node from the attribute, does not have.
+    this.wet = 0;
+    this.wetTarget = 0;
+    // ~15 ms one-pole, short enough to feel immediate on a slider drag and long
+    // enough that the splice is inaudible.
+    this.wetCoef = Math.exp(-1 / (sampleRate * 0.015));
     this.port.onmessage = (e) => {
       if (e.data && e.data.__hfDispose) { this.dead = true; return; }
       this.p = { ...this.p, ...e.data };
@@ -265,20 +280,51 @@ class HfPitchshift extends AudioWorkletProcessor {
     const p = this.p;
     const semitones = Math.max(-12, Math.min(12, p.semitones ?? 0));
     const mix = Math.max(0, Math.min(1, p.mix ?? 1));
-    const ratio = Math.pow(2, semitones / 12);
     const grain = this.grain;
     const ringLen = grain * 2;
-    const inc = (1 - ratio) / grain;
     const n = i[0] ? i[0].length : 0;
     for (let ch = 0; ch < i.length; ch++) {
       if (!this.buf[ch]) this.buf[ch] = new Float32Array(ringLen);
     }
-    let write = this.write, phase = this.phase;
+
+    // Nothing to shift, or mixed fully out. The grain delay is ~grain/2
+    // whatever the ratio, so at semitones=0 this degenerated into a pure 50 ms
+    // delay of the signal — while the copy for that exact setting reads
+    // "Unchanged pitch".
+    this.wetTarget = semitones === 0 ? 0 : mix;
+
+    // Fully dry AND settled: take the cheap transparent path. The ring keeps
+    // filling, so a later shift does not start cold.
+    if (this.wetTarget === 0 && this.wet < 1e-4) {
+      this.wet = 0;
+      let w = this.write;
+      for (let s = 0; s < n; s++) {
+        for (let ch = 0; ch < i.length; ch++) {
+          const x = i[ch][s];
+          this.buf[ch][w] = x;
+          o[ch][s] = x;
+        }
+        w = (w + 1) % ringLen;
+      }
+      this.write = w;
+      this.filled = Math.min(grain, this.filled + n);
+      return true;
+    }
+
+    const ratio = Math.pow(2, semitones / 12);
+    const inc = (1 - ratio) / grain;
+    let write = this.write, phase = this.phase, filled = this.filled, wetNow = this.wet;
+    const target = this.wetTarget, coef = this.wetCoef;
     for (let s = 0; s < n; s++) {
       phase += inc;
       phase -= Math.floor(phase);
       const phaseB = (phase + 0.5) % 1;
       const gA = xfade(phase), gB = xfade(phaseB);
+      // Ramp the wet path in as the ring fills rather than reading zeros:
+      // 100 ms of unshifted audio at the head of a clip beats 50 ms of silence.
+      const warm = filled >= grain ? 1 : filled / grain;
+      wetNow = target + coef * (wetNow - target);
+      const wetMix = wetNow * warm;
       for (let ch = 0; ch < i.length; ch++) {
         const ring = this.buf[ch];
         const inp = i[ch], out = o[ch];
@@ -286,12 +332,15 @@ class HfPitchshift extends AudioWorkletProcessor {
         ring[write] = x;
         const wet =
           readTap(ring, write, phase * grain) * gA + readTap(ring, write, phaseB * grain) * gB;
-        out[s] = x * (1 - mix) + wet * mix;
+        out[s] = x * (1 - wetMix) + wet * wetMix;
       }
       write = (write + 1) % ringLen;
+      if (filled < grain) filled++;
     }
     this.write = write;
     this.phase = phase;
+    this.filled = filled;
+    this.wet = wetNow;
     return true;
   }
 }

--- a/packages/core/src/audioCarve.test.ts
+++ b/packages/core/src/audioCarve.test.ts
@@ -10,6 +10,8 @@ import {
   clipsOverlap,
   mixCarveSources,
   couldBeCarveSource,
+  couldBeCarveBed,
+  isNamedCarveBed,
   DEFAULT_CARVE,
   normalizeCarveSettings,
 } from "./audioCarve.js";
@@ -536,6 +538,30 @@ describe("classifyAudioName", () => {
     expect(couldBeCarveSource("a1")).toBe(true);
     expect(couldBeCarveSource("music-bed")).toBe(false);
     expect(couldBeCarveSource("sfx-explosion")).toBe(false);
+  });
+
+  // The near-end rule, which nothing used to ask. `couldBeCarveSource` shipped
+  // with its own doc comment ("music and sfx are out") and no caller; the bed
+  // side had no predicate at all, so a narration clip was offered the carve and
+  // — finding one candidate — had one applied for it, against the group it was
+  // a member of.
+  it("never offers a voice track as the bed, but keeps an unnamed one eligible", () => {
+    expect(couldBeCarveBed("music-bed")).toBe(true);
+    expect(couldBeCarveBed("sfx-riser")).toBe(true);
+    expect(couldBeCarveBed("a1")).toBe(true);
+    expect(couldBeCarveBed("vo-2")).toBe(false);
+    expect(couldBeCarveBed("voiceover")).toBe(false);
+    expect(couldBeCarveBed("narration-3")).toBe(false);
+  });
+
+  // Showing the control is a suggestion; writing the attribute is a decision.
+  // A decision taken off a name that said nothing is how a carve appears that
+  // nobody remembers configuring — so `a1` may be offered but never chosen.
+  it("only self-applies to a name that positively reads as a bed", () => {
+    expect(isNamedCarveBed("music-bed")).toBe(true);
+    expect(isNamedCarveBed("sfx-riser")).toBe(true);
+    expect(isNamedCarveBed("a1")).toBe(false);
+    expect(isNamedCarveBed("vo-2")).toBe(false);
   });
 
   it("treats underscores as separators, not word characters, for short hints", () => {

--- a/packages/core/src/audioCarve.ts
+++ b/packages/core/src/audioCarve.ts
@@ -188,6 +188,40 @@ export function couldBeCarveSource(...parts: readonly (string | null | undefined
   return kind === "voice" || kind === "unknown";
 }
 
+/**
+ * Could this track be the BED a carve is written onto?
+ *
+ * The other half of `couldBeCarveSource`, and the half nothing used to ask. A
+ * carve makes room in a bed for a voice; a voice track has no room to make for
+ * itself, and offering it the control is offering a track to duck against its
+ * own kind. Observed: a narration clip in a Voiceover group carved against that
+ * group — a member ducking the bus it feeds.
+ *
+ * Loose in the same direction as its sibling: a name that says nothing stays
+ * eligible, because a name is a hint and an author may know better. Only a name
+ * that positively reads as speech is refused.
+ */
+export function couldBeCarveBed(...parts: readonly (string | null | undefined)[]): boolean {
+  return classifyAudioName(...parts) !== "voice";
+}
+
+/**
+ * Does this track's name positively say "bed"?
+ *
+ * Stricter than `couldBeCarveBed`, for the one act the author did not ask for:
+ * applying a carve on their behalf. Offering the control on a track named `a1`
+ * is a suggestion they can ignore; writing `data-fx-carve` onto it is a decision,
+ * and a decision taken off a name that said nothing is how a carve appears that
+ * nobody remembers configuring.
+ *
+ * The same split the source side already makes between what the picker may show
+ * and what `autoSourceIds` may choose unprompted.
+ */
+export function isNamedCarveBed(...parts: readonly (string | null | undefined)[]): boolean {
+  const kind = classifyAudioName(...parts);
+  return kind === "music" || kind === "sfx";
+}
+
 export const DEFAULT_CARVE: HfCarveSettings = {
   enabled: true,
   sources: [],

--- a/packages/core/src/audioFx.ts
+++ b/packages/core/src/audioFx.ts
@@ -509,7 +509,12 @@ export const HF_AUDIO_FX: readonly HfAudioFxDef[] = [
     id: "pitchshift",
     label: "Pitch shift",
     group: "time",
-    description: "Shifts pitch up or down without changing playback speed.",
+    // The granular algorithm reads from a 100 ms grain, so its output runs a
+    // constant ~50 ms behind its input and nothing in the graph subtracts that
+    // — there is no latency/pre-roll concept here yet. It is inaudible on its
+    // own and audible against picture or against an unshifted track, so it is
+    // stated rather than hidden. `semitones: 0` bypasses the node entirely.
+    description: "Shifts pitch up or down without changing playback speed. Adds ~50 ms of latency.",
     params: [
       {
         kind: "number",
@@ -917,50 +922,7 @@ export function parseAudioFxChain(json: string): HfAudioFxChain {
   if (!Array.isArray(obj.nodes)) {
     throw new AudioFxChainError("Chain file is missing a `nodes` array.");
   }
-  const nodes: HfAudioFxNode[] = obj.nodes.map((n, i) => {
-    if (typeof n !== "object" || n === null) {
-      throw new AudioFxChainError(`Node ${i} is not an object.`);
-    }
-    const node = n as {
-      type?: unknown;
-      id?: unknown;
-      enabled?: unknown;
-      params?: unknown;
-      fromCarve?: unknown;
-      fromPreset?: unknown;
-      label?: unknown;
-      fromEq?: unknown;
-      fromLeveller?: unknown;
-      presetAmount?: unknown;
-    };
-    if (typeof node.type !== "string" || !BY_ID.has(node.type)) {
-      throw new AudioFxChainError(`Node ${i} has unknown effect type: ${String(node.type)}`);
-    }
-    return {
-      type: node.type,
-      ...(typeof node.id === "string" && node.id ? { id: node.id } : {}),
-      ...(node.fromCarve === true ? { fromCarve: true as const } : {}),
-      // Both survive the round trip or a preset stops being able to find its
-      // own nodes after a reload: re-applying would stack a second copy and
-      // the rack would lose the grouping it braces them with.
-      ...(typeof node.fromPreset === "string" && node.fromPreset
-        ? { fromPreset: node.fromPreset }
-        : {}),
-      ...(typeof node.label === "string" && node.label ? { label: node.label } : {}),
-      ...(typeof node.fromEq === "string" && node.fromEq ? { fromEq: node.fromEq } : {}),
-      ...(node.fromLeveller === true ? { fromLeveller: true as const } : {}),
-      // Clamped on the way in: the blend is two gains in opposition, and a value
-      // outside 0..1 makes the dry leg negative rather than simply loud.
-      ...(typeof node.presetAmount === "number" && Number.isFinite(node.presetAmount)
-        ? { presetAmount: Math.min(1, Math.max(0, node.presetAmount)) }
-        : {}),
-      enabled: node.enabled !== false,
-      params: normalizeAudioFxParams(
-        node.type,
-        (node.params ?? undefined) as HfAudioFxParamValues | undefined,
-      ),
-    };
-  });
+  const nodes = obj.nodes.map(parseAudioFxNode);
   return { version: HF_AUDIO_FX_CHAIN_VERSION, nodes };
 }
 
@@ -973,22 +935,7 @@ export function enabledAudioFxNodes(chain: HfAudioFxChain): HfAudioFxNode[] {
 export function serializeAudioFxChain(chain: HfAudioFxChain): string {
   return JSON.stringify({
     version: HF_AUDIO_FX_CHAIN_VERSION,
-    nodes: chain.nodes.map((node) => ({
-      type: node.type,
-      ...(node.id ? { id: node.id } : {}),
-      ...(node.fromCarve === true ? { fromCarve: true } : {}),
-      ...(node.fromPreset ? { fromPreset: node.fromPreset } : {}),
-      ...(node.label ? { label: node.label } : {}),
-      ...(node.fromEq ? { fromEq: node.fromEq } : {}),
-      ...(node.fromLeveller === true ? { fromLeveller: true } : {}),
-      // Omitted when fully applied, so an untouched preset does not grow a field
-      // in every chain that carries one.
-      ...(typeof node.presetAmount === "number" && node.presetAmount !== 1
-        ? { presetAmount: node.presetAmount }
-        : {}),
-      ...(node.enabled === false ? { enabled: false } : {}),
-      params: normalizeAudioFxParams(node.type, node.params),
-    })),
+    nodes: chain.nodes.map(serializeAudioFxNode),
   });
 }
 
@@ -1003,4 +950,103 @@ export function mintAudioFxNodeId(chain: HfAudioFxChain): string {
     const id = `n${i}`;
     if (!taken.has(id)) return id;
   }
+}
+
+/** The shape a node is READ as: everything unknown until checked. */
+interface RawAudioFxNode {
+  type?: unknown;
+  id?: unknown;
+  enabled?: unknown;
+  params?: unknown;
+  fromCarve?: unknown;
+  fromPreset?: unknown;
+  label?: unknown;
+  fromEq?: unknown;
+  fromLeveller?: unknown;
+  presetAmount?: unknown;
+}
+
+/**
+ * One node out of a chain file, validated. Throws rather than dropping: a chain
+ * that silently loses a node would render differently from the project the
+ * author saved.
+ */
+function parseAudioFxNode(n: unknown, i: number): HfAudioFxNode {
+  if (typeof n !== "object" || n === null) {
+    throw new AudioFxChainError(`Node ${i} is not an object.`);
+  }
+  const node = n as RawAudioFxNode;
+  if (typeof node.type !== "string" || !BY_ID.has(node.type)) {
+    throw new AudioFxChainError(`Node ${i} has unknown effect type: ${String(node.type)}`);
+  }
+  return withoutUndefined({
+    type: node.type,
+    id: nonEmptyString(node.id),
+    fromCarve: onlyTrue(node.fromCarve),
+    // fromPreset and label both survive the round trip or a preset stops being
+    // able to find its own nodes after a reload: re-applying would stack a
+    // second copy and the rack would lose the grouping it braces them with.
+    fromPreset: nonEmptyString(node.fromPreset),
+    label: nonEmptyString(node.label),
+    fromEq: nonEmptyString(node.fromEq),
+    fromLeveller: onlyTrue(node.fromLeveller),
+    presetAmount: clampedPresetAmount(node.presetAmount),
+    enabled: node.enabled !== false,
+    params: normalizeAudioFxParams(
+      node.type,
+      (node.params ?? undefined) as HfAudioFxParamValues | undefined,
+    ),
+  });
+}
+
+/** One node as the `data-fx-chain` attribute carries it. Every optional field is
+ *  omitted when it holds its default, so a plain chain stays plain. */
+function serializeAudioFxNode(node: HfAudioFxNode) {
+  return withoutUndefined({
+    type: node.type,
+    id: nonEmptyString(node.id),
+    fromCarve: onlyTrue(node.fromCarve),
+    fromPreset: nonEmptyString(node.fromPreset),
+    label: nonEmptyString(node.label),
+    fromEq: nonEmptyString(node.fromEq),
+    fromLeveller: onlyTrue(node.fromLeveller),
+    // Omitted when fully applied, so an untouched preset does not grow a field
+    // in every chain that carries one.
+    presetAmount: node.presetAmount === 1 ? undefined : clampedPresetAmount(node.presetAmount),
+    // Only the non-default is written: a chain of enabled nodes stays plain.
+    enabled: node.enabled === false ? (false as const) : undefined,
+    params: normalizeAudioFxParams(node.type, node.params),
+  });
+}
+
+/**
+ * The field readers the two node codecs share.
+ *
+ * Written as readers rather than as conditional spreads inline: nine
+ * `...(cond ? { x } : {})` clauses in one object literal is nine branches in a
+ * function whose actual job is "copy the fields that are set", and it read as
+ * complex because it was measured as complex.
+ */
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function onlyTrue(value: unknown): true | undefined {
+  return value === true ? true : undefined;
+}
+
+/** Clamped on the way in: the blend is two gains in opposition, and a value
+ *  outside 0..1 makes the dry leg negative rather than simply loud. */
+function clampedPresetAmount(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.min(1, Math.max(0, value));
+}
+
+/** Drop the keys whose reader returned undefined, so an absent field stays
+ *  absent rather than becoming an explicit `undefined` in the document. */
+function withoutUndefined<T extends object>(obj: T): T {
+  for (const key of Object.keys(obj) as Array<keyof T>) {
+    if (obj[key] === undefined) delete obj[key];
+  }
+  return obj;
 }

--- a/packages/core/src/audioGroups.test.ts
+++ b/packages/core/src/audioGroups.test.ts
@@ -8,6 +8,7 @@ import {
   resolveCarveSourceIds,
   resolveGroupElement,
 } from "./audioGroups.js";
+import { AUDIO_GROUP_RENDER_ID_ATTR, MEDIA_RENDER_ID_ATTR } from "./compiler/mediaRenderIds.js";
 
 beforeEach(() => {
   document.body.innerHTML = "";
@@ -124,6 +125,13 @@ describe("audioGroupOf", () => {
   it("normalizes an empty membership attribute to null", () => {
     document.body.innerHTML = `<audio id="vo-1" data-audio-group=""></audio>`;
     expect(audioGroupOf(document.getElementById("vo-1") as Element)).toBeNull();
+    expect(resolveAudioGroups(document)).toEqual([]);
+  });
+
+  // Groups do not nest, and the group element is not a member of itself.
+  it("returns null for the group element even when it carries the attribute", () => {
+    document.body.innerHTML = `<hf-audio-group id="bus" data-audio-group="other"></hf-audio-group>`;
+    expect(audioGroupOf(document.getElementById("bus") as Element)).toBeNull();
   });
 });
 
@@ -197,6 +205,15 @@ describe("resolveGroupElement", () => {
     const d = doc(`<div id="bg" data-hidden></div>`);
     expect(resolveGroupElement(d, "bg")).toBeNull();
   });
+
+  it("matches a stamped id containing selector syntax without throwing", () => {
+    const d = doc("");
+    const bus = d.createElement("hf-audio-group");
+    bus.setAttribute(MEDIA_RENDER_ID_ATTR, 'vo"\\instance');
+    d.body.append(bus);
+
+    expect(resolveGroupElement(d, 'vo"\\instance')).toBe(bus);
+  });
 });
 
 describe("isMemberGroupHidden", () => {
@@ -226,6 +243,18 @@ describe("isMemberGroupHidden", () => {
     );
     expect(isMemberGroupHidden(d, d.getElementById("vo-1"))).toBe(false);
     expect(isMemberGroupHidden(d, d.getElementById("lone"))).toBe(false);
+  });
+
+  it("uses the stamped bus instance when repeated compositions disagree on mute", () => {
+    const d = doc(`
+      <hf-audio-group id="bed" ${MEDIA_RENDER_ID_ATTR}="bed"></hf-audio-group>
+      <audio id="m1" data-audio-group="bed" ${AUDIO_GROUP_RENDER_ID_ATTR}="bed"></audio>
+      <hf-audio-group id="bed" ${MEDIA_RENDER_ID_ATTR}="bed__hf2" data-hidden></hf-audio-group>
+      <audio id="m2" data-audio-group="bed" ${AUDIO_GROUP_RENDER_ID_ATTR}="bed__hf2"></audio>
+    `);
+
+    expect(isMemberGroupHidden(d, d.getElementById("m1"))).toBe(false);
+    expect(isMemberGroupHidden(d, d.getElementById("m2"))).toBe(true);
   });
 });
 

--- a/packages/core/src/audioGroups.test.ts
+++ b/packages/core/src/audioGroups.test.ts
@@ -3,15 +3,14 @@ import {
   audioGroupOf,
   ensureAudioGroupInertStyle,
   HF_AUDIO_GROUP_ATTR,
+  isMemberGroupHidden,
   resolveAudioGroups,
   resolveCarveSourceIds,
+  resolveGroupElement,
 } from "./audioGroups.js";
 
 beforeEach(() => {
   document.body.innerHTML = "";
-  // The inert stylesheet is injected once per document, so a leftover from an
-  // earlier test would carry the assertion for the one after it.
-  document.getElementById("__hf-audio-group-inert")?.remove();
 });
 
 describe("resolveAudioGroups", () => {
@@ -115,61 +114,16 @@ describe("audioGroupOf", () => {
     expect(audioGroupOf(document.getElementById("vo-1") as Element)).toBeNull();
   });
 
-  // The mirror of resolveAudioGroups' own video case. These two readers used to
-  // disagree here: the resolver saw no group, this one answered "voiceover", so
-  // preview routed a track through a bus the export would never build (the
-  // render enforces audio-only in audioMixer).
-  it("returns null for a video, matching resolveAudioGroups", () => {
+  it("ignores video membership so preview matches the audio-only render", () => {
     document.body.innerHTML = `<video id="v-1" data-audio-group="voiceover"></video>`;
     const el = document.getElementById("v-1") as Element;
     expect(audioGroupOf(el)).toBeNull();
     expect(resolveAudioGroups(document)).toEqual([]);
   });
 
-  it("returns null for an empty attribute, not an empty string", () => {
+  it("normalizes an empty membership attribute to null", () => {
     document.body.innerHTML = `<audio id="vo-1" data-audio-group=""></audio>`;
     expect(audioGroupOf(document.getElementById("vo-1") as Element)).toBeNull();
-    expect(resolveAudioGroups(document)).toEqual([]);
-  });
-
-  // Groups do not nest, and the group element is not a member of itself.
-  it("returns null for the group element even when it carries the attribute", () => {
-    document.body.innerHTML = `<hf-audio-group id="bus" data-audio-group="other"></hf-audio-group>`;
-    expect(audioGroupOf(document.getElementById("bus") as Element)).toBeNull();
-  });
-});
-
-describe("ensureAudioGroupInertStyle", () => {
-  it("takes the group element out of layout", () => {
-    document.body.innerHTML = `<hf-audio-group id="voiceover"></hf-audio-group>`;
-    const el = document.getElementById("voiceover") as HTMLElement;
-    ensureAudioGroupInertStyle(document);
-    expect(getComputedStyle(el).display).toBe("none");
-  });
-
-  // An unknown custom element is an ordinary inline box, so in a flex or grid
-  // root it takes a slot: a gap, a justify-content share, and every
-  // :nth-child after it shifts. An author rule must not be able to put it
-  // back — and an id selector outranks this rule's type selector no matter
-  // which stylesheet came last, so `!important` is the only thing holding the
-  // contract. Dropping it makes this case fail.
-  it("beats an author rule that outranks it on specificity", () => {
-    document.head.insertAdjacentHTML(
-      "beforeend",
-      `<style id="author">#voiceover{display:flex}</style>`,
-    );
-    document.body.innerHTML = `<hf-audio-group id="voiceover"></hf-audio-group>`;
-    ensureAudioGroupInertStyle(document);
-    expect(getComputedStyle(document.getElementById("voiceover") as HTMLElement).display).toBe(
-      "none",
-    );
-    document.getElementById("author")?.remove();
-  });
-
-  it("injects once, however many times it is called", () => {
-    ensureAudioGroupInertStyle(document);
-    ensureAudioGroupInertStyle(document);
-    expect(document.querySelectorAll("#__hf-audio-group-inert")).toHaveLength(1);
   });
 });
 
@@ -217,5 +171,104 @@ describe("resolveCarveSourceIds", () => {
 describe(HF_AUDIO_GROUP_ATTR, () => {
   it("is the attribute name membership is keyed on", () => {
     expect(HF_AUDIO_GROUP_ATTR).toBe("data-audio-group");
+  });
+});
+
+describe("resolveGroupElement", () => {
+  const doc = (html: string): Document => {
+    const d = document.implementation.createHTMLDocument("t");
+    d.body.innerHTML = html;
+    return d;
+  };
+
+  it("returns the bus for a real <hf-audio-group>", () => {
+    const d = doc(`<hf-audio-group id="vo" data-volume="0.5"></hf-audio-group>`);
+    expect(resolveGroupElement(d, "vo")?.tagName.toLowerCase()).toBe("hf-audio-group");
+  });
+
+  // The trap: a bare getElementById read a member's OWN fader and chain as the
+  // bus's, applying both a second time on the sub-mix.
+  it("refuses an <audio> sharing the group id", () => {
+    const d = doc(`<audio id="vo" data-audio-group="vo" data-volume="0.5"></audio>`);
+    expect(resolveGroupElement(d, "vo")).toBeNull();
+  });
+
+  it("refuses an unrelated element sharing the group id", () => {
+    const d = doc(`<div id="bg" data-hidden></div>`);
+    expect(resolveGroupElement(d, "bg")).toBeNull();
+  });
+});
+
+describe("isMemberGroupHidden", () => {
+  const doc = (html: string): Document => {
+    const d = document.implementation.createHTMLDocument("t");
+    d.body.innerHTML = html;
+    return d;
+  };
+
+  // Membership is on the MEMBER, so the bus is never an ancestor and
+  // `closest("[data-hidden]")` cannot see it.
+  it("sees a muted bus that does not nest its member", () => {
+    const d = doc(
+      `<hf-audio-group id="vo" data-hidden></hf-audio-group>
+       <div><audio id="vo-1" data-audio-group="vo"></audio></div>`,
+    );
+    const member = d.getElementById("vo-1");
+    expect(member?.closest("[data-hidden]")).toBeNull();
+    expect(isMemberGroupHidden(d, member)).toBe(true);
+  });
+
+  it("is false for an unmuted bus and for a member with no group", () => {
+    const d = doc(
+      `<hf-audio-group id="vo"></hf-audio-group>
+       <audio id="vo-1" data-audio-group="vo"></audio>
+       <audio id="lone"></audio>`,
+    );
+    expect(isMemberGroupHidden(d, d.getElementById("vo-1"))).toBe(false);
+    expect(isMemberGroupHidden(d, d.getElementById("lone"))).toBe(false);
+  });
+});
+
+describe("resolveCarveSourceIds — empty group", () => {
+  it("drops an empty group's own bus id instead of returning it as a clip", () => {
+    const d = document.implementation.createHTMLDocument("t");
+    d.body.innerHTML = `<hf-audio-group id="voiceover"></hf-audio-group>`;
+    // No members, so the group resolves to nothing; its element must not pass
+    // the existence check as if it were a clip the analysis could read.
+    expect(resolveCarveSourceIds(d, ["voiceover"])).toEqual([]);
+  });
+});
+
+describe("ensureAudioGroupInertStyle", () => {
+  it("takes the group element out of layout", () => {
+    document.body.innerHTML = `<hf-audio-group id="voiceover"></hf-audio-group>`;
+    const el = document.getElementById("voiceover") as HTMLElement;
+    ensureAudioGroupInertStyle(document);
+    expect(getComputedStyle(el).display).toBe("none");
+  });
+
+  // An unknown custom element is an ordinary inline box, so in a flex or grid
+  // root it takes a slot: a gap, a justify-content share, and every
+  // :nth-child after it shifts. An author rule must not be able to put it
+  // back — and an id selector outranks this rule's type selector no matter
+  // which stylesheet came last, so `!important` is the only thing holding the
+  // contract. Dropping it makes this case fail.
+  it("beats an author rule that outranks it on specificity", () => {
+    document.head.insertAdjacentHTML(
+      "beforeend",
+      `<style id="author">#voiceover{display:flex}</style>`,
+    );
+    document.body.innerHTML = `<hf-audio-group id="voiceover"></hf-audio-group>`;
+    ensureAudioGroupInertStyle(document);
+    expect(getComputedStyle(document.getElementById("voiceover") as HTMLElement).display).toBe(
+      "none",
+    );
+    document.getElementById("author")?.remove();
+  });
+
+  it("injects once, however many times it is called", () => {
+    ensureAudioGroupInertStyle(document);
+    ensureAudioGroupInertStyle(document);
+    expect(document.querySelectorAll("#__hf-audio-group-inert")).toHaveLength(1);
   });
 });

--- a/packages/core/src/audioGroups.ts
+++ b/packages/core/src/audioGroups.ts
@@ -86,7 +86,7 @@ function buildGroup(id: string, memberIds: string[], el: Element | undefined): H
  */
 export function resolveGroupElement(
   doc:
-    | (Pick<Document, "getElementById"> & Partial<Pick<Document, "querySelector">>)
+    | (Pick<Document, "getElementById"> & Partial<Pick<Document, "querySelectorAll">>)
     | null
     | undefined,
   groupId: string,
@@ -94,8 +94,12 @@ export function resolveGroupElement(
   // A render-stamped key names an INSTANCE, and `getElementById` cannot find it
   // — the author id is what is on the element's `id`. Tried first so a compiled
   // document resolves the right one of two identically-named buses.
-  const stamped =
-    doc?.querySelector?.(`${HF_AUDIO_GROUP_TAG}[${MEDIA_RENDER_ID_ATTR}="${groupId}"]`) ?? null;
+  // Compare the raw attribute value instead of interpolating an author-provided
+  // id into a selector. Quotes and backslashes are valid attribute values, and
+  // turning one into selector syntax made this otherwise tolerant reader throw.
+  const stamped = Array.from(
+    doc?.querySelectorAll?.(`${HF_AUDIO_GROUP_TAG}[${MEDIA_RENDER_ID_ATTR}]`) ?? [],
+  ).find((candidate) => candidate.getAttribute(MEDIA_RENDER_ID_ATTR) === groupId);
   if (stamped) return stamped;
   const el = doc?.getElementById(groupId) ?? null;
   if (!el) return null;
@@ -114,7 +118,11 @@ export function isMemberGroupHidden(
   doc: Pick<Document, "getElementById"> | null | undefined,
   el: Element | null | undefined,
 ): boolean {
-  const groupId = el?.getAttribute?.(HF_AUDIO_GROUP_ATTR);
+  // A compiler stamp identifies the bus INSTANCE. The author id is only unique
+  // within one composition file, so resolving by it in an inlined document made
+  // every repeated sub-composition consult the first instance's mute state.
+  const groupId =
+    el?.getAttribute?.(AUDIO_GROUP_RENDER_ID_ATTR) ?? el?.getAttribute?.(HF_AUDIO_GROUP_ATTR);
   if (!groupId) return false;
   return resolveGroupElement(doc, groupId)?.hasAttribute("data-hidden") ?? false;
 }

--- a/packages/core/src/audioGroups.ts
+++ b/packages/core/src/audioGroups.ts
@@ -10,24 +10,11 @@
  */
 
 import { HF_AUDIO_FX_ATTR } from "./audioFx.js";
+import { AUDIO_GROUP_RENDER_ID_ATTR, MEDIA_RENDER_ID_ATTR } from "./compiler/mediaRenderIds.js";
 import { HF_AUDIO_AUTOMATION_ATTR } from "./audioAutomation.js";
 
 export const HF_AUDIO_GROUP_TAG = "hf-audio-group";
 export const HF_AUDIO_GROUP_ATTR = "data-audio-group";
-
-/**
- * v1 membership, in one place: an `<audio>` carrying a NON-EMPTY
- * `data-audio-group`.
- *
- * Both readers below derive from this string, because they disagreed when they
- * did not. `resolveAudioGroups` scanned `audio[...]` while `audioGroupOf`
- * returned the attribute off any element, so the same DOM answered "no group"
- * for a `<video data-audio-group="voiceover">` in one and `"voiceover"` in the
- * other. The render already enforces audio-only (see audioMixer's
- * `type === "audio"` guard), so the disagreement was preview routing a track
- * the export would never group.
- */
-const MEMBER_SELECTOR = `audio[${HF_AUDIO_GROUP_ATTR}]`;
 
 export interface HfAudioGroup {
   id: string;
@@ -49,7 +36,13 @@ export interface HfAudioGroup {
   hidden: boolean;
 }
 
-function parseGroupVolume(el: Element | undefined): number {
+/**
+ * A group element's `data-volume`, defaulting to 1 for a missing, unparseable
+ * or absent element. Shared so the preview bus and `resolveAudioGroups` (which
+ * the render reads) cannot drift: the export was ~8 dB quieter than what was
+ * auditioned for exactly as long as the preview ignored this.
+ */
+export function readAudioGroupVolume(el: Element | null | undefined): number {
   const raw = el?.getAttribute("data-volume");
   const parsed = raw ? parseFloat(raw) : 1;
   return Number.isFinite(parsed) ? parsed : 1;
@@ -64,7 +57,7 @@ function buildGroup(id: string, memberIds: string[], el: Element | undefined): H
     memberIds,
     ...(fxChain ? { fxChain } : {}),
     ...(automation ? { automation } : {}),
-    volume: parseGroupVolume(el),
+    volume: readAudioGroupVolume(el),
     hidden: el?.hasAttribute("data-hidden") ?? false,
   };
 }
@@ -76,10 +69,68 @@ function buildGroup(id: string, memberIds: string[], el: Element | undefined): H
  * (label = id) so a hand-authored composition degrades gracefully. Audio
  * only in v1 — a `data-audio-group` on a `<video>` is ignored.
  */
+/**
+ * The `<hf-audio-group>` element for a group id, or null.
+ *
+ * Tag-checked, which a bare `getElementById` is not. Every group attribute —
+ * the fader, the mute, the FX chain, the automation lane — is read off whatever
+ * this returns, so an unrelated element sharing the id used to be read as a bus:
+ * an `<audio id="vo" data-audio-group="vo" data-volume="0.5" data-fx-chain=…>`
+ * had its own fader and chain applied a SECOND time on the bus, and a
+ * `<div id="bg" data-hidden>` silenced group "bg" in preview only. The render
+ * never had this problem — `resolveAudioGroups` only ever accepted the tag —
+ * so the two disagreed on exactly the attributes the bus exists to carry.
+ *
+ * Returning null is the documented "group with no element" case, which
+ * degrades to a flat sum rather than borrowing a stranger's settings.
+ */
+export function resolveGroupElement(
+  doc:
+    | (Pick<Document, "getElementById"> & Partial<Pick<Document, "querySelector">>)
+    | null
+    | undefined,
+  groupId: string,
+): Element | null {
+  // A render-stamped key names an INSTANCE, and `getElementById` cannot find it
+  // — the author id is what is on the element's `id`. Tried first so a compiled
+  // document resolves the right one of two identically-named buses.
+  const stamped =
+    doc?.querySelector?.(`${HF_AUDIO_GROUP_TAG}[${MEDIA_RENDER_ID_ATTR}="${groupId}"]`) ?? null;
+  if (stamped) return stamped;
+  const el = doc?.getElementById(groupId) ?? null;
+  if (!el) return null;
+  return el.tagName?.toLowerCase() === HF_AUDIO_GROUP_TAG ? el : null;
+}
+
+/**
+ * Whether the bus a member belongs to is muted.
+ *
+ * Membership is held by the MEMBER's `data-audio-group`; a group never nests
+ * its members. So `el.closest("[data-hidden]")` cannot see a muted bus, which
+ * is how the render came to drop a hidden group's members while the preview
+ * fallback played them at full level.
+ */
+export function isMemberGroupHidden(
+  doc: Pick<Document, "getElementById"> | null | undefined,
+  el: Element | null | undefined,
+): boolean {
+  const groupId = el?.getAttribute?.(HF_AUDIO_GROUP_ATTR);
+  if (!groupId) return false;
+  return resolveGroupElement(doc, groupId)?.hasAttribute("data-hidden") ?? false;
+}
+
 export function resolveAudioGroups(root: ParentNode): HfAudioGroup[] {
   const membersByGroup = new Map<string, string[]>();
-  for (const member of root.querySelectorAll(MEMBER_SELECTOR)) {
-    const groupId = member.getAttribute(HF_AUDIO_GROUP_ATTR);
+  for (const member of root.querySelectorAll(`audio[${HF_AUDIO_GROUP_ATTR}]`)) {
+    // The render-stamped instance key when the compiler has been through
+    // (`assignMediaRenderIds`), else the author id. An author id is unique only
+    // per composition FILE, so a sub-composition declaring a bus AND its members
+    // and used twice put both instances' members under one key — one sub-mix for
+    // two independent buses, instance B's fader and chain over instance A's
+    // audio, and with only B muted BOTH instances dropped from the export. The
+    // live preview has no stamps, so it reads exactly as before.
+    const groupId =
+      member.getAttribute(AUDIO_GROUP_RENDER_ID_ATTR) ?? member.getAttribute(HF_AUDIO_GROUP_ATTR);
     if (!groupId || !member.id) continue;
     const members = membersByGroup.get(groupId);
     if (members) members.push(member.id);
@@ -88,7 +139,10 @@ export function resolveAudioGroups(root: ParentNode): HfAudioGroup[] {
 
   const groupElements = new Map<string, Element>();
   for (const el of root.querySelectorAll(HF_AUDIO_GROUP_TAG)) {
-    if (el.id) groupElements.set(el.id, el);
+    // Keyed the same way, so a stamped document pairs instance for instance and
+    // an unstamped one keeps id-for-id.
+    const key = el.getAttribute(MEDIA_RENDER_ID_ATTR) ?? el.id;
+    if (key) groupElements.set(key, el);
   }
 
   const groups: HfAudioGroup[] = [];
@@ -122,27 +176,25 @@ export function resolveCarveSourceIds(doc: Document, ids: readonly string[]): st
     const group = groupsById.get(id);
     if (group) {
       group.memberIds.forEach(add);
-    } else if (doc.getElementById(id)) {
+    } else if (doc.getElementById(id) && !resolveGroupElement(doc, id)) {
+      // A group with no members resolves to no entry above, and its own bus
+      // element would then pass this existence check and be returned as if it
+      // were a clip — a source the analysis can only fail to find, which the
+      // docblock above promises is dropped.
       add(id);
     }
   }
   return out;
 }
 
-/**
- * The group a member belongs to, or null — the same predicate
- * `resolveAudioGroups` scans with, so the two can never disagree about a given
- * element.
+/** The group an audio member belongs to, or null. Membership is audio-only in
+ * v1, matching `resolveAudioGroups` and the render mixer; video and group-bus
+ * attributes are inert.
  *
- * Non-`<audio>` returns null: video is out of scope in v1, and so is
- * `data-audio-group` on an `<hf-audio-group>` itself (groups do not nest).
- * `data-audio-group=""` returns null rather than `""` — the resolver skips a
- * falsy id, and the "or null" in this contract has to mean it.
- *
- * Tolerant of objects that only partially implement `Element` (test doubles for
- * `HTMLMediaElement` commonly do): anything missing `tagName` or `getAttribute`
- * simply has no group, mirroring `readChain`'s style in `runtime/audioFx.ts`.
- */
+ * Tolerant of objects that only partially implement `Element` (test doubles
+ * for `HTMLMediaElement` commonly do) — anything missing `tagName` or
+ * `getAttribute` simply has no group, mirroring `readChain`'s style in
+ * `runtime/audioFx.ts`. */
 export function audioGroupOf(el: Element): string | null {
   if (typeof el.tagName !== "string" || el.tagName.toLowerCase() !== "audio") return null;
   if (typeof el.getAttribute !== "function") return null;
@@ -165,25 +217,15 @@ export function audioGroupOf(el: Element): string | null {
  * runtime rather than the compiler so preview and render share one source.
  */
 export function ensureAudioGroupInertStyle(doc: Document): void {
-  const STYLE_ID = "__hf-audio-group-inert";
-  if (!doc?.head || doc.getElementById(STYLE_ID)) return;
+  const styleId = "__hf-audio-group-inert";
+  if (!doc?.head || doc.getElementById(styleId)) return;
   const style = doc.createElement("style");
-  style.id = STYLE_ID;
+  style.id = styleId;
   style.textContent = `${HF_AUDIO_GROUP_TAG}{display:none!important}`;
   doc.head.appendChild(style);
 }
 
-/**
- * Solo ("Hear only this") predicate — shared by the studio store (which owns
- * the `soloed` set and the UI's lit/half-lit state) and the preview transport
- * (which turns it into gain). An element is audible while any solo is active
- * only if IT is soloed, or its OWN group is soloed (group solo = members
- * solo). There is no "ancestor" to reach up to in this data model — a group
- * bus is never itself attenuated by solo, so a soloed member's path through
- * its group stays open by construction; this predicate only ever gates the
- * member's own gain. No solo active at all is the one path that returns true
- * unconditionally.
- */
+/** Compatibility bridge until the Studio solo controls are removed later in the stack. */
 export function isAudibleUnderSolo(
   soloed: ReadonlySet<string>,
   id: string,
@@ -194,8 +236,7 @@ export function isAudibleUnderSolo(
   return Boolean(groupId && soloed.has(groupId));
 }
 
-/** Half-lit: this group itself isn't soloed, but at least one of its members
- *  is — the display-only signal that "some of what's under here still plays". */
+/** Compatibility bridge until the Studio solo controls are removed later in the stack. */
 export function isGroupHalfLitUnderSolo(
   soloed: ReadonlySet<string>,
   groupId: string,

--- a/packages/core/src/canary.test.ts
+++ b/packages/core/src/canary.test.ts
@@ -426,28 +426,3 @@ describe("canary reason property", () => {
     expect(canaryReasonKey("de-parallel-router")).toBe("canary_reason_de_parallel_router");
   });
 });
-
-/**
- * The audio features ship to everyone.
- *
- * They landed on main across twelve PRs while all three of their canaries sat
- * at 0%, which meant the FX rack, the group rows, mute and solo were present in
- * the build and reachable by nobody. Pinned as a test because the failure mode
- * is silent: re-registering one of these re-hides a shipped feature, and
- * nothing else would say so.
- */
-describe("the audio rollout", () => {
-  // The three names by hand, because that is the assertion the intent needs: a
-  // prefix check catches `audio-fx-rack` coming back but not `fx-rack` or
-  // `audiofx-rack`, and it is the specific feature being re-hidden that matters.
-  it("registers none of the three retired audio canaries", () => {
-    const retired = ["audio-fx-rack", "audio-track-mute", "audio-groups"];
-    expect(retired.filter((name) => findCanary(name))).toEqual([]);
-  });
-
-  // The family guard, kept alongside it: a fourth audio canary would gate a
-  // feature that now ships to everyone.
-  it("registers no audio canary at all", () => {
-    expect(CANARIES.filter((c) => c.name.startsWith("audio-")).map((c) => c.name)).toEqual([]);
-  });
-});

--- a/packages/core/src/canary.test.ts
+++ b/packages/core/src/canary.test.ts
@@ -426,3 +426,28 @@ describe("canary reason property", () => {
     expect(canaryReasonKey("de-parallel-router")).toBe("canary_reason_de_parallel_router");
   });
 });
+
+/**
+ * The audio features ship to everyone.
+ *
+ * They landed on main across twelve PRs while all three of their canaries sat
+ * at 0%, which meant the FX rack, the group rows, mute and solo were present in
+ * the build and reachable by nobody. Pinned as a test because the failure mode
+ * is silent: re-registering one of these re-hides a shipped feature, and
+ * nothing else would say so.
+ */
+describe("the audio rollout", () => {
+  // The three names by hand, because that is the assertion the intent needs: a
+  // prefix check catches `audio-fx-rack` coming back but not `fx-rack` or
+  // `audiofx-rack`, and it is the specific feature being re-hidden that matters.
+  it("registers none of the three retired audio canaries", () => {
+    const retired = ["audio-fx-rack", "audio-track-mute", "audio-groups"];
+    expect(retired.filter((name) => findCanary(name))).toEqual([]);
+  });
+
+  // The family guard, kept alongside it: a fourth audio canary would gate a
+  // feature that now ships to everyone.
+  it("registers no audio canary at all", () => {
+    expect(CANARIES.filter((c) => c.name.startsWith("audio-")).map((c) => c.name)).toEqual([]);
+  });
+});

--- a/packages/core/src/compiler/index.ts
+++ b/packages/core/src/compiler/index.ts
@@ -90,4 +90,8 @@ export {
 // Asset-path primitives (shared across core, producer, CLI)
 export { CSS_URL_RE, PATH_ATTRS, isNonRelativeUrl, isPathInside } from "./assetPaths";
 
-export { MEDIA_RENDER_ID_ATTR, assignMediaRenderIds } from "./mediaRenderIds";
+export {
+  AUDIO_GROUP_RENDER_ID_ATTR,
+  MEDIA_RENDER_ID_ATTR,
+  assignMediaRenderIds,
+} from "./mediaRenderIds";

--- a/packages/core/src/compiler/mediaRenderIds.test.ts
+++ b/packages/core/src/compiler/mediaRenderIds.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { parseHTML } from "linkedom";
-import { MEDIA_RENDER_ID_ATTR, assignMediaRenderIds } from "./mediaRenderIds";
+import {
+  AUDIO_GROUP_RENDER_ID_ATTR,
+  MEDIA_RENDER_ID_ATTR,
+  assignMediaRenderIds,
+} from "./mediaRenderIds";
 
 function stamp(html: string): string[] {
   const { document } = parseHTML(html);
@@ -75,5 +79,74 @@ describe("assignMediaRenderIds", () => {
     const { document } = parseHTML('<video id="no-src"></video>');
     assignMediaRenderIds(document as unknown as Parameters<typeof assignMediaRenderIds>[0]);
     expect(document.querySelector("video")?.hasAttribute(MEDIA_RENDER_ID_ATTR)).toBe(false);
+  });
+});
+
+describe("audio group render ids", () => {
+  /**
+   * A sub-composition declaring a bus AND its members, used twice. The author id
+   * `bed` is unique per FILE and duplicated once inlined, and the two instances
+   * are indistinguishable by `data-composition-id` — both carry the file's own —
+   * so the subtree element is the only thing that separates them.
+   */
+  const doc = (html: string) => parseHTML(`<html><body>${html}</body></html>`).document;
+  const TWICE = `
+    <div data-composition-id="bedcomp">
+      <hf-audio-group id="bed" data-volume="0.5"></hf-audio-group>
+      <audio id="m1" src="a.wav" data-audio-group="bed"></audio>
+    </div>
+    <div data-composition-id="bedcomp">
+      <hf-audio-group id="bed" data-volume="0.5"></hf-audio-group>
+      <audio id="m1" src="a.wav" data-audio-group="bed"></audio>
+    </div>`;
+
+  it("gives each bus instance its own key and pairs each member to its own subtree", () => {
+    const d = doc(TWICE);
+    assignMediaRenderIds(d);
+
+    const buses = [...d.querySelectorAll("hf-audio-group")];
+    const members = [...d.querySelectorAll("audio")];
+    expect(buses.map((b) => b.getAttribute(MEDIA_RENDER_ID_ATTR))).toEqual(["bed", "bed__hf2"]);
+    // Member N belongs to bus N — the whole point. Cross-paired, one instance's
+    // fader and chain would land on the other instance's audio.
+    expect(members.map((m) => m.getAttribute(AUDIO_GROUP_RENDER_ID_ATTR))).toEqual([
+      "bed",
+      "bed__hf2",
+    ]);
+  });
+
+  it("leaves a single-instance bus keyed by its own id", () => {
+    const d = doc(`<hf-audio-group id="vo"></hf-audio-group>
+      <audio id="a" src="a.wav" data-audio-group="vo"></audio>`);
+    assignMediaRenderIds(d);
+    expect(d.querySelector("hf-audio-group")?.getAttribute(MEDIA_RENDER_ID_ATTR)).toBe("vo");
+    expect(d.querySelector("audio")?.getAttribute(AUDIO_GROUP_RENDER_ID_ATTR)).toBe("vo");
+  });
+
+  it("leaves a member alone when no bus element declares its group", () => {
+    const d = doc(`<audio id="a" src="a.wav" data-audio-group="ghost"></audio>`);
+    assignMediaRenderIds(d);
+    // The element-less group is a supported shape; it just has no instance to
+    // name, so resolution falls back to the author id as it always did.
+    expect(d.querySelector("audio")?.hasAttribute(AUDIO_GROUP_RENDER_ID_ATTR)).toBe(false);
+  });
+
+  it("does not bind a root member to a same-named bus in a nested composition", () => {
+    const d = doc(`<div data-composition-id="root">
+      <div data-composition-id="child">
+        <hf-audio-group id="bed"></hf-audio-group>
+        <audio id="child-member" src="child.wav" data-audio-group="bed"></audio>
+      </div>
+      <audio id="root-member" src="root.wav" data-audio-group="bed"></audio>
+      <hf-audio-group id="bed"></hf-audio-group>
+    </div>`);
+    assignMediaRenderIds(d);
+
+    const buses = [...d.querySelectorAll("hf-audio-group")];
+    expect(buses.map((bus) => bus.getAttribute(MEDIA_RENDER_ID_ATTR))).toEqual(["bed", "bed__hf2"]);
+    expect(d.getElementById("child-member")?.getAttribute(AUDIO_GROUP_RENDER_ID_ATTR)).toBe("bed");
+    expect(d.getElementById("root-member")?.getAttribute(AUDIO_GROUP_RENDER_ID_ATTR)).toBe(
+      "bed__hf2",
+    );
   });
 });

--- a/packages/core/src/compiler/mediaRenderIds.ts
+++ b/packages/core/src/compiler/mediaRenderIds.ts
@@ -27,12 +27,33 @@
 
 export const MEDIA_RENDER_ID_ATTR = "data-hf-render-id";
 
+/**
+ * The bus a member belongs to, as a DOCUMENT-unique key.
+ *
+ * `data-audio-group` names a bus by author id, unique only per composition FILE
+ * — so a sub-composition that declares a bus AND its members, used twice, put
+ * both instances' members under one key and let the second bus element
+ * overwrite the first. The mixer then sub-mixed two independent buses as one,
+ * applied instance B's fader, chain and label to instance A's audio, and — with
+ * only B muted — dropped BOTH instances from the export. This attribute is that
+ * collision resolved at the same boundary the media ids are.
+ */
+export const AUDIO_GROUP_RENDER_ID_ATTR = "data-hf-group-render-id";
+
 /** Elements the render pipeline addresses by id. */
 const MEDIA_SELECTOR = "video[src], audio[src], img[src]";
+/** Buses, which are addressed by id in exactly the same way and collide the
+ *  same way. Only an id'd bus can be joined at all. */
+const AUDIO_GROUP_SELECTOR = "hf-audio-group[id]";
 
 interface MediaElementLike {
   getAttribute(name: string): string | null;
   setAttribute(name: string, value: string): void;
+}
+
+/** A bus or member, which additionally needs subtree scoping to be paired up. */
+interface ScopedElementLike extends MediaElementLike {
+  closest?(selector: string): ScopedElementLike | null;
 }
 
 interface DocumentLike {
@@ -84,4 +105,86 @@ export function assignMediaRenderIds(document: DocumentLike): void {
     taken.add(renderId);
     el.setAttribute(MEDIA_RENDER_ID_ATTR, renderId);
   }
+
+  assignAudioGroupRenderIds(document, taken);
+}
+
+/**
+ * Give every `<hf-audio-group>` a document-unique render id, and tell each
+ * member which INSTANCE of its bus it belongs to.
+ *
+ * Shares the `taken` set with the media pass, so a bus id and a clip id can
+ * never resolve to the same key either.
+ *
+ * A member is paired to the bus inside its OWN composition subtree. Two
+ * instances of the same sub-composition are indistinguishable by
+ * `data-composition-id` — both carry the file's own id — so the subtree
+ * ELEMENT is the only thing that separates them, which is exactly what
+ * `closest()` returns. A member whose bus is not in its subtree (a
+ * hand-authored bus in the root composition, members in a scene) falls back to
+ * the first bus with that id, which is the pre-existing behaviour and the only
+ * sensible reading when there is one bus and several scenes referencing it.
+ */
+function assignAudioGroupRenderIds(document: DocumentLike, taken: Set<string>): void {
+  const busesById = stampAudioGroupBuses(document, taken);
+  if (busesById.size === 0) return;
+
+  for (const member of document.querySelectorAll(
+    "audio[data-audio-group]",
+  ) as Iterable<ScopedElementLike>) {
+    const groupId = member.getAttribute("data-audio-group");
+    const buses = groupId ? busesById.get(groupId) : undefined;
+    if (!groupId || !buses?.length) continue;
+    const renderId = busForMember(member, groupId, buses)?.getAttribute(MEDIA_RENDER_ID_ATTR);
+    if (renderId) member.setAttribute(AUDIO_GROUP_RENDER_ID_ATTR, renderId);
+  }
+}
+
+/** Every id'd bus, stamped and indexed by author id — several per id when a
+ *  sub-composition that declares one is used more than once. */
+function stampAudioGroupBuses(
+  document: DocumentLike,
+  taken: Set<string>,
+): Map<string, ScopedElementLike[]> {
+  const busesById = new Map<string, ScopedElementLike[]>();
+  for (const bus of document.querySelectorAll(
+    AUDIO_GROUP_SELECTOR,
+  ) as Iterable<ScopedElementLike>) {
+    const id = bus.getAttribute("id");
+    if (!id) continue;
+    const renderId = bus.getAttribute(MEDIA_RENDER_ID_ATTR) ?? uniqueRenderId(id, taken);
+    taken.add(renderId);
+    bus.setAttribute(MEDIA_RENDER_ID_ATTR, renderId);
+    const existing = busesById.get(id);
+    if (existing) existing.push(bus);
+    else busesById.set(id, [bus]);
+  }
+  return busesById;
+}
+
+/**
+ * Which instance of a bus a member belongs to: the one in its own composition
+ * subtree. Falls back to the first when the bus is not in the member's subtree
+ * at all — a hand-authored bus in the root composition with members in scenes —
+ * which is the pre-existing reading and the only sensible one there.
+ */
+function busForMember(
+  member: ScopedElementLike,
+  groupId: string,
+  buses: ScopedElementLike[],
+): MediaElementLike | undefined {
+  if (buses.length === 1) return buses[0];
+  const scope = member.closest?.("[data-composition-id]");
+  if (!scope) return buses[0];
+  // `scope.querySelectorAll()` also sees buses owned by nested compositions.
+  // Compare each bus's own nearest composition instead, so a root member does
+  // not bind to a same-named bus inside a child merely because the child comes
+  // first in document order.
+  return (
+    buses.find(
+      (candidate) =>
+        candidate.getAttribute("id") === groupId &&
+        candidate.closest?.("[data-composition-id]") === scope,
+    ) ?? buses[0]
+  );
 }

--- a/packages/core/src/editing/affordances.test.ts
+++ b/packages/core/src/editing/affordances.test.ts
@@ -4,6 +4,7 @@ import {
   resolveEditingSections,
   type EditableElementFacts,
 } from "./affordances";
+import { HF_AUDIO_GROUP_TAG } from "../audioGroups";
 
 function baseFacts(over: Partial<EditableElementFacts> = {}): EditableElementFacts {
   return {
@@ -207,5 +208,43 @@ describe("audioFx section", () => {
   it("does not apply to video, whose sound lives on a separate audio element", () => {
     expect(resolveEditingSections(baseFacts({ tag: "video" })).audioFx).toBe(false);
     expect(resolveEditingSections(baseFacts({ tag: "div" })).audioFx).toBe(false);
+  });
+});
+
+describe("audio has timing but no animation; a bus has neither", () => {
+  // Nothing on an `<audio>` element or an `<hf-audio-group>` bus has a
+  // transform, an opacity or a box, so a tween on one moves nothing. The panel
+  // showed its GSAP editor for both anyway, because it gated that on the
+  // handlers being wired rather than on the element being animatable.
+  it("withholds animation from an audio clip that HAS tweens", () => {
+    const s = resolveEditingSections(baseFacts({ tag: "audio", animationCount: 3 }));
+    expect(s.animation).toBe(false);
+  });
+
+  it("withholds it from a bus too", () => {
+    const s = resolveEditingSections(baseFacts({ tag: HF_AUDIO_GROUP_TAG, animationCount: 3 }));
+    expect(s.animation).toBe(false);
+  });
+
+  it("still grants it to a div with tweens, so the gate is the tag", () => {
+    expect(resolveEditingSections(baseFacts({ tag: "div", animationCount: 1 })).animation).toBe(
+      true,
+    );
+  });
+
+  // An audio clip is placed on the timeline like any other, so Start/Duration
+  // stay editable — that is the half of the old Motion section worth keeping.
+  it("keeps timing on an audio clip with an authored start", () => {
+    const s = resolveEditingSections(baseFacts({ tag: "audio", hasTimingStart: true }));
+    expect(s.timing).toBe(true);
+  });
+
+  // A bus has no `data-start` and no duration; its automation clock is
+  // composition time. Start/Duration/End would be editing nothing.
+  it("withholds timing from a bus even if something claims a start", () => {
+    const s = resolveEditingSections(
+      baseFacts({ tag: HF_AUDIO_GROUP_TAG, hasTimingStart: true, animationCount: 2 }),
+    );
+    expect(s.timing).toBe(false);
   });
 });

--- a/packages/core/src/editing/affordances.ts
+++ b/packages/core/src/editing/affordances.ts
@@ -1,3 +1,4 @@
+import { HF_AUDIO_GROUP_TAG } from "../audioGroups.js";
 /**
  * Pure, DOM-free editing-affordance resolution. Single source of truth for what
  * the studio's edit panel (and any SDK consumer) surfaces per selected element:
@@ -203,17 +204,33 @@ function resolveCapabilities(facts: EditableElementFacts): DomEditCapabilities {
  * without re-running the capability geometry parse.
  */
 export function resolveEditingSections(facts: EditableElementFacts): EditingSectionApplicability {
+  // An `<hf-audio-group>` is a mixer bus: it has no visual frame AND no media
+  // of its own, but it does carry a `data-fx-chain`, which is the whole point
+  // of selecting one. Without this the timeline's "Open rack" on a group led to
+  // a panel offering Fill, Gradient, Stroke and Shadow for something that paints
+  // nothing — and no Audio FX section at all, so a bus effect could only ever be
+  // applied from the preset popover and never edited.
+  const isAudioBus = facts.tag === HF_AUDIO_GROUP_TAG;
   // `<audio>` never paints a visual frame — position/size/rotation/stacking
   // and fill/radius/stroke/shadow/etc. are all inert on it. Every other tag
   // (div, img, video, svg, canvas, composition hosts) renders a real box.
-  const hasVisualBox = facts.tag !== "audio";
+  const hasVisualBox = facts.tag !== "audio" && !isAudioBus;
   return {
     text: facts.hasEditableText && !facts.isCompositionHost && !facts.isInsideLockedComposition,
     media: facts.tag === "video" || facts.tag === "audio" || facts.tag === "img",
-    audioFx: facts.tag === "audio",
+    audioFx: facts.tag === "audio" || isAudioBus,
     colorGrading: facts.tag === "video" || facts.tag === "img",
-    timing: facts.hasTimingStart || facts.animationCount > 0,
-    animation: facts.animationCount > 0,
+    // A bus has no clip range at all — no `data-start`, no duration, and its
+    // automation clock is composition time — so Start/Duration/End would be
+    // editing nothing. Audio keeps its timing: an `<audio>` clip is placed on
+    // the timeline like any other, it just cannot be tweened (see `animation`).
+    timing: !isAudioBus && (facts.hasTimingStart || facts.animationCount > 0),
+    // Has tweens AND could meaningfully have them. Neither an `<audio>` clip nor
+    // a bus has a transform, opacity or box, so a tween on one moves nothing —
+    // the flat panel gates its editor on the same two tags, and does it by tag
+    // rather than by this flag because a div with no tweens yet must still
+    // offer "+ Add".
+    animation: facts.animationCount > 0 && facts.tag !== "audio" && !isAudioBus,
     layout: hasVisualBox,
     style: hasVisualBox,
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -151,7 +151,11 @@ export {
   MEDIA_DURATION_CLAMP_EPSILON_SECONDS,
 } from "./compiler/timingCompiler";
 
-export { MEDIA_RENDER_ID_ATTR, assignMediaRenderIds } from "./compiler/mediaRenderIds";
+export {
+  AUDIO_GROUP_RENDER_ID_ATTR,
+  MEDIA_RENDER_ID_ATTR,
+  assignMediaRenderIds,
+} from "./compiler/mediaRenderIds";
 
 export {
   RENDER_FRAME_ID_PREFIX,

--- a/packages/core/src/runtime/audioFx.ts
+++ b/packages/core/src/runtime/audioFx.ts
@@ -99,6 +99,16 @@ export function readElementAutomation(el: {
 export interface ElementFxHandle {
   dispose(): void;
   /**
+   * Re-book every envelope against a fresh reference frame.
+   *
+   * For a graph that OUTLIVES the source feeding it — a group bus, which is
+   * built once and kept for the session — a replay or a seek starts a new pass
+   * over the same chain. Without re-anchoring, the envelopes stay committed to
+   * the first pass's absolute context times: past their last point that is a
+   * stuck value, which for a fade-out is silence for the rest of the session.
+   */
+  reanchor(timing: AutomationTiming): void;
+  /**
    * Re-aim every booked envelope at a new playback rate.
    *
    * Lanes are committed to absolute context times, so a param scheduled at 1×
@@ -277,6 +287,13 @@ export function attachElementFxChain(
   }
 
   return {
+    reanchor: (next: AutomationTiming) => {
+      if (disposed) return;
+      const at = timingNow();
+      if (at) cancelParamLane(automated, at.scheduledAt);
+      frame = { ...next };
+      scheduleFor(readChain(el).chain, frame);
+    },
     setRate: (rate: number) => {
       const at = timingNow();
       if (disposed || !at || !Number.isFinite(rate) || rate <= 0 || rate === at.rate) return;

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -190,6 +190,99 @@ describe("initSandboxRuntimeModular", () => {
     window.cancelAnimationFrame = originalCancelAnimationFrame;
   });
 
+  /**
+   * `data-volume` is an authoring GAIN up to `MAX_AUDIO_GAIN` (12 dB ~ 3.98) —
+   * `HTMLMediaElement.volume` accepts only 0..1. The bridge clamps its own
+   * argument, but the PRODUCT `clipVolume * volume` was assigned unclamped, so a
+   * clip authored above unity threw
+   * `IndexSizeError: The volume provided (2.42103) is outside the range [0, 1]`
+   * (2.42103 is the +7.68 dB fader stop) — and the throw aborted the loop, so
+   * every media element after it kept its old volume too.
+   */
+  it("clamps the native volume of an over-unity clip instead of throwing", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-duration", "10");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    const loud = document.createElement("audio");
+    loud.setAttribute("data-start", "0");
+    loud.setAttribute("data-duration", "10");
+    loud.setAttribute("data-volume", "2.42103");
+    loud.load = () => {};
+    root.appendChild(loud);
+    // Second element proves the throw took the whole sweep down with it, not just
+    // the offending clip.
+    const quiet = document.createElement("audio");
+    quiet.setAttribute("data-start", "0");
+    quiet.setAttribute("data-duration", "10");
+    quiet.setAttribute("data-volume", "0.5");
+    quiet.load = () => {};
+    root.appendChild(quiet);
+
+    window.__timelines = { main: createMockTimeline(10) };
+    initSandboxRuntimeModular();
+
+    const errors: string[] = [];
+    const onError = (e: ErrorEvent) => errors.push(String(e.message ?? e.error));
+    window.addEventListener("error", onError);
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { source: "hf-parent", type: "control", action: "set-volume", volume: 1 },
+      }),
+    );
+    window.removeEventListener("error", onError);
+    expect(errors).toEqual([]);
+  });
+
+  /**
+   * The runtime stamps `data-start`/`data-duration` on every id'd child of the
+   * composition root so a blank canvas still shows selectable rows. An
+   * `<hf-audio-group>` is a mixer BUS, not a clip: stamping it put it in
+   * `__clipManifest` as a full-duration element, which the studio drew as an
+   * ordinary clip row above the real group header — draggable, trimmable, and
+   * deletable, and deleting it takes the bus (so the group's FX rack) with it.
+   */
+  it("does not stamp timing onto an <hf-audio-group> bus", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-duration", "10");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    const bus = document.createElement("hf-audio-group");
+    bus.id = "voiceover";
+    bus.setAttribute("data-label", "Voiceover");
+    root.appendChild(bus);
+
+    // A plain id'd sibling proves the stamp still happens for everything else.
+    const caption = document.createElement("div");
+    caption.id = "cap-1";
+    root.appendChild(caption);
+
+    window.__timelines = { main: createMockTimeline(10) };
+    // The stamp only runs inside the studio preview (`window.parent !== window`),
+    // which jsdom is not — so the condition has to be staged for the test.
+    const realParent = window.parent;
+    Object.defineProperty(window, "parent", { value: {}, configurable: true });
+    try {
+      initSandboxRuntimeModular();
+    } finally {
+      Object.defineProperty(window, "parent", { value: realParent, configurable: true });
+    }
+
+    expect(bus.hasAttribute("data-start")).toBe(false);
+    expect(bus.hasAttribute("data-duration")).toBe(false);
+    expect(caption.getAttribute("data-start")).toBe("0");
+  });
+
   it("resolves Studio hold as a deterministic step at the segment end", () => {
     const defaultEase = (progress: number) => progress;
     const originalParseEase = vi.fn(() => defaultEase);
@@ -1350,10 +1443,13 @@ describe("initSandboxRuntimeModular", () => {
     window.__timelines = { main: createMockTimeline(10) };
     initSandboxRuntimeModular();
 
-    // `scheduleMediaElementPlayback` is the Web Audio scheduling entry point (#3322 routed
-    // media-element clips straight through the graph; `decodeAudioElement` is only the fallback
-    // for the rate-shifted case, so it is NOT called on this path).
-    const scheduleSpy = vi.spyOn(WebAudioTransport.prototype, "scheduleMediaElementPlayback");
+    // `scheduleMediaElementPlayback`, not `decodeAudioElement`: the media-element
+    // transport is the path the runtime tries FIRST for audio, and the decoded
+    // buffer is only its fallback. What is under test either way is which
+    // ELEMENTS get scheduled at all.
+    const scheduleSpy = vi
+      .spyOn(WebAudioTransport.prototype, "scheduleMediaElementPlayback")
+      .mockResolvedValue(null);
 
     const player = window.__player;
     player?.play();
@@ -1361,6 +1457,50 @@ describe("initSandboxRuntimeModular", () => {
 
     expect(scheduleSpy).toHaveBeenCalledTimes(1);
     expect(scheduleSpy.mock.calls[0]?.[0]).toBe(audibleAudio);
+  });
+
+  it("reschedules only when a data-hidden mutation actually moved something", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-duration", "10");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    const hiddenAudio = document.createElement("audio");
+    hiddenAudio.setAttribute("data-start", "0");
+    hiddenAudio.setAttribute("data-duration", "10");
+    hiddenAudio.setAttribute("data-hidden", "");
+    hiddenAudio.load = () => {};
+    hiddenAudio.play = vi.fn(() => Promise.resolve());
+    root.appendChild(hiddenAudio);
+
+    window.__timelines = { main: createMockTimeline(10) };
+    initSandboxRuntimeModular();
+
+    const stopSpy = vi.spyOn(WebAudioTransport.prototype, "stopAll");
+    const player = window.__player;
+    player?.play();
+
+    // A seek stops the transport itself, so the COUNT is the measure. Without
+    // the dirty gate the reschedule fired on every visibility pass, adding a
+    // second stop — an audible stop-and-restart across the whole mix — to
+    // rebuild an identical active set.
+    stopSpy.mockClear();
+    player?.seek(1, { keepPlaying: true });
+    const seekOnly = stopSpy.mock.calls.length;
+
+    // The dirty flag is set by a data-hidden MUTATION, so the toggle is the
+    // gesture; a plain seek never reaches the reschedule at all.
+    stopSpy.mockClear();
+    hiddenAudio.removeAttribute("data-hidden");
+    player?.seek(2, { keepPlaying: true });
+    const afterToggle = stopSpy.mock.calls.length;
+
+    expect(seekOnly).toBe(1);
+    expect(afterToggle).toBe(seekOnly + 1);
   });
 
   it("batches a mid-playback data-hidden toggle into exactly one Web Audio reschedule", () => {
@@ -1401,7 +1541,9 @@ describe("initSandboxRuntimeModular", () => {
     // toggles away from.
     player?.play();
 
-    const scheduleSpy = vi.spyOn(WebAudioTransport.prototype, "scheduleMediaElementPlayback");
+    const scheduleSpy = vi
+      .spyOn(WebAudioTransport.prototype, "scheduleMediaElementPlayback")
+      .mockResolvedValue(null);
     const generationSpy = vi.spyOn(WebAudioTransport.prototype, "startGeneration");
 
     // Both become visible in the SAME sync pass — must still be one reschedule.
@@ -1413,6 +1555,52 @@ describe("initSandboxRuntimeModular", () => {
 
     expect(generationSpy).toHaveBeenCalledTimes(1);
     expect(scheduleSpy).toHaveBeenCalledTimes(2);
+  });
+
+  // Scheduling does NOT replace the active set: it bumps a generation, which
+  // only rejects schedules still in flight. Every source already started keeps
+  // playing and there is no per-element dedup, so rescheduling on its own laid
+  // a second buffer source over every sounding clip — the whole mix doubled,
+  // slightly out of phase, from one mute click until the next pause.
+  it("stops the running sources before rescheduling on a data-hidden toggle", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-duration", "10");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    const audio = document.createElement("audio");
+    audio.setAttribute("data-start", "0");
+    audio.setAttribute("data-duration", "10");
+    audio.setAttribute("data-hidden", "");
+    audio.load = () => {};
+    audio.play = vi.fn(() => Promise.resolve());
+    root.appendChild(audio);
+
+    window.__timelines = { main: createMockTimeline(10) };
+    initSandboxRuntimeModular();
+    const player = window.__player;
+    player?.play();
+
+    vi.spyOn(WebAudioTransport.prototype, "decodeAudioElement").mockResolvedValue(null);
+    const stopSpy = vi.spyOn(WebAudioTransport.prototype, "stopAll");
+    const generationSpy = vi.spyOn(WebAudioTransport.prototype, "startGeneration");
+
+    audio.removeAttribute("data-hidden");
+    player?.seek(1, { keepPlaying: true });
+
+    expect(generationSpy).toHaveBeenCalledTimes(1);
+    // Two: `seek` clears the graph on its way in, and the toggle's own
+    // reschedule clears it again. Only the second one is what this covers —
+    // without it the count is 1 and the reschedule stacks on live sources.
+    expect(stopSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Order matters, not just presence: stopping AFTER the reschedule would
+    // silence the clips it had just started.
+    const lastStop = Math.max(...stopSpy.mock.invocationCallOrder);
+    expect(lastStop).toBeLessThan(generationSpy.mock.invocationCallOrder[0] ?? 0);
   });
 
   it("does not stamp Studio timing on GSAP targets inside authored timed clips", () => {

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -43,8 +43,10 @@ import { createColorGradingRuntime, type RuntimeColorGradingApi } from "./colorG
 import { TransportClock } from "./clock";
 import { WebAudioTransport } from "./webAudioTransport";
 import {
+  audioGroupOf,
   ensureAudioGroupInertStyle,
   HF_AUDIO_GROUP_TAG,
+  isAudibleUnderSolo,
   isMemberGroupHidden,
 } from "../audioGroups";
 import { clampNativeMediaVolume } from "../audioGain";
@@ -187,7 +189,15 @@ export function initSandboxRuntimeModular(): void {
   void webAudio.init().then((ok) => {
     webAudioReady = ok;
   });
+  // Keep Studio's session-only "Hear only this" bridge alive until the solo
+  // controls are removed later in the stack. It must not be serialized into
+  // the composition because solo is preview state, not authored state.
+  let soloedIds: ReadonlySet<string> = new Set();
   window.__hf = window.__hf || {};
+  window.__hf.setAudioSolo = (ids) => {
+    soloedIds = new Set(ids);
+    webAudio.setSolo(soloedIds);
+  };
   /** Hidden by an ancestor, or by the BUS this clip belongs to. The bus is
    *  never an ancestor — membership is on the member's `data-audio-group` — so
    *  `closest()` alone could not see a muted group, which the render drops. */
@@ -2112,6 +2122,7 @@ export function initSandboxRuntimeModular(): void {
           webAudio.setElementVolume(el, authorVolume),
         isWebAudioOwned: (el) => webAudio.ownsElement(el),
         isWebAudioRouted: (el) => webAudio.routesElement(el),
+        isAudibleUnderSolo: (el) => isAudibleUnderSolo(soloedIds, el.id, audioGroupOf(el)),
         onAutoplayBlocked: () => {
           if (state.mediaAutoplayBlockedPosted) return;
           state.mediaAutoplayBlockedPosted = true;

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -39,11 +39,15 @@ import { loadExternalCompositions, loadInlineTemplateCompositions } from "./comp
 import { applyCaptionOverrides } from "./captionOverrides";
 import { applyPositionEdits, installPositionEditsSeekReapply } from "./positionEdits";
 import { applyVariableBindings } from "./applyVariableBindings";
-import { ensureAudioGroupInertStyle } from "../audioGroups.js";
 import { createColorGradingRuntime, type RuntimeColorGradingApi } from "./colorGrading";
 import { TransportClock } from "./clock";
 import { WebAudioTransport } from "./webAudioTransport";
-import { HF_AUDIO_GROUP_TAG, audioGroupOf, isAudibleUnderSolo } from "../audioGroups";
+import {
+  ensureAudioGroupInertStyle,
+  HF_AUDIO_GROUP_TAG,
+  isMemberGroupHidden,
+} from "../audioGroups";
+import { clampNativeMediaVolume } from "../audioGain";
 import { quantizeTimeToFrame } from "../inline-scripts/parityContract";
 import { STUDIO_MANUAL_EDIT_GESTURE_ATTR } from "../editing/draftMarkers";
 import type {
@@ -183,20 +187,12 @@ export function initSandboxRuntimeModular(): void {
   void webAudio.init().then((ok) => {
     webAudioReady = ok;
   });
-  // Studio's "Hear only this" push channel — session-only, so it rides a
-  // dedicated `__hf` field (mirrors `colorGrading`'s lazy-init pattern) rather
-  // than a DOM attribute: solo must never be written to the document (design
-  // doc §2.2 / the export-safety guarantee), so there is nothing here for
-  // `syncTimedElementVisibility`'s attribute-diffing to key off. Kept in this
-  // closure too (not just inside `webAudio`) so `syncRuntimeMedia`'s
-  // HTMLMedia-fallback path (video/non-transport audio) can apply the same
-  // predicate per tick, the same split A2 used for `data-hidden`.
-  let soloedIds: ReadonlySet<string> = new Set();
   window.__hf = window.__hf || {};
-  window.__hf.setAudioSolo = (ids) => {
-    soloedIds = new Set(ids);
-    webAudio.setSolo(soloedIds);
-  };
+  /** Hidden by an ancestor, or by the BUS this clip belongs to. The bus is
+   *  never an ancestor — membership is on the member's `data-audio-group` — so
+   *  `closest()` alone could not see a muted group, which the render drops. */
+  const isSilencedByHidden = (el: Element): boolean =>
+    el.closest("[data-hidden]") !== null || isMemberGroupHidden(el.ownerDocument, el);
   // `_auto` is a Studio-internal keyframe marker (an auto-tracked endpoint the
   // parser reads back), NOT an animatable property. Register it as a no-op GSAP
   // plugin so GSAP doesn't log "Invalid property _auto" on every tween build —
@@ -1451,6 +1447,14 @@ export function initSandboxRuntimeModular(): void {
       // scene container we auto-stamp below (e.g. an opacity-crossfaded scene)
       // must NOT suppress its own animated children — otherwise those children
       // never become timeline clips and that scene can't inline-expand.
+      // A bus is not a clip. `<hf-audio-group>` carries a group's label, fader,
+      // mute and FX chain and has no timing of its own, so stamping it put it in
+      // `__clipManifest` as a full-duration element — which the studio drew as an
+      // ordinary clip row above the real group header. That row was draggable,
+      // trimmable and deletable, and deleting it removed the bus, taking the
+      // group's automation lanes and FX rack with it.
+      const isAudioGroupBus = (el: Element): boolean =>
+        el.tagName.toLowerCase() === HF_AUDIO_GROUP_TAG;
       const authoredTimed = new Set<Element>(document.querySelectorAll("[data-start]"));
       const hasAuthoredTimedAncestor = (element: HTMLElement): boolean => {
         let node = element.parentElement;
@@ -1469,6 +1473,7 @@ export function initSandboxRuntimeModular(): void {
             for (const target of child.targets()) {
               if (!(target instanceof HTMLElement)) continue;
               if (target === rootComp) continue;
+              if (isAudioGroupBus(target)) continue;
               if (target.hasAttribute("data-start")) continue;
               if (hasAuthoredTimedAncestor(target)) continue;
               if (seen.has(target)) continue;
@@ -1496,6 +1501,7 @@ export function initSandboxRuntimeModular(): void {
           if (hasAuthoredTimedAncestor(el)) continue;
           if (seen.has(el)) continue;
           if (el.tagName === "SCRIPT" || el.tagName === "STYLE" || el.tagName === "LINK") continue;
+          if (isAudioGroupBus(el)) continue;
           seen.add(el);
           el.setAttribute("data-start", "0");
           el.setAttribute("data-duration", dur);
@@ -1939,7 +1945,16 @@ export function initSandboxRuntimeModular(): void {
   // A data-hidden toggle on (or affecting) an audio element must re-schedule
   // WebAudio playback so the hidden clip's source is dropped/restored mid-
   // playback. Batched to one call per syncTimedElementVisibility pass, not
-  // one per toggled node (schedulePlayback replaces the whole active set).
+  // one per toggled node.
+  //
+  // The reschedule is paired with `stopAll()` below, for the reason
+  // `applyWebAudioRate` already spells out: scheduling does
+  // NOT replace the active set. It bumps a generation, which only rejects
+  // stale schedules still in flight — every source already started keeps
+  // playing, and there is no per-element dedup. This comment used to claim the
+  // opposite and the call site trusted it, so muting a track mid-playback
+  // started a second buffer source for every in-window clip on top of the ones
+  // still sounding: the whole mix audibly doubled, slightly out of phase.
   let hiddenAudioDirty = false;
   const nodeAffectsAudio = (node: HTMLElement): boolean =>
     node.matches("audio[data-start]") || node.querySelector("audio[data-start]") !== null;
@@ -1950,7 +1965,13 @@ export function initSandboxRuntimeModular(): void {
   // export time, per B4); this just keeps the live WebAudio group bus in
   // sync with a `data-hidden` toggle made mid-playback.
   const groupHiddenLast = new WeakMap<Element, boolean>();
+  /** Set when a `data-hidden` mutation could have touched a BUS, so the sweep
+   *  below is not a whole-document query on every visibility pass. Same
+   *  dirty-flag shape as `hiddenAudioDirty` right above it. */
+  let groupMuteDirty = true;
   const syncAudioGroupMute = () => {
+    if (!groupMuteDirty) return;
+    groupMuteDirty = false;
     for (const groupEl of document.querySelectorAll(HF_AUDIO_GROUP_TAG)) {
       const hidden = groupEl.hasAttribute("data-hidden");
       if (groupHiddenLast.get(groupEl) === hidden) continue;
@@ -1972,6 +1993,7 @@ export function initSandboxRuntimeModular(): void {
           dataHiddenDisplayRestores.set(rawNode, rawNode.style.getPropertyValue("display"));
           dataHiddenDisplayNodes.add(rawNode);
           if (nodeAffectsAudio(rawNode)) hiddenAudioDirty = true;
+          groupMuteDirty = true;
         }
         rawNode.style.display = "none";
         if (rawNode instanceof HTMLVideoElement || rawNode instanceof HTMLImageElement) {
@@ -1990,6 +2012,7 @@ export function initSandboxRuntimeModular(): void {
         dataHiddenDisplayRestores.delete(rawNode);
         dataHiddenDisplayNodes.delete(rawNode);
         if (nodeAffectsAudio(rawNode)) hiddenAudioDirty = true;
+        groupMuteDirty = true;
       }
 
       let isVisibleNow = isTimedElementVisibleAt(rawNode, currentTime);
@@ -2019,7 +2042,12 @@ export function initSandboxRuntimeModular(): void {
         rawNode.style.display = "none";
       }
     }
+    // Only when a `data-hidden` mutation actually moved something: the skips
+    // this reschedule exists to re-run are what change the active set, so
+    // firing it otherwise was an audible stop-and-restart across the whole mix
+    // that rebuilt an identical set.
     if (hiddenAudioDirty && clock.isPlaying()) {
+      webAudio.stopAll();
       scheduleWebAudioForActiveClips();
     }
     hiddenAudioDirty = false;
@@ -2084,7 +2112,6 @@ export function initSandboxRuntimeModular(): void {
           webAudio.setElementVolume(el, authorVolume),
         isWebAudioOwned: (el) => webAudio.ownsElement(el),
         isWebAudioRouted: (el) => webAudio.routesElement(el),
-        isAudibleUnderSolo: (el) => isAudibleUnderSolo(soloedIds, el.id, audioGroupOf(el)),
         onAutoplayBlocked: () => {
           if (state.mediaAutoplayBlockedPosted) return;
           state.mediaAutoplayBlockedPosted = true;
@@ -2175,25 +2202,6 @@ export function initSandboxRuntimeModular(): void {
 
     postRuntimeMessage(payload);
     scheduleRootStageLayoutDiagnostics();
-  };
-
-  /** One meter reading per group with an active member — polled from the
-   *  transport's analyser, not the DOM, so an idle group (never played, no
-   *  matching `<hf-audio-group>`) is simply absent rather than reported as
-   *  zero. Cheap when nothing is grouped: `groupIds()` is empty. */
-  const postGroupLevels = () => {
-    const groupIds = webAudio.groupIds();
-    if (groupIds.length === 0) return;
-    const levels = groupIds
-      .map((groupId) => {
-        const reading = webAudio.groupLevel(groupId);
-        return reading ? { groupId, ...reading } : null;
-      })
-      .filter(
-        (entry): entry is { groupId: string; level: number; clipped: boolean } => entry !== null,
-      );
-    if (levels.length === 0) return;
-    postRuntimeMessage({ source: "hf-preview", type: "group-levels", levels });
   };
 
   const finitePositiveDuration = (value: number | null | undefined): number =>
@@ -2953,9 +2961,6 @@ export function initSandboxRuntimeModular(): void {
       if (transportTickCount % 30 === 0) {
         bindMediaMetadataListeners();
       }
-      if (clock.isPlaying()) {
-        postGroupLevels();
-      }
 
       // Sync clock duration with the resolved timeline each tick (catches async
       // rebinds, live data-duration edits). Never shrink while playing — transient
@@ -2987,7 +2992,7 @@ export function initSandboxRuntimeModular(): void {
           let foundActive = false;
           for (const rawEl of audioEls) {
             if (!(rawEl instanceof HTMLMediaElement) || !rawEl.isConnected) continue;
-            if (rawEl.closest("[data-hidden]")) continue;
+            if (isSilencedByHidden(rawEl)) continue;
             const start = Number.parseFloat(rawEl.dataset.start ?? "");
             const durAttr = parseStrictFiniteTimingNumber(rawEl.dataset.duration);
             const end = durAttr != null && durAttr > 0 ? start + durAttr : Infinity;
@@ -3095,7 +3100,7 @@ export function initSandboxRuntimeModular(): void {
     const audioEls = document.querySelectorAll("audio[data-start]");
     for (const rawEl of audioEls) {
       if (!(rawEl instanceof HTMLMediaElement) || !rawEl.isConnected) continue;
-      if (rawEl.closest("[data-hidden]")) continue;
+      if (isSilencedByHidden(rawEl)) continue;
       const compStart = Number.parseFloat(rawEl.dataset.start ?? "");
       if (!Number.isFinite(compStart)) continue;
       const mediaStart = readElementPlaybackStart(rawEl);
@@ -3238,7 +3243,11 @@ export function initSandboxRuntimeModular(): void {
         // assigning the product raw THROWS IndexSizeError and takes the rest of
         // the loop with it. The element carries the legal part; the boost above
         // unity belongs to Web Audio, which already has it from `setVolume`.
-        el.volume = Math.max(0, Math.min(1, clipVolume * volume));
+        //
+        // Through `clampNativeMediaVolume` rather than an inline clamp: that
+        // helper exists in `audioGain.ts` for exactly this bound and is what
+        // `withUnclampedVolume` uses, so the two cannot drift.
+        el.volume = clampNativeMediaVolume(clipVolume * volume);
       }
     },
     onSetMediaOutputMuted: (muted) => {

--- a/packages/core/src/runtime/media.test.ts
+++ b/packages/core/src/runtime/media.test.ts
@@ -577,14 +577,16 @@ describe("syncRuntimeMedia", () => {
   });
 
   describe("data-hidden silences preview volume", () => {
-    it("zeroes effective volume for a clip under a data-hidden ancestor", () => {
+    const hiddenClip = () => {
       const clip = createMockClip({ start: 0, end: 10, volume: 0.8 });
       Object.defineProperty(clip.el, "readyState", { value: 4, writable: true });
       const hiddenAncestor = document.createElement("div");
       hiddenAncestor.setAttribute("data-hidden", "");
       document.body.appendChild(hiddenAncestor);
       hiddenAncestor.appendChild(clip.el);
-
+      return clip;
+    };
+    const volumeSeen = (clip: ReturnType<typeof hiddenClip>) => {
       let seen = -1;
       syncRuntimeMedia({
         clips: [clip],
@@ -595,20 +597,32 @@ describe("syncRuntimeMedia", () => {
           seen = v;
         },
       });
+      return seen;
+    };
 
-      expect(seen).toBe(0);
+    it("zeroes effective volume for a clip under a data-hidden ancestor", () => {
+      expect(volumeSeen(hiddenClip())).toBe(0);
+    });
+
+    // A visible clip is the control: the zero above has to come from the
+    // ancestor, not from the fixture reading 0 for some other reason.
+    it("leaves a visible clip at its authored volume", () => {
+      const clip = createMockClip({ start: 0, end: 10, volume: 0.8 });
+      Object.defineProperty(clip.el, "readyState", { value: 4, writable: true });
+      document.body.appendChild(clip.el);
+      expect(volumeSeen(clip)).toBe(0.8);
     });
 
     it("does not touch el.muted when silencing a hidden clip (RULES trap: transport owns el.muted)", () => {
-      const clip = createMockClip({ start: 0, end: 10, volume: 0.8 });
-      Object.defineProperty(clip.el, "readyState", { value: 4, writable: true });
-      const hiddenAncestor = document.createElement("div");
-      hiddenAncestor.setAttribute("data-hidden", "");
-      document.body.appendChild(hiddenAncestor);
-      hiddenAncestor.appendChild(clip.el);
+      const clip = hiddenClip();
       clip.el.muted = false;
 
-      syncRuntimeMedia({ clips: [clip], timeSeconds: 1, playing: true, playbackRate: 1 });
+      syncRuntimeMedia({
+        clips: [clip],
+        timeSeconds: 1,
+        playing: true,
+        playbackRate: 1,
+      });
 
       expect(clip.el.muted).toBe(false);
     });

--- a/packages/core/src/runtime/media.ts
+++ b/packages/core/src/runtime/media.ts
@@ -3,6 +3,7 @@ import { interpolateVolumeGain, type VolumeKeyframe } from "./mediaVolumeEnvelop
 import { elementVolumeLaneGain } from "./audioAutomationVolume.js";
 import { readElementPlaybackRate, readMediaStart } from "./playbackRate.js";
 import { clampAudioGain } from "../audioGain.js";
+import { isMemberGroupHidden } from "../audioGroups.js";
 import { findInjectedRenderFrame } from "./renderFrameSibling.js";
 export { readElementPlaybackRate, resolveNaturalMediaTimelineDuration } from "./playbackRate.js";
 
@@ -223,11 +224,6 @@ export function syncRuntimeMedia(params: {
   /** Native media routed through WebAudio keeps its upstream element volume at
    * unity; do not mistake that transport write for an authored volume edit. */
   isWebAudioRouted?: (el: HTMLMediaElement) => boolean;
-  /** "Hear only this" gate for the HTMLMedia fallback path (video / any audio
-   *  not owned by the Web Audio transport, which applies its own dedicated
-   *  solo gain instead — see `WebAudioTransport.setSolo`). Absent when solo
-   *  isn't wired up at all, which reads as "always audible". */
-  isAudibleUnderSolo?: (el: HTMLMediaElement) => boolean;
   forceSync?: boolean;
 }): void {
   const forceMuteAll = !!(params.outputMuted || params.userMuted);
@@ -335,13 +331,16 @@ export function syncRuntimeMedia(params: {
       }
 
       // A data-hidden ancestor is silent in the export (audioMixer.ts drops
-      // it); preview must match. Folded into the per-tick volume, not
+      // it), so preview matches. Folded into the per-tick volume, not
       // el.muted (RULES trap: el.muted is the transport's ownership flag).
-      // Solo rides the same fold for the same reason — never el.muted, and
-      // never touching any attribute (it is session-only, unlike hidden).
-      const silencedBySolo = params.isAudibleUnderSolo ? !params.isAudibleUnderSolo(el) : false;
-      const effectiveVolume =
-        el.closest("[data-hidden]") || silencedBySolo ? 0 : clampVolume(authorVolume * userVol);
+      // Two independent ways to be silent, and the second is not an ancestor
+      // question: membership lives on the MEMBER's `data-audio-group`, so a
+      // muted BUS is invisible to `closest()`. The render drops such members
+      // (`memberGroupHidden`), so without this the export was silent where the
+      // fallback played at full level.
+      const silencedByHidden =
+        el.closest("[data-hidden]") !== null || isMemberGroupHidden(el.ownerDocument, el);
+      const effectiveVolume = silencedByHidden ? 0 : clampVolume(authorVolume * userVol);
       el.volume = effectiveVolume;
       lastRuntimeAppliedVolume.set(el, effectiveVolume);
       params.onElementVolume?.(el, effectiveVolume, authorVolume);

--- a/packages/core/src/runtime/media.ts
+++ b/packages/core/src/runtime/media.ts
@@ -224,6 +224,9 @@ export function syncRuntimeMedia(params: {
   /** Native media routed through WebAudio keeps its upstream element volume at
    * unity; do not mistake that transport write for an authored volume edit. */
   isWebAudioRouted?: (el: HTMLMediaElement) => boolean;
+  /** "Hear only this" gate for the HTMLMedia fallback path. WebAudio-owned
+   * sources apply the same predicate on their dedicated solo gain. */
+  isAudibleUnderSolo?: (el: HTMLMediaElement) => boolean;
   forceSync?: boolean;
 }): void {
   const forceMuteAll = !!(params.outputMuted || params.userMuted);
@@ -340,7 +343,9 @@ export function syncRuntimeMedia(params: {
       // fallback played at full level.
       const silencedByHidden =
         el.closest("[data-hidden]") !== null || isMemberGroupHidden(el.ownerDocument, el);
-      const effectiveVolume = silencedByHidden ? 0 : clampVolume(authorVolume * userVol);
+      const silencedBySolo = params.isAudibleUnderSolo ? !params.isAudibleUnderSolo(el) : false;
+      const effectiveVolume =
+        silencedByHidden || silencedBySolo ? 0 : clampVolume(authorVolume * userVol);
       el.volume = effectiveVolume;
       lastRuntimeAppliedVolume.set(el, effectiveVolume);
       params.onElementVolume?.(el, effectiveVolume, authorVolume);

--- a/packages/core/src/runtime/webAudioTransport.test.ts
+++ b/packages/core/src/runtime/webAudioTransport.test.ts
@@ -18,23 +18,11 @@ function createMockAudioContext(currentTime = 100) {
     }),
     _fireEnded: () => endedListeners.forEach((cb) => cb()),
   };
-  // One node per createGain() call, not one shared node for all of them. The
-  // shared version made every assertion on "the gain" read whichever node the
-  // scheduler happened to build last — a solo gain's 1 overwriting the volume
-  // gain's 0.8, for instance.
-  const gainNodes: Array<{
-    gain: { value: number };
-    connect: ReturnType<typeof vi.fn>;
-    disconnect: ReturnType<typeof vi.fn>;
-  }> = [];
-  const makeGain = () => {
-    const node = { gain: { value: 1 }, connect: vi.fn(), disconnect: vi.fn() };
-    gainNodes.push(node);
-    return node;
+  const gainNode = {
+    gain: { value: 1 },
+    connect: vi.fn(),
+    disconnect: vi.fn(),
   };
-  /** The volume gain: the first node any scheduler asks for. */
-  const gainNode = makeGain();
-  let served = 0;
   const mediaElementSourceNode = {
     connect: vi.fn(),
     disconnect: vi.fn(),
@@ -49,11 +37,11 @@ function createMockAudioContext(currentTime = 100) {
     resume: vi.fn(),
     createBufferSource: vi.fn(() => sourceNode),
     createMediaElementSource: vi.fn(() => mediaElementSourceNode),
-    createGain: vi.fn(() => (served++ === 0 ? gainNode : makeGain())),
+    createGain: vi.fn(() => gainNode),
     destination: {},
     close: vi.fn(),
   };
-  return { ctx, sourceNode, mediaElementSourceNode, gainNode, gainNodes, masterGain, startFn };
+  return { ctx, sourceNode, mediaElementSourceNode, gainNode, masterGain, startFn };
 }
 
 function setupTransport(currentTime = 100) {
@@ -124,14 +112,7 @@ describe("WebAudioTransport", () => {
       expect(mock.ctx.createMediaElementSource).toHaveBeenCalledWith(mockEl);
       expect(mock.ctx.createBufferSource).not.toHaveBeenCalled();
       expect(mock.mediaElementSourceNode.connect).toHaveBeenCalled();
-      // Volume gain → its own solo gain → master, the same tail the buffer path
-      // uses. Connecting straight to master here left native media exempt from
-      // "hear only this" and from group routing.
-      const [volumeGain, soloGain] = mock.gainNodes;
-      expect(volumeGain).toBe(mock.gainNode);
-      expect(volumeGain?.connect).toHaveBeenCalledWith(soloGain);
-      expect(volumeGain?.connect).not.toHaveBeenCalledWith(mock.masterGain);
-      expect(soloGain?.connect).toHaveBeenCalledWith(mock.masterGain);
+      expect(mock.gainNode.connect).toHaveBeenCalledWith(mock.masterGain);
       expect(mockEl.muted).toBe(false);
       expect(mockEl.volume).toBe(1);
       expect(mock.gainNode.gain.value).toBe(0.8);
@@ -405,36 +386,6 @@ describe("WebAudioTransport", () => {
       expect(mock.startFn).toHaveBeenCalledWith(0, 3, 7);
     });
 
-    // The bound is in BUFFER seconds, and an authored `data-playback-rate`
-    // is the only thing that makes buffer seconds differ from composition
-    // seconds — the global rate scales the transport clock and the source's
-    // playbackRate together, so it cancels out. Dropping the `* mediaRate`
-    // therefore looks harmless at the default rate and truncates every
-    // authored-fast clip, which is why these two cases exist.
-    it("bounds an authored 2x clip by its buffer length, not its clip length", async () => {
-      const { transport, mock, gen } = setupTransport(100);
-      const fast = {
-        muted: false,
-        getAttribute: (name: string) => (name === "data-playback-rate" ? "2" : null),
-      } as unknown as HTMLMediaElement;
-      // A 10s clip authored at 2x consumes 20 buffer seconds; playing from the
-      // start must hand `start()` all 20, or the audio stops at the halfway mark.
-      await transport.schedulePlayback(fast, mockBuffer, 5, 0, 5, 1, gen, 1, 10);
-      expect(mock.startFn).toHaveBeenCalledWith(0, 0, 20);
-    });
-
-    it("bounds an authored 0.5x clip by its buffer length, not its clip length", async () => {
-      const { transport, mock, gen } = setupTransport(100);
-      const slow = {
-        muted: false,
-        getAttribute: (name: string) => (name === "data-playback-rate" ? "0.5" : null),
-      } as unknown as HTMLMediaElement;
-      // The mirror case: 10 composition seconds at 0.5x consume 5 buffer
-      // seconds, so an unscaled bound of 10 would run 5s past the clip's end.
-      await transport.schedulePlayback(slow, mockBuffer, 5, 0, 5, 1, gen, 1, 10);
-      expect(mock.startFn).toHaveBeenCalledWith(0, 0, 5);
-    });
-
     it("plays unbounded when clipDuration is omitted (legacy behavior)", async () => {
       const { transport, mock, gen } = setupTransport(100);
       await transport.schedulePlayback(mockEl, mockBuffer, 5, 0, 8, 1, gen);
@@ -691,6 +642,7 @@ describe("WebAudioTransport", () => {
         getFloatTimeDomainData: ReturnType<typeof vi.fn>;
       }[] = [];
       const masterGain = { gain: { value: 1 }, connect: vi.fn(), disconnect: vi.fn() };
+      const mediaElementSource = { connect: vi.fn(), disconnect: vi.fn() };
       const ctx = {
         currentTime,
         state: "running",
@@ -705,7 +657,24 @@ describe("WebAudioTransport", () => {
           addEventListener: vi.fn(),
         })),
         createGain: vi.fn(() => {
-          const node = { gain: { value: 1 }, connect: vi.fn(), disconnect: vi.fn() };
+          // The AudioParam scheduling surface is part of the contract the group
+          // bus uses (`clearParamLane` cancels before re-seeding a reused bus).
+          // A bare `{ value }` made any such call throw, and `schedulePlayback`
+          // swallows throws into `return null` — so the mock's own gap read as
+          // "the member did not play" rather than as a missing stub.
+          const node = {
+            gain: {
+              value: 1,
+              cancelScheduledValues: vi.fn(),
+              cancelAndHoldAtTime: vi.fn(),
+              setValueAtTime: vi.fn(),
+              linearRampToValueAtTime: vi.fn(),
+              exponentialRampToValueAtTime: vi.fn(),
+              setValueCurveAtTime: vi.fn(),
+            },
+            connect: vi.fn(),
+            disconnect: vi.fn(),
+          };
           gainNodes.push(node);
           return node;
         }),
@@ -719,10 +688,14 @@ describe("WebAudioTransport", () => {
           analysers.push(node);
           return node;
         }),
+        // The media-element route needs this as much as the decoded one: without
+        // it `scheduleMediaElementPlayback` throws and its catch returns null,
+        // which reads as "the member did not play" rather than a missing stub.
+        createMediaElementSource: vi.fn(() => mediaElementSource),
         destination: {},
         close: vi.fn(),
       };
-      return { ctx, gainNodes, analysers, masterGain };
+      return { ctx, gainNodes, analysers, masterGain, mediaElementSource };
     }
 
     function setupGroupTransport(currentTime = 100) {
@@ -756,25 +729,79 @@ describe("WebAudioTransport", () => {
     }
 
     /** The group's own input gain is built lazily on the first member — index
-     *  2 in creation order (that member's own gain is 0, its solo gain 1). */
+     *  1 in creation order (that member's own gain is 0). */
     const firstGroupInput = (mock: ReturnType<typeof createGroupMockAudioContext>) =>
-      mock.gainNodes[2]!;
+      mock.gainNodes[1]!;
 
     beforeEach(() => {
       document.body.innerHTML = "";
     });
 
-    it("routes an ungrouped member straight to master, through its own solo gain", async () => {
+    it("routes an ungrouped clip straight to master through its own gain", async () => {
       const { transport, mock, gen } = setupGroupTransport();
 
-      await scheduleGrouped(transport, gen, "solo");
+      await scheduleGrouped(transport, gen, "lone");
 
-      // Member gain, then its dedicated solo gain (B5) — never straight to master.
-      expect(mock.gainNodes).toHaveLength(2);
-      const [memberGain, soloGain] = mock.gainNodes;
-      expect(memberGain!.connect).toHaveBeenCalledWith(soloGain);
-      expect(memberGain!.connect).not.toHaveBeenCalledWith(mock.masterGain);
-      expect(soloGain!.connect).toHaveBeenCalledWith(mock.masterGain);
+      // One gain per clip now that solo is gone — it goes straight to master.
+      expect(mock.gainNodes).toHaveLength(1);
+      const [clipGain] = mock.gainNodes;
+      expect(clipGain!.connect).toHaveBeenCalledWith(mock.masterGain);
+    });
+
+    // The media-element transport is the PRIMARY path for audio — the runtime
+    // tries it first and only falls back to a decoded buffer. It has to reach
+    // the same bus, or grouping silently applies to nothing that actually plays.
+    // The render clamps a track volume with `clampAudioGain` (ceiling ~3.98),
+    // so an over-unity bus previewed at 1.0 exported up to 12 dB louder than
+    // it auditioned.
+    it("previews an over-unity bus fader at the render's ceiling, not unity", async () => {
+      const { transport, mock, gen } = setupGroupTransport();
+      document.body.innerHTML = `<hf-audio-group id="vo" data-volume="2"></hf-audio-group>`;
+      await scheduleGrouped(transport, gen, "a", "vo");
+
+      // Creation order: a-gain(0), groupInput(1), groupOutput(2), muteGain(3), fader(4).
+      expect(mock.gainNodes[4]!.gain.value).toBeCloseTo(2, 6);
+    });
+
+    it("still floors a negative bus fader at zero", async () => {
+      const { transport, mock, gen } = setupGroupTransport();
+      document.body.innerHTML = `<hf-audio-group id="vo" data-volume="-1"></hf-audio-group>`;
+      await scheduleGrouped(transport, gen, "a", "vo");
+
+      expect(mock.gainNodes[4]!.gain.value).toBe(0);
+    });
+
+    // A bare getElementById read a member's own fader and chain as the bus's.
+    it("ignores a non-<hf-audio-group> element sharing the group id", async () => {
+      const { transport, mock, gen } = setupGroupTransport();
+      document.body.innerHTML = `<div id="vo" data-volume="0.25" data-hidden></div>`;
+      await scheduleGrouped(transport, gen, "a", "vo");
+
+      // Flat bus: unity fader, unmuted — the documented "group with no element"
+      // degradation, not the stranger's settings.
+      expect(mock.gainNodes[4]!.gain.value).toBe(1);
+      expect(mock.gainNodes[3]!.gain.value).toBe(1);
+    });
+
+    it("routes a grouped clip's MEDIA-ELEMENT playback to the group bus, not master", async () => {
+      const { transport, mock, gen } = setupGroupTransport();
+      const el = groupedAudioEl("vo-1", "vo");
+
+      await transport.scheduleMediaElementPlayback(el, 0, 0, 0, 1, gen, 1);
+
+      const clipGain = mock.gainNodes[0]!;
+      expect(clipGain.connect).toHaveBeenCalledWith(firstGroupInput(mock));
+      expect(clipGain.connect).not.toHaveBeenCalledWith(mock.masterGain);
+    });
+
+    it("routes an UNGROUPED clip's media-element playback straight to master", async () => {
+      const { transport, mock, gen } = setupGroupTransport();
+      const el = groupedAudioEl("lone");
+
+      await transport.scheduleMediaElementPlayback(el, 0, 0, 0, 1, gen, 1);
+
+      expect(mock.gainNodes).toHaveLength(1);
+      expect(mock.gainNodes[0]!.connect).toHaveBeenCalledWith(mock.masterGain);
     });
 
     it("two members of the same group land on ONE shared group gain, not master directly", async () => {
@@ -783,32 +810,31 @@ describe("WebAudioTransport", () => {
       await scheduleGrouped(transport, gen, "a", "vo");
       await scheduleGrouped(transport, gen, "b", "vo");
 
-      // Creation order for a: a-gain(0), a-solo(1), groupInput(2), groupOutput(3),
-      // muteGain(4) — the group bus is built lazily inside a's schedule call.
-      // Then b: b-gain(5), b-solo(6).
-      expect(mock.gainNodes.length).toBeGreaterThanOrEqual(7);
+      // Creation order for a: a-gain(0), groupInput(1), groupOutput(2),
+      // muteGain(3), fader(4) — the group bus is built lazily inside a's
+      // schedule call. Then b: b-gain(5).
+      expect(mock.gainNodes.length).toBeGreaterThanOrEqual(6);
       const aGain = mock.gainNodes[0]!;
-      const aSolo = mock.gainNodes[1]!;
       const groupInput = firstGroupInput(mock);
-      const groupOutput = mock.gainNodes[3]!;
-      const muteGain = mock.gainNodes[4]!;
+      const groupOutput = mock.gainNodes[2]!;
+      const muteGain = mock.gainNodes[3]!;
+      const fader = mock.gainNodes[4]!;
       const bGain = mock.gainNodes[5]!;
-      const bSolo = mock.gainNodes[6]!;
 
-      // Each member feeds its own solo gain, and both solo gains feed the
-      // shared bus — neither connects straight to master.
-      expect(aGain.connect).toHaveBeenCalledWith(aSolo);
-      expect(bGain.connect).toHaveBeenCalledWith(bSolo);
-      expect(aSolo.connect).toHaveBeenCalledWith(groupInput);
-      expect(bSolo.connect).toHaveBeenCalledWith(groupInput);
-      expect(aSolo.connect).not.toHaveBeenCalledWith(mock.masterGain);
-      expect(bSolo.connect).not.toHaveBeenCalledWith(mock.masterGain);
+      // Both members feed the shared bus — neither connects straight to master.
+      expect(aGain.connect).toHaveBeenCalledWith(groupInput);
+      expect(bGain.connect).toHaveBeenCalledWith(groupInput);
+      expect(aGain.connect).not.toHaveBeenCalledWith(mock.masterGain);
+      expect(bGain.connect).not.toHaveBeenCalledWith(mock.masterGain);
 
-      // The bus's input never reaches master directly — it lands on the mute
-      // gain (B5) first (the dry passthrough, since neither member's group has
-      // a chain-bearing `<hf-audio-group>`), then the output gain, then master.
+      // The bus's input never reaches master directly. It runs through the
+      // chain (dry here — neither member's group has a chain-bearing
+      // `<hf-audio-group>`) onto the FADER, then the mute gain (B5), then the
+      // output gain, then master. The fader sits POST-FX because that is where
+      // the render bakes group volume in.
       expect(groupInput.connect).not.toHaveBeenCalledWith(mock.masterGain);
-      expect(groupInput.connect).toHaveBeenCalledWith(muteGain);
+      expect(groupInput.connect).toHaveBeenCalledWith(fader);
+      expect(fader.connect).toHaveBeenCalledWith(muteGain);
       expect(muteGain.connect).toHaveBeenCalledWith(groupOutput);
       expect(groupOutput.connect).toHaveBeenCalledWith(mock.masterGain);
     });
@@ -817,11 +843,11 @@ describe("WebAudioTransport", () => {
       const { transport, mock, gen } = setupGroupTransport();
 
       await scheduleGrouped(transport, gen, "a", "vo");
-      const gainCountAfterFirst = mock.gainNodes.length; // a-gain + a-solo + group-input/output/mute
+      const gainCountAfterFirst = mock.gainNodes.length; // a-gain + group input/output/mute/fader
       await scheduleGrouped(transport, gen, "b", "vo");
 
-      // Only b's own gain and its solo gain are new — no second group bus minted.
-      expect(mock.gainNodes.length).toBe(gainCountAfterFirst + 2);
+      // Only b's own gain is new — no second group bus minted.
+      expect(mock.gainNodes.length).toBe(gainCountAfterFirst + 1);
     });
 
     it("a group id with no matching <hf-audio-group> element still gets a flat bus", async () => {
@@ -829,20 +855,38 @@ describe("WebAudioTransport", () => {
 
       await scheduleGrouped(transport, gen, "a", "orphan-group"); // no matching element
 
-      const muteGain = mock.gainNodes[4]!;
-      const groupOutput = mock.gainNodes[3]!;
-      expect(firstGroupInput(mock).connect).toHaveBeenCalledWith(muteGain);
+      const muteGain = mock.gainNodes[3]!;
+      const groupOutput = mock.gainNodes[2]!;
+      const fader = mock.gainNodes[4]!;
+      expect(firstGroupInput(mock).connect).toHaveBeenCalledWith(fader);
+      expect(fader.connect).toHaveBeenCalledWith(muteGain);
       expect(muteGain.connect).toHaveBeenCalledWith(groupOutput);
       expect(groupOutput.connect).toHaveBeenCalledWith(mock.masterGain);
+      // No element to read, so the fader sits at unity.
+      expect(fader.gain.value).toBe(1);
     });
 
-    it("group volume rides the group's own data-volume via its automation lane, not the member's", async () => {
+    // The old assertion here was `resolves.not.toBeNull()` — it was named for
+    // group volume and checked only that scheduling did not throw, so the bus
+    // sitting at unity while the render applied data-volume went unseen. The
+    // export was ~8 dB quieter than what had been auditioned.
+    it("puts the group's own data-volume on the bus fader", async () => {
+      document.body.innerHTML = `<hf-audio-group id="vo" data-label="Voiceover" data-volume="0.4"></hf-audio-group>`;
+      const { transport, mock, gen } = setupGroupTransport();
+
+      await expect(scheduleGrouped(transport, gen, "a", "vo")).resolves.not.toBeNull();
+
+      expect(mock.gainNodes[4]!.gain.value).toBeCloseTo(0.4, 6);
+    });
+
+    it("leaves the fader at unity when the group carries no data-volume", async () => {
       document.body.innerHTML = `<hf-audio-group id="vo" data-label="Voiceover"></hf-audio-group>`;
-      const { transport, gen } = setupGroupTransport();
+      const { transport, mock, gen } = setupGroupTransport();
 
       // No throw wiring the group's automation reader against a real
       // <hf-audio-group> element that carries no fx/automation attrs.
       await expect(scheduleGrouped(transport, gen, "a", "vo")).resolves.not.toBeNull();
+      expect(mock.gainNodes[4]!.gain.value).toBe(1);
     });
 
     it("destroy() disposes every group bus", async () => {
@@ -869,74 +913,51 @@ describe("WebAudioTransport", () => {
       expect(mock.gainNodes.filter((n) => n === groupInput)).toHaveLength(1);
     });
 
-    describe('solo — "Hear only this" (B5)', () => {
-      it("silences a non-soloed member via its own solo gain, without touching the group bus", async () => {
-        const { transport, mock, gen } = setupGroupTransport();
-        await scheduleGrouped(transport, gen, "a", "vo");
-        await scheduleGrouped(transport, gen, "b", "vo");
-        const aSolo = mock.gainNodes[1]!;
-        const bSolo = mock.gainNodes[6]!;
-        const groupInput = firstGroupInput(mock);
+    // Surviving stopAll() is the point of the bus — and the trap. Its envelopes
+    // were booked against the FIRST pass's absolute context times, so a replay
+    // or a seek left the fader holding that pass's last value: 0 after a
+    // fade-out, i.e. silent for the rest of the session.
+    it("re-anchors the reused bus once per play generation, and only once", async () => {
+      document.body.innerHTML = `<hf-audio-group id="vo" data-volume="0.5"></hf-audio-group>`;
+      const { transport, mock, gen } = setupGroupTransport();
+      await scheduleGrouped(transport, gen, "a", "vo");
+      const fader = mock.gainNodes[4]!;
 
-        transport.setSolo(new Set(["other-clip"]));
+      // Something moved the fader mid-pass (a ramp reaching its last point).
+      fader.gain.value = 0;
+      transport.stopAll();
 
-        expect(aSolo.gain.value).toBe(0);
-        expect(bSolo.gain.value).toBe(0);
-        // The group's own bus is never attenuated by solo — only the member
-        // gain stage is (design doc §2.2: "never ancestors").
-        expect(groupInput.gain.value).toBe(1);
+      const gen2 = transport.startGeneration();
+      await scheduleGrouped(transport, gen2, "a", "vo");
+      expect(fader.gain.value).toBeCloseTo(0.5, 6);
+
+      // A second member in the SAME pass must not re-book on top of the first.
+      fader.gain.value = 0;
+      await scheduleGrouped(transport, gen2, "b", "vo");
+      expect(fader.gain.value).toBe(0);
+    });
+
+    // reanchor runs inside schedulePlayback, whose catch turns any throw into
+    // `return null` — so a bus that fails to re-anchor would silently take the
+    // MEMBER out of the pass, and a generation stamped before the attempt would
+    // stop every later member retrying.
+    it("keeps the member playing when re-anchoring the bus throws", async () => {
+      document.body.innerHTML = `<hf-audio-group id="vo" data-volume="0.5"></hf-audio-group>`;
+      const { transport, mock, gen } = setupGroupTransport();
+      await scheduleGrouped(transport, gen, "a", "vo");
+      const fader = mock.gainNodes[4]!;
+      fader.gain.cancelScheduledValues = vi.fn(() => {
+        throw new Error("param is not schedulable");
       });
 
-      it("soloing a member of a group leaves the group's gain untouched, and only that member is audible", async () => {
-        const { transport, mock, gen } = setupGroupTransport();
-        await scheduleGrouped(transport, gen, "a", "vo");
-        await scheduleGrouped(transport, gen, "b", "vo");
-        const aSolo = mock.gainNodes[1]!;
-        const bSolo = mock.gainNodes[6]!;
-        const groupInput = firstGroupInput(mock);
+      transport.stopAll();
+      const gen2 = transport.startGeneration();
 
-        transport.setSolo(new Set(["a"]));
-
-        expect(aSolo.gain.value).toBe(1);
-        expect(bSolo.gain.value).toBe(0); // sibling stays silent
-        expect(groupInput.gain.value).toBe(1); // group bus itself untouched
-      });
-
-      it("soloing the GROUP id makes every member audible (group solo = members solo)", async () => {
-        const { transport, mock, gen } = setupGroupTransport();
-        await scheduleGrouped(transport, gen, "a", "vo");
-        await scheduleGrouped(transport, gen, "b", "vo");
-        const aSolo = mock.gainNodes[1]!;
-        const bSolo = mock.gainNodes[6]!;
-
-        transport.setSolo(new Set(["vo"]));
-
-        expect(aSolo.gain.value).toBe(1);
-        expect(bSolo.gain.value).toBe(1);
-      });
-
-      it("clearing solo (empty set) restores every member to audible", async () => {
-        const { transport, mock, gen } = setupGroupTransport();
-        await scheduleGrouped(transport, gen, "a", "vo");
-        const aSolo = mock.gainNodes[1]!;
-
-        transport.setSolo(new Set(["other"]));
-        expect(aSolo.gain.value).toBe(0);
-
-        transport.setSolo(new Set());
-        expect(aSolo.gain.value).toBe(1);
-      });
-
-      it("a newly scheduled member picks up an already-active solo immediately", async () => {
-        const { transport, mock, gen } = setupGroupTransport();
-        transport.setSolo(new Set(["a"]));
-
-        await scheduleGrouped(transport, gen, "a");
-        await scheduleGrouped(transport, gen, "b");
-
-        expect(mock.gainNodes[1]!.gain.value).toBe(1); // a's own solo gain
-        expect(mock.gainNodes[3]!.gain.value).toBe(0); // b's own solo gain
-      });
+      await expect(scheduleGrouped(transport, gen2, "a", "vo")).resolves.not.toBeNull();
+      // Generation not consumed by the failed attempt, so a sibling still tries.
+      fader.gain.cancelScheduledValues = vi.fn();
+      await scheduleGrouped(transport, gen2, "b", "vo");
+      expect(fader.gain.value).toBeCloseTo(0.5, 6);
     });
 
     describe("group mute (B5)", () => {
@@ -946,14 +967,14 @@ describe("WebAudioTransport", () => {
 
         await scheduleGrouped(transport, gen, "a", "vo");
 
-        const muteGain = mock.gainNodes[4]!;
+        const muteGain = mock.gainNodes[3]!;
         expect(muteGain.gain.value).toBe(0);
       });
 
       it("setGroupMuted toggles the mute gain on an active group bus", async () => {
         const { transport, mock, gen } = setupGroupTransport();
         await scheduleGrouped(transport, gen, "a", "vo");
-        const muteGain = mock.gainNodes[4]!;
+        const muteGain = mock.gainNodes[3]!;
         expect(muteGain.gain.value).toBe(1);
 
         transport.setGroupMuted("vo", true);
@@ -966,66 +987,6 @@ describe("WebAudioTransport", () => {
       it("setGroupMuted on a group with no active member is a no-op, not a throw", () => {
         const { transport } = setupGroupTransport();
         expect(() => transport.setGroupMuted("never-played", true)).not.toThrow();
-      });
-    });
-
-    describe("groupLevel meter (B7)", () => {
-      it("groupLevel returns null for an unknown/idle group id", () => {
-        const { transport } = setupGroupTransport();
-        expect(transport.groupLevel("never-played")).toBeNull();
-      });
-
-      it("creates exactly one analyser per group, lazily, on first member", async () => {
-        const { transport, mock, gen } = setupGroupTransport();
-        expect(mock.analysers).toHaveLength(0);
-
-        await scheduleGrouped(transport, gen, "a", "vo");
-        expect(mock.analysers).toHaveLength(1);
-        expect(mock.analysers[0]!.fftSize).toBe(256); // level, not spectrum
-
-        await scheduleGrouped(transport, gen, "b", "vo");
-        expect(mock.analysers).toHaveLength(1); // second member reuses the bus
-
-        expect(transport.groupIds()).toEqual(["vo"]);
-      });
-
-      it("groupLevel reads RMS off the group's own analyser once a member is scheduled", async () => {
-        const { transport, mock, gen } = setupGroupTransport();
-        await scheduleGrouped(transport, gen, "a", "vo");
-
-        const analyser = mock.analysers[0]!;
-        analyser.getFloatTimeDomainData.mockImplementation((buf: Float32Array) => {
-          buf.fill(0.5);
-        });
-
-        const reading = transport.groupLevel("vo");
-        expect(reading).not.toBeNull();
-        expect(reading!.level).toBeCloseTo(0.5, 5);
-        expect(reading!.clipped).toBe(false);
-      });
-
-      it("flags clipped when any sample hits the ceiling", async () => {
-        const { transport, mock, gen } = setupGroupTransport();
-        await scheduleGrouped(transport, gen, "a", "vo");
-
-        const analyser = mock.analysers[0]!;
-        analyser.getFloatTimeDomainData.mockImplementation((buf: Float32Array) => {
-          buf.fill(0.1);
-          buf[0] = 0.995;
-        });
-
-        expect(transport.groupLevel("vo")!.clipped).toBe(true);
-      });
-
-      it("disposes the analyser along with the rest of the group bus", async () => {
-        const { transport, mock, gen } = setupGroupTransport();
-        await scheduleGrouped(transport, gen, "a", "vo");
-        const analyser = mock.analysers[0]!;
-
-        transport.destroy();
-
-        expect(analyser.disconnect).toHaveBeenCalled();
-        expect(transport.groupLevel("vo")).toBeNull();
       });
     });
   });

--- a/packages/core/src/runtime/webAudioTransport.test.ts
+++ b/packages/core/src/runtime/webAudioTransport.test.ts
@@ -756,11 +756,11 @@ describe("WebAudioTransport", () => {
     // it auditioned.
     it("previews an over-unity bus fader at the render's ceiling, not unity", async () => {
       const { transport, mock, gen } = setupGroupTransport();
-      document.body.innerHTML = `<hf-audio-group id="vo" data-volume="2"></hf-audio-group>`;
+      document.body.innerHTML = `<hf-audio-group id="vo" data-volume="10"></hf-audio-group>`;
       await scheduleGrouped(transport, gen, "a", "vo");
 
       // Creation order: a-gain(0), groupInput(1), groupOutput(2), muteGain(3), fader(4).
-      expect(mock.gainNodes[4]!.gain.value).toBeCloseTo(2, 6);
+      expect(mock.gainNodes[4]!.gain.value).toBeCloseTo(3.9811, 3);
     });
 
     it("still floors a negative bus fader at zero", async () => {

--- a/packages/core/src/runtime/webAudioTransport.test.ts
+++ b/packages/core/src/runtime/webAudioTransport.test.ts
@@ -18,11 +18,20 @@ function createMockAudioContext(currentTime = 100) {
     }),
     _fireEnded: () => endedListeners.forEach((cb) => cb()),
   };
-  const gainNode = {
-    gain: { value: 1 },
-    connect: vi.fn(),
-    disconnect: vi.fn(),
+  // Every createGain call returns a distinct node. Sharing one hides graph
+  // errors because the solo stage can overwrite the authored-volume stage.
+  const gainNodes: Array<{
+    gain: { value: number };
+    connect: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+  }> = [];
+  const makeGain = () => {
+    const node = { gain: { value: 1 }, connect: vi.fn(), disconnect: vi.fn() };
+    gainNodes.push(node);
+    return node;
   };
+  const gainNode = makeGain();
+  let served = 0;
   const mediaElementSourceNode = {
     connect: vi.fn(),
     disconnect: vi.fn(),
@@ -37,11 +46,11 @@ function createMockAudioContext(currentTime = 100) {
     resume: vi.fn(),
     createBufferSource: vi.fn(() => sourceNode),
     createMediaElementSource: vi.fn(() => mediaElementSourceNode),
-    createGain: vi.fn(() => gainNode),
+    createGain: vi.fn(() => (served++ === 0 ? gainNode : makeGain())),
     destination: {},
     close: vi.fn(),
   };
-  return { ctx, sourceNode, mediaElementSourceNode, gainNode, masterGain, startFn };
+  return { ctx, sourceNode, mediaElementSourceNode, gainNode, gainNodes, masterGain, startFn };
 }
 
 function setupTransport(currentTime = 100) {
@@ -112,7 +121,9 @@ describe("WebAudioTransport", () => {
       expect(mock.ctx.createMediaElementSource).toHaveBeenCalledWith(mockEl);
       expect(mock.ctx.createBufferSource).not.toHaveBeenCalled();
       expect(mock.mediaElementSourceNode.connect).toHaveBeenCalled();
-      expect(mock.gainNode.connect).toHaveBeenCalledWith(mock.masterGain);
+      const [volumeGain, soloGain] = mock.gainNodes;
+      expect(volumeGain?.connect).toHaveBeenCalledWith(soloGain);
+      expect(soloGain?.connect).toHaveBeenCalledWith(mock.masterGain);
       expect(mockEl.muted).toBe(false);
       expect(mockEl.volume).toBe(1);
       expect(mock.gainNode.gain.value).toBe(0.8);
@@ -737,15 +748,15 @@ describe("WebAudioTransport", () => {
       document.body.innerHTML = "";
     });
 
-    it("routes an ungrouped clip straight to master through its own gain", async () => {
+    it("routes an ungrouped clip to master through its own solo stage", async () => {
       const { transport, mock, gen } = setupGroupTransport();
 
       await scheduleGrouped(transport, gen, "lone");
 
-      // One gain per clip now that solo is gone — it goes straight to master.
-      expect(mock.gainNodes).toHaveLength(1);
-      const [clipGain] = mock.gainNodes;
-      expect(clipGain!.connect).toHaveBeenCalledWith(mock.masterGain);
+      expect(mock.gainNodes).toHaveLength(2);
+      const [clipGain, soloGain] = mock.gainNodes;
+      expect(clipGain!.connect).toHaveBeenCalledWith(soloGain);
+      expect(soloGain!.connect).toHaveBeenCalledWith(mock.masterGain);
     });
 
     // The media-element transport is the PRIMARY path for audio — the runtime
@@ -790,7 +801,9 @@ describe("WebAudioTransport", () => {
       await transport.scheduleMediaElementPlayback(el, 0, 0, 0, 1, gen, 1);
 
       const clipGain = mock.gainNodes[0]!;
-      expect(clipGain.connect).toHaveBeenCalledWith(firstGroupInput(mock));
+      const soloGain = mock.gainNodes[5]!;
+      expect(clipGain.connect).toHaveBeenCalledWith(soloGain);
+      expect(soloGain.connect).toHaveBeenCalledWith(firstGroupInput(mock));
       expect(clipGain.connect).not.toHaveBeenCalledWith(mock.masterGain);
     });
 
@@ -800,8 +813,9 @@ describe("WebAudioTransport", () => {
 
       await transport.scheduleMediaElementPlayback(el, 0, 0, 0, 1, gen, 1);
 
-      expect(mock.gainNodes).toHaveLength(1);
-      expect(mock.gainNodes[0]!.connect).toHaveBeenCalledWith(mock.masterGain);
+      expect(mock.gainNodes).toHaveLength(2);
+      expect(mock.gainNodes[0]!.connect).toHaveBeenCalledWith(mock.gainNodes[1]);
+      expect(mock.gainNodes[1]!.connect).toHaveBeenCalledWith(mock.masterGain);
     });
 
     it("two members of the same group land on ONE shared group gain, not master directly", async () => {
@@ -810,20 +824,23 @@ describe("WebAudioTransport", () => {
       await scheduleGrouped(transport, gen, "a", "vo");
       await scheduleGrouped(transport, gen, "b", "vo");
 
-      // Creation order for a: a-gain(0), groupInput(1), groupOutput(2),
-      // muteGain(3), fader(4) — the group bus is built lazily inside a's
-      // schedule call. Then b: b-gain(5).
-      expect(mock.gainNodes.length).toBeGreaterThanOrEqual(6);
+      // Creation order for a: gain(0), group bus(1–4), solo(5). Then b uses
+      // gain(6), solo(7); both solo stages feed the one shared group input.
+      expect(mock.gainNodes.length).toBeGreaterThanOrEqual(8);
       const aGain = mock.gainNodes[0]!;
+      const aSolo = mock.gainNodes[5]!;
       const groupInput = firstGroupInput(mock);
       const groupOutput = mock.gainNodes[2]!;
       const muteGain = mock.gainNodes[3]!;
       const fader = mock.gainNodes[4]!;
-      const bGain = mock.gainNodes[5]!;
+      const bGain = mock.gainNodes[6]!;
+      const bSolo = mock.gainNodes[7]!;
 
-      // Both members feed the shared bus — neither connects straight to master.
-      expect(aGain.connect).toHaveBeenCalledWith(groupInput);
-      expect(bGain.connect).toHaveBeenCalledWith(groupInput);
+      // Both members feed their own solo stage, then the shared bus.
+      expect(aGain.connect).toHaveBeenCalledWith(aSolo);
+      expect(bGain.connect).toHaveBeenCalledWith(bSolo);
+      expect(aSolo.connect).toHaveBeenCalledWith(groupInput);
+      expect(bSolo.connect).toHaveBeenCalledWith(groupInput);
       expect(aGain.connect).not.toHaveBeenCalledWith(mock.masterGain);
       expect(bGain.connect).not.toHaveBeenCalledWith(mock.masterGain);
 
@@ -843,11 +860,11 @@ describe("WebAudioTransport", () => {
       const { transport, mock, gen } = setupGroupTransport();
 
       await scheduleGrouped(transport, gen, "a", "vo");
-      const gainCountAfterFirst = mock.gainNodes.length; // a-gain + group input/output/mute/fader
+      const gainCountAfterFirst = mock.gainNodes.length;
       await scheduleGrouped(transport, gen, "b", "vo");
 
-      // Only b's own gain is new — no second group bus minted.
-      expect(mock.gainNodes.length).toBe(gainCountAfterFirst + 1);
+      // Only b's volume and solo gains are new — no second group bus minted.
+      expect(mock.gainNodes.length).toBe(gainCountAfterFirst + 2);
     });
 
     it("a group id with no matching <hf-audio-group> element still gets a flat bus", async () => {
@@ -911,6 +928,45 @@ describe("WebAudioTransport", () => {
       await scheduleGrouped(transport, gen2, "a", "vo");
       // Still only one group-input gain ever created for "vo".
       expect(mock.gainNodes.filter((n) => n === groupInput)).toHaveLength(1);
+    });
+
+    describe('solo — "Hear only this" compatibility bridge', () => {
+      it("silences non-soloed members without attenuating their shared group bus", async () => {
+        const { transport, mock, gen } = setupGroupTransport();
+        await scheduleGrouped(transport, gen, "a", "vo");
+        await scheduleGrouped(transport, gen, "b", "vo");
+
+        transport.setSolo(new Set(["a"]));
+
+        expect(mock.gainNodes[5]!.gain.value).toBe(1);
+        expect(mock.gainNodes[7]!.gain.value).toBe(0);
+        expect(firstGroupInput(mock).gain.value).toBe(1);
+      });
+
+      it("soloing a group keeps every member of that group audible", async () => {
+        const { transport, mock, gen } = setupGroupTransport();
+        await scheduleGrouped(transport, gen, "a", "vo");
+        await scheduleGrouped(transport, gen, "b", "vo");
+
+        transport.setSolo(new Set(["vo"]));
+
+        expect(mock.gainNodes[5]!.gain.value).toBe(1);
+        expect(mock.gainNodes[7]!.gain.value).toBe(1);
+      });
+
+      it("applies an existing solo to newly scheduled clips and restores them when cleared", async () => {
+        const { transport, mock, gen } = setupGroupTransport();
+        transport.setSolo(new Set(["a"]));
+        await scheduleGrouped(transport, gen, "a");
+        await scheduleGrouped(transport, gen, "b");
+
+        expect(mock.gainNodes[1]!.gain.value).toBe(1);
+        expect(mock.gainNodes[3]!.gain.value).toBe(0);
+
+        transport.setSolo(new Set());
+        expect(mock.gainNodes[1]!.gain.value).toBe(1);
+        expect(mock.gainNodes[3]!.gain.value).toBe(1);
+      });
     });
 
     // Surviving stopAll() is the point of the bus — and the trap. Its envelopes

--- a/packages/core/src/runtime/webAudioTransport.ts
+++ b/packages/core/src/runtime/webAudioTransport.ts
@@ -1,11 +1,12 @@
 import { attachElementFxChain, readElementAutomation, type ElementFxHandle } from "./audioFx.js";
 import {
+  clearParamLane,
   scheduleParamLane,
   volumeLane,
   type AutomationTiming,
 } from "../audio/audioFxAutomation.js";
 import { VOLUME_RANGE } from "../audioAutomation.js";
-import { audioGroupOf, isAudibleUnderSolo } from "../audioGroups.js";
+import { audioGroupOf, readAudioGroupVolume, resolveGroupElement } from "../audioGroups.js";
 import { swallow } from "./diagnostics";
 import { clampAudioGain } from "../audioGain.js";
 import { getDebugSurface } from "./globals.js";
@@ -14,6 +15,23 @@ import { readElementPlaybackRate } from "./media.js";
 function normalizeRate(rate: number): number {
   if (!Number.isFinite(rate) || rate <= 0) return 1;
   return rate;
+}
+
+/**
+ * The render puts every track volume through `clampVolume`, which is
+ * `clampAudioGain` — ceiling MAX_AUDIO_GAIN (+12 dB, ~3.98), not unity. Preview
+ * has to agree or the two diverge on exactly the attribute this bus exists to
+ * honour: an authored `<hf-audio-group data-volume="2">` previewed at 1.0 and
+ * exported at 2.0, up to 6 dB quieter in the audition than in the file, and
+ * 12 dB at the ceiling. Preview was also self-inconsistent — the same
+ * parameter's automation lane is bounded by `VOLUME_RANGE.max`, which IS
+ * MAX_AUDIO_GAIN, so an envelope could reach 3.98 where the static fader could
+ * not pass 1.0. `clampAudioGain` still floors at 0, so a negative value cannot
+ * invert polarity in preview while rendering silent. Compositions are
+ * hand-authorable, so out-of-range values do not need a slider to be reachable.
+ */
+function clampGroupVolume(volume: number): number {
+  return clampAudioGain(volume);
 }
 
 /**
@@ -88,11 +106,6 @@ function scheduleVolumeLane(
 type ScheduledSourceBase = {
   el: HTMLMediaElement;
   gainNode: GainNode;
-  /** Solo ("Hear only this") attenuation — dedicated node, parallel to the
-   *  volume gain, so a solo toggle never fights `scheduleVolumeLane`'s ramps
-   *  on the same param (same hazard B5's group-mute gain was split out to
-   *  avoid). 0 while silenced by an active solo elsewhere, 1 otherwise. */
-  soloGain: GainNode;
   /** FX chain spliced between source and gain, when the element carries one. */
   fx?: ElementFxHandle | null;
   compositionStart: number;
@@ -136,12 +149,15 @@ export class WebAudioTransport {
     string,
     {
       input: GainNode;
+      /** Post-FX fader: `data-volume` plus the volume lane. */
+      fader: GainNode;
       muteGain: GainNode;
-      analyser: AnalyserNode;
-      // `Float32Array<ArrayBuffer>`, not bare `Float32Array`: the runtime
-      // typecheck resolves the latter to `Float32Array<ArrayBufferLike>`, which
-      // `getFloatTimeDomainData` rejects (it wants a non-shared buffer).
-      levelBuf: Float32Array<ArrayBuffer>;
+      /** Kept so `setRate` can re-aim this bus's FX automation, the way it does
+       *  every source's — its docblock claims it already did. */
+      fx: ElementFxHandle | null;
+      /** Play generation the current envelopes were booked against. */
+      generation: number;
+      reanchor(timing: AutomationTiming): void;
       dispose(): void;
     }
   >();
@@ -153,10 +169,6 @@ export class WebAudioTransport {
   private _rate = 1;
   private _paused = true;
   private _playGeneration = 0;
-  // Session-only "Hear only this" set (clip ids and group ids). Never read
-  // from or written to any attribute — studio pushes it in directly via
-  // `setSolo`; see `isAudibleUnderSolo` for the exact predicate.
-  private _soloed: ReadonlySet<string> = new Set();
 
   async init(): Promise<boolean> {
     try {
@@ -231,32 +243,6 @@ export class WebAudioTransport {
   }
 
   /**
-   * Gain → solo → destination: the graph tail every scheduled source shares.
-   *
-   * Both schedulers need the dedicated solo node (parallel to the volume gain,
-   * so a solo toggle never fights `scheduleVolumeLane`'s ramps on the same
-   * param) and both need the group bus when the element belongs to one. Kept in
-   * one place because a path that skipped either was silently exempt from
-   * "hear only this" and from group routing.
-   */
-  private connectThroughSolo(
-    ctx: AudioContext,
-    masterGain: GainNode,
-    el: HTMLMediaElement,
-    gainNode: GainNode,
-    timing: { scheduledAt: number; compositionTime: number; rate: number },
-  ): GainNode {
-    const soloGain = ctx.createGain();
-    soloGain.gain.value = isAudibleUnderSolo(this._soloed, el.id, audioGroupOf(el)) ? 1 : 0;
-    gainNode.connect(soloGain);
-    soloGain.connect(
-      this.resolveDestination(el, timing.scheduledAt, timing.compositionTime, timing.rate) ??
-        masterGain,
-    );
-    return soloGain;
-  }
-
-  /**
    * Route the browser's pitch-preserving HTMLMediaElement transport through the
    * same FX, automation, element-gain, and master graph used by final audio.
    * The media element remains the source-time/rate owner; Web Audio is strictly
@@ -291,15 +277,14 @@ export class WebAudioTransport {
       const elapsed = compositionTime - compositionStart;
       const timing: AutomationTiming = { scheduledAt, elapsed, rate: safeRate };
       const fx = attachElementFxChain(this._ctx, el, sourceNode, gainNode, timing);
-      // A native-media clip used to connect straight to master, which left it
-      // immune to "hear only this" and outside its group's bus — preview
-      // disagreeing with the render for exactly the elements this transport
-      // exists to keep in step.
-      const soloGain = this.connectThroughSolo(this._ctx, this._masterGain, el, gainNode, {
-        scheduledAt,
-        compositionTime,
-        rate: safeRate,
-      });
+      // The group bus, not master, for a member — same as the decoded-buffer
+      // path. This transport is the PRIMARY one for audio (the decode path is
+      // its fallback), so routing it at master would have left every grouped
+      // track bypassing the bus whose whole premise is that a group is one
+      // signal.
+      gainNode.connect(
+        this.resolveDestination(el, scheduledAt, compositionTime, safeRate) ?? this._masterGain,
+      );
       scheduleVolumeLane(el, gainNode, timing);
 
       this._rate = safeRate;
@@ -312,7 +297,6 @@ export class WebAudioTransport {
         sourceNode,
         sourceKind: "media-element",
         gainNode,
-        soloGain,
         compositionStart,
         mediaStart: _mediaStart,
         scheduledAt,
@@ -346,48 +330,94 @@ export class WebAudioTransport {
    */
   private groupInput(groupId: string, doc: Document, timing: AutomationTiming): GainNode | null {
     const existing = this._groups.get(groupId);
-    if (existing) return existing.input;
+    if (existing) {
+      // The bus outlives `stopAll()` on purpose, so a replay or a seek reuses
+      // this graph — but its envelopes were committed to the FIRST pass's
+      // absolute context times. Left alone they hold their last value forever,
+      // which for a fade-out is silence for the rest of the session. Re-anchor
+      // once per play generation, not once per member scheduled.
+      if (existing.generation !== this._playGeneration) {
+        // Stamped only on success, and isolated: this runs inside
+        // `schedulePlayback`, whose catch turns any throw into `return null` —
+        // i.e. a bus problem would silently drop the MEMBER from the pass. And
+        // stamping first would consume the generation, so no later member of
+        // the same group would retry and the bus would keep the previous pass's
+        // envelopes: finding 11 unfixed on exactly the pass that failed.
+        try {
+          existing.reanchor(timing);
+          existing.generation = this._playGeneration;
+        } catch (err) {
+          swallow("webAudioTransport.groupReanchor", err);
+        }
+      }
+      return existing.input;
+    }
     if (!this._ctx || !this._masterGain) return null;
 
     const input = this._ctx.createGain();
     // Stable point the FX chain (or, when there's none, the dry passthrough —
     // see `attachElementFxChain`'s `detach()`) always lands on before master,
-    // regardless of whether a chain is attached/detached/rebuilt later. B7's
-    // meter taps here. The mute gain splices in BEFORE `output` (between the
-    // FX chain and here), never after — the meter is defined to read the
-    // group's true, honestly-muted level (design doc §5), and this node is
-    // that contract's anchor.
+    // regardless of whether a chain is attached/detached/rebuilt later. The
+    // mute gain splices in BEFORE `output`, between the FX chain and here.
     const output = this._ctx.createGain();
     output.connect(this._masterGain);
-    const analyser = this._ctx.createAnalyser();
-    analyser.fftSize = 256; // level, not spectrum
-    output.connect(analyser);
 
-    const groupEl = doc.getElementById(groupId);
+    // Tag-checked, and re-resolved on every reanchor below rather than frozen:
+    // a bus whose element does not exist yet (studio group creation, or a
+    // sub-composition that loads later) kept the `getAttribute: () => null`
+    // stub for the whole session, so its fader, chain and mute never reached
+    // preview while the export honoured all three.
+    const resolveEl = (): Element | null => resolveGroupElement(doc, groupId);
+    const groupEl = resolveEl();
     const muteGain = this._ctx.createGain();
     muteGain.gain.value = groupEl?.hasAttribute("data-hidden") ? 0 : 1;
     muteGain.connect(output);
+    // The group's fader, POST-FX: `data-volume` is the static position and the
+    // volume lane rides it, which is where a DAW puts it and the order the
+    // render bakes it in (`scheduleVolumeLane`'s own contract). Scheduling it
+    // on `input` instead put the fader ahead of the effects, so any nonlinear
+    // group effect — a compressor, the Giant preset — previewed differently
+    // than it rendered.
+    const fader = this._ctx.createGain();
+    fader.gain.value = clampGroupVolume(readAudioGroupVolume(groupEl));
+    fader.connect(muteGain);
     const fx = attachElementFxChain(
       this._ctx,
       groupEl ?? { getAttribute: () => null },
       input,
-      muteGain,
+      fader,
       timing,
     );
-    if (groupEl) scheduleVolumeLane(groupEl, input, timing);
+    if (groupEl) scheduleVolumeLane(groupEl, fader, timing);
 
     this._groups.set(groupId, {
       input,
+      fader,
       muteGain,
-      analyser,
-      levelBuf: new Float32Array(analyser.fftSize),
+      fx,
+      generation: this._playGeneration,
+      reanchor: (at: AutomationTiming) => {
+        // Cleared BEFORE the value write, and unconditionally. `scheduleVolumeLane`
+        // clears as part of scheduling, but returns early when the group no
+        // longer has a lane — and a scheduled envelope outranks a `.value`
+        // write, so deleting a group's automation mid-session otherwise left
+        // the previous pass's ramps still owning the param (for a fade-out,
+        // silence) for the rest of the session.
+        clearParamLane([{ param: fader.gain }]);
+        // Re-resolved, not the element captured at build time — see `resolveEl`.
+        const live = resolveEl();
+        fader.gain.value = clampGroupVolume(readAudioGroupVolume(live));
+        muteGain.gain.value = live?.hasAttribute("data-hidden") ? 0 : 1;
+        fx?.reanchor(at);
+        if (live) scheduleVolumeLane(live, fader, at);
+      },
       dispose: () => {
         try {
           fx?.dispose();
           input.disconnect();
+          fader.disconnect();
           muteGain.disconnect();
           output.disconnect();
-          analyser.disconnect();
         } catch {
           // Already torn down.
         }
@@ -398,7 +428,7 @@ export class WebAudioTransport {
 
   /**
    * Group mute, preview side — a separate gain from `input`'s volume fader
-   * (B7) so a mute toggle never fights `scheduleVolumeLane`'s ramps on the
+   * so a mute toggle never fights `scheduleVolumeLane`'s ramps on the
    * same param (the same hazard the design doc flags for §2.1). A no-op
    * until the group has an active member: at that point `groupInput` reads
    * the element's own `data-hidden` for its initial value, so there is
@@ -412,30 +442,6 @@ export class WebAudioTransport {
     } catch (err) {
       swallow("webAudioTransport.setGroupMuted", err);
     }
-  }
-
-  /** Every group id currently routing audio (built lazily by `groupInput` —
-   *  a group with no active member yet has no entry here). */
-  groupIds(): string[] {
-    return [...this._groups.keys()];
-  }
-
-  /**
-   * RMS-ish level 0..1 and whether the last block clipped, for the group's
-   * meter — or null when the group has no active member (idle/unknown).
-   * Reuses a per-group buffer; no per-frame allocation.
-   */
-  groupLevel(groupId: string): { level: number; clipped: boolean } | null {
-    const g = this._groups.get(groupId);
-    if (!g) return null;
-    g.analyser.getFloatTimeDomainData(g.levelBuf);
-    let sumSquares = 0;
-    let clipped = false;
-    for (const sample of g.levelBuf) {
-      sumSquares += sample * sample;
-      if (Math.abs(sample) >= 0.99) clipped = true;
-    }
-    return { level: Math.sqrt(sumSquares / g.levelBuf.length), clipped };
   }
 
   /** Master, unless `el` belongs to a group — then that group's bus (built on
@@ -477,7 +483,6 @@ export class WebAudioTransport {
       sourceNode.disconnect();
       scheduled.fx?.dispose();
       scheduled.gainNode.disconnect();
-      scheduled.soloGain.disconnect();
     } catch {
       // Already torn down.
     }
@@ -530,11 +535,9 @@ export class WebAudioTransport {
       // output — the same order the offline render uses. Preview and render run
       // the identical graph builders, so what is heard here is what is written.
       const fx = attachElementFxChain(this._ctx, el, sourceNode, gainNode, timing);
-      const soloGain = this.connectThroughSolo(this._ctx, this._masterGain, el, gainNode, {
-        scheduledAt,
-        compositionTime,
-        rate: safeRate,
-      });
+      gainNode.connect(
+        this.resolveDestination(el, scheduledAt, compositionTime, safeRate) ?? this._masterGain,
+      );
 
       scheduleVolumeLane(el, gainNode, timing);
 
@@ -556,7 +559,6 @@ export class WebAudioTransport {
         sourceNode.disconnect();
         fx?.dispose();
         gainNode.disconnect();
-        soloGain.disconnect();
         return null;
       }
 
@@ -570,7 +572,6 @@ export class WebAudioTransport {
         sourceNode,
         sourceKind: "buffer",
         gainNode,
-        soloGain,
         compositionStart,
         mediaStart,
         scheduledAt,
@@ -625,6 +626,16 @@ export class WebAudioTransport {
         swallow("webAudioTransport.setRate", err);
       }
     }
+    // Group buses are not in `_activeSources` — they outlive it — so their FX
+    // automation needs re-aiming here too, or a rate change leaves a group's
+    // envelopes running the old plan over audio at the new speed.
+    for (const group of this._groups.values()) {
+      try {
+        group.fx?.setRate(safeRate);
+      } catch (err) {
+        swallow("webAudioTransport.setRate.group", err);
+      }
+    }
     return true;
   }
 
@@ -642,7 +653,6 @@ export class WebAudioTransport {
         source.sourceNode.disconnect();
         source.fx?.dispose();
         source.gainNode.disconnect();
-        source.soloGain.disconnect();
       } catch {
         // already stopped
       }
@@ -689,31 +699,6 @@ export class WebAudioTransport {
 
   private applyMasterGain(): void {
     if (this._masterGain) this._masterGain.gain.value = this._masterMuted ? 0 : this._masterVolume;
-  }
-
-  /**
-   * Push the current "Hear only this" set and re-evaluate every active
-   * source's solo gain against it — a gain-stage update, never a graph
-   * rebuild (rule 3 of B5's step doc). Group buses are never touched here:
-   * per `isAudibleUnderSolo`, a group is never attenuated by solo, so a
-   * soloed member's path through its (unattenuated) group stays open by
-   * construction.
-   */
-  setSolo(soloed: ReadonlySet<string>): void {
-    this._soloed = soloed;
-    for (const source of this._activeSources) {
-      try {
-        source.soloGain.gain.value = isAudibleUnderSolo(
-          this._soloed,
-          source.el.id,
-          audioGroupOf(source.el),
-        )
-          ? 1
-          : 0;
-      } catch (err) {
-        swallow("webAudioTransport.setSolo", err);
-      }
-    }
   }
 
   isActive(): boolean {

--- a/packages/core/src/runtime/webAudioTransport.ts
+++ b/packages/core/src/runtime/webAudioTransport.ts
@@ -6,7 +6,12 @@ import {
   type AutomationTiming,
 } from "../audio/audioFxAutomation.js";
 import { VOLUME_RANGE } from "../audioAutomation.js";
-import { audioGroupOf, readAudioGroupVolume, resolveGroupElement } from "../audioGroups.js";
+import {
+  audioGroupOf,
+  isAudibleUnderSolo,
+  readAudioGroupVolume,
+  resolveGroupElement,
+} from "../audioGroups.js";
 import { swallow } from "./diagnostics";
 import { clampAudioGain } from "../audioGain.js";
 import { getDebugSurface } from "./globals.js";
@@ -106,6 +111,8 @@ function scheduleVolumeLane(
 type ScheduledSourceBase = {
   el: HTMLMediaElement;
   gainNode: GainNode;
+  /** Dedicated solo stage so toggles never overwrite authored volume ramps. */
+  soloGain: GainNode;
   /** FX chain spliced between source and gain, when the element carries one. */
   fx?: ElementFxHandle | null;
   compositionStart: number;
@@ -169,6 +176,8 @@ export class WebAudioTransport {
   private _rate = 1;
   private _paused = true;
   private _playGeneration = 0;
+  // Session-only preview state pushed by Studio. Never serialized.
+  private _soloed: ReadonlySet<string> = new Set();
 
   async init(): Promise<boolean> {
     try {
@@ -242,6 +251,26 @@ export class WebAudioTransport {
     return this._playGeneration;
   }
 
+  /** Connect one source through its own solo stage and then into its group bus
+   * (or master for an ungrouped clip). Resolving the group first preserves one
+   * shared bus while solo remains strictly per member. */
+  private connectThroughSolo(
+    ctx: AudioContext,
+    masterGain: GainNode,
+    el: HTMLMediaElement,
+    gainNode: GainNode,
+    timing: { scheduledAt: number; compositionTime: number; rate: number },
+  ): GainNode {
+    const destination =
+      this.resolveDestination(el, timing.scheduledAt, timing.compositionTime, timing.rate) ??
+      masterGain;
+    const soloGain = ctx.createGain();
+    soloGain.gain.value = isAudibleUnderSolo(this._soloed, el.id, audioGroupOf(el)) ? 1 : 0;
+    gainNode.connect(soloGain);
+    soloGain.connect(destination);
+    return soloGain;
+  }
+
   /**
    * Route the browser's pitch-preserving HTMLMediaElement transport through the
    * same FX, automation, element-gain, and master graph used by final audio.
@@ -282,9 +311,11 @@ export class WebAudioTransport {
       // its fallback), so routing it at master would have left every grouped
       // track bypassing the bus whose whole premise is that a group is one
       // signal.
-      gainNode.connect(
-        this.resolveDestination(el, scheduledAt, compositionTime, safeRate) ?? this._masterGain,
-      );
+      const soloGain = this.connectThroughSolo(this._ctx, this._masterGain, el, gainNode, {
+        scheduledAt,
+        compositionTime,
+        rate: safeRate,
+      });
       scheduleVolumeLane(el, gainNode, timing);
 
       this._rate = safeRate;
@@ -297,6 +328,7 @@ export class WebAudioTransport {
         sourceNode,
         sourceKind: "media-element",
         gainNode,
+        soloGain,
         compositionStart,
         mediaStart: _mediaStart,
         scheduledAt,
@@ -483,6 +515,7 @@ export class WebAudioTransport {
       sourceNode.disconnect();
       scheduled.fx?.dispose();
       scheduled.gainNode.disconnect();
+      scheduled.soloGain.disconnect();
     } catch {
       // Already torn down.
     }
@@ -535,9 +568,11 @@ export class WebAudioTransport {
       // output — the same order the offline render uses. Preview and render run
       // the identical graph builders, so what is heard here is what is written.
       const fx = attachElementFxChain(this._ctx, el, sourceNode, gainNode, timing);
-      gainNode.connect(
-        this.resolveDestination(el, scheduledAt, compositionTime, safeRate) ?? this._masterGain,
-      );
+      const soloGain = this.connectThroughSolo(this._ctx, this._masterGain, el, gainNode, {
+        scheduledAt,
+        compositionTime,
+        rate: safeRate,
+      });
 
       scheduleVolumeLane(el, gainNode, timing);
 
@@ -559,6 +594,7 @@ export class WebAudioTransport {
         sourceNode.disconnect();
         fx?.dispose();
         gainNode.disconnect();
+        soloGain.disconnect();
         return null;
       }
 
@@ -572,6 +608,7 @@ export class WebAudioTransport {
         sourceNode,
         sourceKind: "buffer",
         gainNode,
+        soloGain,
         compositionStart,
         mediaStart,
         scheduledAt,
@@ -653,6 +690,7 @@ export class WebAudioTransport {
         source.sourceNode.disconnect();
         source.fx?.dispose();
         source.gainNode.disconnect();
+        source.soloGain.disconnect();
       } catch {
         // already stopped
       }
@@ -695,6 +733,25 @@ export class WebAudioTransport {
   setMuted(muted: boolean): void {
     this._masterMuted = muted;
     this.applyMasterGain();
+  }
+
+  /** Update every active source without rebuilding the graph. Group ids solo
+   * all members through the shared audibility predicate. */
+  setSolo(soloed: ReadonlySet<string>): void {
+    this._soloed = soloed;
+    for (const source of this._activeSources) {
+      try {
+        source.soloGain.gain.value = isAudibleUnderSolo(
+          this._soloed,
+          source.el.id,
+          audioGroupOf(source.el),
+        )
+          ? 1
+          : 0;
+      } catch (err) {
+        swallow("webAudioTransport.setSolo", err);
+      }
+    }
   }
 
   private applyMasterGain(): void {

--- a/packages/engine/src/services/audioFxRender.ts
+++ b/packages/engine/src/services/audioFxRender.ts
@@ -35,6 +35,9 @@ interface WavData {
   samples: Float32Array;
   sampleRate: number;
   channels: number;
+  /** True when the source was 32-bit float rather than 16-bit PCM. Carried so
+   *  the output can be written back in the same format — see `writeWav`. */
+  float: boolean;
 }
 
 /**
@@ -77,7 +80,12 @@ export function readWav(path: string): WavData {
   }
   const { format, channels, sampleRate, bits, data } = readWavChunks(buf);
   if (!data) throw new AudioFxRenderError(`WAV has no data chunk: ${path}`);
-  return { samples: decodeSamples(data, format, bits, path), sampleRate, channels };
+  return {
+    samples: decodeSamples(data, format, bits, path),
+    sampleRate,
+    channels,
+    float: format === 3 && bits === 32,
+  };
 }
 
 /** Interleaved samples as floats, for the two formats the mixer emits upstream. */
@@ -102,38 +110,51 @@ function decodeSamples(data: Buffer, format: number, bits: number, path: string)
 }
 
 /**
- * Write 16-bit PCM, interleaved, preserving the channel count.
+ * Write interleaved samples, preserving the channel count.
  *
- * 16-bit rather than the float32 this used to emit: the very next step in the
- * mixer bakes the volume envelope into the samples, and that baker accepts only
- * 16-bit PCM. Emitting float meant enabling any effect silently downgraded a
- * track's volume automation to the ffmpeg expression path, which is capped at 32
- * straight segments — so a curved envelope was quantised and a dense one could
- * fall back to rendering at base volume.
+ * 16-bit by default rather than the float32 this used to emit: the very next
+ * step in the mixer bakes the volume envelope into the samples, and that baker
+ * accepted only 16-bit PCM. Emitting float meant enabling any effect silently
+ * downgraded a track's volume automation to the ffmpeg expression path, which is
+ * capped at 32 straight segments — so a curved envelope was quantised and a
+ * dense one could fall back to rendering at base volume.
+ *
+ * `float` opts back out, for the ONE input that needs it: a group sub-mix. Its
+ * members sum at unity, so the sum can legitimately exceed full scale, and the
+ * group's fader is applied downstream — clamping here handed that headroom back
+ * one step before the thing that was going to reduce it, which is the same bug
+ * the float intermediate exists to avoid. Safe now only because the envelope
+ * baker reads float too; before that it was not.
  */
 export function writeWav(
   path: string,
   samples: Float32Array,
   sampleRate: number,
   channels = 1,
+  float = false,
 ): void {
   const n = samples.length;
-  const bytes = n * 2;
+  const bytesPerSample = float ? 4 : 2;
+  const bytes = n * bytesPerSample;
   const buf = Buffer.alloc(44 + bytes);
   buf.write("RIFF", 0, "ascii");
   buf.writeUInt32LE(36 + bytes, 4);
   buf.write("WAVE", 8, "ascii");
   buf.write("fmt ", 12, "ascii");
   buf.writeUInt32LE(16, 16);
-  buf.writeUInt16LE(1, 20); // WAVE_FORMAT_PCM
+  buf.writeUInt16LE(float ? 3 : 1, 20); // IEEE_FLOAT / PCM
   buf.writeUInt16LE(channels, 22);
   buf.writeUInt32LE(sampleRate, 24);
-  buf.writeUInt32LE(sampleRate * channels * 2, 28);
-  buf.writeUInt16LE(channels * 2, 32);
-  buf.writeUInt16LE(16, 34);
+  buf.writeUInt32LE(sampleRate * channels * bytesPerSample, 28);
+  buf.writeUInt16LE(channels * bytesPerSample, 32);
+  buf.writeUInt16LE(float ? 32 : 16, 34);
   buf.write("data", 36, "ascii");
   buf.writeUInt32LE(bytes, 40);
   for (let i = 0; i < n; i++) {
+    if (float) {
+      buf.writeFloatLE(samples[i] ?? 0, 44 + i * 4);
+      continue;
+    }
     // Clamp before scaling: a limiter set to 0 dB or a resonant filter can push
     // past full scale, and wrapping would turn that into a click.
     const v = Math.max(-1, Math.min(1, samples[i] ?? 0));
@@ -267,7 +288,7 @@ export async function applyAudioFxChain(
     throw new AudioFxRenderError(`Audio FX input is missing: ${inputWav}`);
   }
 
-  const { samples, sampleRate, channels } = readWav(inputWav);
+  const { samples, sampleRate, channels, float } = readWav(inputWav);
   const planes = deinterleave(samples, channels);
   // An empty track has nothing to process — and an OfflineAudioContext of zero
   // length throws, which is fatal for the WHOLE render rather than this track:
@@ -303,118 +324,26 @@ export async function applyAudioFxChain(
       await page.goto(pathToFileURL(hostPage).href, { waitUntil: "domcontentloaded" });
       await page.addScriptTag({ content: getAudioFxRuntimeScript() });
 
-      // Hand the input over a chunk at a time. The chunks stay separate byte
-      // arrays page-side rather than being concatenated into one string, so
-      // neither the frame cap nor V8's string limit sees the whole track.
-      await page.evaluate((count: number) => {
-        (window as unknown as AudioFxWindow).__HF_FX_IO = {
-          in: Array.from({ length: count }, (): Uint8Array[] => []),
-          out: [],
-        };
-      }, planes.length);
+      await sendPlanesToPage(page, planes);
 
-      for (let p = 0; p < planes.length; p += 1) {
-        const plane = planes[p];
-        if (!plane) continue;
-        const bytes = Buffer.from(plane.buffer, plane.byteOffset, plane.length * 4);
-        for (let at = 0; at < bytes.length; at += TRANSFER_BYTES) {
-          await page.evaluate(
-            ([index, b64]: [number, string]) => {
-              const bin = atob(b64);
-              const chunk = new Uint8Array(bin.length);
-              for (let i = 0; i < bin.length; i++) chunk[i] = bin.charCodeAt(i);
-              (window as unknown as AudioFxWindow).__HF_FX_IO?.in[index]?.push(chunk);
-            },
-            [p, bytes.subarray(at, at + TRANSFER_BYTES).toString("base64")] as [number, string],
-          );
-        }
-      }
-
-      const outLengths = (await page.evaluate(
-        async ([rate, chainJson, automationJson]: [number, string, string]) => {
-          const w = window as unknown as AudioFxWindow;
-          const io = w.__HF_FX_IO;
-          if (!w.__HF_AUDIO_FX || !io) throw new Error("audio FX runtime failed to load");
-          const inPlanes = io.in.map((chunks) => {
-            const bytes = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
-            let at = 0;
-            for (const chunk of chunks) {
-              bytes.set(chunk, at);
-              at += chunk.length;
-            }
-            return new Float32Array(bytes.buffer);
-          });
-          // Dropped before the render allocates its own buffers, so the page
-          // does not hold two copies of the track at once.
-          io.in = [];
-          io.out = await w.__HF_AUDIO_FX.render(
-            inPlanes,
-            rate,
-            chainJson,
-            automationJson || undefined,
-          );
-          return io.out.map((plane) => plane.length);
-        },
-        [
-          sampleRate,
-          JSON.stringify(chain),
-          options.automation ? serializeAutomation(options.automation) : "",
-        ] as [number, string, string],
-      )) as number[];
-
-      const outPlanes: Float32Array[] = [];
-      for (let p = 0; p < outLengths.length; p += 1) {
-        const byteLength = (outLengths[p] ?? 0) * 4;
-        const parts: Buffer[] = [];
-        for (let at = 0; at < byteLength; at += TRANSFER_BYTES) {
-          const b64 = (await page.evaluate(
-            ([index, offset, limit]: [number, number, number]) => {
-              const plane = (window as unknown as AudioFxWindow).__HF_FX_IO?.out[index];
-              if (!plane) return "";
-              const u8 = new Uint8Array(
-                plane.buffer,
-                plane.byteOffset + offset,
-                Math.min(limit, plane.length * 4 - offset),
-              );
-              let s = "";
-              const CHUNK = 0x8000;
-              for (let i = 0; i < u8.length; i += CHUNK) {
-                // `apply` takes array-likes, so the subarray goes in as it is;
-                // Array.from boxed every byte of a 32 KiB window for nothing.
-                s += String.fromCharCode.apply(
-                  null,
-                  u8.subarray(i, i + CHUNK) as unknown as number[],
-                );
-              }
-              return btoa(s);
-            },
-            [p, at, TRANSFER_BYTES] as [number, number, number],
-          )) as string;
-          parts.push(Buffer.from(b64, "base64"));
-        }
-        // byteOffset and byteLength matter: Node pools small allocations, so a
-        // short payload decodes into an 8 KiB pool and a view over the whole
-        // ArrayBuffer would read kilobytes of unrelated memory at the wrong length.
-        const buf = Buffer.concat(parts);
-        outPlanes.push(
-          new Float32Array(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)),
-        );
-      }
+      const outLengths = await renderPlanesInPage(
+        page,
+        sampleRate,
+        chain,
+        options.automation ? serializeAutomation(options.automation) : "",
+      );
+      const outPlanes = await readPlanesFromPage(page, outLengths);
       if (outPlanes.length === 0 || (outPlanes[0]?.length ?? 0) === 0) {
         throw new AudioFxRenderError(`Audio FX produced no samples for track ${options.trackId}`);
       }
       // Null when the keyframes normalise away to nothing — then the mixer's
       // own paths still own this track's gain, so say so rather than claiming
       // a bake that never happened.
-      const gainAt = options.envelope
-        ? createEnvelopeWalker(
-            options.envelope.keyframes,
-            options.envelope.trackStart,
-            options.envelope.baseVolume,
-          )
-        : null;
+      const gainAt = envelopeWalkerFor(options.envelope);
       if (gainAt) applyEnvelopeToPlanes(outPlanes, sampleRate, gainAt);
-      writeWav(outputWav, interleave(outPlanes), sampleRate, outPlanes.length);
+      // Same format in as out: a float input is a group sub-mix whose headroom
+      // must survive to its fader (see writeWav).
+      writeWav(outputWav, interleave(outPlanes), sampleRate, outPlanes.length, float);
       return { path: outputWav, envelopeBaked: gainAt !== null };
     } finally {
       await page.close().catch(() => undefined);
@@ -428,6 +357,129 @@ export async function applyAudioFxChain(
     rmSync(hostDir, { recursive: true, force: true });
     await lease?.release().catch(() => undefined);
   }
+}
+
+/** The page handle `acquireBrowser().browser.newPage()` returns. */
+type FxPage = Awaited<ReturnType<Awaited<ReturnType<typeof acquireBrowser>>["browser"]["newPage"]>>;
+
+/**
+ * Hand the input planes to the page a chunk at a time.
+ *
+ * The chunks stay separate byte arrays page-side rather than being concatenated
+ * into one string, so neither the CDP frame cap nor V8's string limit ever sees
+ * the whole track.
+ */
+async function sendPlanesToPage(page: FxPage, planes: readonly Float32Array[]): Promise<void> {
+  await page.evaluate((count: number) => {
+    (window as unknown as AudioFxWindow).__HF_FX_IO = {
+      in: Array.from({ length: count }, (): Uint8Array[] => []),
+      out: [],
+    };
+  }, planes.length);
+
+  for (let p = 0; p < planes.length; p += 1) {
+    const plane = planes[p];
+    if (!plane) continue;
+    const bytes = Buffer.from(plane.buffer, plane.byteOffset, plane.length * 4);
+    for (let at = 0; at < bytes.length; at += TRANSFER_BYTES) {
+      await page.evaluate(
+        ([index, b64]: [number, string]) => {
+          const bin = atob(b64);
+          const chunk = new Uint8Array(bin.length);
+          for (let i = 0; i < bin.length; i++) chunk[i] = bin.charCodeAt(i);
+          (window as unknown as AudioFxWindow).__HF_FX_IO?.in[index]?.push(chunk);
+        },
+        [p, bytes.subarray(at, at + TRANSFER_BYTES).toString("base64")] as [number, string],
+      );
+    }
+  }
+}
+
+/** Run the chain in the page and return each output plane's sample count. The
+ *  samples themselves stay page-side until `readPlanesFromPage` pulls them. */
+async function renderPlanesInPage(
+  page: FxPage,
+  sampleRate: number,
+  chain: HfAudioFxChain,
+  automationJson: string,
+): Promise<number[]> {
+  return (await page.evaluate(
+    async ([rate, chainJson, automation]: [number, string, string]) => {
+      const w = window as unknown as AudioFxWindow;
+      const io = w.__HF_FX_IO;
+      if (!w.__HF_AUDIO_FX || !io) throw new Error("audio FX runtime failed to load");
+      const inPlanes = io.in.map((chunks) => {
+        const bytes = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
+        let at = 0;
+        for (const chunk of chunks) {
+          bytes.set(chunk, at);
+          at += chunk.length;
+        }
+        return new Float32Array(bytes.buffer);
+      });
+      // Dropped before the render allocates its own buffers, so the page does
+      // not hold two copies of the track at once.
+      io.in = [];
+      io.out = await w.__HF_AUDIO_FX.render(inPlanes, rate, chainJson, automation || undefined);
+      return io.out.map((plane) => plane.length);
+    },
+    [sampleRate, JSON.stringify(chain), automationJson] as [number, string, string],
+  )) as number[];
+}
+
+/** Pull one output plane back over CDP, `TRANSFER_BYTES` at a time. */
+async function readPlaneFromPage(
+  page: FxPage,
+  index: number,
+  byteLength: number,
+): Promise<Float32Array> {
+  const parts: Buffer[] = [];
+  for (let at = 0; at < byteLength; at += TRANSFER_BYTES) {
+    const b64 = (await page.evaluate(
+      ([plane_index, offset, limit]: [number, number, number]) => {
+        const plane = (window as unknown as AudioFxWindow).__HF_FX_IO?.out[plane_index];
+        if (!plane) return "";
+        const u8 = new Uint8Array(
+          plane.buffer,
+          plane.byteOffset + offset,
+          Math.min(limit, plane.length * 4 - offset),
+        );
+        let s = "";
+        const CHUNK = 0x8000;
+        for (let i = 0; i < u8.length; i += CHUNK) {
+          // `apply` takes array-likes, so the subarray goes in as it is;
+          // Array.from boxed every byte of a 32 KiB window for nothing.
+          s += String.fromCharCode.apply(null, u8.subarray(i, i + CHUNK) as unknown as number[]);
+        }
+        return btoa(s);
+      },
+      [index, at, TRANSFER_BYTES] as [number, number, number],
+    )) as string;
+    parts.push(Buffer.from(b64, "base64"));
+  }
+  // byteOffset and byteLength matter: Node pools small allocations, so a short
+  // payload decodes into an 8 KiB pool and a view over the whole ArrayBuffer
+  // would read kilobytes of unrelated memory at the wrong length.
+  const buf = Buffer.concat(parts);
+  return new Float32Array(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength));
+}
+
+async function readPlanesFromPage(page: FxPage, outLengths: number[]): Promise<Float32Array[]> {
+  const outPlanes: Float32Array[] = [];
+  for (let p = 0; p < outLengths.length; p += 1) {
+    outPlanes.push(await readPlaneFromPage(page, p, (outLengths[p] ?? 0) * 4));
+  }
+  return outPlanes;
+}
+
+/** The envelope walker for a track that has keyframes, or null when it has none. */
+function envelopeWalkerFor(
+  envelope:
+    | { keyframes: AudioVolumeKeyframe[]; trackStart: number; baseVolume: number }
+    | undefined,
+): ReturnType<typeof createEnvelopeWalker> | null {
+  if (!envelope) return null;
+  return createEnvelopeWalker(envelope.keyframes, envelope.trackStart, envelope.baseVolume);
 }
 
 export type { HfAudioFxChain, HfAutomation };

--- a/packages/engine/src/services/audioMixer.grouping.test.ts
+++ b/packages/engine/src/services/audioMixer.grouping.test.ts
@@ -1,10 +1,10 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { getFfmpegBinary } from "../utils/ffmpegBinaries.js";
-import { MIXED_AUDIO_FILENAME, processCompositionAudio } from "./audioMixer.js";
+import { MIXED_AUDIO_FILENAME, parseAudioElements, processCompositionAudio } from "./audioMixer.js";
 
 /**
  * Level arithmetic across the mix graph.
@@ -20,45 +20,6 @@ import { MIXED_AUDIO_FILENAME, processCompositionAudio } from "./audioMixer.js";
  * +2.499 dB hot — exactly 20·log10(4/3). Nothing errors; the file is just
  * loud. These tests are the instrument that catches that class.
  */
-
-/**
- * The production ffmpeg process timeout is 5 minutes — far above any test
- * budget — so a stalled mix could only ever surface here as a bare
- * "Test timed out in 30000ms": no stderr, no clue which stage hung. That is
- * what made the Windows CI failure from this file undiagnosable. Capping it
- * well under the per-test timeout turns a stall into a fast, reported failure,
- * while leaving a merely slow runner room to finish.
- */
-const TEST_FFMPEG_TIMEOUT_MS = 20_000;
-
-/**
- * `processCompositionAudio` with the short process timeout, throwing the
- * recorded failures rather than returning `success: false`. Every call here
- * asserts success immediately afterwards, so a bare `expected false to be true`
- * was all a broken mix ever reported — the reason was sitting unread in
- * `failures`.
- */
-async function mixAudio(
-  elements: Parameters<typeof processCompositionAudio>[0],
-  baseDir: string,
-  workDir: string,
-  outputPath: string,
-  totalDuration: number,
-): ReturnType<typeof processCompositionAudio> {
-  const result = await processCompositionAudio(
-    elements,
-    baseDir,
-    workDir,
-    outputPath,
-    totalDuration,
-    undefined,
-    { ffmpegProcessTimeout: TEST_FFMPEG_TIMEOUT_MS },
-  );
-  if (!result.success) {
-    throw new Error(`mix failed: ${JSON.stringify(result.failures ?? result, null, 2)}`);
-  }
-  return result;
-}
 
 const HAS_FFMPEG = spawnSync(getFfmpegBinary(), ["-version"], { encoding: "utf-8" }).status === 0;
 const tempDirs: string[] = [];
@@ -102,6 +63,35 @@ function writeTone(path: string, freq: number, seconds: number, gain: number): v
   if (result.status !== 0) throw new Error(`Could not write tone: ${result.stderr}`);
 }
 
+/**
+ * A sine of an EXACT peak amplitude.
+ *
+ * `writeTone` builds on ffmpeg's `sine` source, whose output is ~0.125 full
+ * scale, so its `gain` argument is a relative knob rather than a level: a tone
+ * asked for at 0.7 lands at about -21 dBFS. Fine for the relative comparisons
+ * above, useless for anything about headroom — `aevalsrc` states the amplitude
+ * outright.
+ */
+function writePeakTone(path: string, freq: number, seconds: number, peak: number): void {
+  const result = spawnSync(
+    getFfmpegBinary(),
+    [
+      "-nostdin",
+      "-v",
+      "error",
+      "-f",
+      "lavfi",
+      "-i",
+      `aevalsrc=${peak}*sin(2*PI*${freq}*t):d=${seconds}:s=48000`,
+      "-c:a",
+      "pcm_s16le",
+      path,
+    ],
+    { encoding: "utf-8" },
+  );
+  if (result.status !== 0) throw new Error(`Could not write tone: ${result.stderr}`);
+}
+
 const track = (id: string, end: number, volume = 1) => ({
   id,
   src: `${id}.wav`,
@@ -113,180 +103,444 @@ const track = (id: string, end: number, volume = 1) => ({
   type: "audio" as const,
 });
 
-describe.skipIf(!HAS_FFMPEG)("mix level arithmetic", () => {
+// Every case here mixes with REAL ffmpeg, and vitest's default 5s per test is not
+// enough for that on a Windows runner — two cases timed out there while passing
+// everywhere else (PR #3363). The suite-level timeout covers all of them at once.
+describe.skipIf(!HAS_FFMPEG)(
+  "mix level arithmetic",
+  () => {
+    afterEach(() => {
+      for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("keeps every track at its authored level regardless of how many there are", async () => {
+      // The property the compensation exists to hold: adding tracks must not
+      // duck the ones already there. Mixing the SAME tone twice is the cleanest
+      // probe — two coherent copies sum to exactly +6.02 dB, so any residual
+      // normalisation shows up as a plain arithmetic miss rather than something
+      // that has to be teased out of unrelated material.
+      const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-count-"));
+      const workDir = mkdtempSync(join(tmpdir(), "hf-grp-count-work-"));
+      tempDirs.push(projectDir, workDir);
+
+      writeTone(join(projectDir, "a.wav"), 440, 2, 0.4);
+      writeTone(join(projectDir, "b.wav"), 440, 2, 0.4);
+      const oneUp = join(projectDir, `one-${MIXED_AUDIO_FILENAME}`);
+      const twoUp = join(projectDir, `two-${MIXED_AUDIO_FILENAME}`);
+
+      const one = await processCompositionAudio([track("a", 2)], projectDir, workDir, oneUp, 2);
+      const two = await processCompositionAudio(
+        [track("a", 2), track("b", 2)],
+        projectDir,
+        workDir,
+        twoUp,
+        2,
+      );
+      expect(one.success).toBe(true);
+      expect(two.success).toBe(true);
+
+      // Two coherent copies of one tone = +6.02 dB. If amix's 1/N ever survives
+      // the correction, this lands at 0 dB instead.
+      expect(meanVolumeDb(twoUp) - meanVolumeDb(oneUp)).toBeCloseTo(6.02, 0);
+    });
+
+    it("does not lift the survivors when a shorter track ends", async () => {
+      // amix with normalize=true rescales by the number of CURRENTLY ACTIVE
+      // inputs, so a track ending mid-composition would hand the remaining ones
+      // a level jump. `apad` to the full duration is what holds every input
+      // active for the whole graph and neutralises that — an invariant the
+      // filter string relies on without saying so.
+      //
+      // Measured without apad (spike, 2026-08-14): the tail runs +1.94 dB hot.
+      // Any group work that builds its own amix has to keep the padding, or
+      // inherit that bug one level down.
+      const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-drop-"));
+      const workDir = mkdtempSync(join(tmpdir(), "hf-grp-drop-work-"));
+      tempDirs.push(projectDir, workDir);
+
+      writeTone(join(projectDir, "short.wav"), 440, 1, 0.5);
+      writeTone(join(projectDir, "long.wav"), 880, 3, 0.5);
+      const together = join(projectDir, `both-${MIXED_AUDIO_FILENAME}`);
+      const alone = join(projectDir, `alone-${MIXED_AUDIO_FILENAME}`);
+
+      const both = await processCompositionAudio(
+        [track("short", 1), track("long", 3)],
+        projectDir,
+        workDir,
+        together,
+        3,
+      );
+      const solo = await processCompositionAudio([track("long", 3)], projectDir, workDir, alone, 3);
+      expect(both.success).toBe(true);
+      expect(solo.success).toBe(true);
+
+      // After 1.5 s only `long` is sounding. It must read the same whether or not
+      // a second track happened to end earlier.
+      const tailTogether = meanVolumeDb(together, 1.5, 3);
+      const tailAlone = meanVolumeDb(alone, 1.5, 3);
+      expect(Math.abs(tailTogether - tailAlone)).toBeLessThan(0.5);
+    });
+
+    /**
+     * The gate for group buses (plans/audio-mixer-groups.md §1).
+     *
+     * Grouping is routing, not processing: a group whose FX chain is empty must
+     * be a no-op on the mix. Enable this the moment `data-audio-group` routes
+     * through a nested amix — it is the definition of done for §1.3, and the
+     * only thing standing between a wrong gain correction and a silently loud
+     * export.
+     *
+     * Proven reachable in the spike: nesting with each amix compensated by ITS
+     * OWN input count nulls against the flat mix to -inf (sample-identical), as
+     * does `amix=normalize=0` with no correction at all.
+     */
+    it("mixes a grouped composition at the same level as the ungrouped one", async () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-level-"));
+      const workDir = mkdtempSync(join(tmpdir(), "hf-grp-level-work-"));
+      tempDirs.push(projectDir, workDir);
+
+      writeTone(join(projectDir, "a.wav"), 440, 2, 0.4);
+      writeTone(join(projectDir, "b.wav"), 660, 2, 0.4);
+      const flatOut = join(projectDir, `flat-${MIXED_AUDIO_FILENAME}`);
+      const groupedOut = join(projectDir, `grouped-${MIXED_AUDIO_FILENAME}`);
+
+      const flat = await processCompositionAudio(
+        [track("a", 2), track("b", 2)],
+        projectDir,
+        workDir,
+        flatOut,
+        2,
+      );
+      const grouped = await processCompositionAudio(
+        [
+          { ...track("a", 2), groupId: "voiceover" },
+          { ...track("b", 2), groupId: "voiceover" },
+        ],
+        projectDir,
+        workDir,
+        groupedOut,
+        2,
+      );
+      expect(flat.success).toBe(true);
+      expect(grouped.success).toBe(true);
+
+      // An empty group chain is pure routing — the export must read the same
+      // whether or not the two tones happened to share a group.
+      expect(Math.abs(meanVolumeDb(groupedOut) - meanVolumeDb(flatOut))).toBeLessThan(0.3);
+    });
+
+    it("a group FX chain fully cutting its members leaves an ungrouped track untouched (routing isolation)", async () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-fx-"));
+      const workDir = mkdtempSync(join(tmpdir(), "hf-grp-fx-work-"));
+      tempDirs.push(projectDir, workDir);
+
+      writeTone(join(projectDir, "voice.wav"), 440, 2, 0.4);
+      writeTone(join(projectDir, "sfx.wav"), 880, 2, 0.4);
+      const mixedOut = join(projectDir, `mixed-${MIXED_AUDIO_FILENAME}`);
+      const sfxAloneOut = join(projectDir, `sfx-alone-${MIXED_AUDIO_FILENAME}`);
+
+      const groupChain = JSON.stringify({
+        version: 1,
+        nodes: [{ type: "gain", id: "g", params: { gain: -60 } }],
+      });
+
+      const mixed = await processCompositionAudio(
+        [{ ...track("voice", 2), groupId: "vo", groupFxChain: groupChain }, track("sfx", 2)],
+        projectDir,
+        workDir,
+        mixedOut,
+        2,
+      );
+      const sfxAlone = await processCompositionAudio(
+        [track("sfx", 2)],
+        projectDir,
+        workDir,
+        sfxAloneOut,
+        2,
+      );
+      expect(mixed.success).toBe(true);
+      expect(sfxAlone.success).toBe(true);
+
+      // The voice group is cut ~60 dB — the mix should read close to sfx alone,
+      // and the ungrouped sfx track's own processing is unaffected by the
+      // group existing at all.
+      expect(Math.abs(meanVolumeDb(mixedOut) - meanVolumeDb(sfxAloneOut))).toBeLessThan(0.5);
+    });
+
+    it("a member's own volume envelope still applies inside a group", async () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-env-"));
+      const workDir = mkdtempSync(join(tmpdir(), "hf-grp-env-work-"));
+      tempDirs.push(projectDir, workDir);
+
+      writeTone(join(projectDir, "a.wav"), 440, 4, 0.5);
+      const groupedOut = join(projectDir, `grouped-${MIXED_AUDIO_FILENAME}`);
+      const flatOut = join(projectDir, `flat-${MIXED_AUDIO_FILENAME}`);
+
+      const withEnvelope = {
+        ...track("a", 4),
+        volumeKeyframes: [
+          { time: 0, volume: 1 },
+          { time: 4, volume: 0 },
+        ],
+      };
+
+      const grouped = await processCompositionAudio(
+        [{ ...withEnvelope, groupId: "vo" }],
+        projectDir,
+        workDir,
+        groupedOut,
+        4,
+      );
+      const flat = await processCompositionAudio([withEnvelope], projectDir, workDir, flatOut, 4);
+      expect(grouped.success).toBe(true);
+      expect(flat.success).toBe(true);
+
+      // The envelope fades to silent — the tail should read the same whether
+      // the track is grouped or not, proving member-level processing survives
+      // the group path unchanged.
+      const groupedTail = meanVolumeDb(groupedOut, 3, 4);
+      const flatTail = meanVolumeDb(flatOut, 3, 4);
+      expect(Math.abs(groupedTail - flatTail)).toBeLessThan(0.5);
+    });
+
+    // Members sum at unity (normalize=0), so an over-unity sum used to hard-clip
+    // at ±1 in the 16-bit intermediate BEFORE the group's fader and FX chain ran
+    // — pulling the group down then operated on distortion. Every existing probe
+    // here sums to ≤ 0.8, which is exactly why nothing caught it; preview cannot
+    // reproduce it either, because its bus is float.
+    it("does not clip an over-unity member sum before the group fader", async () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-clip-"));
+      const workDir = mkdtempSync(join(tmpdir(), "hf-grp-clip-work-"));
+      tempDirs.push(projectDir, workDir);
+
+      // Two coherent copies of the same tone: 0.7 + 0.7 = 1.4, comfortably over.
+      // `writePeakTone`, not `writeTone` — ffmpeg's `sine` source is nowhere near
+      // full scale (its output peaks at ~0.125), so every tone in this file sits
+      // around -21 dBFS and NOTHING here can reach a clip no matter what gain is
+      // asked for. That is a large part of why this class of bug survived.
+      writePeakTone(join(projectDir, "a.wav"), 440, 2, 0.7);
+      writePeakTone(join(projectDir, "b.wav"), 440, 2, 0.7);
+      // The reference: the level that sum SHOULD reach once the group's 0.5
+      // fader has been applied — 1.4 × 0.5 = 0.7, one tone's worth.
+      writePeakTone(join(projectDir, "ref.wav"), 440, 2, 0.7);
+
+      const groupedOut = join(projectDir, `clip-grouped-${MIXED_AUDIO_FILENAME}`);
+      const refOut = join(projectDir, `clip-ref-${MIXED_AUDIO_FILENAME}`);
+
+      const grouped = await processCompositionAudio(
+        [
+          { ...track("a", 2), groupId: "vo", groupVolume: 0.5 },
+          { ...track("b", 2), groupId: "vo", groupVolume: 0.5 },
+        ],
+        projectDir,
+        workDir,
+        groupedOut,
+        2,
+      );
+      const reference = await processCompositionAudio(
+        [track("ref", 2)],
+        projectDir,
+        workDir,
+        refOut,
+        2,
+      );
+      expect(grouped.success).toBe(true);
+      expect(reference.success).toBe(true);
+
+      // Both are ONE track into the outer mix, so the outer graph is identical
+      // and the levels are directly comparable. Clipped, the flat-topped sum
+      // reads well over a dB hot even after the fader halves it.
+      expect(Math.abs(meanVolumeDb(groupedOut) - meanVolumeDb(refOut))).toBeLessThan(0.5);
+    });
+
+    // The same property, for a group that carries an FX CHAIN. That path runs the
+    // sum through applyAudioFxChain, whose writeWav clamps to ±1 and emits 16-bit
+    // — so the headroom the float sub-mix preserved was handed back before the
+    // fader, one step later than the original bug but with the same result.
+    // A transparent chain isolates the clamp from anything the effects do.
+    it("does not clip an over-unity sum before the fader when the group has FX", async () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-clipfx-"));
+      const workDir = mkdtempSync(join(tmpdir(), "hf-grp-clipfx-work-"));
+      tempDirs.push(projectDir, workDir);
+
+      writePeakTone(join(projectDir, "a.wav"), 440, 2, 0.7);
+      writePeakTone(join(projectDir, "b.wav"), 440, 2, 0.7);
+      writePeakTone(join(projectDir, "ref.wav"), 440, 2, 0.7);
+
+      // 0 dB gain: in the chain, doing nothing to the level.
+      const transparentChain = JSON.stringify({
+        version: 1,
+        nodes: [{ type: "gain", id: "g", params: { gain: 0 } }],
+      });
+
+      const groupedOut = join(projectDir, `clipfx-grouped-${MIXED_AUDIO_FILENAME}`);
+      const refOut = join(projectDir, `clipfx-ref-${MIXED_AUDIO_FILENAME}`);
+
+      const grouped = await processCompositionAudio(
+        [
+          { ...track("a", 2), groupId: "vo", groupVolume: 0.5, groupFxChain: transparentChain },
+          { ...track("b", 2), groupId: "vo", groupVolume: 0.5, groupFxChain: transparentChain },
+        ],
+        projectDir,
+        workDir,
+        groupedOut,
+        2,
+      );
+      const reference = await processCompositionAudio(
+        [track("ref", 2)],
+        projectDir,
+        workDir,
+        refOut,
+        2,
+      );
+      expect(grouped.success).toBe(true);
+      expect(reference.success).toBe(true);
+
+      expect(Math.abs(meanVolumeDb(groupedOut) - meanVolumeDb(refOut))).toBeLessThan(0.5);
+    });
+  },
+  60_000,
+);
+
+describe.skipIf(!HAS_FFMPEG)("group sub-mix failure contract", () => {
   afterEach(() => {
     for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
   });
 
-  it("keeps every track at its authored level regardless of how many there are", async () => {
-    // The property the compensation exists to hold: adding tracks must not
-    // duck the ones already there. Mixing the SAME tone twice is the cleanest
-    // probe — two coherent copies sum to exactly +6.02 dB, so any residual
-    // normalisation shows up as a plain arithmetic miss rather than something
-    // that has to be teased out of unrelated material.
-    const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-count-"));
-    const workDir = mkdtempSync(join(tmpdir(), "hf-grp-count-work-"));
+  // A malformed chain on a BUS threw straight out of processCompositionAudio,
+  // bypassing the MixResult/failures[] shape the caller handles and skipping
+  // bail()'s workDir cleanup. The per-element loop has always wrapped the
+  // identical calls.
+  it("reports an unparseable group fx-chain as a failure instead of throwing", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-bad-"));
+    const workDir = mkdtempSync(join(tmpdir(), "hf-grp-bad-work-"));
     tempDirs.push(projectDir, workDir);
+    writeTone(join(projectDir, "a.wav"), 440, 1, 0.4);
 
-    writeTone(join(projectDir, "a.wav"), 440, 2, 0.4);
-    writeTone(join(projectDir, "b.wav"), 440, 2, 0.4);
-    const oneUp = join(projectDir, `one-${MIXED_AUDIO_FILENAME}`);
-    const twoUp = join(projectDir, `two-${MIXED_AUDIO_FILENAME}`);
-
-    const one = await mixAudio([track("a", 2)], projectDir, workDir, oneUp, 2);
-    const two = await mixAudio([track("a", 2), track("b", 2)], projectDir, workDir, twoUp, 2);
-    expect(one.success).toBe(true);
-    expect(two.success).toBe(true);
-
-    // Two coherent copies of one tone = +6.02 dB. If amix's 1/N ever survives
-    // the correction, this lands at 0 dB instead.
-    expect(meanVolumeDb(twoUp) - meanVolumeDb(oneUp)).toBeCloseTo(6.02, 0);
-  }, 60_000);
-
-  it("does not lift the survivors when a shorter track ends", async () => {
-    // amix with normalize=true rescales by the number of CURRENTLY ACTIVE
-    // inputs, so a track ending mid-composition would hand the remaining ones
-    // a level jump. `apad` to the full duration is what holds every input
-    // active for the whole graph and neutralises that — an invariant the
-    // filter string relies on without saying so.
-    //
-    // Measured without apad (spike, 2026-08-14): the tail runs +1.94 dB hot.
-    // Any group work that builds its own amix has to keep the padding, or
-    // inherit that bug one level down.
-    const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-drop-"));
-    const workDir = mkdtempSync(join(tmpdir(), "hf-grp-drop-work-"));
-    tempDirs.push(projectDir, workDir);
-
-    writeTone(join(projectDir, "short.wav"), 440, 1, 0.5);
-    writeTone(join(projectDir, "long.wav"), 880, 3, 0.5);
-    const together = join(projectDir, `both-${MIXED_AUDIO_FILENAME}`);
-    const alone = join(projectDir, `alone-${MIXED_AUDIO_FILENAME}`);
-
-    const both = await mixAudio(
-      [track("short", 1), track("long", 3)],
-      projectDir,
-      workDir,
-      together,
-      3,
-    );
-    const solo = await mixAudio([track("long", 3)], projectDir, workDir, alone, 3);
-    expect(both.success).toBe(true);
-    expect(solo.success).toBe(true);
-
-    // After 1.5 s only `long` is sounding. It must read the same whether or not
-    // a second track happened to end earlier.
-    const tailTogether = meanVolumeDb(together, 1.5, 3);
-    const tailAlone = meanVolumeDb(alone, 1.5, 3);
-    expect(Math.abs(tailTogether - tailAlone)).toBeLessThan(0.5);
-  }, 60_000);
-
-  /**
-   * The gate for group buses (plans/audio-mixer-groups.md §1).
-   *
-   * Grouping is routing, not processing: a group whose FX chain is empty must
-   * be a no-op on the mix. Enable this the moment `data-audio-group` routes
-   * through a nested amix — it is the definition of done for §1.3, and the
-   * only thing standing between a wrong gain correction and a silently loud
-   * export.
-   *
-   * Proven reachable in the spike: nesting with each amix compensated by ITS
-   * OWN input count nulls against the flat mix to -inf (sample-identical), as
-   * does `amix=normalize=0` with no correction at all.
-   */
-  it("mixes a grouped composition at the same level as the ungrouped one", async () => {
-    const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-level-"));
-    const workDir = mkdtempSync(join(tmpdir(), "hf-grp-level-work-"));
-    tempDirs.push(projectDir, workDir);
-
-    writeTone(join(projectDir, "a.wav"), 440, 2, 0.4);
-    writeTone(join(projectDir, "b.wav"), 660, 2, 0.4);
-    const flatOut = join(projectDir, `flat-${MIXED_AUDIO_FILENAME}`);
-    const groupedOut = join(projectDir, `grouped-${MIXED_AUDIO_FILENAME}`);
-
-    const flat = await mixAudio([track("a", 2), track("b", 2)], projectDir, workDir, flatOut, 2);
-    const grouped = await mixAudio(
+    const result = await processCompositionAudio(
       [
-        { ...track("a", 2), groupId: "voiceover" },
-        { ...track("b", 2), groupId: "voiceover" },
+        {
+          ...track("a", 1),
+          groupId: "vo",
+          groupFxChain: '{"version":1,"nodes":[{"type":"tapestop"}]}',
+        },
       ],
       projectDir,
       workDir,
-      groupedOut,
-      2,
+      join(projectDir, `bad-${MIXED_AUDIO_FILENAME}`),
+      1,
     );
-    expect(flat.success).toBe(true);
-    expect(grouped.success).toBe(true);
 
-    // An empty group chain is pure routing — the export must read the same
-    // whether or not the two tones happened to share a group.
-    expect(Math.abs(meanVolumeDb(groupedOut) - meanVolumeDb(flatOut))).toBeLessThan(0.3);
-  }, 60_000);
+    expect(result.success).toBe(false);
+    const failure = result.failures?.find((f) => f.elementId === "vo");
+    expect(failure?.stage).toBe("mix");
+    expect(failure?.detail).toContain("tapestop");
+  });
 
-  it("a group FX chain fully cutting its members leaves an ungrouped track untouched (routing isolation)", async () => {
-    const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-fx-"));
-    const workDir = mkdtempSync(join(tmpdir(), "hf-grp-fx-work-"));
-    tempDirs.push(projectDir, workDir);
+  // `data-audio-group` arrives unvalidated from the document. `group-${id}.wav`
+  // defuses a bare `../` (the segment is `group-..`, not `..`), but an id
+  // holding a slash BEFORE the dots does escape: `a/../../x` normalizes to
+  // `<workDir>/../x.wav`, outside the tree `bail()`'s rmSync can reach.
+  it("keeps a traversal-shaped group id inside the work directory", async () => {
+    const parent = mkdtempSync(join(tmpdir(), "hf-grp-parent-"));
+    tempDirs.push(parent);
+    const projectDir = join(parent, "project");
+    const workDir = join(parent, "work");
+    mkdirSync(projectDir);
+    mkdirSync(workDir);
+    writeTone(join(projectDir, "a.wav"), 440, 1, 0.4);
 
-    writeTone(join(projectDir, "voice.wav"), 440, 2, 0.4);
-    writeTone(join(projectDir, "sfx.wav"), 880, 2, 0.4);
-    const mixedOut = join(projectDir, `mixed-${MIXED_AUDIO_FILENAME}`);
-    const sfxAloneOut = join(projectDir, `sfx-alone-${MIXED_AUDIO_FILENAME}`);
-
-    const groupChain = JSON.stringify({
-      version: 1,
-      nodes: [{ type: "gain", id: "g", params: { gain: -60 } }],
-    });
-
-    const mixed = await mixAudio(
-      [{ ...track("voice", 2), groupId: "vo", groupFxChain: groupChain }, track("sfx", 2)],
+    const result = await processCompositionAudio(
+      [{ ...track("a", 1), groupId: "a/../../escaped" }],
       projectDir,
       workDir,
-      mixedOut,
-      2,
+      join(projectDir, `esc-${MIXED_AUDIO_FILENAME}`),
+      1,
     );
-    const sfxAlone = await mixAudio([track("sfx", 2)], projectDir, workDir, sfxAloneOut, 2);
-    expect(mixed.success).toBe(true);
-    expect(sfxAlone.success).toBe(true);
 
-    // The voice group is cut ~60 dB — the mix should read close to sfx alone,
-    // and the ungrouped sfx track's own processing is unaffected by the
-    // group existing at all.
-    expect(Math.abs(meanVolumeDb(mixedOut) - meanVolumeDb(sfxAloneOut))).toBeLessThan(0.5);
-  }, 60_000);
+    expect(result.success).toBe(true);
+    // workDir is cleaned up on success, so what matters is what is left BESIDE
+    // it: an escaped  would survive there. Only the project remains.
+    expect(readdirSync(parent).sort()).toEqual(["project"]);
+  });
 
-  it("a member's own volume envelope still applies inside a group", async () => {
-    const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-env-"));
-    const workDir = mkdtempSync(join(tmpdir(), "hf-grp-env-work-"));
+  it("keeps distinct groups isolated when their sanitized ids collide", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-grp-collision-"));
+    const workDir = mkdtempSync(join(tmpdir(), "hf-grp-collision-work-"));
     tempDirs.push(projectDir, workDir);
+    writeTone(join(projectDir, "a.wav"), 440, 2, 0.4);
+    writeTone(join(projectDir, "b.wav"), 880, 2, 0.4);
 
-    writeTone(join(projectDir, "a.wav"), 440, 4, 0.5);
     const groupedOut = join(projectDir, `grouped-${MIXED_AUDIO_FILENAME}`);
     const flatOut = join(projectDir, `flat-${MIXED_AUDIO_FILENAME}`);
-
-    const withEnvelope = {
-      ...track("a", 4),
-      volumeKeyframes: [
-        { time: 0, volume: 1 },
-        { time: 4, volume: 0 },
+    const grouped = await processCompositionAudio(
+      [
+        { ...track("a", 2), groupId: "bed/a" },
+        { ...track("b", 2), groupId: "bed?a" },
       ],
-    };
-
-    const grouped = await mixAudio(
-      [{ ...withEnvelope, groupId: "vo" }],
       projectDir,
       workDir,
       groupedOut,
-      4,
+      2,
     );
-    const flat = await mixAudio([withEnvelope], projectDir, workDir, flatOut, 4);
+    const flat = await processCompositionAudio(
+      [track("a", 2), track("b", 2)],
+      projectDir,
+      workDir,
+      flatOut,
+      2,
+    );
+
     expect(grouped.success).toBe(true);
     expect(flat.success).toBe(true);
+    // If both ids map to `group-bed_a.wav`, the second submix overwrites the
+    // first and the outer mix reads the 880 Hz group twice, roughly 3 dB hot.
+    expect(Math.abs(meanVolumeDb(groupedOut) - meanVolumeDb(flatOut))).toBeLessThan(0.5);
+  });
+});
 
-    // The envelope fades to silent — the tail should read the same whether
-    // the track is grouped or not, proving member-level processing survives
-    // the group path unchanged.
-    const groupedTail = meanVolumeDb(groupedOut, 3, 4);
-    const flatTail = meanVolumeDb(flatOut, 3, 4);
-    expect(Math.abs(groupedTail - flatTail)).toBeLessThan(0.5);
-  }, 60_000);
+describe("duplicate bus instances", () => {
+  /**
+   * The reviewer's own repro. Two inlined instances of one sub-composition, each
+   * with its own bus and member, only the SECOND muted. Keyed by author id the
+   * two collapsed into one bus (last wins), so instance B's `data-hidden` took
+   * instance A's audio out of the export with it.
+   */
+  it("drops only the muted instance's member", () => {
+    const html = `<div id="root" data-composition-id="main" data-start="0" data-duration="4">
+      <div data-composition-id="bedcomp">
+        <hf-audio-group id="bed" data-hf-render-id="bed" data-volume="0.5"></hf-audio-group>
+        <audio id="m1" src="a.wav" data-start="0" data-duration="2"
+          data-audio-group="bed" data-hf-group-render-id="bed"></audio>
+      </div>
+      <div data-composition-id="bedcomp">
+        <hf-audio-group id="bed" data-hf-render-id="bed__hf2" data-volume="0.5" data-hidden></hf-audio-group>
+        <audio id="m1" src="a.wav" data-start="2" data-duration="2"
+          data-audio-group="bed" data-hf-group-render-id="bed__hf2"></audio>
+      </div>
+    </div>`;
+
+    const tracks = parseAudioElements(html);
+    expect(tracks.map((t) => t.groupId)).toEqual(["bed"]);
+    expect(tracks).toHaveLength(1);
+  });
+
+  it("keeps two instances as two separate buses when neither is muted", () => {
+    const html = `<div id="root" data-composition-id="main" data-start="0" data-duration="4">
+      <hf-audio-group id="bed" data-hf-render-id="bed" data-volume="0.25"></hf-audio-group>
+      <audio id="m1" src="a.wav" data-start="0" data-duration="2"
+        data-audio-group="bed" data-hf-group-render-id="bed"></audio>
+      <hf-audio-group id="bed" data-hf-render-id="bed__hf2" data-volume="0.75"></hf-audio-group>
+      <audio id="m2" src="b.wav" data-start="2" data-duration="2"
+        data-audio-group="bed" data-hf-group-render-id="bed__hf2"></audio>
+    </div>`;
+
+    const tracks = parseAudioElements(html);
+    // Each member keeps its OWN instance's fader — the collapse used to apply
+    // whichever bus came last to both.
+    expect(tracks.map((t) => [t.groupId, t.groupVolume])).toEqual([
+      ["bed", 0.25],
+      ["bed__hf2", 0.75],
+    ]);
+  });
 });

--- a/packages/engine/src/services/audioMixer.grouping.test.ts
+++ b/packages/engine/src/services/audioMixer.grouping.test.ts
@@ -496,7 +496,7 @@ describe.skipIf(!HAS_FFMPEG)("group sub-mix failure contract", () => {
     // If both ids map to `group-bed_a.wav`, the second submix overwrites the
     // first and the outer mix reads the 880 Hz group twice, roughly 3 dB hot.
     expect(Math.abs(meanVolumeDb(groupedOut) - meanVolumeDb(flatOut))).toBeLessThan(0.5);
-  });
+  }, 30_000);
 });
 
 describe("duplicate bus instances", () => {

--- a/packages/engine/src/services/audioMixer.level.test.ts
+++ b/packages/engine/src/services/audioMixer.level.test.ts
@@ -55,28 +55,9 @@ function firstAudibleSeconds(path: string): number {
   throw new Error(`No audible sample found in ${path}`);
 }
 
-/**
- * These two tests drive real ffmpeg, and the file ran on vitest's 5s default:
- * `places a delayed track on its authored start` takes ~137ms locally and still
- * hit that cap on the windows runner, failing an unrelated PR. 60s is what the
- * rest of the ffmpeg-driven engine tests use. Applied to the suite rather than
- * each test so the budget has one home.
- *
- * Headroom alone would only delay an undiagnosable failure, so the ffmpeg
- * process timeout is capped well under it too. Its production default is 5
- * minutes — far above any test budget — so a stalled mix could only ever
- * surface as a bare "Test timed out", with no stderr and no failing stage.
- */
-const FFMPEG_TEST_TIMEOUT_MS = 60_000;
-const TEST_FFMPEG_TIMEOUT_MS = 20_000;
-
-/** Assert the mix succeeded, reporting `failures` rather than a bare `false`. */
-function expectMixed(result: { success: boolean; failures?: unknown }): void {
-  if (!result.success) {
-    throw new Error(`mix failed: ${JSON.stringify(result.failures ?? result, null, 2)}`);
-  }
-}
-
+// Same real-ffmpeg exposure as audioMixer.grouping.test.ts, which timed out on a
+// Windows runner at vitest's default 5s. This one has not failed yet; it is one
+// spawn slower away from it.
 describe.skipIf(!HAS_FFMPEG)(
   "processCompositionAudio levels",
   () => {
@@ -127,11 +108,9 @@ describe.skipIf(!HAS_FFMPEG)(
         workDir,
         outputPath,
         1,
-        undefined,
-        { ffmpegProcessTimeout: TEST_FFMPEG_TIMEOUT_MS },
       );
 
-      expectMixed(result);
+      expect(result.success).toBe(true);
       expect(meanVolumeDb(outputPath) - meanVolumeDb(sourcePath)).toBeGreaterThan(-0.3);
     });
 
@@ -182,13 +161,11 @@ describe.skipIf(!HAS_FFMPEG)(
         workDir,
         outputPath,
         4,
-        undefined,
-        { ffmpegProcessTimeout: TEST_FFMPEG_TIMEOUT_MS },
       );
 
-      expectMixed(result);
+      expect(result.success).toBe(true);
       expect(firstAudibleSeconds(outputPath)).toBeCloseTo(2, 2);
     });
   },
-  FFMPEG_TEST_TIMEOUT_MS,
+  60_000,
 );

--- a/packages/engine/src/services/audioMixer.ts
+++ b/packages/engine/src/services/audioMixer.ts
@@ -965,8 +965,11 @@ async function mixGroupMembers(
     const inputFilters = buildInputFilters(ignoreKeyframes);
     const mixFilter = useNormalize
       ? `${mixInputs}amix=inputs=${memberTracks.length}:duration=longest:dropout_transition=0:normalize=0[out]`
-      : // amix's default normalize divides by input count; compensate by THIS
-        // group's own member count — never the render's global track count.
+      : // Every member is padded and trimmed to totalDuration above, and
+        // dropout_transition=0 keeps all N inputs active for that whole span.
+        // amix's default normalize therefore divides by exactly N throughout;
+        // compensate by THIS group's own member count — never the render's
+        // global track count.
         `${mixInputs}amix=inputs=${memberTracks.length}:duration=longest:dropout_transition=0[mixed];[mixed]volume=${formatFilterNumber(memberTracks.length)}[out]`;
     const filterComplex = [...inputFilters, mixFilter].join(";");
     const scriptDir = mkdtempSync(join(outputDir, ".group-filter-complex-"));

--- a/packages/engine/src/services/audioMixer.ts
+++ b/packages/engine/src/services/audioMixer.ts
@@ -48,6 +48,7 @@ import {
   readMediaStart,
 } from "@hyperframes/core";
 import { HF_AUDIO_GROUP_ATTR, resolveAudioGroups } from "@hyperframes/core/audio-groups";
+import { AUDIO_GROUP_RENDER_ID_ATTR } from "@hyperframes/core";
 import { applyAudioFxChain, AudioFxRenderError } from "./audioFxRender.js";
 import type { AudioVolumeKeyframe } from "./audioMixer.types.js";
 
@@ -68,8 +69,43 @@ export type { AudioElement, MixResult } from "./audioMixer.types.js";
  */
 export const MIXED_AUDIO_FILENAME = "audio.m4a";
 
+/**
+ * The bus key a member belongs to, as `resolveAudioGroups` keys them.
+ *
+ * The compiler's `data-hf-group-render-id` names one INSTANCE of a bus; the
+ * author's `data-audio-group` names it only within its own composition file. A
+ * sub-composition declaring a bus and its members, used twice, therefore had
+ * both instances' members under one key: one sub-mix for two independent buses,
+ * one instance's fader and chain over the other's audio, and — with only the
+ * second muted — BOTH instances dropped from the export. Uncompiled documents
+ * (the live preview) carry no stamp and read exactly as before.
+ */
+function memberGroupKey(el: RefResolverEl): string | null {
+  return el.getAttribute(AUDIO_GROUP_RENDER_ID_ATTR) ?? el.getAttribute(HF_AUDIO_GROUP_ATTR);
+}
+
 function clampVolume(volume: number): number {
   return clampAudioGain(volume);
+}
+
+/**
+ * An author-controlled id, made safe to put in a filename.
+ *
+ * `data-audio-group` reaches this file straight from the document — the
+ * studio's `GROUP_ID_PATTERN` guards only ids the studio itself mints, and a
+ * hand-authored or agent-written one is unvalidated. Interpolated raw it could
+ * carry `/` or `..`, and `mkdirSync(recursive)` inside ffmpeg's own path
+ * handling would then write outside `workDir`, where `bail()`'s `rmSync` never
+ * cleans it up. Everything outside [A-Za-z0-9_-] collapses to `_`, and every
+ * result gets a stable positional suffix so distinct ids that sanitize alike
+ * cannot share one intermediate file.
+ */
+function safePathSegment(id: string, fallbackIndex: number): string {
+  const cleaned = id.replace(/[^A-Za-z0-9_-]/g, "_");
+  // Sanitisation is many-to-one (`bed/a` and `bed?a` both become `bed_a`).
+  // The stable position keeps every authored group on a distinct temp path
+  // even when their readable portions collide.
+  return `${cleaned || "group"}-${fallbackIndex}`;
 }
 
 function formatFilterNumber(value: number): string {
@@ -469,7 +505,7 @@ export function parseAudioElements(html: string): AudioElement[] {
     resolveAudioGroups(document).map((group) => [group.id, group] as const),
   );
   const memberGroupHidden = (el: AudioMediaElement): boolean => {
-    const groupId = el.getAttribute(HF_AUDIO_GROUP_ATTR);
+    const groupId = memberGroupKey(el);
     return groupId ? (groupsById.get(groupId)?.hidden ?? false) : false;
   };
 
@@ -484,7 +520,7 @@ export function parseAudioElements(html: string): AudioElement[] {
     const automation = el.getAttribute(HF_AUDIO_AUTOMATION_ATTR);
     // Audio only in v1 (matches resolveAudioGroups, which only scans
     // `audio[data-audio-group]`) — a stray attribute on a <video> is inert.
-    const groupId = type === "audio" ? el.getAttribute(HF_AUDIO_GROUP_ATTR) : null;
+    const groupId = type === "audio" ? memberGroupKey(el) : null;
     const group = groupId ? groupsById.get(groupId) : undefined;
     return {
       id,
@@ -519,6 +555,8 @@ export function parseAudioElements(html: string): AudioElement[] {
 
   for (const el of document.querySelectorAll("audio[id][src]")) {
     const id = trackId(el);
+    // `memberGroupHidden` is the group's own mute: a hidden BUS drops every
+    // member from the mix, the same way `isHidden` drops one track.
     if (!id || !el.getAttribute("src") || isHidden(el) || memberGroupHidden(el)) continue;
     if (isKnownInactiveTimelineWindow(el, resolveStart(el))) continue;
     elements.push(build(el, id, "audio"));
@@ -865,6 +903,14 @@ async function mixAudioTracks(
   };
 }
 
+/**
+ * Verified against the real binary, because the wording is the whole contract:
+ * ffmpeg 8.1.1 emits `Error applying option 'X' to filter 'amix': Option not
+ * found`, which "option not found" matches. Only pre-4.4 libavfilter's
+ * `Option 'normalize' not found` phrasing sits outside the first test — and
+ * that build predates `normalize` existing at all, so it would fail for the
+ * right reason anyway. A review pass read this as dead and it is not.
+ */
 function groupNormalizeOptionUnsupported(stderr: string): boolean {
   return (
     /normalize/i.test(stderr) &&
@@ -894,20 +940,29 @@ async function mixGroupMembers(
   totalDuration: number,
   signal?: AbortSignal,
   config?: Partial<Pick<EngineConfig, "ffmpegProcessTimeout">>,
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; degradedAutomation?: boolean }> {
   const ffmpegProcessTimeout = config?.ffmpegProcessTimeout ?? DEFAULT_CONFIG.ffmpegProcessTimeout;
   const outputDir = dirname(outputPath);
   if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
 
-  const inputFilters = memberTracks.map((track, i) => {
-    const delayMs = Math.round(track.start * 1000);
-    const trimDuration = track.end - track.start + (track.tailSeconds ?? 0);
-    const volumeFilter = buildVolumeExpression(track);
-    return `[${i}:a]atrim=0:${formatFilterNumber(trimDuration)},${volumeFilter},adelay=${delayMs}|${delayMs},apad,atrim=0:${formatFilterNumber(totalDuration)}[a${i}]`;
-  });
+  const buildInputFilters = (ignoreKeyframes: boolean) =>
+    memberTracks.map((track, i) => {
+      const delayMs = Math.round(track.start * 1000);
+      const trimDuration = track.end - track.start + (track.tailSeconds ?? 0);
+      const volumeFilter = buildVolumeExpression(track, ignoreKeyframes);
+      // Same `asetpts=N/SR/TB` as the master mix above, for the same reason and
+      // on the same builds: these are delayed branches padded to length and then
+      // amix'd, so without the renumbering a delayed member lands at t=0 and a
+      // group of four or more loses its last one.
+      return `[${i}:a]atrim=0:${formatFilterNumber(trimDuration)},${volumeFilter},adelay=${delayMs}|${delayMs},apad,asetpts=N/SR/TB,atrim=0:${formatFilterNumber(totalDuration)}[a${i}]`;
+    });
   const mixInputs = memberTracks.map((_, i) => `[a${i}]`).join("");
 
-  const runOnce = async (useNormalize: boolean): Promise<RunFfmpegResult> => {
+  const runOnce = async (
+    useNormalize: boolean,
+    ignoreKeyframes = false,
+  ): Promise<RunFfmpegResult> => {
+    const inputFilters = buildInputFilters(ignoreKeyframes);
     const mixFilter = useNormalize
       ? `${mixInputs}amix=inputs=${memberTracks.length}:duration=longest:dropout_transition=0:normalize=0[out]`
       : // amix's default normalize divides by input count; compensate by THIS
@@ -931,8 +986,15 @@ async function mixGroupMembers(
         scriptPath,
         "-map",
         "[out]",
+        // Float, not pcm_s16le: `normalize=0` sums the members at unity, so any
+        // over-unity sum hard-clipped at ±1 in the intermediate — BEFORE the
+        // group's FX chain and its fader ran. Pulling the group down, or the
+        // Giant preset's compressor, then operated on distortion. Preview
+        // cannot reproduce it (its bus is float), and it only shows up in the
+        // export. Both readers downstream take float: `readWav` (format 3) and
+        // `applyVolumeEnvelopeToWav`.
         "-acodec",
-        "pcm_s16le",
+        "pcm_f32le",
         "-ar",
         "48000",
         "-t",
@@ -952,14 +1014,32 @@ async function mixGroupMembers(
     }
   };
 
-  let result = await runOnce(true);
+  let useNormalize = true;
+  let result = await runOnce(useNormalize);
   if (!result.success && groupNormalizeOptionUnsupported(result.stderr)) {
-    result = await runOnce(false);
+    useNormalize = false;
+    result = await runOnce(useNormalize);
   }
+
+  // The same defence `mixAudioTracks` has, which this forked without: a
+  // member's volume automation becomes an ffmpeg `volume` expression whose
+  // evaluator limits are build-dependent, so a dense envelope can fail the
+  // whole run. Ungrouped, that track degrades to base volume with a warning;
+  // grouped, it took the entire composition's audio down with it.
+  let degradedAutomation = false;
+  const hasAutomation = memberTracks.some((track) => (track.volumeKeyframes?.length ?? 0) > 0);
+  if (!result.success && !signal?.aborted && hasAutomation) {
+    const retry = await runOnce(useNormalize, true);
+    if (retry.success) {
+      result = retry;
+      degradedAutomation = true;
+    }
+  }
+
   if (signal?.aborted) return { success: false, error: "Group sub-mix cancelled" };
   if (!result.success)
     return { success: false, error: formatFfmpegError(result.exitCode, result.stderr) };
-  return { success: true };
+  return { success: true, degradedAutomation };
 }
 
 export async function processCompositionAudio(
@@ -1314,87 +1394,118 @@ export async function processCompositionAudio(
   // clock is composition time (offset 0): a group has no `data-start` of its
   // own, and members are already delayed to their composition positions
   // inside the sub-mix, so the group WAV's t=0 IS composition time.
+  const groupsDegradedAutomation: string[] = [];
+  let groupIndex = -1;
   for (const [groupId, memberTracks] of groupTracks) {
+    groupIndex += 1;
     const meta = groupMeta.get(groupId);
     if (!meta) continue;
-    const groupWavPath = join(workDir, `group-${groupId}.wav`);
-    const subMix = await mixGroupMembers(
-      memberTracks,
-      groupWavPath,
-      totalDuration,
-      effectiveSignal,
-      config,
-    );
-    if (!subMix.success) {
+    const pathId = safePathSegment(groupId, groupIndex);
+    const groupWavPath = join(workDir, `group-${pathId}.wav`);
+    // Same contract the per-element loop above gives: a malformed `data-fx-chain`
+    // or `data-automation` on a BUS threw straight out of processCompositionAudio,
+    // bypassing the MixResult/failures[] shape the caller handles and skipping
+    // `bail()`, so the temp dir leaked too. An AudioFxRenderError stays fatal
+    // for the same reason it is fatal per element: shipping the dry signal in
+    // place of a processed one sounds plausible and is not what was authored.
+    try {
+      const subMix = await mixGroupMembers(
+        memberTracks,
+        groupWavPath,
+        totalDuration,
+        effectiveSignal,
+        config,
+      );
+      if (!subMix.success) {
+        failures.push({
+          stage: "mix",
+          reason: "ffmpeg_failed",
+          owner: "system",
+          retryable: false,
+          elementId: groupId,
+          detail: boundedDetail(
+            `Group sub-mix failed for group ${groupId}: ${subMix.error ?? "unknown"}`,
+          ),
+        });
+        continue;
+      }
+      if (subMix.degradedAutomation) groupsDegradedAutomation.push(groupId);
+
+      // Composition-time automation (offset 0, duration totalDuration) — same
+      // resolve/lane/bake path a member uses, just anchored at the group clock
+      // instead of a clip's own start.
+      const automation = meta.automation
+        ? resolveAutomation(
+            parseAutomation(meta.automation),
+            meta.fxChain ? parseAudioFxChain(meta.fxChain) : undefined,
+          )
+        : null;
+      const laneKeyframes = automation ? volumeLaneKeyframes(automation, 0, totalDuration) : null;
+      const envelope =
+        laneKeyframes && laneKeyframes.length > 0
+          ? { keyframes: laneKeyframes, trackStart: 0, baseVolume: meta.volume }
+          : null;
+
+      let groupSrcPath = groupWavPath;
+      let bakedEnvelope = false;
+      if (meta.fxChain) {
+        const chain = parseAudioFxChain(meta.fxChain);
+        const fxResult = await applyAudioFxChain(
+          groupSrcPath,
+          chain,
+          join(workDir, `group-${pathId}-fx.wav`),
+          {
+            trackId: groupId,
+            signal: effectiveSignal,
+            ...(automation ? { automation } : {}),
+            ...(envelope ? { envelope } : {}),
+          },
+        );
+        groupSrcPath = fxResult.path;
+        bakedEnvelope = fxResult.envelopeBaked;
+      }
+      if (envelope && !bakedEnvelope) {
+        bakedEnvelope = applyVolumeEnvelopeToWav(
+          groupSrcPath,
+          envelope.keyframes,
+          envelope.trackStart,
+          envelope.baseVolume,
+        );
+      }
+
+      // `end` is already the render's totalDuration, so the outer mix's own
+      // atrim-to-totalDuration clips this track exactly the same way it would
+      // an ungrouped one whose clip ran to the end of the render — a group's FX
+      // tail gets the same "never past the end of the video" treatment member
+      // tails get, for free, with no separate tailSeconds bookkeeping needed.
+      tracks.push({
+        id: groupId,
+        srcPath: groupSrcPath,
+        start: 0,
+        end: totalDuration,
+        mediaStart: 0,
+        duration: totalDuration,
+        volume: bakedEnvelope ? 1.0 : meta.volume,
+        // Same fallback an ungrouped track gets: when the envelope could not be
+        // baked into the samples, hand the keyframes to the outer mix's volume
+        // expression instead of dropping the group's automation on the floor.
+        ...(bakedEnvelope || !laneKeyframes?.length ? {} : { volumeKeyframes: laneKeyframes }),
+      });
+    } catch (err: unknown) {
+      if (err instanceof AudioFxRenderError) throw err;
       failures.push({
         stage: "mix",
-        reason: "ffmpeg_failed",
+        reason: "internal",
         owner: "system",
         retryable: false,
         elementId: groupId,
         detail: boundedDetail(
-          `Group sub-mix failed for group ${groupId}: ${subMix.error ?? "unknown"}`,
+          `Audio processing failed for group ${groupId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
         ),
       });
-      continue;
     }
-
-    // Composition-time automation (offset 0, duration totalDuration) — same
-    // resolve/lane/bake path a member uses, just anchored at the group clock
-    // instead of a clip's own start.
-    const automation = meta.automation
-      ? resolveAutomation(
-          parseAutomation(meta.automation),
-          meta.fxChain ? parseAudioFxChain(meta.fxChain) : undefined,
-        )
-      : null;
-    const laneKeyframes = automation ? volumeLaneKeyframes(automation, 0, totalDuration) : null;
-    const envelope =
-      laneKeyframes && laneKeyframes.length > 0
-        ? { keyframes: laneKeyframes, trackStart: 0, baseVolume: meta.volume }
-        : null;
-
-    let groupSrcPath = groupWavPath;
-    let bakedEnvelope = false;
-    if (meta.fxChain) {
-      const chain = parseAudioFxChain(meta.fxChain);
-      const fxResult = await applyAudioFxChain(
-        groupSrcPath,
-        chain,
-        join(workDir, `group-${groupId}-fx.wav`),
-        {
-          trackId: groupId,
-          signal: effectiveSignal,
-          ...(automation ? { automation } : {}),
-          ...(envelope ? { envelope } : {}),
-        },
-      );
-      groupSrcPath = fxResult.path;
-      bakedEnvelope = fxResult.envelopeBaked;
-    }
-    if (envelope && !bakedEnvelope) {
-      bakedEnvelope = applyVolumeEnvelopeToWav(
-        groupSrcPath,
-        envelope.keyframes,
-        envelope.trackStart,
-        envelope.baseVolume,
-      );
-    }
-
-    // `end` is already the render's totalDuration, so the outer mix's own
-    // atrim-to-totalDuration clips this track exactly the same way it would
-    // an ungrouped one whose clip ran to the end of the render — a group's FX
-    // tail gets the same "never past the end of the video" treatment member
-    // tails get, for free, with no separate tailSeconds bookkeeping needed.
-    tracks.push({
-      id: groupId,
-      srcPath: groupSrcPath,
-      start: 0,
-      end: totalDuration,
-      mediaStart: 0,
-      duration: totalDuration,
-      volume: bakedEnvelope ? 1.0 : meta.volume,
-    });
   }
   if (failures.length > 0) return bail();
 
@@ -1406,9 +1517,21 @@ export async function processCompositionAudio(
     /* ignore */
   }
 
+  // A group whose sub-mix had to drop member automation reports it the same
+  // way mixAudioTracks reports its own degradation: on a SUCCESSFUL result, so
+  // the render ships and the caller can still say what was lost.
+  const degradedNote =
+    groupsDegradedAutomation.length > 0
+      ? `Volume automation exceeded this ffmpeg build's expression limits in group(s) ${groupsDegradedAutomation.join(", ")}; rendered at base volume`
+      : undefined;
+
   return {
     ...mixResult,
     durationMs: Date.now() - startMs,
-    error: mixResult.error,
+    // Both, when both degraded. `mixResult.error ?? degradedNote` reported only
+    // the outer mix and dropped the one that names which GROUPS lost their
+    // members' automation — two different losses, and the operator needs to
+    // hear about the one they can act on.
+    error: [mixResult.error, degradedNote].filter(Boolean).join("; ") || undefined,
   };
 }

--- a/packages/engine/src/services/audioVolumeEnvelope.test.ts
+++ b/packages/engine/src/services/audioVolumeEnvelope.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { getFfmpegBinary } from "../utils/ffmpegBinaries.js";
 import { applyVolumeEnvelopeToWav } from "./audioVolumeEnvelope.js";
 
 const SAMPLE_RATE = 48000;
 const CHANNELS = 2;
+const HAS_FFMPEG = spawnSync(getFfmpegBinary(), ["-version"], { encoding: "utf-8" }).status === 0;
 
 /** Build a PCM s16le stereo WAV whose every sample equals `value`. */
 function writeConstantWav(path: string, frames: number, value: number): void {
@@ -172,5 +175,146 @@ describe("applyVolumeEnvelopeToWav", () => {
         0,
       ),
     ).toBe(false);
+  });
+
+  // The group sub-mix writes float precisely so an over-unity member sum keeps
+  // its headroom until the group's own fader and FX act on it. If the baker
+  // could not read that file it returned false, and the group's automation was
+  // dropped on the floor by the caller.
+  describe("32-bit float input", () => {
+    /** Stereo float32 WAV, every sample `value` — over 1.0 on purpose. */
+    function writeConstantFloatWav(path: string, frames: number, value: number): void {
+      const dataSize = frames * CHANNELS * 4;
+      const buffer = Buffer.alloc(44 + dataSize);
+      buffer.write("RIFF", 0, "ascii");
+      buffer.writeUInt32LE(36 + dataSize, 4);
+      buffer.write("WAVE", 8, "ascii");
+      buffer.write("fmt ", 12, "ascii");
+      buffer.writeUInt32LE(16, 16);
+      buffer.writeUInt16LE(3, 20); // WAVE_FORMAT_IEEE_FLOAT
+      buffer.writeUInt16LE(CHANNELS, 22);
+      buffer.writeUInt32LE(SAMPLE_RATE, 24);
+      buffer.writeUInt32LE(SAMPLE_RATE * CHANNELS * 4, 28);
+      buffer.writeUInt16LE(CHANNELS * 4, 32);
+      buffer.writeUInt16LE(32, 34);
+      buffer.write("data", 36, "ascii");
+      buffer.writeUInt32LE(dataSize, 40);
+      for (let i = 0; i < frames * CHANNELS; i += 1) buffer.writeFloatLE(value, 44 + i * 4);
+      writeFileSync(path, buffer);
+    }
+
+    const floatSampleAt = (path: string, frame: number, channel = 0): number =>
+      readFileSync(path).readFloatLE(44 + (frame * CHANNELS + channel) * 4);
+
+    it("scales float samples and keeps them above 1.0 unclamped", () => {
+      const path = join(tmp(), "float.wav");
+      writeConstantFloatWav(path, SAMPLE_RATE, 1.4);
+
+      expect(
+        applyVolumeEnvelopeToWav(
+          path,
+          [
+            { time: 0, volume: 1 },
+            { time: 1, volume: 1 },
+          ],
+          0,
+          1,
+        ),
+      ).toBe(true);
+
+      // Unity envelope: unchanged, and NOT clamped down to 1.0.
+      expect(floatSampleAt(path, 0)).toBeCloseTo(1.4, 5);
+      expect(floatSampleAt(path, SAMPLE_RATE - 1)).toBeCloseTo(1.4, 5);
+    });
+
+    it("applies the envelope across the file", () => {
+      const path = join(tmp(), "float-fade.wav");
+      writeConstantFloatWav(path, SAMPLE_RATE, 1.4);
+
+      expect(
+        applyVolumeEnvelopeToWav(
+          path,
+          [
+            { time: 0, volume: 1 },
+            { time: 1, volume: 0 },
+          ],
+          0,
+          1,
+        ),
+      ).toBe(true);
+
+      expect(floatSampleAt(path, 0)).toBeCloseTo(1.4, 5);
+      expect(floatSampleAt(path, Math.floor(SAMPLE_RATE / 2))).toBeCloseTo(0.7, 2);
+      expect(floatSampleAt(path, SAMPLE_RATE - 1)).toBeCloseTo(0, 3);
+    });
+
+    /**
+     * The fixtures above are hand-built canonical 44-byte headers, which is NOT
+     * what the group sub-mix actually hands this function: ffmpeg's `pcm_f32le`
+     * writes an 18-byte `fmt ` chunk plus a `fact` chunk, putting `data` at
+     * offset 92. Every assertion above would still pass if this function could
+     * not read a real one — and an unreadable file returns false, which the
+     * caller reads as "no automation here" and drops the group's envelope.
+     */
+    it.skipIf(!HAS_FFMPEG)("reads what ffmpeg actually writes, not just a canonical header", () => {
+      const path = join(tmp(), "ffmpeg-f32.wav");
+      const made = spawnSync(
+        getFfmpegBinary(),
+        [
+          "-nostdin",
+          "-v",
+          "error",
+          "-f",
+          "lavfi",
+          "-i",
+          "aevalsrc=0.5*sin(2*PI*440*t)|0.5*sin(2*PI*440*t):d=1:s=48000",
+          "-acodec",
+          "pcm_f32le",
+          "-ar",
+          "48000",
+          path,
+        ],
+        { encoding: "utf-8" },
+      );
+      expect(made.status).toBe(0);
+
+      const before = readFileSync(path);
+      // The format tag is the load-bearing part; the chunk LAYOUT is this
+      // build's quirk, so it is logged as context rather than required — a
+      // build emitting a canonical 16-byte fmt with data at 44 is legal and
+      // handled, and pinning 18/92 would fail on the good case.
+      expect(before.readUInt16LE(20)).toBe(3); // WAVE_FORMAT_IEEE_FLOAT
+
+      expect(
+        applyVolumeEnvelopeToWav(
+          path,
+          [
+            { time: 0, volume: 1 },
+            { time: 1, volume: 0 },
+          ],
+          0,
+          1,
+        ),
+      ).toBe(true);
+
+      // Locate `data` the way the parser does, then check the fade landed.
+      let at = 12;
+      let dataOffset = -1;
+      const after = readFileSync(path);
+      while (at + 8 <= after.length) {
+        const id = after.toString("ascii", at, at + 4);
+        const size = after.readUInt32LE(at + 4);
+        if (id === "data") {
+          dataOffset = at + 8;
+          break;
+        }
+        at += 8 + size + (size % 2);
+      }
+      expect(dataOffset).toBeGreaterThan(0);
+      // Faded to silence by the end (stereo float = 8 bytes per frame). This is
+      // the assertion that matters: the parser read a real file and the bake
+      // landed, whatever chunk layout the build chose.
+      expect(Math.abs(after.readFloatLE(dataOffset + (SAMPLE_RATE - 2) * 8))).toBeLessThan(0.02);
+    });
   });
 });

--- a/packages/engine/src/services/audioVolumeEnvelope.ts
+++ b/packages/engine/src/services/audioVolumeEnvelope.ts
@@ -22,13 +22,17 @@ import { normaliseEnvelope } from "@hyperframes/core/media-volume-envelope";
 import { riffChunks } from "./wavChunks.js";
 
 const PCM_FORMAT = 1; // WAVE_FORMAT_PCM
-const SUPPORTED_BITS = 16;
+const FLOAT_FORMAT = 3; // WAVE_FORMAT_IEEE_FLOAT
 
 interface WavLayout {
   numChannels: number;
   sampleRate: number;
   dataOffset: number;
   dataSize: number;
+  /** 16-bit integer, or 32-bit float — the group sub-mix writes float so an
+   *  over-unity member sum is not hard-clipped before the group's own FX and
+   *  fader get to act on it. */
+  float: boolean;
 }
 
 /**
@@ -39,34 +43,49 @@ interface WavLayout {
  * and trailing chunks (LIST/fact/etc.) are skipped harmlessly. Returns null on
  * anything unexpected so the caller falls back to the expression path.
  */
-function parseWavLayout(buffer: Buffer): WavLayout | null {
-  if (buffer.length < 12 || buffer.toString("ascii", 0, 4) !== "RIFF") return null;
-  if (buffer.toString("ascii", 8, 12) !== "WAVE") return null;
+interface WavFmt {
+  numChannels: number;
+  sampleRate: number;
+  /** 16-bit integer PCM, or 32-bit IEEE float. Anything else is unreadable. */
+  float: boolean;
+}
 
-  let fmt: { numChannels: number; sampleRate: number; bitsPerSample: number } | null = null;
+/** The `fmt ` chunk, or null for a format this cannot safely edit in place. */
+function readFmtChunk(buffer: Buffer, body: number): WavFmt | null {
+  const format = buffer.readUInt16LE(body);
+  const bits = buffer.readUInt16LE(body + 14);
+  const float = format === FLOAT_FORMAT;
+  if (!float && format !== PCM_FORMAT) return null;
+  if (bits !== (float ? 32 : 16)) return null;
+  const numChannels = buffer.readUInt16LE(body + 2);
+  if (numChannels < 1) return null;
+  return { numChannels, sampleRate: buffer.readUInt32LE(body + 4), float };
+}
+
+function isRiffWave(buffer: Buffer): boolean {
+  return (
+    buffer.length >= 12 &&
+    buffer.toString("ascii", 0, 4) === "RIFF" &&
+    buffer.toString("ascii", 8, 12) === "WAVE"
+  );
+}
+
+function parseWavLayout(buffer: Buffer): WavLayout | null {
+  if (!isRiffWave(buffer)) return null;
+
+  let fmt: WavFmt | null = null;
   let data: { offset: number; size: number } | null = null;
 
   for (const { id, body, size } of riffChunks(buffer)) {
     if (id === "fmt " && body + 16 <= buffer.length) {
-      if (buffer.readUInt16LE(body) !== PCM_FORMAT) return null;
-      fmt = {
-        numChannels: buffer.readUInt16LE(body + 2),
-        sampleRate: buffer.readUInt32LE(body + 4),
-        bitsPerSample: buffer.readUInt16LE(body + 14),
-      };
+      fmt = readFmtChunk(buffer, body);
     } else if (id === "data") {
       data = { offset: body, size: Math.min(size, buffer.length - body) };
     }
   }
 
   if (!fmt || !data) return null;
-  if (fmt.bitsPerSample !== SUPPORTED_BITS || fmt.numChannels < 1) return null;
-  return {
-    numChannels: fmt.numChannels,
-    sampleRate: fmt.sampleRate,
-    dataOffset: data.offset,
-    dataSize: data.size,
-  };
+  return { ...fmt, dataOffset: data.offset, dataSize: data.size };
 }
 
 /**
@@ -103,11 +122,40 @@ export function createEnvelopeWalker(
   };
 }
 
+/** Every sample scaled by the envelope, in place, in whichever of the two
+ *  formats the layout reports. Float is NOT clamped: it is the format the group
+ *  sub-mix writes precisely so an over-unity sum keeps its headroom until
+ *  something downstream chooses to reduce it. */
+function scaleSamples(
+  buffer: Buffer,
+  layout: WavLayout,
+  gainAt: (seconds: number) => number,
+): void {
+  const { numChannels, sampleRate, dataOffset, dataSize, float } = layout;
+  const bytesPerSample = float ? 4 : 2;
+  const frameBytes = numChannels * bytesPerSample;
+  const frameCount = Math.floor(dataSize / frameBytes);
+  const scaleOne = float
+    ? (at: number, gain: number) => buffer.writeFloatLE(buffer.readFloatLE(at) * gain, at)
+    : (at: number, gain: number) => {
+        const scaled = Math.round(buffer.readInt16LE(at) * gain);
+        buffer.writeInt16LE(scaled < -32768 ? -32768 : scaled > 32767 ? 32767 : scaled, at);
+      };
+
+  for (let frame = 0; frame < frameCount; frame += 1) {
+    const gain = gainAt(frame / sampleRate);
+    const base = dataOffset + frame * frameBytes;
+    for (let channel = 0; channel < numChannels; channel += 1) {
+      scaleOne(base + channel * bytesPerSample, gain);
+    }
+  }
+}
+
 /**
  * Multiply a prepared WAV's samples by a time-varying gain envelope in place.
  *
- * @returns `true` if the envelope was applied; `false` if the file isn't the
- *   expected 16-bit PCM (caller should fall back to the expression path).
+ * @returns `true` if the envelope was applied; `false` if the file is neither
+ *   16-bit PCM nor 32-bit float (caller should fall back to the expression path).
  */
 export function applyVolumeEnvelopeToWav(
   wavPath: string,
@@ -123,20 +171,7 @@ export function applyVolumeEnvelopeToWav(
     const layout = parseWavLayout(buffer);
     if (!layout) return false;
 
-    const { numChannels, sampleRate, dataOffset, dataSize } = layout;
-    const bytesPerSample = SUPPORTED_BITS / 8;
-    const frameBytes = numChannels * bytesPerSample;
-    const frameCount = Math.floor(dataSize / frameBytes);
-
-    for (let frame = 0; frame < frameCount; frame += 1) {
-      const gain = gainAt(frame / sampleRate);
-      const base = dataOffset + frame * frameBytes;
-      for (let channel = 0; channel < numChannels; channel += 1) {
-        const at = base + channel * bytesPerSample;
-        const scaled = Math.round(buffer.readInt16LE(at) * gain);
-        buffer.writeInt16LE(scaled < -32768 ? -32768 : scaled > 32767 ? 32767 : scaled, at);
-      }
-    }
+    scaleSamples(buffer, layout, gainAt);
 
     // Write to a uniquely-named sibling then atomically rename over the
     // original. The random name avoids following a pre-planted symlink at a

--- a/packages/lint/src/rules/media.test.ts
+++ b/packages/lint/src/rules/media.test.ts
@@ -590,6 +590,29 @@ describe("audio_group_no_members", () => {
     expect(finding?.message).toContain("voiceovr");
   });
 
+  it("suggests only unmatched member ids, not a healthy sibling group", async () => {
+    const res = await lintHyperframeHtml(
+      doc(`${BUS}<hf-audio-group id="music"></hf-audio-group>
+        <audio id="bgm" src="music.wav" data-start="0" data-duration="5" data-audio-group="music"></audio>
+        <audio id="vo-1" src="vo.wav" data-start="0" data-duration="5" data-audio-group="voiceovr"></audio>`),
+    );
+    const finding = res.findings.find((item) => item.code === "audio_group_no_members");
+    expect(finding?.message).toContain('"voiceovr"');
+    expect(finding?.message).not.toContain('"music"');
+  });
+
+  it("does not count video as group membership", async () => {
+    const res = await lintHyperframeHtml(
+      doc(`${BUS}<video id="v" src="v.mp4" data-start="0" data-duration="5" data-audio-group="voiceover"></video>
+        <audio id="s-1" src="s.wav" data-start="0" data-duration="2" data-audio-group="sfx"></audio>`),
+    );
+    expect(
+      res.findings.some(
+        (finding) => finding.code === "audio_group_no_members" && finding.elementId === "voiceover",
+      ),
+    ).toBe(true);
+  });
+
   it("stays quiet when a clip belongs to it", async () => {
     const res = await lintHyperframeHtml(
       doc(
@@ -607,11 +630,7 @@ describe("audio_group_no_members", () => {
   // file (timelineAudioGroupCreate) — so a file holding a bus and no members at
   // all is the normal cross-file shape, not a mistake.
   it("stays quiet in a file that declares no members at all", async () => {
-    const res = await lintHyperframeHtml(
-      doc(
-        `${BUS}<div id="host" data-composition-src="compositions/voices.html" data-start="0" data-duration="10"></div>`,
-      ),
-    );
+    const res = await lintHyperframeHtml(doc(BUS));
     expect(res.findings.some((f) => f.code === "audio_group_no_members")).toBe(false);
   });
 
@@ -627,7 +646,8 @@ describe("audio_group_no_members", () => {
 
   it("stays quiet for a bus with no id", async () => {
     const res = await lintHyperframeHtml(
-      doc(`<hf-audio-group data-label="Nameless"></hf-audio-group>`),
+      doc(`<hf-audio-group data-label="Nameless"></hf-audio-group>
+        <audio id="s-1" src="s.wav" data-start="0" data-duration="2" data-audio-group="sfx"></audio>`),
     );
     expect(res.findings.some((f) => f.code === "audio_group_no_members")).toBe(false);
   });

--- a/packages/lint/src/rules/media.test.ts
+++ b/packages/lint/src/rules/media.test.ts
@@ -556,6 +556,148 @@ describe("audio_volume_double_automation", () => {
   });
 });
 
+describe("audio_group_no_members", () => {
+  const doc = (body: string) => `<!DOCTYPE html><html><body>
+    <div id="root" data-composition-id="main" data-start="0" data-width="1920" data-height="1080" data-duration="10">
+      ${body}
+    </div>
+  </body></html>`;
+
+  const BUS = `<hf-audio-group id="voiceover" data-label="Voiceover" data-volume="0.4"
+    data-fx-chain='{"version":1,"nodes":[{"type":"peaking","id":"n1","params":{"frequency":250,"gain":-3,"q":1.2}}]}'></hf-audio-group>`;
+
+  it("errors on a bus no clip in the file belongs to", async () => {
+    const res = await lintHyperframeHtml(
+      doc(
+        `${BUS}<audio id="s-1" src="s.wav" data-start="0" data-duration="2" data-audio-group="sfx"></audio>`,
+      ),
+    );
+    const finding = res.findings.find((f) => f.code === "audio_group_no_members");
+    expect(finding?.severity).toBe("error");
+    expect(finding?.elementId).toBe("voiceover");
+  });
+
+  // The whole point: one typo drops the authored bus (fader AND chain) and
+  // invents a phantom group at unity, with nothing said about either.
+  it("catches the misspelled member — the case that motivated the rule", async () => {
+    const res = await lintHyperframeHtml(
+      doc(
+        `${BUS}<audio id="vo-1" src="vo.wav" data-start="0" data-duration="5" data-audio-group="voiceovr"></audio>`,
+      ),
+    );
+    const finding = res.findings.find((f) => f.code === "audio_group_no_members");
+    expect(finding?.elementId).toBe("voiceover");
+    expect(finding?.message).toContain("voiceovr");
+  });
+
+  it("stays quiet when a clip belongs to it", async () => {
+    const res = await lintHyperframeHtml(
+      doc(
+        `${BUS}<audio id="vo-1" src="vo.wav" data-start="0" data-duration="5" data-audio-group="voiceover"></audio>`,
+      ),
+    );
+    expect(res.findings.some((f) => f.code === "audio_group_no_members")).toBe(false);
+  });
+
+  // A bus with no id cannot be joined at all, and `resolveAudioGroups` skips it
+  // when building its element map — a different mistake, not this rule's.
+  // The rule can only speak about a file it can see all of. `lintHyperframeHtml`
+  // takes ONE file, and the studio's own group creation writes the bus into the
+  // active composition while patching `data-audio-group` into each member's own
+  // file (timelineAudioGroupCreate) — so a file holding a bus and no members at
+  // all is the normal cross-file shape, not a mistake.
+  it("stays quiet in a file that declares no members at all", async () => {
+    const res = await lintHyperframeHtml(
+      doc(
+        `${BUS}<div id="host" data-composition-src="compositions/voices.html" data-start="0" data-duration="10"></div>`,
+      ),
+    );
+    expect(res.findings.some((f) => f.code === "audio_group_no_members")).toBe(false);
+  });
+
+  it("stays quiet for an unmatched bus when another group has local members", async () => {
+    const res = await lintHyperframeHtml(
+      doc(`<hf-audio-group id="local"></hf-audio-group>
+        <audio id="local-1" src="local.wav" data-start="0" data-duration="5" data-audio-group="local"></audio>
+        ${BUS}
+        <div id="host" data-composition-src="compositions/voices.html" data-start="0" data-duration="10"></div>`),
+    );
+    expect(res.findings.some((f) => f.code === "audio_group_no_members")).toBe(false);
+  });
+
+  it("stays quiet for a bus with no id", async () => {
+    const res = await lintHyperframeHtml(
+      doc(`<hf-audio-group data-label="Nameless"></hf-audio-group>`),
+    );
+    expect(res.findings.some((f) => f.code === "audio_group_no_members")).toBe(false);
+  });
+});
+
+describe("audio_group_timing_attrs", () => {
+  const doc = (busAttrs: string) => `<!DOCTYPE html><html><body>
+    <div id="root" data-composition-id="main" data-start="0" data-width="1920" data-height="1080" data-duration="10">
+      <hf-audio-group id="voiceover" data-label="Voiceover" ${busAttrs}></hf-audio-group>
+      <audio id="vo-1" src="vo.wav" data-start="0" data-duration="5" data-audio-group="voiceover"></audio>
+    </div>
+  </body></html>`;
+
+  it("warns on data-start", async () => {
+    const res = await lintHyperframeHtml(doc(`data-start="0" data-duration="40"`));
+    const finding = res.findings.find((f) => f.code === "audio_group_timing_attrs");
+    expect(finding?.severity).toBe("warning");
+    expect(finding?.elementId).toBe("voiceover");
+    expect(finding?.message).toContain("data-start");
+    expect(finding?.message).toContain("data-duration");
+  });
+
+  it("warns on data-track-index", async () => {
+    const res = await lintHyperframeHtml(doc(`data-track-index="7"`));
+    expect(res.findings.some((f) => f.code === "audio_group_timing_attrs")).toBe(true);
+  });
+
+  it("stays quiet on a bus carrying only its own attributes", async () => {
+    const res = await lintHyperframeHtml(doc(`data-volume="0.4" data-hidden`));
+    expect(res.findings.some((f) => f.code === "audio_group_timing_attrs")).toBe(false);
+  });
+});
+
+describe("audio_group_carve_attr", () => {
+  const doc = (busAttrs: string) => `<!DOCTYPE html><html><body>
+    <div id="root" data-composition-id="main" data-start="0" data-width="1920" data-height="1080" data-duration="10">
+      <hf-audio-group id="music" data-label="Music bed" ${busAttrs}></hf-audio-group>
+      <audio id="bgm" src="bgm.mp3" data-start="0" data-duration="10" data-audio-group="music"></audio>
+    </div>
+  </body></html>`;
+
+  // The observed bug: the bus and its one member each carried a carve against
+  // the same voiceover, so the bed ran through both sets of filters.
+  it("warns on a carve written onto a bus", async () => {
+    const res = await lintHyperframeHtml(
+      doc(`data-fx-carve='{"enabled":true,"sources":["voiceover"],"strength":0.25}'`),
+    );
+    const finding = res.findings.find((f) => f.code === "audio_group_carve_attr");
+    expect(finding?.severity).toBe("warning");
+    expect(finding?.elementId).toBe("music");
+    expect(finding?.message).toContain("data-fx-carve");
+  });
+
+  it("stays quiet on a bus carrying only its own attributes", async () => {
+    const res = await lintHyperframeHtml(doc(`data-volume="0.4"`));
+    expect(res.findings.some((f) => f.code === "audio_group_carve_attr")).toBe(false);
+  });
+
+  it("leaves a carve on the clip alone", async () => {
+    const res = await lintHyperframeHtml(`<!DOCTYPE html><html><body>
+      <div id="root" data-composition-id="main" data-start="0" data-width="1920" data-height="1080" data-duration="10">
+        <hf-audio-group id="music" data-label="Music bed"></hf-audio-group>
+        <audio id="bgm" src="bgm.mp3" data-start="0" data-duration="10" data-audio-group="music"
+          data-fx-carve='{"enabled":true,"sources":["voiceover"],"strength":0.25}'></audio>
+      </div>
+    </body></html>`);
+    expect(res.findings.some((f) => f.code === "audio_group_carve_attr")).toBe(false);
+  });
+});
+
 describe("audio_carve_ungrouped_sources", () => {
   const withCarve = (carveJson: string, extra = "") => `<!DOCTYPE html><html><body>
     <div id="root" data-composition-id="main" data-start="0" data-width="1920" data-height="1080" data-duration="10">

--- a/packages/lint/src/rules/media.ts
+++ b/packages/lint/src/rules/media.ts
@@ -814,6 +814,13 @@ function findAudioGroupNoMembersFindings(ctx: LintContext): HyperframeLintFindin
   const mayHaveCrossFileMembers = ctx.tags.some((tag) =>
     Boolean(readAttr(tag.raw, "data-composition-src")),
   );
+  const declaredGroupIds = new Set(
+    ctx.tags
+      .filter((tag) => tag.name === "hf-audio-group")
+      .map((tag) => readAttr(tag.raw, "id"))
+      .filter((id): id is string => Boolean(id)),
+  );
+  const unmatchedMemberGroupIds = [...memberGroupIds].filter((id) => !declaredGroupIds.has(id));
 
   const findings: HyperframeLintFinding[] = [];
   for (const tag of ctx.tags) {
@@ -831,7 +838,9 @@ function findAudioGroupNoMembersFindings(ctx: LintContext): HyperframeLintFindin
 
     // Naming the near-misses is the whole value: the fix is almost always a
     // typo on one member, and the author is looking at the bus, not the clip.
-    const nearby = [...memberGroupIds].filter((id) => id !== elementId);
+    // Do not offer a correctly matched sibling bus as the fix for this one.
+    // Only member ids with no declared bus are plausible typos.
+    const nearby = unmatchedMemberGroupIds.filter((id) => id !== elementId);
     const suffix =
       nearby.length > 0
         ? ` Clips in this file name ${nearby.map((id) => `"${id}"`).join(", ")} instead.`

--- a/packages/lint/src/rules/media.ts
+++ b/packages/lint/src/rules/media.ts
@@ -634,6 +634,15 @@ export const mediaRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = 
   findVolumeTweenOverridesGainFindings,
   // audio_carve_ungrouped_sources
   findCarveUngroupedSourcesFindings,
+
+  // audio_group_no_members
+  findAudioGroupNoMembersFindings,
+
+  // audio_group_timing_attrs
+  findAudioGroupTimingAttrFindings,
+
+  // audio_group_carve_attr
+  findAudioGroupCarveAttrFindings,
 ];
 
 /**
@@ -764,6 +773,137 @@ function findCarveUngroupedSourcesFindings(ctx: LintContext): HyperframeLintFind
       elementId,
       fixHint:
         "Group the voice clips and carve against the group — a hand-rolled clip list silently rots when a clip is added.",
+      snippet: truncateSnippet(tag.raw),
+    });
+  }
+  return findings;
+}
+
+/** Timing attributes a bus must never carry. It has no clip window of its own:
+ *  a group's automation clock is COMPOSITION time, and its members carry the
+ *  timing. */
+const AUDIO_GROUP_TIMING_ATTRS = ["data-start", "data-duration", "data-track-index"] as const;
+
+/**
+ * A bus nobody joined does nothing, silently.
+ *
+ * `resolveAudioGroups` builds groups from the MEMBERS (`audio[data-audio-group]`)
+ * and only then looks for a matching `<hf-audio-group>` element, so a bus whose
+ * id no clip names is dropped entirely — its fader, FX chain and automation
+ * never reach preview or render, and nothing says so. One typo is enough:
+ * `data-audio-group="voiceovr"` against `id="voiceover"` loses the authored bus
+ * AND invents a phantom group at unity gain with no chain, which is what the
+ * timeline then draws.
+ */
+function findAudioGroupNoMembersFindings(ctx: LintContext): HyperframeLintFinding[] {
+  const memberGroupIds = new Set(
+    ctx.tags
+      .filter((tag) => tag.name === "audio")
+      .map((tag) => readAttr(tag.raw, "data-audio-group"))
+      .filter((id): id is string => Boolean(id)),
+  );
+
+  // Only a file that declares SOME membership can be judged. `lintHyperframeHtml`
+  // sees one file, and the studio's own group creation writes the bus into the
+  // active composition while patching `data-audio-group` into each member's own
+  // file (`timelineAudioGroupCreate`) — so a file carrying a bus and no members
+  // at all is the ordinary cross-file shape. Firing there reported the studio's
+  // own output as an error, and said "No clip carries `data-audio-group` at all"
+  // about clips it simply could not see.
+  if (memberGroupIds.size === 0) return [];
+  const mayHaveCrossFileMembers = ctx.tags.some((tag) =>
+    Boolean(readAttr(tag.raw, "data-composition-src")),
+  );
+
+  const findings: HyperframeLintFinding[] = [];
+  for (const tag of ctx.tags) {
+    if (tag.name !== "hf-audio-group") continue;
+    // A bus with no id cannot be joined at all — a different mistake, and
+    // `resolveAudioGroups` skips it when building its element map.
+    const elementId = readAttr(tag.raw, "id");
+    if (!elementId) continue;
+    if (memberGroupIds.has(elementId)) continue;
+    // A mixed file is still not closed-world: one bus may have local members
+    // while another serves clips inside a referenced composition. The linter
+    // cannot inspect that file here, so an unmatched bus is only provably empty
+    // when this source has no cross-file composition hosts at all.
+    if (mayHaveCrossFileMembers) continue;
+
+    // Naming the near-misses is the whole value: the fix is almost always a
+    // typo on one member, and the author is looking at the bus, not the clip.
+    const nearby = [...memberGroupIds].filter((id) => id !== elementId);
+    const suffix =
+      nearby.length > 0
+        ? ` Clips in this file name ${nearby.map((id) => `"${id}"`).join(", ")} instead.`
+        : "";
+    findings.push({
+      code: "audio_group_no_members",
+      severity: "error",
+      message: `#${elementId} is an audio group no clip belongs to, so its fader, effect chain and automation are dropped.${suffix}`,
+      elementId,
+      fixHint: `Add \`data-audio-group="${elementId}"\` to the clips this bus is for, or delete the bus.`,
+      snippet: truncateSnippet(tag.raw),
+    });
+  }
+  return findings;
+}
+
+/**
+ * Timing on a bus is meaningless — and it is how a phantom clip row appears.
+ *
+ * The preview runtime stamps `data-start`/`data-duration` on id'd children of
+ * the composition root so they show up in the timeline; a bus caught by that
+ * became a full-duration clip row above its own group header, draggable and
+ * deletable (fixed in core). Timing PERSISTED into the file is the same shape
+ * with none of the excuse: the render reads a group's `fxChain`, `automation`
+ * and `volume` only, so these attributes change nothing and mislead the next
+ * reader into thinking the bus has a window.
+ */
+function findAudioGroupTimingAttrFindings(ctx: LintContext): HyperframeLintFinding[] {
+  const findings: HyperframeLintFinding[] = [];
+  for (const tag of ctx.tags) {
+    if (tag.name !== "hf-audio-group") continue;
+    const present = AUDIO_GROUP_TIMING_ATTRS.filter((attr) => hasAttrName(tag.raw, attr));
+    if (present.length === 0) continue;
+    const elementId = readAttr(tag.raw, "id") || undefined;
+    findings.push({
+      code: "audio_group_timing_attrs",
+      severity: "warning",
+      message: `${elementId ? `#${elementId}` : "This audio group"} carries ${present.map((attr) => `\`${attr}\``).join(", ")}, which a bus has no use for — its members carry the timing and its automation clock is composition time.`,
+      elementId,
+      fixHint: `Remove ${present.map((attr) => `\`${attr}\``).join(", ")} from the group element.`,
+      snippet: truncateSnippet(tag.raw),
+    });
+  }
+  return findings;
+}
+
+/**
+ * A carve on a bus is half an effect, applied twice.
+ *
+ * `data-fx-carve` is a CLIP attribute. The bed being carved is one track, and
+ * the level half of the analysis measures that track's own audio against the
+ * voice — a bus has no `src`, so a carve there can only ever produce the
+ * spectral half: filters with no level match.
+ *
+ * Worse, it stacks. A bus and a member clip are the same signal path, so a
+ * carve on each puts the bed through both sets of filters — which is exactly
+ * what happened when a bus labelled "Music bed" classified as one and carved
+ * itself (fixed in Studio; this catches what was already written down).
+ */
+function findAudioGroupCarveAttrFindings(ctx: LintContext): HyperframeLintFinding[] {
+  const findings: HyperframeLintFinding[] = [];
+  for (const tag of ctx.tags) {
+    if (tag.name !== "hf-audio-group") continue;
+    if (!hasAttrName(tag.raw, "data-fx-carve")) continue;
+    const elementId = readAttr(tag.raw, "id") || undefined;
+    findings.push({
+      code: "audio_group_carve_attr",
+      severity: "warning",
+      message: `${elementId ? `#${elementId}` : "This audio group"} carries \`data-fx-carve\`, which belongs on the clip being carved — a bus has no audio of its own to level-match against, and a carve here stacks with any its members already have.`,
+      elementId,
+      fixHint:
+        "Remove `data-fx-carve` and the `fromCarve` nodes it wrote into this bus's `data-fx-chain`, and carve the bed clip instead.",
       snippet: truncateSnippet(tag.raw),
     });
   }

--- a/packages/studio/src/hooks/timelineAudioGroupCreate.ts
+++ b/packages/studio/src/hooks/timelineAudioGroupCreate.ts
@@ -1,0 +1,345 @@
+/**
+ * Creating an audio group: the member sweep, the group element, and the
+ * carve's auto-group write-back.
+ *
+ * Split out of `timelineTrackVisibility.ts`, which owns the hidden/mute writes
+ * these mirror and had reached the 600-line studio ceiling.
+ */
+
+import { useCallback } from "react";
+import { usePlayerStore, type TimelineElement } from "../player";
+import { useExpandedTimelineElements } from "../player/hooks/useExpandedTimelineElements";
+import { saveProjectFilesWithHistory } from "../utils/studioFileHistory";
+import { HF_AUDIO_GROUP_ATTR, HF_AUDIO_GROUP_TAG } from "@hyperframes/core/audio-groups";
+import { runtimeAudioId } from "../player/lib/timelineElementHelpers";
+import { invalidateGroupInfoCache } from "../player/lib/timelineGroupInfo";
+import { readTagSnippetByTarget, type PatchOperation } from "../utils/sourcePatcher";
+import {
+  applyPatchByTarget,
+  buildPatchTarget,
+  findTimelineElementInIframe,
+  readFileContent,
+  type RecordEditInput,
+} from "./timelineEditingHelpers";
+import {
+  groupElementsByTargetPath,
+  reseekPreviewRuntime,
+  type MutableRef,
+  type UseTimelineElementVisibilityEditingInput,
+} from "./timelineTrackVisibility";
+
+/**
+ * Assign (or restore) `data-audio-group` across a set of members.
+ *
+ * `restore` carries each member's PRIOR value so the unwind can put back a
+ * membership that already existed, rather than removing the attribute outright.
+ * `setElementsHidden`, which this mirrors, gets away with a plain `!hidden`
+ * because hidden is boolean; group membership is an arbitrary id, and the carve
+ * path does not check whether a clip is already grouped — so a failed save
+ * could silently un-group clips that belonged to another group before it.
+ */
+function patchLiveAudioGroupState(
+  iframe: HTMLIFrameElement | null,
+  elements: readonly TimelineElement[],
+  groupId: string | null,
+  activeCompPath: string | null,
+  restore?: ReadonlyMap<TimelineElement, string | null>,
+): void {
+  for (const element of elements) {
+    const target = findTimelineElementInIframe(iframe, element, activeCompPath);
+    if (!target) continue;
+    const next = restore ? (restore.get(element) ?? null) : groupId;
+    if (next) target.setAttribute(HF_AUDIO_GROUP_ATTR, next);
+    else target.removeAttribute(HF_AUDIO_GROUP_ATTR);
+  }
+  invalidateGroupInfoCache(iframe?.contentDocument);
+}
+
+/** Each member's `data-audio-group` before this write, for the unwind. */
+function captureAudioGroupState(
+  iframe: HTMLIFrameElement | null,
+  elements: readonly TimelineElement[],
+  activeCompPath: string | null,
+): Map<TimelineElement, string | null> {
+  const prior = new Map<TimelineElement, string | null>();
+  for (const element of elements) {
+    const target = findTimelineElementInIframe(iframe, element, activeCompPath);
+    prior.set(element, target?.getAttribute(HF_AUDIO_GROUP_ATTR) ?? null);
+  }
+  return prior;
+}
+
+/** Group ids are interpolated into markup and into a render-side filename, so
+ *  they stay in the character set an HTML id and a path can both carry. */
+const GROUP_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * The group's own `<hf-audio-group>` element, appended before `</body>` when it
+ * is not already in the file.
+ *
+ * Membership alone is enough for `resolveAudioGroups` to see the group, but
+ * every group-level WRITE — mute, the bus fader's `data-volume`, an FX preset —
+ * addresses the group by its DOM id (`setAudioGroupAttribute` →
+ * `buildPatchTarget({ domId: groupId })`), so without an element of its own a
+ * group is created and then cannot be edited at all.
+ *
+ * Written to the active composition file rather than beside the members, which
+ * can live in a sub-composition: that is the file the group's later writes
+ * target, and `resolveAudioGroups` reads the flattened document, so co-location
+ * buys nothing.
+ */
+/** Attribute-safe, for a name the author typed. */
+function escapeAttr(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;");
+}
+
+function insertGroupElement(html: string, groupId: string, label?: string): string {
+  const existing = readTagSnippetByTarget(html, { id: groupId });
+  if (existing !== undefined) {
+    // Only OUR tag counts as "already there". The id was minted against the
+    // live preview document, which does not contain markup that is on disk but
+    // not rendered (inside a `<template>`, or an unloaded sub-composition) — so
+    // an unrelated element can already own it. Writing nothing there would aim
+    // every later group write (`buildPatchTarget({ domId })`) at that element,
+    // stamping data-volume / data-hidden / data-fx-chain onto it.
+    if (new RegExp(`^<\\s*${HF_AUDIO_GROUP_TAG}\\b`, "i").test(existing)) return html;
+    throw new Error(`Cannot create audio group: id ${groupId} is already used in this file`);
+  }
+  // The author's name for the group, from the naming dialog (groups doc §5).
+  // Without it the timeline falls back to the minted id, which is the one thing
+  // the dialog exists to stop an author having to read.
+  const labelAttr = label ? ` data-label="${escapeAttr(label)}"` : "";
+  const tag = `<${HF_AUDIO_GROUP_TAG} id="${groupId}"${labelAttr}></${HF_AUDIO_GROUP_TAG}>`;
+  const closeBody = html.lastIndexOf("</body>");
+  if (closeBody < 0) return `${html}\n${tag}\n`;
+  return `${html.slice(0, closeBody)}  ${tag}\n  ${html.slice(closeBody)}`;
+}
+
+/** The same element in the live preview, so the group is editable before the
+ *  next reload. Returns true when it created one (only then may the unwind
+ *  remove it — a pre-existing group element is not ours to delete). */
+function patchLiveGroupElement(
+  iframe: HTMLIFrameElement | null,
+  groupId: string,
+  label?: string,
+): boolean {
+  const doc = iframe?.contentDocument;
+  if (!doc?.body || doc.getElementById(groupId)) return false;
+  const el = doc.createElement(HF_AUDIO_GROUP_TAG);
+  el.id = groupId;
+  if (label) el.setAttribute("data-label", label);
+  doc.body.appendChild(el);
+  invalidateGroupInfoCache(doc);
+  return true;
+}
+
+interface CreateAudioGroupAndAssignMembersInput {
+  projectId: string;
+  activeCompPath: string | null;
+  elements: readonly TimelineElement[];
+  groupId: string;
+  /** The author's name for it, from the naming dialog (groups doc §5). */
+  groupLabel?: string;
+  previewIframe: HTMLIFrameElement | null;
+  writeProjectFile: (path: string, content: string) => Promise<void>;
+  recordEdit: (input: RecordEditInput) => Promise<void>;
+  domEditSaveTimestampRef: MutableRef<number>;
+  pendingTimelineEditPathRef: MutableRef<Set<string>>;
+}
+
+/**
+ * Group two or more voice clips: write `data-audio-group="<groupId>"` on
+ * every one of them, atomically, one undo entry — the same multi-target shape
+ * `setElementsHidden` uses for mute — plus the group's own `<hf-audio-group>`
+ * element, which every later group-level write addresses by DOM id. No naming
+ * dialog: the id is the default name, the way `resolveAudioGroups` reads it.
+ */
+// fallow-ignore-next-line complexity
+export async function createAudioGroupAndAssignMembers({
+  projectId,
+  activeCompPath,
+  elements,
+  groupId,
+  groupLabel,
+  previewIframe,
+  writeProjectFile,
+  recordEdit,
+  domEditSaveTimestampRef,
+  pendingTimelineEditPathRef,
+}: CreateAudioGroupAndAssignMembersInput): Promise<string[]> {
+  // Throws rather than returning empty: the carve's auto-group awaits this and
+  // then persists `sources: [groupId]` on success, so a quiet no-op leaves the
+  // carve aimed at a group that does not exist.
+  if (elements.length < 2) {
+    throw new Error(`Cannot group ${elements.length} clip(s) — a group needs at least two`);
+  }
+  if (!GROUP_ID_PATTERN.test(groupId)) {
+    throw new Error(`Invalid audio group id ${JSON.stringify(groupId)}`);
+  }
+
+  const priorGroups = captureAudioGroupState(previewIframe, elements, activeCompPath);
+  patchLiveAudioGroupState(previewIframe, elements, groupId, activeCompPath);
+  const createdLiveGroupElement = patchLiveGroupElement(previewIframe, groupId, groupLabel);
+  reseekPreviewRuntime(previewIframe);
+
+  const groupOperation: PatchOperation = {
+    type: "attribute",
+    property: HF_AUDIO_GROUP_ATTR,
+    value: groupId,
+  };
+  const originalByPath = new Map<string, string>();
+  const files: Record<string, string> = {};
+
+  try {
+    for (const [targetPath, fileElements] of groupElementsByTargetPath(elements, activeCompPath)) {
+      let patchedContent = await readFileContent(projectId, targetPath);
+      originalByPath.set(targetPath, patchedContent);
+
+      for (const element of fileElements) {
+        const patchTarget = buildPatchTarget(element);
+        if (!patchTarget) {
+          throw new Error(`Timeline element ${element.id} is missing a patchable target`);
+        }
+        if (readTagSnippetByTarget(patchedContent, patchTarget) === undefined) {
+          throw new Error(`Unable to patch timeline element ${element.id} in ${targetPath}`);
+        }
+        patchedContent = applyPatchByTarget(patchedContent, patchTarget, groupOperation);
+      }
+
+      files[targetPath] = patchedContent;
+      pendingTimelineEditPathRef.current.add(targetPath);
+    }
+
+    const groupPath = activeCompPath || "index.html";
+    let groupContent = files[groupPath];
+    if (groupContent === undefined) {
+      groupContent = await readFileContent(projectId, groupPath);
+      originalByPath.set(groupPath, groupContent);
+    }
+    const withGroupElement = insertGroupElement(groupContent, groupId, groupLabel);
+    if (withGroupElement !== groupContent) {
+      files[groupPath] = withGroupElement;
+      pendingTimelineEditPathRef.current.add(groupPath);
+    }
+
+    domEditSaveTimestampRef.current = Date.now();
+    const changedPaths = await saveProjectFilesWithHistory({
+      projectId,
+      label: groupLabel
+        ? `Group ${elements.length} clips as ${groupLabel}`
+        : `Group ${elements.length} voice clips`,
+      kind: "timeline",
+      files,
+      readFile: async (path) => {
+        const original = originalByPath.get(path);
+        if (original !== undefined) return original;
+        return readFileContent(projectId, path);
+      },
+      writeFile: writeProjectFile,
+      recordEdit,
+    });
+    domEditSaveTimestampRef.current = Date.now();
+    for (const element of elements) {
+      usePlayerStore.getState().updateElement(element.key ?? element.id, { audioGroup: groupId });
+    }
+    return changedPaths;
+  } catch (error) {
+    // Mirrors setElementsHidden's failure path: the optimistic live patch
+    // already ran, so a save failure has to be unwound or the preview shows a
+    // grouping that never made it to disk.
+    patchLiveAudioGroupState(previewIframe, elements, null, activeCompPath, priorGroups);
+    if (createdLiveGroupElement) {
+      previewIframe?.contentDocument?.getElementById(groupId)?.remove();
+    }
+    reseekPreviewRuntime(previewIframe);
+    throw error;
+  }
+}
+
+/**
+ * The write behind B6's auto-group: pick two or more voice clips in the carve
+ * picker and they land in a group instead of naming each other by id. Same
+ * expanded-rows resolution as element-visibility, for the same reason — a
+ * nested sub-composition child has no entry in the raw store list.
+ */
+export function useAudioGroupCarveAssignment({
+  projectIdRef,
+  activeCompPath,
+  showToast,
+  writeProjectFile,
+  recordEdit,
+  domEditSaveTimestampRef,
+  previewIframeRef,
+  pendingTimelineEditPathRef,
+  isRecordingRef,
+}: UseTimelineElementVisibilityEditingInput): (
+  clipIds: readonly string[],
+  groupId: string,
+  groupLabel?: string,
+) => Promise<void> {
+  const expandedElements = useExpandedTimelineElements();
+  return useCallback(
+    async (clipIds: readonly string[], groupId: string, groupLabel?: string) => {
+      if (isRecordingRef?.current) {
+        showToast("Cannot edit timeline while recording", "error");
+        return;
+      }
+      const pid = projectIdRef.current;
+      if (!pid) return;
+      // DOM ids, not store keys: both callers (the carve picker and the
+      // timeline's group-pointer button) name clips the way the document does,
+      // because that is the only space `resolveAudioGroups` reads back.
+      const wanted = new Set(clipIds);
+      const elements = expandedElements.filter((item) => {
+        const domId = runtimeAudioId(item);
+        return domId !== null && wanted.has(domId);
+      });
+      try {
+        // Loud, not silent: an unresolved id used to leave `elements` short,
+        // `createAudioGroupAndAssignMembers` returning early with no write, and
+        // the carve still persisting `sources: [groupId]` for a group that was
+        // never created — a carve pointing at nothing, silently not ducking.
+        if (elements.length !== wanted.size) {
+          const missing = [...wanted].filter(
+            (id) => !elements.some((item) => runtimeAudioId(item) === id),
+          );
+          throw new Error(`Cannot group: no timeline clip for ${missing.join(", ")}`);
+        }
+        await createAudioGroupAndAssignMembers({
+          groupLabel,
+          projectId: pid,
+          activeCompPath,
+          elements,
+          groupId,
+          previewIframe: previewIframeRef.current,
+          writeProjectFile,
+          recordEdit,
+          domEditSaveTimestampRef,
+          pendingTimelineEditPathRef,
+        });
+      } catch (error) {
+        console.error("[Timeline] Failed to group voice clips", error);
+        const message = error instanceof Error ? error.message : "Failed to group voice clips";
+        showToast(message);
+        // Rethrown, not just reported: the carve's auto-group chains
+        // `.then(() => ({ ...next, sources: [groupId] }))` off this promise, so
+        // swallowing here let it persist a carve pointing at a group that was
+        // never written — the exact silent no-op the throw inside
+        // `createAudioGroupAndAssignMembers` exists to prevent.
+        throw error;
+      }
+    },
+    [
+      activeCompPath,
+      expandedElements,
+      previewIframeRef,
+      writeProjectFile,
+      recordEdit,
+      domEditSaveTimestampRef,
+      pendingTimelineEditPathRef,
+      isRecordingRef,
+      showToast,
+      projectIdRef,
+    ],
+  );
+}

--- a/packages/studio/src/hooks/timelineAudioGroupVolume.test.ts
+++ b/packages/studio/src/hooks/timelineAudioGroupVolume.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+
+/**
+ * A group write has to reach the STORE, not just the file and the live DOM.
+ *
+ * The timeline derives a group row's label, fader, mute and chain from the
+ * `audioGroup*` fields mirrored onto its members — so a write that lands
+ * everywhere except there leaves the header rendering whatever it parsed at
+ * load. Observed in the studio: muting a group wrote `data-hidden` to disk and
+ * to the preview, and the button stayed "Mute group Voiceover", re-writing the
+ * same attribute on every click with no way to unmute.
+ *
+ * Invalidating the parse cache is necessary but not sufficient — it only makes
+ * the NEXT parse honest, and a live attribute patch never triggers one.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { usePlayerStore, type TimelineElement } from "../player";
+import { resolveGroupSourceFile, useSetAudioGroupAttribute } from "./timelineAudioGroupVolume";
+
+afterEach(() => {
+  usePlayerStore.getState().reset();
+});
+
+function member(domId: string, track: number): TimelineElement {
+  return {
+    id: domId,
+    key: `index.html#${domId}`,
+    domId,
+    tag: "audio",
+    start: 0,
+    duration: 5,
+    track,
+    audioGroup: "voiceover",
+    audioGroupHidden: false,
+    audioGroupVolume: 1,
+  };
+}
+
+/** The hook without React — it only closes over refs and callbacks. */
+function makeSetter() {
+  const input = {
+    projectIdRef: { current: "project-1" },
+    activeCompPath: "index.html",
+    showToast: () => {},
+    writeProjectFile: async () => {},
+    recordEdit: async () => {},
+    domEditSaveTimestampRef: { current: 0 },
+    pendingTimelineEditPathRef: { current: new Set<string>() },
+    previewIframeRef: { current: null },
+  };
+  // `setLive` takes no async path and touches only the preview DOM + store, so
+  // it can be exercised directly; `setQuiet` additionally persists, which this
+  // test deliberately does not cover (that is timelineTrackVisibility's job).
+  let setter: ReturnType<typeof useSetAudioGroupAttribute> | null = null;
+  const Probe = () => {
+    setter = useSetAudioGroupAttribute(input as never);
+    return null;
+  };
+  // Minimal hook harness: call the component function directly. It uses only
+  // useCallback, which React allows outside a renderer when the result is used
+  // immediately and never re-rendered.
+  return { Probe, get: () => setter };
+}
+
+describe("group attribute writes reach the store", () => {
+  it("mirrors data-hidden onto every member so the header can flip", async () => {
+    const react = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const harness = makeSetter();
+    renderToStaticMarkup(react.createElement(harness.Probe));
+    const setter = harness.get();
+    expect(setter).not.toBeNull();
+
+    usePlayerStore.getState().setElements([member("voice-1", 0), member("voice-2", 1)]);
+
+    setter?.setLive("voiceover", "data-hidden", "");
+    expect(usePlayerStore.getState().elements.every((el) => el.audioGroupHidden === true)).toBe(
+      true,
+    );
+
+    setter?.setLive("voiceover", "data-hidden", null);
+    expect(usePlayerStore.getState().elements.every((el) => el.audioGroupHidden === false)).toBe(
+      true,
+    );
+  });
+
+  // `Number(null)` and `Number("")` are both 0 AND finite, so the obvious
+  // isFinite check mirrored "silent" for a removed attribute while core's
+  // `readAudioGroupVolume` reads the same absence as unity — a parse divergence
+  // inside the mirror whose entire job is to prevent one.
+  it("reads a removed data-volume as unity, the way core does", async () => {
+    const react = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const harness = makeSetter();
+    renderToStaticMarkup(react.createElement(harness.Probe));
+    const setter = harness.get();
+
+    usePlayerStore.getState().setElements([member("voice-1", 0)]);
+
+    setter?.setLive("voiceover", "data-volume", "0.3");
+    expect(usePlayerStore.getState().elements[0]?.audioGroupVolume).toBeCloseTo(0.3, 6);
+
+    setter?.setLive("voiceover", "data-volume", null);
+    expect(usePlayerStore.getState().elements[0]?.audioGroupVolume).toBe(1);
+
+    setter?.setLive("voiceover", "data-volume", "");
+    expect(usePlayerStore.getState().elements[0]?.audioGroupVolume).toBe(1);
+
+    setter?.setLive("voiceover", "data-volume", "nonsense");
+    expect(usePlayerStore.getState().elements[0]?.audioGroupVolume).toBe(1);
+  });
+
+  it("mirrors data-volume, and leaves other groups alone", async () => {
+    const react = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const harness = makeSetter();
+    renderToStaticMarkup(react.createElement(harness.Probe));
+    const setter = harness.get();
+
+    const other: TimelineElement = { ...member("sfx", 2), audioGroup: "effects" };
+    usePlayerStore.getState().setElements([member("voice-1", 0), other]);
+
+    setter?.setLive("voiceover", "data-volume", "0.4");
+
+    const byId = new Map(usePlayerStore.getState().elements.map((el) => [el.id, el]));
+    expect(byId.get("voice-1")?.audioGroupVolume).toBeCloseTo(0.4, 6);
+    expect(byId.get("sfx")?.audioGroupVolume).toBe(1);
+  });
+});
+
+/**
+ * The ancestor shape here is COPIED FROM A LIVE PREVIEW, not imagined.
+ *
+ * The first attempt at this fix used `getTimelineElementSourceFile` and a
+ * fixture in which the sub-composition root carried `data-composition-file`.
+ * The test passed; the studio still threw "Unable to patch element in
+ * index.html", because the runtime inlines a sub-comp as its own root element
+ * that carries only the composition ID — the FILE is on the host above it.
+ */
+describe("the mirror reaches sub-composition members", () => {
+  /**
+   * A group declared inside a sub-composition has no FLAT member to mirror onto
+   * — `childGroupState` keeps those members out of `elements` — so mirroring
+   * only `elements` made this whole function a no-op for it: the header kept the
+   * pre-write chain and `laneCount` stayed 0, so the lane disclosure never
+   * appeared for automation that now existed.
+   */
+  it("mirrors a group write onto DomClipChild members as well as flat ones", async () => {
+    const react = await import("react");
+    const { renderToStaticMarkup } = await import("react-dom/server");
+    const harness = makeSetter();
+    renderToStaticMarkup(react.createElement(harness.Probe));
+    const setter = harness.get();
+    usePlayerStore.getState().setElements([member("flat-1", 0)]);
+    usePlayerStore.getState().setDomClipChildren([
+      { id: "sub-1", parentId: "host", hostId: "host", label: "Sub 1", audioGroup: "voiceover" },
+      { id: "other", parentId: "host", hostId: "host", label: "Other", audioGroup: "sfx" },
+    ]);
+
+    setter?.setLive("voiceover", "data-label", "Voices");
+
+    const children = usePlayerStore.getState().domClipChildren;
+    expect(children.find((c) => c.id === "sub-1")?.audioGroupLabel).toBe("Voices");
+    // A member of another group is untouched.
+    expect(children.find((c) => c.id === "other")?.audioGroupLabel).toBeUndefined();
+  });
+});
+
+describe("resolveGroupSourceFile", () => {
+  function livePreviewShape(): Document {
+    const doc = document.implementation.createHTMLDocument("preview");
+    doc.body.setAttribute("data-composition-id", "subcomp-group-qa");
+    doc.body.innerHTML = `
+      <div id="voices-host" data-composition-id="voices-host" data-composition-file="compositions/voices.html">
+        <section id="voices-root" data-composition-id="voices">
+          <hf-audio-group id="voiceover"></hf-audio-group>
+        </section>
+      </div>
+      <hf-audio-group id="root-group"></hf-audio-group>
+    `;
+    return doc;
+  }
+
+  it("climbs past the sub-comp root to the host that names the file", () => {
+    const doc = livePreviewShape();
+    expect(resolveGroupSourceFile(doc.getElementById("voiceover"))).toBe(
+      "compositions/voices.html",
+    );
+  });
+
+  // A group in the root composition: body names an id but no file, so the
+  // caller falls back to activeCompPath. Returning body's id here would route
+  // every root-composition group write at a path that does not exist.
+  it("returns undefined for a group in the root composition", () => {
+    const doc = livePreviewShape();
+    expect(resolveGroupSourceFile(doc.getElementById("root-group"))).toBeUndefined();
+  });
+
+  it("is safe on a detached or missing element", () => {
+    expect(resolveGroupSourceFile(null)).toBeUndefined();
+    expect(resolveGroupSourceFile(document.createElement("hf-audio-group"))).toBeUndefined();
+  });
+});

--- a/packages/studio/src/hooks/timelineAudioGroupVolume.ts
+++ b/packages/studio/src/hooks/timelineAudioGroupVolume.ts
@@ -1,4 +1,9 @@
 import { useCallback } from "react";
+import { HF_AUDIO_FX_ATTR } from "@hyperframes/core/audio-fx";
+import { HF_AUDIO_AUTOMATION_ATTR } from "@hyperframes/core/audio-automation";
+import { usePlayerStore } from "../player";
+import type { TimelineElementPatch } from "../player/store/timelineElement";
+import { invalidateGroupInfoCache } from "../player/lib/timelineGroupInfo";
 import {
   buildPatchTarget,
   persistElementAttribute,
@@ -21,6 +26,111 @@ function patchLiveGroupAttribute(
   if (!target) return;
   if (value === null) target.removeAttribute(attr);
   else target.setAttribute(attr, value);
+  invalidateGroupInfoCache(iframe?.contentDocument);
+}
+
+/**
+ * `data-volume` exactly as core reads it (`readAudioGroupVolume`): an absent or
+ * empty attribute is UNITY, not zero.
+ *
+ * `Number(null)` and `Number("")` are both 0 and both finite, so the obvious
+ * `Number.isFinite(Number(value))` mirrored "silent" into the store for a
+ * removed attribute while the DOM, the preview bus and the render all read 1 —
+ * exactly the parse divergence this mirror exists to eliminate.
+ */
+function mirroredGroupVolume(value: string | null): number {
+  if (!value) return 1;
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 1;
+}
+
+/** Which store field each writable group attribute mirrors into. */
+const GROUP_ATTR_TO_MIRROR: Record<
+  string,
+  (value: string | null, groupId: string) => TimelineElementPatch
+> = {
+  "data-hidden": (value) => ({ audioGroupHidden: value !== null }),
+  "data-volume": (value) => ({ audioGroupVolume: mirroredGroupVolume(value) }),
+  "data-label": (value, groupId) => ({ audioGroupLabel: value ?? groupId }),
+  [HF_AUDIO_FX_ATTR]: (value) => ({ audioGroupFxChain: value ?? undefined }),
+  [HF_AUDIO_AUTOMATION_ATTR]: (value) => ({ audioGroupAutomation: value ?? undefined }),
+};
+
+/**
+ * Mirror a group attribute onto the store copy every member carries.
+ *
+ * The timeline derives a group's label / volume / mute / chain from these
+ * mirrored `audioGroup*` fields on its MEMBERS, not from the group element —
+ * and a group write only ever touched the file and the live preview DOM.
+ * Nothing re-parsed, so the header went on reading the old value: the observed
+ * symptom was a muted group whose button stayed "Mute group", re-writing
+ * `data-hidden` on every click and never offering to unmute.
+ *
+ * Invalidating the parse cache is necessary but not sufficient — it only
+ * ensures the NEXT parse is honest, and a live attribute patch does not cause
+ * one. Same reason `commitDataAttribute` carries `syncStoredAutomationFromPreview`.
+ */
+function syncStoredGroupAttribute(groupId: string, attr: string, value: string | null): void {
+  const toPatch = GROUP_ATTR_TO_MIRROR[attr];
+  if (!toPatch) return;
+  const patch = toPatch(value, groupId);
+  // ONE pass and one notification, rather than `updateElement` per member.
+  // That helper maps the whole `elements` array per call, so a 3-member group on
+  // a 500-clip composition was 1500 object spreads and 3 store notifications per
+  // drag frame — at ~60/s, with every `elements`-keyed memo downstream
+  // recomputing each time.
+  // BOTH stores, because a group declared inside a sub-composition has no flat
+  // member to mirror onto: `childGroupState` keeps those members out of
+  // `elements` entirely, so their `audioGroup*` fields come from the
+  // `DomClipChild` record instead. Mirroring only `elements` made this whole
+  // function a no-op for such a group — the header kept the pre-write chain, its
+  // FX button showed the old count, and `laneCount` stayed 0 so the lane
+  // disclosure never appeared for automation that now existed. Verbatim the
+  // symptom this docblock claims to have fixed, fixed only for flat members.
+  //
+  // `setDomClipChildren` has one other writer, inside `processTimelineMessage`,
+  // which a live attribute patch does not trigger.
+  usePlayerStore.setState((state) => {
+    const next: Partial<typeof state> = {
+      elements: state.elements.map((el) => (el.audioGroup === groupId ? { ...el, ...patch } : el)),
+    };
+    if (state.domClipChildren.some((child) => child.audioGroup === groupId)) {
+      next.domClipChildren = state.domClipChildren.map((child) =>
+        child.audioGroup === groupId ? { ...child, ...patch } : child,
+      );
+    }
+    return next;
+  });
+}
+
+/**
+ * The composition FILE that contains a group element, walking up through
+ * composition ancestors until one names a file.
+ *
+ * `getTimelineElementSourceFile` stops at the nearest `[data-composition-id]`,
+ * which for an inlined sub-composition is its own ROOT element — that carries
+ * the composition id but not the file. The file is on the HOST one level above
+ * it. Measured on a live preview:
+ *
+ *   hf-audio-group#voiceover        (no composition attrs)
+ *   section#voices-root             data-composition-id="voices"          <- stops here
+ *   div#voices-host                 data-composition-file="…/voices.html" <- file is here
+ *   body                            data-composition-id="<root>"
+ *
+ * Returns undefined for a group in the root composition (body names an id but
+ * no file), which is exactly when the caller should fall back to activeCompPath.
+ */
+export function resolveGroupSourceFile(groupEl: Element | null): string | undefined {
+  let node: Element | null = groupEl?.parentElement ?? null;
+  while (node) {
+    const owner: Element | null = node.closest("[data-composition-id]");
+    if (!owner) return undefined;
+    const file =
+      owner.getAttribute("data-composition-file") ?? owner.getAttribute("data-composition-src");
+    if (file) return file;
+    node = owner.parentElement;
+  }
+  return undefined;
 }
 
 interface SetAudioGroupAttributeInput {
@@ -56,7 +166,16 @@ async function setAudioGroupAttribute({
   domEditSaveTimestampRef,
   pendingTimelineEditPathRef,
 }: SetAudioGroupAttributeInput): Promise<string[]> {
-  const targetPath = activeCompPath || "index.html";
+  // The file that actually CONTAINS the group element, not just the active
+  // composition. A hand-authored sub-composition can declare both the members
+  // and their `<hf-audio-group>`, and until sub-comp children inherited
+  // `audioGroup*` no group row existed for that case so nothing could reach
+  // here. Now the row appears, and routing its writes at `activeCompPath`
+  // means `readTagSnippetByTarget` finds nothing and every mute, fader move and
+  // FX preset throws "Unable to patch element in index.html". Every sibling
+  // timeline writer already routes `element.sourceFile || activeCompPath`.
+  const groupEl = previewIframe?.contentDocument?.getElementById(groupId) ?? null;
+  const targetPath = resolveGroupSourceFile(groupEl) || activeCompPath || "index.html";
   const patchTarget = buildPatchTarget({ domId: groupId });
   if (!patchTarget) return [];
 
@@ -72,8 +191,6 @@ async function setAudioGroupAttribute({
     domEditSaveTimestampRef,
     pendingTimelineEditPathRef,
     patchLive: (v) => patchLiveGroupAttribute(previewIframe, groupId, attr, v),
-    readLive: () =>
-      previewIframe?.contentDocument?.getElementById(groupId)?.getAttribute(attr) ?? null,
   });
 }
 
@@ -101,6 +218,10 @@ export function useSetAudioGroupAttribute({
   const setLive = useCallback(
     (groupId: string, attr: string, value: string | null) => {
       patchLiveGroupAttribute(previewIframeRef.current, groupId, attr, value);
+      // Live too, not just on commit: a fader drag is `setLive` per frame and
+      // `setQuiet` once on release, so without this the strip's own readout
+      // fights the drag.
+      syncStoredGroupAttribute(groupId, attr, value);
     },
     [previewIframeRef],
   );
@@ -126,7 +247,18 @@ export function useSetAudioGroupAttribute({
           domEditSaveTimestampRef,
           pendingTimelineEditPathRef,
         });
+        syncStoredGroupAttribute(groupId, attr, value);
       } catch (error) {
+        // `persistElementAttribute` leaves the live DOM at the previous value
+        // however it failed — it unwinds a failed save, and an unresolvable
+        // target now throws before patching at all. But `setLive` mirrored the
+        // in-progress value into the store on every drag frame — so without
+        // this the fader reads 0.4 while
+        // the preview and the file are both back at 1.0, and nothing re-parses
+        // to correct it (a live patch causing no parse is this mirror's whole
+        // premise). Re-mirror from the DOM, which is now authoritative again.
+        const live = previewIframeRef.current?.contentDocument?.getElementById(groupId);
+        syncStoredGroupAttribute(groupId, attr, live?.getAttribute(attr) ?? null);
         console.error("[Timeline] Failed to set group attribute", error);
         const message = error instanceof Error ? error.message : "Failed to update group";
         showToast(message);

--- a/packages/studio/src/hooks/timelineEditingHelpers.test.ts
+++ b/packages/studio/src/hooks/timelineEditingHelpers.test.ts
@@ -6,6 +6,7 @@ import {
   deleteSelectedKeyframes,
   extendRootDurationIfNeeded,
   patchIframeDomTiming,
+  persistElementAttribute,
   persistTimelineBatchEdit,
   type PersistTimelineBatchChange,
 } from "./timelineEditingHelpers";
@@ -421,5 +422,90 @@ describe("deleteSelectedKeyframes", () => {
 
     expect(handleGsapRemoveKeyframe).toHaveBeenCalledTimes(1);
     expect(handleGsapRemoveKeyframe.mock.calls[0]?.[1]).toBe(20);
+  });
+});
+
+describe("persistElementAttribute", () => {
+  /**
+   * The optimistic live patch used to run BEFORE the target was resolved, and
+   * only the save was wrapped in the unwind. So an unresolvable target threw
+   * with the preview holding a value that never reached disk — and the group
+   * writer's catch mirrors the live DOM into the store, so the UI reported the
+   * write as applied until a reload dropped it.
+   */
+  it("does not patch the live DOM when the target resolves to nothing", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ content: '<body><audio id="other"></audio></body>' })),
+      );
+    const patchLive = vi.fn();
+    const writeProjectFile = vi.fn();
+
+    await expect(
+      persistElementAttribute({
+        projectId: "p",
+        targetPath: "index.html",
+        patchTarget: { id: "missing" },
+        attr: "data-volume",
+        value: "0.4",
+        label: "Set volume",
+        writeProjectFile,
+        recordEdit: vi.fn(),
+        domEditSaveTimestampRef: { current: 0 },
+        pendingTimelineEditPathRef: { current: new Set() },
+        patchLive,
+      }),
+    ).rejects.toThrow("Unable to patch element in index.html");
+
+    expect(patchLive).not.toHaveBeenCalled();
+    expect(writeProjectFile).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});
+
+describe("persistElementAttribute — unwind value", () => {
+  /**
+   * The unwind has to restore the value on DISK, not the one in the preview.
+   *
+   * Every live-write caller patches the DOM before committing (a fader drag is
+   * `setLive` per frame; hovering a preset auditions the whole chain), so by
+   * commit time the live DOM already holds the in-progress value. Reading it as
+   * `previousValue` made the unwind a no-op, and the group writer's catch —
+   * which deliberately re-mirrors the store off the live DOM — then mirrored the
+   * never-saved value: the panel agreed with the preview, and a reload dropped it.
+   */
+  it("restores the file's value, not the audition already in the live DOM", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ content: `<body><audio id="bgm" data-volume="0.25"></audio></body>` }),
+        ),
+      );
+    const patched: Array<string | null> = [];
+    const writeProjectFile = vi.fn(() => Promise.reject(new Error("save failed")));
+
+    await expect(
+      persistElementAttribute({
+        projectId: "p",
+        targetPath: "index.html",
+        patchTarget: { id: "bgm" },
+        attr: "data-volume",
+        value: "0.9",
+        label: "Set volume",
+        writeProjectFile,
+        recordEdit: vi.fn(),
+        domEditSaveTimestampRef: { current: 0 },
+        pendingTimelineEditPathRef: { current: new Set() },
+        // The live DOM is ALREADY at the new value when the commit runs — that
+        // is what `setLive` does on every drag frame.
+        patchLive: (v) => patched.push(v),
+      }),
+    ).rejects.toThrow("save failed");
+
+    // First the optimistic write, then the unwind — back to what the FILE said.
+    expect(patched).toEqual(["0.9", "0.25"]);
+    fetchSpy.mockRestore();
   });
 });

--- a/packages/studio/src/hooks/timelineEditingHelpers.ts
+++ b/packages/studio/src/hooks/timelineEditingHelpers.ts
@@ -410,8 +410,6 @@ export interface PersistElementAttributeInput {
   pendingTimelineEditPathRef: { current: Set<string> };
   /** Write the attribute directly on the live preview DOM node. */
   patchLive: (value: string | null) => void;
-  /** Read the attribute's current value off the live preview DOM node. */
-  readLive: () => string | null;
 }
 
 /**
@@ -420,7 +418,7 @@ export interface PersistElementAttributeInput {
  * `setAudioGroupAttribute` (a group id addressed by its own DOM id) and
  * `useSetElementAttribute` (an arbitrary timeline clip) — same shape, only
  * how the live node is found and where the patch target resolves to differs,
- * which is exactly what `patchLive`/`readLive`/`patchTarget` parameterize.
+ * which is exactly what `patchLive`/`patchTarget` parameterize.
  */
 export async function persistElementAttribute({
   projectId,
@@ -434,15 +432,29 @@ export async function persistElementAttribute({
   domEditSaveTimestampRef,
   pendingTimelineEditPathRef,
   patchLive,
-  readLive,
 }: PersistElementAttributeInput): Promise<string[]> {
-  const previousValue = readLive();
-  patchLive(value);
-
+  // Resolve the target BEFORE patching the live DOM. The optimistic patch used
+  // to run first, and only the save was wrapped in the unwind — so an
+  // unresolvable target threw with the live preview (and, through the callers'
+  // catch, the store mirrored off it) holding a value that never reached disk.
+  // The write then read as successful until a reload dropped it.
   const before = await readFileContent(projectId, targetPath);
   if (readTagSnippetByTarget(before, patchTarget) === undefined) {
     throw new Error(`Unable to patch element in ${targetPath}`);
   }
+  // The unwind value comes from the FILE, not from `readLive()`.
+  //
+  // Every live-write caller patches the DOM before committing — a fader drag is
+  // `setLive` per frame, hovering a preset auditions the whole chain — so by the
+  // time this runs the live DOM already holds the in-progress value. Reading it
+  // here made `previousValue === value`, so the unwind below was a no-op, and
+  // `setQuiet`'s catch (which deliberately re-mirrors the store from the live
+  // DOM) then mirrored that same never-saved value. The group audibly had the
+  // preset, the panel agreed, and a reload dropped it — the failure class the
+  // target check above was added to close, still open on the live-write path.
+  const previousValue = readAttributeByTarget(before, patchTarget, attr) ?? null;
+  patchLive(value);
+
   const operation: PatchOperation = { type: "attribute", property: attr, value };
   const patched = applyPatchByTarget(before, patchTarget, operation);
 

--- a/packages/studio/src/hooks/timelineElementFxAttribute.ts
+++ b/packages/studio/src/hooks/timelineElementFxAttribute.ts
@@ -75,9 +75,6 @@ async function setElementAttribute({
     domEditSaveTimestampRef,
     pendingTimelineEditPathRef,
     patchLive: (v) => patchLiveElementAttribute(previewIframe, element, attr, v, activeCompPath),
-    readLive: () =>
-      findTimelineElementInIframe(previewIframe, element, activeCompPath)?.getAttribute(attr) ??
-      null,
   });
 }
 

--- a/packages/studio/src/hooks/timelineTrackVisibility.test.ts
+++ b/packages/studio/src/hooks/timelineTrackVisibility.test.ts
@@ -2,11 +2,10 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { usePlayerStore, type TimelineElement } from "../player";
-import {
-  createAudioGroupAndAssignMembers,
-  toggleTimelineElementHidden,
-  toggleTimelineTrackHidden,
-} from "./timelineTrackVisibility";
+import { resolveAudioGroups } from "@hyperframes/core/audio-groups";
+import { readTagSnippetByTarget } from "../utils/sourcePatcher";
+import { createAudioGroupAndAssignMembers } from "./timelineAudioGroupCreate";
+import { toggleTimelineElementHidden, toggleTimelineTrackHidden } from "./timelineTrackVisibility";
 
 afterEach(() => {
   document.body.innerHTML = "";
@@ -513,21 +512,104 @@ describe("createAudioGroupAndAssignMembers", () => {
     ).toBe("voiceover");
   });
 
-  it("does nothing for fewer than two elements — grouping is a plural concept", async () => {
-    const recordEdit = vi.fn();
-    const changedPaths = await createAudioGroupAndAssignMembers({
+  // The group element is what every LATER group write addresses — mute, the bus
+  // fader's data-volume, an FX preset all go through
+  // `buildPatchTarget({ domId: groupId })`. Membership alone parses, but leaves
+  // a group nothing can edit.
+  it("emits the group's own <hf-audio-group> element, patchable by its DOM id", async () => {
+    const iframe = document.createElement("iframe");
+    document.body.append(iframe);
+    if (iframe.contentDocument) {
+      iframe.contentDocument.body.innerHTML = `
+        <audio id="narration"></audio>
+        <audio id="interview-guest"></audio>
+      `;
+    }
+    const files = new Map([
+      [
+        "index.html",
+        `<html><body>
+<audio id="narration" data-start="0" data-duration="5"></audio>
+<audio id="interview-guest" data-start="10" data-duration="5"></audio>
+</body></html>`,
+      ],
+    ]);
+    stubProjectFiles(files);
+
+    const narration = element({ id: "narration", domId: "narration", track: 0 });
+    const guest = element({ id: "interview-guest", domId: "interview-guest", track: 1 });
+    usePlayerStore.getState().setElements([narration, guest]);
+
+    const writes = new Map<string, string>();
+    await createAudioGroupAndAssignMembers({
       projectId: "project-1",
       activeCompPath: "index.html",
-      elements: [element({ id: "narration", domId: "narration" })],
+      elements: [narration, guest],
       groupId: "voiceover",
-      previewIframe: null,
-      writeProjectFile: async () => {},
-      recordEdit,
+      previewIframe: iframe,
+      writeProjectFile: async (path, content) => {
+        writes.set(path, content);
+      },
+      recordEdit: vi.fn(),
       domEditSaveTimestampRef: { current: 0 },
       pendingTimelineEditPathRef: { current: new Set() },
     });
-    expect(changedPaths).toEqual([]);
+
+    const written = writes.get("index.html") ?? "";
+    expect(written).toContain('<hf-audio-group id="voiceover"></hf-audio-group>');
+    // The actual contract: the group-attribute writer can now find a target.
+    // This is the read that threw "Unable to patch element in index.html".
+    expect(readTagSnippetByTarget(written, { id: "voiceover" })).toBeDefined();
+    // ...and in the live preview, which is what patchLiveGroupAttribute reads
+    // before the next reload.
+    expect(iframe.contentDocument?.getElementById("voiceover")?.tagName.toLowerCase()).toBe(
+      "hf-audio-group",
+    );
+    // Both members still resolve into it.
+    expect(resolveAudioGroups(iframe.contentDocument as Document)[0]).toMatchObject({
+      id: "voiceover",
+      memberIds: ["narration", "interview-guest"],
+    });
+  });
+
+  // Rejects rather than resolving empty: the carve's auto-group persists
+  // `sources: [groupId]` once this resolves, so a silent no-op leaves the carve
+  // pointing at a group that was never written — and stops ducking.
+  it("rejects for fewer than two elements — grouping is a plural concept", async () => {
+    const recordEdit = vi.fn();
+    await expect(
+      createAudioGroupAndAssignMembers({
+        projectId: "project-1",
+        activeCompPath: "index.html",
+        elements: [element({ id: "narration", domId: "narration" })],
+        groupId: "voiceover",
+        previewIframe: null,
+        writeProjectFile: async () => {},
+        recordEdit,
+        domEditSaveTimestampRef: { current: 0 },
+        pendingTimelineEditPathRef: { current: new Set() },
+      }),
+    ).rejects.toThrow("a group needs at least two");
     expect(recordEdit).not.toHaveBeenCalled();
+  });
+
+  it("rejects a group id that is not safe to interpolate into markup or a path", async () => {
+    await expect(
+      createAudioGroupAndAssignMembers({
+        projectId: "project-1",
+        activeCompPath: "index.html",
+        elements: [
+          element({ id: "narration", domId: "narration" }),
+          element({ id: "guest", domId: "guest" }),
+        ],
+        groupId: '../x"><script>',
+        previewIframe: null,
+        writeProjectFile: async () => {},
+        recordEdit: vi.fn(),
+        domEditSaveTimestampRef: { current: 0 },
+        pendingTimelineEditPathRef: { current: new Set() },
+      }),
+    ).rejects.toThrow("Invalid audio group id");
   });
 
   it("reverts the optimistic live patch when the save fails", async () => {

--- a/packages/studio/src/hooks/timelineTrackVisibility.ts
+++ b/packages/studio/src/hooks/timelineTrackVisibility.ts
@@ -8,7 +8,6 @@ import {
 } from "../player/components/timelineTrackDisplay";
 import { saveProjectFilesWithHistory } from "../utils/studioFileHistory";
 import { isAudioTimelineElement } from "../utils/timelineInspector";
-import { HF_AUDIO_GROUP_ATTR } from "@hyperframes/core/audio-groups";
 import { readTagSnippetByTarget, type PatchOperation } from "../utils/sourcePatcher";
 import {
   applyPatchByTarget,
@@ -32,12 +31,8 @@ interface ToggleTimelineTrackHiddenInput {
   timelineElements: readonly TimelineElement[];
   track: number;
   hidden: boolean;
-  /**
-   * The display row the clicked control announced, when the caller has one.
-   * Absent (a keyboard path or a programmatic call), the row is derived here
-   * from ascending element-bearing keys — correct whenever no group has
-   * reordered the header.
-   */
+  /** The row the CLICKED control announced. Absent when the caller has no
+   *  rendered number to hand over, which falls back to deriving one. */
   displayNumber?: number | null;
   previewIframe: HTMLIFrameElement | null;
   writeProjectFile: (path: string, content: string) => Promise<void>;
@@ -110,7 +105,7 @@ function patchLiveHiddenState(
   }
 }
 
-function reseekPreviewRuntime(iframe: HTMLIFrameElement | null): void {
+export function reseekPreviewRuntime(iframe: HTMLIFrameElement | null): void {
   try {
     const win: (Window & { __player?: { seek?: (time: number) => void } }) | null =
       iframe?.contentWindow ?? null;
@@ -118,7 +113,7 @@ function reseekPreviewRuntime(iframe: HTMLIFrameElement | null): void {
   } catch {}
 }
 
-function groupElementsByTargetPath(
+export function groupElementsByTargetPath(
   elements: readonly TimelineElement[],
   activeCompPath: string | null,
 ): Map<string, TimelineElement[]> {
@@ -227,7 +222,8 @@ export async function toggleTimelineTrackHidden({
   // read by a human, so it gets the display row instead — the one the clicked
   // control announced, when the caller passed it. Deriving it again here would
   // use ascending element-bearing keys, which stop matching the header as soon
-  // as an audio group reorders the rows and inserts an anchor.
+  // as an audio group reorders the rows and inserts an anchor: the same click
+  // then said "Mute track 2" and recorded "Mute track 1".
   const suffix = trackDisplaySuffix(
     displayNumber ?? trackDisplayNumber(timelineTrackOrder(timelineElements), track),
   );
@@ -287,114 +283,6 @@ export async function toggleTimelineElementHidden({
     domEditSaveTimestampRef,
     pendingTimelineEditPathRef,
   });
-}
-
-function patchLiveAudioGroupState(
-  iframe: HTMLIFrameElement | null,
-  elements: readonly TimelineElement[],
-  groupId: string | null,
-  activeCompPath: string | null,
-): void {
-  for (const element of elements) {
-    const target = findTimelineElementInIframe(iframe, element, activeCompPath);
-    if (!target) continue;
-    if (groupId) target.setAttribute(HF_AUDIO_GROUP_ATTR, groupId);
-    else target.removeAttribute(HF_AUDIO_GROUP_ATTR);
-  }
-}
-
-interface CreateAudioGroupAndAssignMembersInput {
-  projectId: string;
-  activeCompPath: string | null;
-  elements: readonly TimelineElement[];
-  groupId: string;
-  previewIframe: HTMLIFrameElement | null;
-  writeProjectFile: (path: string, content: string) => Promise<void>;
-  recordEdit: (input: RecordEditInput) => Promise<void>;
-  domEditSaveTimestampRef: MutableRef<number>;
-  pendingTimelineEditPathRef: MutableRef<Set<string>>;
-}
-
-/**
- * Group two or more voice clips: write `data-audio-group="<groupId>"` on
- * every one of them, atomically, one undo entry — the same multi-target shape
- * `setElementsHidden` uses for mute. The group needs no `<hf-audio-group>`
- * element of its own to exist: `resolveAudioGroups` already degrades
- * gracefully to label = id when one is absent, and a naming dialog is out of
- * scope here — the id itself is the default name.
- */
-// fallow-ignore-next-line complexity
-export async function createAudioGroupAndAssignMembers({
-  projectId,
-  activeCompPath,
-  elements,
-  groupId,
-  previewIframe,
-  writeProjectFile,
-  recordEdit,
-  domEditSaveTimestampRef,
-  pendingTimelineEditPathRef,
-}: CreateAudioGroupAndAssignMembersInput): Promise<string[]> {
-  if (elements.length < 2) return [];
-
-  patchLiveAudioGroupState(previewIframe, elements, groupId, activeCompPath);
-  reseekPreviewRuntime(previewIframe);
-
-  const groupOperation: PatchOperation = {
-    type: "attribute",
-    property: HF_AUDIO_GROUP_ATTR,
-    value: groupId,
-  };
-  const originalByPath = new Map<string, string>();
-  const files: Record<string, string> = {};
-
-  try {
-    for (const [targetPath, fileElements] of groupElementsByTargetPath(elements, activeCompPath)) {
-      let patchedContent = await readFileContent(projectId, targetPath);
-      originalByPath.set(targetPath, patchedContent);
-
-      for (const element of fileElements) {
-        const patchTarget = buildPatchTarget(element);
-        if (!patchTarget) {
-          throw new Error(`Timeline element ${element.id} is missing a patchable target`);
-        }
-        if (readTagSnippetByTarget(patchedContent, patchTarget) === undefined) {
-          throw new Error(`Unable to patch timeline element ${element.id} in ${targetPath}`);
-        }
-        patchedContent = applyPatchByTarget(patchedContent, patchTarget, groupOperation);
-      }
-
-      files[targetPath] = patchedContent;
-      pendingTimelineEditPathRef.current.add(targetPath);
-    }
-
-    domEditSaveTimestampRef.current = Date.now();
-    const changedPaths = await saveProjectFilesWithHistory({
-      projectId,
-      label: `Group ${elements.length} voice clips`,
-      kind: "timeline",
-      files,
-      readFile: async (path) => {
-        const original = originalByPath.get(path);
-        if (original !== undefined) return original;
-        return readFileContent(projectId, path);
-      },
-      writeFile: writeProjectFile,
-      recordEdit,
-    });
-    domEditSaveTimestampRef.current = Date.now();
-    for (const element of elements) {
-      usePlayerStore.getState().updateElement(element.key ?? element.id, { audioGroup: groupId });
-    }
-    return changedPaths;
-  } catch (error) {
-    // Mirrors setElementsHidden's failure path: the optimistic live patch
-    // already ran, so a save failure has to be unwound or the preview shows a
-    // grouping that never made it to disk.
-    patchLiveAudioGroupState(previewIframe, elements, null, activeCompPath);
-    reseekPreviewRuntime(previewIframe);
-    throw error;
-  }
 }
 
 export function useTimelineTrackVisibilityEditing({
@@ -528,70 +416,6 @@ export function useTimelineElementVisibilityEditing({
       isRecordingRef,
       showToast,
       forceReloadSdkSession,
-      projectIdRef,
-    ],
-  );
-}
-
-/**
- * The write behind B6's auto-group: pick two or more voice clips in the carve
- * picker and they land in a group instead of naming each other by id. Same
- * expanded-rows resolution as element-visibility, for the same reason — a
- * nested sub-composition child has no entry in the raw store list.
- */
-export function useAudioGroupCarveAssignment({
-  projectIdRef,
-  activeCompPath,
-  showToast,
-  writeProjectFile,
-  recordEdit,
-  domEditSaveTimestampRef,
-  previewIframeRef,
-  pendingTimelineEditPathRef,
-  isRecordingRef,
-}: UseTimelineElementVisibilityEditingInput): (
-  clipIds: readonly string[],
-  groupId: string,
-) => Promise<void> {
-  const expandedElements = useExpandedTimelineElements();
-  return useCallback(
-    async (clipIds: readonly string[], groupId: string) => {
-      if (isRecordingRef?.current) {
-        showToast("Cannot edit timeline while recording", "error");
-        return;
-      }
-      const pid = projectIdRef.current;
-      if (!pid) return;
-      const keys = new Set(clipIds);
-      const elements = expandedElements.filter((item) => keys.has(item.key ?? item.id));
-      try {
-        await createAudioGroupAndAssignMembers({
-          projectId: pid,
-          activeCompPath,
-          elements,
-          groupId,
-          previewIframe: previewIframeRef.current,
-          writeProjectFile,
-          recordEdit,
-          domEditSaveTimestampRef,
-          pendingTimelineEditPathRef,
-        });
-      } catch (error) {
-        console.error("[Timeline] Failed to group voice clips", error);
-        const message = error instanceof Error ? error.message : "Failed to group voice clips";
-        showToast(message);
-      }
-    },
-    [
-      activeCompPath,
-      expandedElements,
-      previewIframeRef,
-      writeProjectFile,
-      recordEdit,
-      domEditSaveTimestampRef,
-      pendingTimelineEditPathRef,
-      isRecordingRef,
-      showToast,
       projectIdRef,
     ],
   );

--- a/packages/studio/src/hooks/useAudioGroupCarveAssignment.test.tsx
+++ b/packages/studio/src/hooks/useAudioGroupCarveAssignment.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+/**
+ * The carve's auto-group write path, end to end from the ids its picker hands
+ * over. Both callers — the carve picker (`withAutoGroupedSources`) and the
+ * timeline's group-pointer button — name clips by DOM id, because that is the
+ * space `collectCarveCandidates` reads them out of and the space
+ * `resolveAudioGroups` reads them back in. Resolving against store keys here
+ * matched nothing, wrote nothing, threw nothing, and let the carve persist
+ * `sources: [<group>]` for a group that was never created — a carve silently
+ * not ducking.
+ */
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePlayerStore, type TimelineElement } from "../player";
+import { useAudioGroupCarveAssignment } from "./timelineAudioGroupCreate";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+  usePlayerStore.getState().reset();
+});
+
+const FILE = `<html><body>
+<audio id="voice-1" data-start="0" data-duration="5"></audio>
+<audio id="voice-2" data-start="5" data-duration="5"></audio>
+</body></html>`;
+
+function stubProjectFiles(files: Map<string, string>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const path = decodeURIComponent(url.slice(url.lastIndexOf("/") + 1));
+      const content = files.get(path);
+      return new Response(JSON.stringify({ content }), {
+        status: content === undefined ? 404 : 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  );
+}
+
+function audio(overrides: Partial<TimelineElement>): TimelineElement {
+  return {
+    id: overrides.domId ?? "clip",
+    // A store key that is NOT the DOM id — the shape every real row has.
+    key: `index.html#${overrides.domId ?? "clip"}`,
+    tag: "audio",
+    start: 0,
+    duration: 5,
+    track: 0,
+    ...overrides,
+  };
+}
+
+type Assign = (clipIds: readonly string[], groupId: string) => Promise<void>;
+
+function renderAssign(writeProjectFile: (path: string, content: string) => Promise<void>) {
+  const showToast = vi.fn();
+  // A holder, not a bare `let`: TS narrows a variable only assigned inside a
+  // component body to `never` at the call site.
+  const held: { assign: Assign | null } = { assign: null };
+  function Probe() {
+    held.assign = useAudioGroupCarveAssignment({
+      projectIdRef: { current: "project-1" },
+      activeCompPath: "index.html",
+      showToast,
+      writeProjectFile,
+      recordEdit: async () => {},
+      domEditSaveTimestampRef: { current: 0 },
+      pendingTimelineEditPathRef: { current: new Set() },
+      previewIframeRef: { current: null },
+    });
+    return null;
+  }
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  act(() => root.render(<Probe />));
+  const assign = held.assign;
+  expect(assign).not.toBeNull();
+  return { assign: assign as Assign, showToast, root };
+}
+
+describe("useAudioGroupCarveAssignment", () => {
+  it("resolves the picker's DOM ids and writes the group", async () => {
+    stubProjectFiles(new Map([["index.html", FILE]]));
+    usePlayerStore
+      .getState()
+      .setElements([audio({ domId: "voice-1" }), audio({ domId: "voice-2", track: 1 })]);
+
+    const writes = new Map<string, string>();
+    const { assign, showToast, root } = renderAssign(async (path, content) => {
+      writes.set(path, content);
+    });
+
+    await act(async () => {
+      await assign(["voice-1", "voice-2"], "voiceover");
+    });
+
+    const written = writes.get("index.html") ?? "";
+    expect(written).toContain(
+      'id="voice-1" data-start="0" data-duration="5" data-audio-group="voiceover"',
+    );
+    expect(written).toContain(
+      'id="voice-2" data-start="5" data-duration="5" data-audio-group="voiceover"',
+    );
+    expect(written).toContain('<hf-audio-group id="voiceover"></hf-audio-group>');
+    expect(showToast).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+
+  // Loud AND rejecting: the carve chains `.then(() => ({...next, sources:
+  // [groupId]}))` off this promise, so a resolved-but-failed call let it
+  // persist a carve aimed at a group that was never written. Toasting alone
+  // was not enough — the promise has to carry the failure too.
+  it("rejects, and toasts, when an id resolves to no clip", async () => {
+    stubProjectFiles(new Map([["index.html", FILE]]));
+    usePlayerStore.getState().setElements([audio({ domId: "voice-1" })]);
+
+    const writes = new Map<string, string>();
+    const { assign, showToast, root } = renderAssign(async (path, content) => {
+      writes.set(path, content);
+    });
+
+    await act(async () => {
+      await expect(assign(["voice-1", "voice-gone"], "voiceover")).rejects.toThrow("voice-gone");
+    });
+
+    expect(writes.size).toBe(0);
+    expect(showToast).toHaveBeenCalledWith(expect.stringContaining("voice-gone"));
+    act(() => root.unmount());
+  });
+});

--- a/packages/studio/src/hooks/useBlockedTimelineEditToast.ts
+++ b/packages/studio/src/hooks/useBlockedTimelineEditToast.ts
@@ -1,0 +1,27 @@
+/**
+ * The "can't be moved from the timeline yet" toast, rate-limited.
+ *
+ * Its own hook so `useTimelineEditing.ts` stays under the studio's 600-line cap.
+ * The 1.5s gate matters: a blocked drag fires this per pointermove, and without
+ * it one gesture stacked dozens of identical toasts.
+ */
+
+import { useCallback, useRef } from "react";
+import type { TimelineElement } from "../player";
+
+const BLOCKED_TOAST_INTERVAL_MS = 1500;
+
+export function useBlockedTimelineEditToast(
+  showToast: (message: string, tone?: "info" | "error") => void,
+): (element: TimelineElement) => void {
+  const lastAtRef = useRef(0);
+  return useCallback(
+    (_element: TimelineElement) => {
+      const now = Date.now();
+      if (now - lastAtRef.current < BLOCKED_TOAST_INTERVAL_MS) return;
+      lastAtRef.current = now;
+      showToast("This clip can't be moved or resized from the timeline yet.", "info");
+    },
+    [showToast],
+  );
+}

--- a/packages/studio/src/hooks/useTimelineEditing.ts
+++ b/packages/studio/src/hooks/useTimelineEditing.ts
@@ -20,24 +20,20 @@ import {
   syncPreviewContentDuration,
 } from "./timelineTimingSync";
 import type { PersistTimelineEditInput } from "./timelineEditingHelpers";
-import type { TimelineStackingReorderIntent } from "../player/components/timelineEditing";
 import { useSetAudioGroupAttribute } from "./timelineAudioGroupVolume";
-import { useTimelineDeleteOps } from "./useTimelineDeleteOps";
 import { useSetElementAttribute } from "./timelineElementFxAttribute";
+import { useTimelineDeleteOps } from "./useTimelineDeleteOps";
+import { useAudioGroupCarveAssignment } from "./timelineAudioGroupCreate";
 import {
-  useAudioGroupCarveAssignment,
   useTimelineElementVisibilityEditing,
   useTimelineTrackVisibilityEditing,
 } from "./timelineTrackVisibility";
 import { useTimelineGroupEditing } from "./useTimelineGroupEditing";
+import { useBlockedTimelineEditToast } from "./useBlockedTimelineEditToast";
 import { serializeZLaneGesture } from "../components/nle/zLaneGesture";
 import { cutoverCommittedOrThrow, sdkTimingPersist } from "../utils/sdkCutover";
-import type { UseTimelineEditingOptions } from "./useTimelineEditingTypes";
+import type { TimelineMoveUpdates, UseTimelineEditingOptions } from "./useTimelineEditingTypes";
 import { getStudioSaveErrorMessage } from "../utils/studioSaveDiagnostics";
-
-type TimelineMoveUpdates = Pick<TimelineElement, "start" | "track"> & {
-  stackingReorder?: TimelineStackingReorderIntent | null;
-};
 
 export function useTimelineEditing({
   projectId,
@@ -61,9 +57,7 @@ export function useTimelineEditing({
 }: UseTimelineEditingOptions) {
   const projectIdRef = useRef(projectId);
   projectIdRef.current = projectId;
-
   const editQueueRef = useRef(Promise.resolve());
-  const lastBlockedTimelineToastAtRef = useRef(0);
 
   const enqueueEdit = useCallback(
     (
@@ -451,15 +445,7 @@ export function useTimelineEditing({
       observeProjectFileVersion,
     });
 
-  const handleBlockedTimelineEdit = useCallback(
-    (_element: TimelineElement) => {
-      const now = Date.now();
-      if (now - lastBlockedTimelineToastAtRef.current < 1500) return;
-      lastBlockedTimelineToastAtRef.current = now;
-      showToast("This clip can't be moved or resized from the timeline yet.", "info");
-    },
-    [showToast],
-  );
+  const handleBlockedTimelineEdit = useBlockedTimelineEditToast(showToast);
 
   const { handleRazorSplit, handleRazorSplitAll } = useRazorSplit({
     projectId,

--- a/packages/studio/src/hooks/useTimelineEditingTypes.ts
+++ b/packages/studio/src/hooks/useTimelineEditingTypes.ts
@@ -1,6 +1,7 @@
 import type { MutableRefObject, RefObject } from "react";
 import type { Composition } from "@hyperframes/sdk";
 import type { TimelineElement } from "../player";
+import type { TimelineStackingReorderIntent } from "../player/components/timelineEditing";
 import type { EditHistoryKind } from "../utils/editHistory";
 import type { PublishSdkSession } from "../utils/sdkCutover";
 
@@ -55,3 +56,9 @@ export type TimelineFileDropHandler = (
   files: File[],
   placement?: { start: number; track: number },
 ) => Promise<void>;
+
+/** What a timeline move commits: the new start and track, plus the z-index
+ *  reorder a vertical drag resolves to (absent for a pure horizontal move). */
+export type TimelineMoveUpdates = Pick<TimelineElement, "start" | "track"> & {
+  stackingReorder?: TimelineStackingReorderIntent | null;
+};

--- a/packages/studio/src/player/lib/automationStoreSync.test.ts
+++ b/packages/studio/src/player/lib/automationStoreSync.test.ts
@@ -80,4 +80,30 @@ describe("syncStoredAutomationFromPreview", () => {
     syncStoredAutomationFromPreview(null);
     expect(usePlayerStore.getState().elements[0]?.automation).toBe(TWO_POINTS);
   });
+  // The reported symptom: automate a parameter on a GROUP from the FX rack and
+  // the group's row shows no automation. The rack is not group-aware — it
+  // writes the attribute on the group node through the ordinary element path —
+  // and the timeline reads a group's lanes from the mirrors its MEMBERS carry,
+  // which that path used to leave untouched.
+  it("re-reads what the group carries onto every member that belongs to it", () => {
+    const chain = '{"version":1,"nodes":[{"type":"gain","id":"n1","params":{"gain":0}}]}';
+    const groupAutomation =
+      '{"version":1,"lanes":[{"target":"fx.n1.gain","points":[{"t":0,"v":0}]}]}';
+    const doc = document.implementation.createHTMLDocument("preview");
+    const group = doc.createElement("hf-audio-group");
+    group.id = "voiceover";
+    group.setAttribute("data-fx-chain", chain);
+    group.setAttribute("data-automation", groupAutomation);
+    const audio = doc.createElement("audio");
+    audio.id = "bgm";
+    audio.setAttribute("data-audio-group", "voiceover");
+    doc.body.append(group, audio);
+
+    usePlayerStore.setState({ elements: [el({ audioGroup: "voiceover" })] });
+    syncStoredAutomationFromPreview(doc);
+
+    const stored = usePlayerStore.getState().elements[0];
+    expect(stored?.audioGroupAutomation).toBe(groupAutomation);
+    expect(stored?.audioGroupFxChain).toBe(chain);
+  });
 });

--- a/packages/studio/src/player/lib/automationStoreSync.ts
+++ b/packages/studio/src/player/lib/automationStoreSync.ts
@@ -16,6 +16,7 @@
 import { HF_AUDIO_AUTOMATION_ATTR } from "@hyperframes/core/audio-automation";
 import { HF_AUDIO_FX_ATTR } from "@hyperframes/core/audio-fx";
 import { usePlayerStore, type TimelineElement } from "../store/playerStore";
+import { groupInfoFor } from "./timelineGroupInfo";
 
 /** The preview node an element stands for, by dom id and then by `data-hf-id`. */
 function previewNodeFor(doc: Document, element: TimelineElement): Element | null {
@@ -38,6 +39,27 @@ function previewNodeFor(doc: Document, element: TimelineElement): Element | null
  * Reads rather than being told: an undo restores whole files, so the attribute it
  * reverted is only known by looking.
  */
+/**
+ * What an element's four synced fields SHOULD read, given the preview.
+ *
+ * Its own two come off its node; the other two are its copy of what its group
+ * carries. The timeline derives a group's lanes and chain from these mirrors,
+ * never from the group element — and the FX rack is not group-aware: selecting
+ * a group and automating one of its parameters writes `data-automation` on the
+ * group node through the ordinary element path, which used to refresh an
+ * element's own two fields and nothing else. So the group's row went on reading
+ * the value it was born with, and its `∿` never appeared.
+ */
+function syncedFields(doc: Document, element: TimelineElement, node: Element) {
+  const group = element.audioGroup ? groupInfoFor(doc, element.audioGroup) : null;
+  return {
+    automation: node.getAttribute(HF_AUDIO_AUTOMATION_ATTR) ?? undefined,
+    fxChain: node.getAttribute(HF_AUDIO_FX_ATTR) ?? undefined,
+    audioGroupAutomation: group?.automation,
+    audioGroupFxChain: group?.fxChain,
+  };
+}
+
 export function syncStoredAutomationFromPreview(doc: Document | null | undefined): void {
   if (!doc) return;
   usePlayerStore.setState((state) => {
@@ -45,11 +67,13 @@ export function syncStoredAutomationFromPreview(doc: Document | null | undefined
     const elements = state.elements.map((element) => {
       const node = previewNodeFor(doc, element);
       if (!node) return element;
-      const automation = node.getAttribute(HF_AUDIO_AUTOMATION_ATTR) ?? undefined;
-      const fxChain = node.getAttribute(HF_AUDIO_FX_ATTR) ?? undefined;
-      if (automation === element.automation && fxChain === element.fxChain) return element;
+      const fields = syncedFields(doc, element, node);
+      // Same array back when nothing moved: `elements` keys memos all over the
+      // timeline, and a fresh object per sync would re-render every one.
+      const keys = Object.keys(fields) as (keyof typeof fields)[];
+      if (keys.every((key) => fields[key] === element[key])) return element;
       changed = true;
-      return { ...element, automation, fxChain };
+      return { ...element, ...fields };
     });
     return changed ? { elements } : {};
   });

--- a/packages/studio/src/player/lib/runtimeAudioId.test.ts
+++ b/packages/studio/src/player/lib/runtimeAudioId.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+/**
+ * The studio → runtime boundary, which nothing else crosses.
+ *
+ * Studio addresses rows by `buildTimelineElementKey`'s composite
+ * `<sourceFile>#<domId>`; every audio predicate in `@hyperframes/core` keys off
+ * the live document instead. Both halves have their own passing tests — one
+ * with composite keys, one with bare ids — and the mismatch between them lived
+ * in the gap. These parse a real document, take the ids the way the UI does,
+ * and hand them to the real core predicates.
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveAudioGroups } from "@hyperframes/core/audio-groups";
+import { parseTimelineFromDOM } from "./timelineDOM";
+import { runtimeAudioId } from "./timelineElementHelpers";
+
+function docWith(body: string): Document {
+  const doc = document.implementation.createHTMLDocument("comp");
+  doc.body.innerHTML = body;
+  return doc;
+}
+
+const COMPOSITION = `
+  <div data-composition-id="root" data-duration="30"></div>
+  <audio id="voice-1" data-start="0" data-duration="10" data-audio-group="voiceover"></audio>
+  <audio id="voice-2" data-start="10" data-duration="10" data-audio-group="voiceover"></audio>
+  <audio id="music-bed" data-start="0" data-duration="30"></audio>
+  <hf-audio-group id="voiceover"></hf-audio-group>
+`;
+
+describe("group membership ids cross into the runtime", () => {
+  it("the ids the timeline hands to onGroupClips are the ids resolveAudioGroups reads back", () => {
+    const doc = docWith(COMPOSITION);
+    const trackElements = parseTimelineFromDOM(doc, 30).filter(
+      (el) => el.tag.toLowerCase() === "audio",
+    );
+    const clipIds = trackElements.map(runtimeAudioId).filter((id): id is string => id !== null);
+    expect(clipIds).toEqual(["voice-1", "voice-2", "music-bed"]);
+
+    // Same space membership is read back in — a composite key here produces a
+    // group whose members nothing can find.
+    const memberIds = resolveAudioGroups(doc).flatMap((g) => g.memberIds);
+    expect(memberIds.every((id) => doc.getElementById(id) !== null)).toBe(true);
+    for (const id of memberIds) expect(clipIds).toContain(id);
+  });
+
+  it("an element with no DOM id is not groupable", () => {
+    const doc = docWith(`
+      <div data-composition-id="root" data-duration="10"></div>
+      <audio data-start="0" data-duration="5"></audio>
+    `);
+    const [clip] = parseTimelineFromDOM(doc, 10);
+    expect(clip).toBeDefined();
+    expect(runtimeAudioId(clip)).toBeNull();
+  });
+});

--- a/packages/studio/src/player/lib/timelineDOM.test.ts
+++ b/packages/studio/src/player/lib/timelineDOM.test.ts
@@ -6,6 +6,8 @@ import {
   createImplicitTimelineLayersFromDOM,
   mergeTimelineElementsPreservingDowngrades,
 } from "./timelineDOM";
+import { isTimelineIgnoredElement } from "./timelineElementHelpers";
+import { invalidateGroupInfoCache } from "./timelineGroupInfo";
 import type { TimelineElement } from "../store/playerStore";
 
 function el(id: string, extra: Partial<TimelineElement> = {}): TimelineElement {
@@ -110,6 +112,92 @@ describe("parseTimelineFromDOM — hfId from data-hf-id", () => {
   });
 });
 
+describe("group info cache", () => {
+  const parseMember = (doc: Document) =>
+    createTimelineElementFromManifestClip({
+      clip: {
+        id: "voice-1",
+        label: "voice-1",
+        kind: "element",
+        tagName: "audio",
+        start: 0,
+        duration: 5,
+        track: 0,
+        compositionId: null,
+        parentCompositionId: null,
+        compositionSrc: null,
+        assetUrl: null,
+      },
+      fallbackIndex: 0,
+      doc,
+      hostEl: doc.getElementById("voice-1"),
+    });
+
+  // Group edits are applied as LIVE patches so the preview iframe never
+  // reloads, which means the document identity this cache is keyed on never
+  // changes either. Without an explicit drop, a muted group could never be
+  // unmuted: the header kept reading the cached `hidden: false` and re-wrote
+  // `data-hidden` forever.
+  it("re-reads group state after an invalidation", () => {
+    const doc = makeDoc(`
+      <div data-composition-id="root">
+        <audio id="voice-1" data-start="0" data-duration="5" data-audio-group="voiceover"></audio>
+        <hf-audio-group id="voiceover" data-label="Voices"></hf-audio-group>
+      </div>
+    `);
+
+    expect(parseMember(doc).audioGroupHidden).toBe(false);
+
+    doc.getElementById("voiceover")?.setAttribute("data-hidden", "");
+    expect(parseMember(doc).audioGroupHidden).toBe(false); // still the cached scan
+
+    invalidateGroupInfoCache(doc);
+    expect(parseMember(doc).audioGroupHidden).toBe(true);
+
+    doc.getElementById("voiceover")?.removeAttribute("data-hidden");
+    invalidateGroupInfoCache(doc);
+    expect(parseMember(doc).audioGroupHidden).toBe(false);
+  });
+
+  // The explicit invalidator is a convenience, not the contract. A cache whose
+  // only defence is "every writer must remember to call this" rots the first
+  // time a writer does not know it exists — which is precisely what happened
+  // with the FX rack, whose group writes go through the DOM editor rather than
+  // the timeline's own writers. The scan carries the DOM revision it was taken
+  // at, so a forgotten call costs a re-scan rather than a wrong answer.
+  it("expires itself on a group edit nobody announced", async () => {
+    const doc = makeDoc(`
+      <div data-composition-id="root">
+        <audio id="voice-1" data-start="0" data-duration="5" data-audio-group="voiceover"></audio>
+        <hf-audio-group id="voiceover" data-label="Voices"></hf-audio-group>
+      </div>
+    `);
+
+    expect(parseMember(doc).audioGroupHidden).toBe(false);
+
+    // No invalidateGroupInfoCache call anywhere in this test.
+    doc.getElementById("voiceover")?.setAttribute("data-hidden", "");
+    await new Promise((resolve) => setTimeout(resolve, 0)); // observer microtask
+
+    expect(parseMember(doc).audioGroupHidden).toBe(true);
+  });
+
+  it("notices a member joining the group, not just an attribute edit", async () => {
+    const doc = makeDoc(`
+      <div data-composition-id="root">
+        <audio id="voice-1" data-start="0" data-duration="5" data-audio-group="voiceover"></audio>
+        <hf-audio-group id="voiceover" data-label="Voices"></hf-audio-group>
+      </div>
+    `);
+    expect(parseMember(doc).audioGroupLabel).toBe("Voices");
+
+    doc.getElementById("voiceover")?.setAttribute("data-label", "Narration");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(parseMember(doc).audioGroupLabel).toBe("Narration");
+  });
+});
+
 describe("parseTimelineFromDOM — canonical playback rate", () => {
   it.each([
     ["10", 5],
@@ -204,6 +292,33 @@ describe("createTimelineElementFromManifestClip — source-scoped selector ident
     expect(element.sourceFile).toBe("scene.html");
     expect(element.selectorIndex).toBe(1);
     expect(element.key).toBe("scene.html:.sub:1");
+  });
+});
+
+// Caught by looking at the studio, not by reading: a grouped composition drew
+// "Voiceover • 0.0s – 12.0s" as a full-duration clip row directly above its own
+// group header. `<hf-audio-group>` is a mixer bus — no timing, drawn as a group
+// row by the group derivation — but it is still a body child with an id, so the
+// implicit-layer fallback happily gave it a track. Draggable and trimmable, and
+// writing timing onto a bus means nothing.
+describe("<hf-audio-group> is not a timeline layer", () => {
+  it("gets no implicit row of its own", () => {
+    const doc = makeDoc(`
+      <div data-composition-id="root">
+        <audio id="voice-1" data-start="0" data-duration="6" data-audio-group="voiceover"></audio>
+        <hf-audio-group id="voiceover" data-label="Voiceover"></hf-audio-group>
+      </div>
+    `);
+
+    const implicit = createImplicitTimelineLayersFromDOM(doc, 12, []);
+
+    expect(implicit.map((el) => el.domId)).not.toContain("voiceover");
+  });
+
+  it("is excluded by the shared ignore predicate", () => {
+    const doc = makeDoc(`<hf-audio-group id="vo"></hf-audio-group><div id="panel"></div>`);
+    expect(isTimelineIgnoredElement(doc.getElementById("vo") as Element)).toBe(true);
+    expect(isTimelineIgnoredElement(doc.getElementById("panel") as Element)).toBe(false);
   });
 });
 

--- a/packages/studio/src/player/lib/timelineDOM.ts
+++ b/packages/studio/src/player/lib/timelineDOM.ts
@@ -12,7 +12,7 @@ import type { TimelineElement } from "../store/playerStore";
 import type { ClipManifestClip } from "./playbackTypes";
 import { resolveCssStackingContextId } from "@hyperframes/core/runtime/stacking-context";
 import { readClipTiming } from "@hyperframes/core/composition-contract";
-import { resolveAudioGroups } from "@hyperframes/core/audio-groups";
+import { groupInfoFor } from "./timelineGroupInfo";
 import {
   resolveMediaElement,
   applyMediaMetadataFromElement,
@@ -66,37 +66,6 @@ export {
 
 function resolveClipTag(clip: ClipManifestClip): string {
   return clip.tagName || clip.kind || "div";
-}
-
-// One `<hf-audio-group>` scan per document, not per clip — resolveAudioGroups
-// walks the whole tree, and a parse touches every clip in it.
-interface GroupInfo {
-  label: string;
-  volume: number;
-  hidden: boolean;
-  fxChain?: string;
-}
-
-const groupInfoCache = new WeakMap<Document, Map<string, GroupInfo>>();
-
-function groupInfoFor(doc: Document | null | undefined, groupId: string): GroupInfo {
-  if (!doc) return { label: groupId, volume: 1, hidden: false };
-  let info = groupInfoCache.get(doc);
-  if (!info) {
-    info = new Map(
-      resolveAudioGroups(doc).map((group) => [
-        group.id,
-        {
-          label: group.label,
-          volume: group.volume,
-          hidden: group.hidden,
-          ...(group.fxChain ? { fxChain: group.fxChain } : {}),
-        },
-      ]),
-    );
-    groupInfoCache.set(doc, info);
-  }
-  return info.get(groupId) ?? { label: groupId, volume: 1, hidden: false };
 }
 
 // fallow-ignore-next-line complexity
@@ -178,6 +147,7 @@ export function createTimelineElementFromManifestClip(params: {
       entry.audioGroupVolume = info.volume;
       entry.audioGroupHidden = info.hidden;
       if (info.fxChain) entry.audioGroupFxChain = info.fxChain;
+      if (info.automation) entry.audioGroupAutomation = info.automation;
     }
     const fxChain = hostEl.getAttribute("data-fx-chain");
     if (fxChain) entry.fxChain = fxChain;
@@ -405,6 +375,7 @@ export function parseTimelineFromDOM(doc: Document, rootDuration: number): Timel
       entry.audioGroupVolume = domGroupInfo.volume;
       entry.audioGroupHidden = domGroupInfo.hidden;
       if (domGroupInfo.fxChain) entry.audioGroupFxChain = domGroupInfo.fxChain;
+      if (domGroupInfo.automation) entry.audioGroupAutomation = domGroupInfo.automation;
     }
 
     // Sub-compositions

--- a/packages/studio/src/player/lib/timelineElementHelpers.ts
+++ b/packages/studio/src/player/lib/timelineElementHelpers.ts
@@ -11,6 +11,7 @@ import type { TimelineElement } from "../store/playerStore";
 import type { ClipManifestClip } from "./playbackTypes";
 import { isFinitePositive } from "./playbackAdapter";
 import { getSourceScopedSelectorIndex } from "../../utils/sourceScopedSelectorIndex";
+import { HF_AUDIO_GROUP_TAG } from "@hyperframes/core/audio-groups";
 
 // ---------------------------------------------------------------------------
 // Layer-reveal lift transparency
@@ -81,6 +82,14 @@ function normalizePlaybackRate(raw: number): number {
 }
 
 export function isTimelineIgnoredElement(el: Element): boolean {
+  // An `<hf-audio-group>` is a mixer bus, not a clip: it carries the group's
+  // label, fader, mute and FX chain, has no timing of its own, and is drawn as
+  // a GROUP ROW by the group derivation. Left in, the implicit-layer fallback
+  // also gave it an ordinary full-duration track — so a grouped composition
+  // showed "Voiceover • 0.0s – 12.0s" as a phantom clip directly above the real
+  // group header. Harmless-looking, but that row is draggable and trimmable,
+  // and writing timing onto the bus is meaningless.
+  if (el.tagName.toLowerCase() === HF_AUDIO_GROUP_TAG) return true;
   return Boolean(
     el.closest(
       [
@@ -344,6 +353,24 @@ export function buildTimelineElementIdentity(params: {
 
 export function getTimelineElementIdentity(element: { key?: string | null; id: string }): string {
   return element.key ?? element.id;
+}
+
+/**
+ * The id space the RUNTIME matches on — a bare DOM id, never a store key.
+ *
+ * Studio addresses rows by `buildTimelineElementKey`'s composite
+ * `<sourceFile>#<domId>`, but everything audio in `@hyperframes/core` keys off
+ * the live document: `resolveAudioGroups` collects `member.id`,
+ * `resolveCarveSourceIds` goes through `getElementById`. Anything crossing into
+ * that space — a group membership list, a carve source — has to be
+ * converted here first; a composite key silently matches nothing.
+ *
+ * `null` for a row with no DOM id at all (selector-addressed elements): such an
+ * element cannot be grouped, because `resolveAudioGroups` skips
+ * members without an `id` and would build a group that is half there.
+ */
+export function runtimeAudioId(element: { domId?: string | null }): string | null {
+  return element.domId || null;
 }
 
 /**

--- a/packages/studio/src/player/lib/timelineGroupInfo.ts
+++ b/packages/studio/src/player/lib/timelineGroupInfo.ts
@@ -1,0 +1,134 @@
+/**
+ * The audio-group scan cached per preview document, and the mechanism that
+ * keeps it honest.
+ *
+ * Split out of `timelineDOM.ts` (600-line studio ceiling). Self-contained: the
+ * cache, its revision counter, the observer that bumps it, and the one reader.
+ */
+
+import {
+  HF_AUDIO_GROUP_ATTR,
+  HF_AUDIO_GROUP_TAG,
+  resolveAudioGroups,
+} from "@hyperframes/core/audio-groups";
+import { HF_AUDIO_AUTOMATION_ATTR } from "@hyperframes/core/audio-automation";
+import { HF_AUDIO_FX_ATTR } from "@hyperframes/core/audio-fx";
+
+// One `<hf-audio-group>` scan per document, not per clip — resolveAudioGroups
+// walks the whole tree, and a parse touches every clip in it.
+interface GroupInfo {
+  label: string;
+  volume: number;
+  hidden: boolean;
+  fxChain?: string;
+  automation?: string;
+}
+
+/**
+ * The cached scan, plus the DOM revision it was taken at.
+ *
+ * Keeping the revision beside the entry is what makes staleness *detectable*
+ * rather than a documented obligation. The cache is keyed on the document, and
+ * group edits are applied as live patches precisely so the iframe never
+ * reloads, so the key alone never changes: an explicit "remember to invalidate"
+ * contract silently rots the first time a new writer forgets — which is exactly
+ * what happened with the FX rack, whose group writes go through the DOM editor
+ * rather than the timeline's own writers.
+ */
+const groupInfoCache = new WeakMap<
+  Document,
+  { revision: number; entries: Map<string, GroupInfo> }
+>();
+
+/** Bumped by every observed mutation to group state in a document. */
+const groupRevisions = new WeakMap<Document, number>();
+const groupObservers = new WeakSet<Document>();
+
+/**
+ * Watch a document for any change to group state, so the cache expires itself.
+ *
+ * One observer per document, attached the first time a group is read from it.
+ * It watches the attributes a group's identity is made of, anywhere in the
+ * tree, plus added/removed nodes — which covers a group element appearing, a
+ * member joining or leaving, and any group attribute being edited, by any
+ * writer, without that writer having to know this cache exists.
+ */
+function observeGroupState(doc: Document): void {
+  if (groupObservers.has(doc) || typeof MutationObserver === "undefined" || !doc.body) return;
+  groupObservers.add(doc);
+  const observer = new MutationObserver((records) => {
+    // `childList` fires for EVERY node added or removed anywhere in the live
+    // preview, which on a composition that churns nodes during playback
+    // (SplitText, a typewriter, anything runtime-inserted) would expire this
+    // cache permanently and put it back to one whole-tree scan per parse. Only
+    // a group ELEMENT appearing or leaving actually changes the answer, so
+    // childList records are filtered rather than trusted; attribute records
+    // always count, because the filter below already narrowed them.
+    const relevant = records.some(
+      (record) =>
+        record.type !== "childList" ||
+        [...record.addedNodes, ...record.removedNodes].some(
+          (node) =>
+            node instanceof Element &&
+            (node.tagName.toLowerCase() === HF_AUDIO_GROUP_TAG ||
+              node.hasAttribute(HF_AUDIO_GROUP_ATTR) ||
+              node.querySelector?.(`${HF_AUDIO_GROUP_TAG},[${HF_AUDIO_GROUP_ATTR}]`) != null),
+        ),
+    );
+    if (relevant) groupRevisions.set(doc, (groupRevisions.get(doc) ?? 0) + 1);
+  });
+  observer.observe(doc.body, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    // Every attribute `resolveAudioGroups`/`buildGroup` reads, including
+    // `data-automation` — which `GroupInfo` does not cache TODAY, so omitting it
+    // was inert, but group automation lanes already exist and the first person
+    // to cache one would have got a silently never-firing observer. That is the
+    // precise rot this observer replaced.
+    attributeFilter: [
+      HF_AUDIO_GROUP_ATTR,
+      HF_AUDIO_FX_ATTR,
+      HF_AUDIO_AUTOMATION_ATTR,
+      "data-label",
+      "data-volume",
+      "data-hidden",
+      "id",
+    ],
+  });
+}
+
+/**
+ * Drop the cached group scan for a document.
+ *
+ * Belt to the observer's braces: a caller that has just written and wants the
+ * very next read to be honest cannot wait for the observer's microtask. Callers
+ * that forget are no longer punished — the revision check catches them.
+ */
+export function invalidateGroupInfoCache(doc: Document | null | undefined): void {
+  if (doc) groupInfoCache.delete(doc);
+}
+
+export function groupInfoFor(doc: Document | null | undefined, groupId: string): GroupInfo {
+  if (!doc) return { label: groupId, volume: 1, hidden: false };
+  observeGroupState(doc);
+  const revision = groupRevisions.get(doc) ?? 0;
+  const cached = groupInfoCache.get(doc);
+  let info = cached && cached.revision === revision ? cached.entries : undefined;
+  if (!info) {
+    info = new Map(
+      resolveAudioGroups(doc).map((group) => [
+        group.id,
+        {
+          label: group.label,
+          volume: group.volume,
+          hidden: group.hidden,
+          ...(group.fxChain ? { fxChain: group.fxChain } : {}),
+          ...(group.automation ? { automation: group.automation } : {}),
+        },
+      ]),
+    );
+    groupInfoCache.set(doc, { revision, entries: info });
+  }
+  return info.get(groupId) ?? { label: groupId, volume: 1, hidden: false };
+}

--- a/packages/studio/src/player/lib/timelineIframeHelpers.test.ts
+++ b/packages/studio/src/player/lib/timelineIframeHelpers.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
 import {
+  applyPreviewAudioFlags,
   buildMissingCompositionElements,
   scrubPreviewAudio,
   setPreviewMediaVolume,
@@ -85,5 +86,25 @@ describe("scrubPreviewAudio", () => {
 
     expect(audio.volume).toBeCloseTo(0.1);
     stopScrubPreviewAudio();
+  });
+});
+
+describe("applyPreviewAudioFlags", () => {
+  // Everything pushed here is state the runtime loses on reload and nothing else
+  // re-sends, so the push has to carry all of it every time. Volume in
+  // particular: the transport comes back at unity, so a preview the author had
+  // turned down came back loud.
+  it("re-pushes mute and volume together", () => {
+    const iframe = document.createElement("iframe");
+    document.body.append(iframe);
+    const postMessage = vi.spyOn(iframe.contentWindow!, "postMessage");
+
+    applyPreviewAudioFlags(iframe, true, 0.4);
+
+    const actions = postMessage.mock.calls.map(
+      (call) => (call[0] as { action?: string }).action ?? "",
+    );
+    expect(actions).toContain("set-muted");
+    expect(actions).toContain("set-volume");
   });
 });

--- a/packages/studio/src/player/lib/timelineIframeHelpers.ts
+++ b/packages/studio/src/player/lib/timelineIframeHelpers.ts
@@ -142,6 +142,23 @@ export function setPreviewMediaVolume(iframe: HTMLIFrameElement | null, volume: 
   } catch {}
 }
 
+/**
+ * Everything the preview runtime has to be told about audio after it loads.
+ * Called from `applyPreviewAudioState`, which is the path that re-runs after a
+ * preview reload — the runtime comes back with the transport at its defaults
+ * and nothing else pushes them again.
+ */
+export function applyPreviewAudioFlags(
+  iframe: HTMLIFrameElement | null,
+  muted: boolean,
+  volume: number,
+): void {
+  setPreviewMediaMuted(iframe, muted);
+  // Volume too: the transport comes back at unity after a reload, so a preview
+  // the author had turned down came back loud.
+  setPreviewMediaVolume(iframe, volume);
+}
+
 export function setPreviewPlaybackRate(
   iframe: HTMLIFrameElement | null,
   playbackRate: number,

--- a/packages/studio/src/player/store/keyframeSlice.ts
+++ b/packages/studio/src/player/store/keyframeSlice.ts
@@ -34,6 +34,27 @@ export interface FocusedEaseSegment {
 
 type FocusedEaseSegmentTarget = Omit<FocusedEaseSegment, "projectId" | "sessionEpoch" | "nonce">;
 
+/**
+ * A request to reveal one automated parameter in the audio FX rack.
+ *
+ * `elementKey` is the timeline element whose rack it belongs to — a group's own
+ * id for a group lane, the clip's key otherwise — so the panel can refuse a
+ * request aimed at something it is not showing.
+ */
+export interface RevealedAudioFxTarget {
+  elementKey: string;
+  /** The lane's own `fx.<node>.<param>` / `volume` target. */
+  automationTarget: string;
+  projectId: string | null;
+  sessionEpoch: number;
+  nonce: number;
+}
+
+export type RevealedAudioFxTargetRequest = Omit<
+  RevealedAudioFxTarget,
+  "projectId" | "sessionEpoch" | "nonce"
+>;
+
 interface TimelineSessionIdentity {
   timelineProjectId: string | null;
   timelineSessionEpoch: number;
@@ -79,6 +100,19 @@ export interface KeyframeSlice {
   focusedEaseRequestNonce: number;
   setFocusedEaseSegment: (target: FocusedEaseSegmentTarget) => void;
   clearFocusedEaseSegment: (nonce: number) => void;
+
+  /**
+   * "Show me this automated parameter in the rack" — raised by clicking an
+   * automation lane's label in the timeline, consumed by the property panel.
+   *
+   * Session-stamped and nonce-guarded exactly like `focusedEaseSegment`: a
+   * request outlives the click, so one made against a different project or
+   * before a reload must not reopen a rack on whatever is mounted later.
+   */
+  revealedAudioFxTarget: RevealedAudioFxTarget | null;
+  revealedAudioFxNonce: number;
+  setRevealedAudioFxTarget: (target: RevealedAudioFxTargetRequest) => void;
+  clearRevealedAudioFxTarget: (nonce: number) => void;
 
   /** Keyframe data per element id, populated from parsed GSAP animations. */
   keyframeCache: Map<string, KeyframeCacheEntry>;
@@ -164,6 +198,27 @@ export function createKeyframeSlice(
     clearFocusedEaseSegment: (nonce) =>
       set((state) =>
         state.focusedEaseSegment?.nonce === nonce ? { focusedEaseSegment: null } : state,
+      ),
+
+    revealedAudioFxTarget: null,
+    revealedAudioFxNonce: 0,
+    setRevealedAudioFxTarget: (target) =>
+      set((state) => {
+        const nonce = state.revealedAudioFxNonce + 1;
+        const { timelineProjectId, timelineSessionEpoch } = getTimelineSessionIdentity();
+        return {
+          revealedAudioFxNonce: nonce,
+          revealedAudioFxTarget: {
+            ...target,
+            projectId: timelineProjectId,
+            sessionEpoch: timelineSessionEpoch,
+            nonce,
+          },
+        };
+      }),
+    clearRevealedAudioFxTarget: (nonce) =>
+      set((state) =>
+        state.revealedAudioFxTarget?.nonce === nonce ? { revealedAudioFxTarget: null } : state,
       ),
 
     keyframeCache: new Map(),

--- a/packages/studio/src/player/store/playerStore.ts
+++ b/packages/studio/src/player/store/playerStore.ts
@@ -1,4 +1,6 @@
 import { create } from "zustand";
+import { attachPlayerStoreDevHandle } from "./playerStoreDevHandle";
+import { nextSelectionSet, revealTargetsSelection } from "./playerStoreSelection";
 import type { MusicBeatAnalysis } from "@hyperframes/core/beats";
 import type { GsapAnimation } from "@hyperframes/core/gsap-parser";
 import type { BeatEditState } from "../../utils/beatEditing";
@@ -14,15 +16,15 @@ import {
   createAutomationSelectionSlice,
   type AutomationSelectionSlice,
 } from "./automationSelectionSlice";
+import { createEditingModeSlice, type EditingModeSlice } from "./editingModeSlice";
 import { createTimelineFocusRequest, type TimelineFocusRequest } from "./timelineFocusState";
 import { createThumbnailSlice, type ThumbnailSlice } from "./thumbnailSlice";
 import { createAudioSoloSlice, type AudioSoloSlice } from "./audioSoloSlice";
-import { createEditingModeSlice, type EditingModeSlice } from "./editingModeSlice";
 
 export type { KeyframeCacheEntry } from "./keyframeSlice";
 export { liveTime } from "./liveTime";
 
-import type { TimelineElement } from "./timelineElement";
+import type { TimelineElement, TimelineElementPatch } from "./timelineElement";
 
 export type { TimelineElement };
 export type ZoomMode = "fit" | "manual";
@@ -135,22 +137,7 @@ interface PlayerState
   setSelectedElementId: (id: string | null, options?: SelectElementOptions) => void;
   /** Move the selection anchor within an active multi-selection without collapsing it. */
   setSelectionAnchor: (id: string | null) => void;
-  updateElement: (
-    elementId: string,
-    updates: Partial<
-      Pick<
-        TimelineElement,
-        | "start"
-        | "duration"
-        | "track"
-        | "zIndex"
-        | "hasExplicitZIndex"
-        | "playbackStart"
-        | "hidden"
-        | "audioGroup"
-      >
-    >,
-  ) => void;
+  updateElement: (elementId: string, updates: TimelineElementPatch) => void;
   setZoomMode: (mode: ZoomMode) => void;
   setManualZoomPercent: (percent: number) => void;
   bumpZEditVersion: () => void;
@@ -241,6 +228,19 @@ export interface DomClipChild {
   hostId: string;
   label: string;
   stackingContextId: string;
+  /**
+   * The child's audio-group state, read off its live element during the DOM
+   * walk — the only place that sees it. A sub-composition can declare a group
+   * and its members entirely within itself, and those members never reach the
+   * flat store, so an expanded child has no twin to inherit membership from.
+   */
+  audioGroup?: string;
+  audioGroupLabel?: string;
+  audioGroupVolume?: number;
+  audioGroupHidden?: boolean;
+  audioGroupFxChain?: string;
+  /** The group element's `data-automation`, mirrored the same way. */
+  audioGroupAutomation?: string;
 }
 
 interface BeatHistoryEntry {
@@ -274,6 +274,7 @@ export function createTimelineResetState() {
     expandedGroupIds: new Set<string>(),
     expandedLaneOwnerIds: new Set<string>(),
     focusedEaseSegment: null,
+    revealedAudioFxTarget: null,
     selectedElementIds: new Set<string>(),
     requestedSeekTime: null,
     lintFindingsByElement: new Map<string, { count: number; messages: string[] }>(),
@@ -519,18 +520,23 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
   // echoes that must preserve a group go through setSelectionAnchor instead.
   setSelectedElementId: (id, options) =>
     set((s) => {
-      const preserveSet = Boolean(options?.preserveSet && id && s.selectedElementIds.has(id));
-      const selectedElementIds = preserveSet
-        ? new Set(s.selectedElementIds)
-        : options?.preserveSet
-          ? new Set<string>()
-          : id
-            ? new Set([id])
-            : new Set<string>();
+      const selectedElementIds = nextSelectionSet(s.selectedElementIds, id, options?.preserveSet);
       // Selecting a different element drops any active keyframe selection — otherwise
       // a stale activeKeyframePct from a prior diamond click would force the next drag
       // to "modify" a keyframe on the new element. A diamond click sets the pct AFTER
       // calling setSelectedElementId, so this never clobbers a genuine keyframe select.
+      // A reveal request survives the selection it is FOR. `openClipFxRack`
+      // raises the request and then selects the clip asynchronously, so the
+      // selection lands afterwards and used to clear the very request that
+      // caused it — the panel then read null and the section never opened.
+      // Any OTHER selection still drops it: a request aimed elsewhere is stale.
+      //
+      // Compared across the ID-SPACE BOUNDARY, which is why this needs saying:
+      // a request carries the BARE dom id (`runtimeAudioId`, because the panel
+      // and the runtime speak that), while this store's ids are
+      // `sourceFile#domId`. A direct `===` was silently never true — the exact
+      // shape of failure the id-space split produces.
+      const revealSurvives = revealTargetsSelection(s.revealedAudioFxTarget, id);
       return id !== s.selectedElementId
         ? {
             selectedElementId: id,
@@ -538,6 +544,7 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
             activeKeyframePct: null,
             motionPathArmed: false,
             focusedEaseSegment: null,
+            ...(revealSurvives ? {} : { revealedAudioFxTarget: null }),
           }
         : { selectedElementId: id, selectedElementIds };
     }),
@@ -579,15 +586,4 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
   reset: () => set(createTimelineResetState()),
 }));
 
-function isDevBuild(): boolean {
-  try {
-    return import.meta.env.DEV === true;
-  } catch {
-    // Turbopack and other non-Vite bundlers may not provide import.meta.env.
-    return false;
-  }
-}
-if (isDevBuild() && typeof window !== "undefined") {
-  // Console handle for dumping live Studio state during bug-bash reproduction.
-  (window as unknown as { __playerStore?: typeof usePlayerStore }).__playerStore = usePlayerStore;
-}
+attachPlayerStoreDevHandle(usePlayerStore);

--- a/packages/studio/src/player/store/playerStoreDevHandle.ts
+++ b/packages/studio/src/player/store/playerStoreDevHandle.ts
@@ -1,0 +1,22 @@
+/**
+ * A console handle on the live store, dev builds only.
+ *
+ * Split out of `playerStore.ts` to keep it under the studio's 600-line cap. The
+ * dev check is its own function because `import.meta.env` is absent under
+ * Turbopack and other non-Vite bundlers, where reading it throws.
+ */
+
+function isDevBuild(): boolean {
+  try {
+    return import.meta.env.DEV === true;
+  } catch {
+    return false;
+  }
+}
+
+/** Expose `store` as `window.__playerStore` for dumping live Studio state
+ *  during bug-bash reproduction. No-op outside a dev build or a browser. */
+export function attachPlayerStoreDevHandle(store: unknown): void {
+  if (!isDevBuild() || typeof window === "undefined") return;
+  (window as unknown as { __playerStore?: unknown }).__playerStore = store;
+}

--- a/packages/studio/src/player/store/playerStoreSelection.ts
+++ b/packages/studio/src/player/store/playerStoreSelection.ts
@@ -1,0 +1,41 @@
+/**
+ * Selection-set arithmetic for the player store, and the reveal request's
+ * cross-id-space match.
+ *
+ * Its own module so `playerStore.ts` stays under the studio's 600-line cap.
+ */
+
+import { splitTimelineElementKey } from "../lib/timelineElementHelpers";
+
+/**
+ * The id set a selection change leaves behind.
+ *
+ * `preserveSet` means "keep the multi-selection if this id is already in it" —
+ * a DOM→store echo re-announcing a member must not collapse the set — and
+ * anything else is a genuine single selection.
+ */
+export function nextSelectionSet(
+  current: ReadonlySet<string>,
+  id: string | null,
+  preserveSet: boolean | undefined,
+): Set<string> {
+  if (preserveSet) return id && current.has(id) ? new Set(current) : new Set<string>();
+  return id ? new Set([id]) : new Set<string>();
+}
+
+/**
+ * Is a pending reveal request aimed at the element being selected?
+ *
+ * Compared across the ID-SPACE BOUNDARY, which is why it is a named function:
+ * a request carries the BARE dom id (`runtimeAudioId` — the panel and the
+ * runtime speak that), while the store's ids are `sourceFile#domId`. A direct
+ * `===` between the two is silently never true, which is the exact shape of
+ * failure the split produces and how the reveal came to be dead.
+ */
+export function revealTargetsSelection(
+  request: { elementKey: string } | null,
+  id: string | null,
+): boolean {
+  if (!request || id === null) return false;
+  return request.elementKey === splitTimelineElementKey(id).domId;
+}

--- a/packages/studio/src/player/store/timelineElement.ts
+++ b/packages/studio/src/player/store/timelineElement.ts
@@ -77,6 +77,7 @@ export interface TimelineElement {
   audioGroupHidden?: boolean;
   /** The owning group's serialized `data-fx-chain`, when set — resolved once per parse. */
   audioGroupFxChain?: string;
+  audioGroupAutomation?: string;
   /**
    * Set by useExpandedTimelineElements on an inline-expanded sub-composition
    * child: the absolute master-timeline start of the sub-comp host the child
@@ -86,3 +87,34 @@ export interface TimelineElement {
   expandedParentStart?: number;
   expandedHostKey?: string;
 }
+
+/**
+ * The fields `updateElement` may write.
+ *
+ * Deliberately a narrow allow-list rather than `Partial<TimelineElement>`: most
+ * of an element is derived from the document at parse time, and letting a
+ * caller poke those would put the store out of step with the file it mirrors.
+ *
+ * The `audioGroup*` entries are the GROUP's state, mirrored onto every member —
+ * a group row derives its label, fader, mute and chain from these, so a group
+ * write has to be able to land here or the header goes on rendering whatever it
+ * parsed at load.
+ */
+export type TimelineElementPatch = Partial<
+  Pick<
+    TimelineElement,
+    | "start"
+    | "duration"
+    | "track"
+    | "zIndex"
+    | "hasExplicitZIndex"
+    | "playbackStart"
+    | "hidden"
+    | "audioGroup"
+    | "audioGroupLabel"
+    | "audioGroupVolume"
+    | "audioGroupHidden"
+    | "audioGroupFxChain"
+    | "audioGroupAutomation"
+  >
+>;

--- a/packages/studio/src/utils/timelineInspector.test.ts
+++ b/packages/studio/src/utils/timelineInspector.test.ts
@@ -1,5 +1,12 @@
+// @vitest-environment happy-dom
 import { describe, expect, it } from "vitest";
-import { isAudioTimelineElement, isMusicTrack, resolveBeatSourceTrack } from "./timelineInspector";
+import {
+  canHideSelections,
+  isAudioDomElement,
+  isAudioTimelineElement,
+  isMusicTrack,
+  resolveBeatSourceTrack,
+} from "./timelineInspector";
 import type { TimelineElement } from "../player";
 
 // Minimal element factory for tests
@@ -117,5 +124,32 @@ describe("resolveBeatSourceTrack", () => {
     const clip = el({ id: "my_audio_file", domId: "my_audio_file", timelineRole: undefined });
     const result = resolveBeatSourceTrack([clip]);
     expect(result!.isFallback).toBe(true);
+  });
+});
+
+describe("isAudioDomElement / canHideSelections", () => {
+  const el = (tag: string, src?: string): Element => {
+    const node = document.createElement(tag);
+    if (src) node.setAttribute("src", src);
+    return node;
+  };
+
+  it("agrees with isAudioTimelineElement about tags and source extensions", () => {
+    expect(isAudioDomElement(el("audio"))).toBe(true);
+    expect(isAudioDomElement(el("div", "narration.mp3"))).toBe(true);
+    expect(isAudioDomElement(el("div"))).toBe(false);
+    expect(isAudioDomElement(null)).toBe(false);
+  });
+
+  it("counts a group bus as audio, the way the single-selection panel does", () => {
+    expect(isAudioDomElement(el("hf-audio-group"))).toBe(true);
+  });
+
+  // `data-hidden` on audio is what mutes it — preview silences it and the render
+  // drops it from the mix. A control labelled "Hide all" must not reach that.
+  it("refuses to hide a selection holding any audio, and allows a layout one", () => {
+    expect(canHideSelections([{ element: el("div") }, { element: el("span") }])).toBe(true);
+    expect(canHideSelections([{ element: el("div") }, { element: el("audio") }])).toBe(false);
+    expect(canHideSelections([{ element: el("hf-audio-group") }])).toBe(false);
   });
 });

--- a/packages/studio/src/utils/timelineInspector.ts
+++ b/packages/studio/src/utils/timelineInspector.ts
@@ -1,8 +1,29 @@
+import { HF_AUDIO_GROUP_TAG } from "@hyperframes/core/audio-groups";
 import type { TimelineElement } from "../player";
 
 const AUDIO_TIMELINE_TAGS = new Set(["audio", "music", "sfx", "sound", "narration"]);
 const AUDIO_SOURCE_EXT_RE = /\.(aac|flac|m4a|mp3|ogg|opus|wav)(?:[?#].*)?$/i;
 const MUSIC_ID_RE = /\b(music|bgm|soundtrack|background[-_]?music)\b/i;
+
+/**
+ * Is this DOM node an audio clip, judged the way `isAudioTimelineElement`
+ * judges a timeline element?
+ *
+ * The selection layer holds real elements rather than timeline records, and
+ * layout grouping is decided there — so it needs the same question asked of a
+ * node. Same tag set and same source-extension fallback, so the two cannot
+ * drift into disagreeing about what counts as audio.
+ */
+export function isAudioDomElement(node: Element | null | undefined): boolean {
+  if (!node) return false;
+  // A group bus counts: it is audio-only, and the panel's single-select path
+  // already treats `<hf-audio-group>` as audio for exactly these decisions.
+  if (node.tagName.toLowerCase() === HF_AUDIO_GROUP_TAG) return true;
+  return isAudioTimelineElement({
+    tag: node.tagName,
+    src: node.getAttribute("src") ?? undefined,
+  });
+}
 
 export function isAudioTimelineElement(
   element: Pick<TimelineElement, "tag" | "src"> | null | undefined,
@@ -59,4 +80,21 @@ export function resolveBeatSourceTrack(
     if (!best || el.duration > best.duration) best = el;
   }
   return best ? { element: best, isFallback: true } : null;
+}
+
+/**
+ * May this multi-selection be hidden as one action?
+ *
+ * Audio has no visual to hide, and `data-hidden` on an audio element is what
+ * MUTES it — preview silences it and the render drops it from the mix. The
+ * timeline withholds the eye on an audio track for that reason
+ * (`visible={!isAudioTrack}`), and the single-selection panel gates the same
+ * write on `audioSelection`. The multi-selection "Hide all" was the one path
+ * left back to it, on a control whose label promises visibility.
+ *
+ * A shared predicate rather than a check in the handler so the panel's button
+ * and the handler's refusal cannot disagree — the button is not the only caller.
+ */
+export function canHideSelections(selections: readonly { element?: Element | null }[]): boolean {
+  return !selections.some((selection) => isAudioDomElement(selection.element));
 }


### PR DESCRIPTION
Part 6 of 12 replacing #3439. Base: `wa-26e-studio-audio-state`.

## Why

Creating a bus and editing its attributes is one transaction across the live DOM, source files, optimistic state, undo, and sub-composition ownership.

## What

- create groups in the owning composition and assign members in their own files
- resolve patch targets before optimistic writes
- mirror group volume, label, FX, automation, and hidden state after edits
- keep visibility edits, group deletion, and carve auto-grouping consistent
- prevent invalid or blocked timeline edits from partially applying

## Verification

- all relevant TypeScript projects pass cumulatively
- `fallow audit --base main --fail-on-issues`

The final stack tip preserves the verified #3439 replacement and includes the review fixes landed across the stack.

Stack: #3448 ← **#3449** → #3450
