### PR TITLE
chore: release v0.8.12

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,38 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.12"
+  description="Released - 2026-08-24"
+  tags={["Release", "Audio", "Studio", "Core", "Engine", "Lint"]}
+>
+Grouped audio now stays consistent from Studio preview through export, with safer edits, carve analysis, and validation. This release also removes the unfinished solo and group meter controls.
+
+## Breaking Changes
+
+- **Studio:** Remove the session-only “Hear only this” control and live group meter. Existing compositions need no migration because neither wrote project data ([05affaae2](https://github.com/heygen-com/hyperframes/commit/05affaae2175a6dde0e2eafa5e702b67863d721c), [#3454](https://github.com/heygen-com/hyperframes/pull/3454)).
+- **Core:** Remove `window.__hf.setAudioSolo`. Custom Studio integrations must stop calling this preview bridge ([05affaae2](https://github.com/heygen-com/hyperframes/commit/05affaae2175a6dde0e2eafa5e702b67863d721c), [#3454](https://github.com/heygen-com/hyperframes/pull/3454)).
+
+## Features
+
+- **Lint:** Report invalid group timing, misplaced carve settings, and membership problems without rejecting valid cross-file groups ([54091b501](https://github.com/heygen-com/hyperframes/commit/54091b5015aa0d45ca61275e75567701daf6e2b2), [#3447](https://github.com/heygen-com/hyperframes/pull/3447)).
+
+## Fixes
+
+- **Core, Engine:** Keep group identity, mute state, gain, automation, and FX routing consistent across inlined previews and FFmpeg exports ([#3444](https://github.com/heygen-com/hyperframes/pull/3444), [#3445](https://github.com/heygen-com/hyperframes/pull/3445), [#3446](https://github.com/heygen-com/hyperframes/pull/3446)).
+- **Engine:** Preserve bus headroom and clean temporary files when grouped mixes fail. Render errors now retain structured context ([1aec3b4a0](https://github.com/heygen-com/hyperframes/commit/1aec3b4a09ea99e35b8d082b329fd3152d088e78), [#3446](https://github.com/heygen-com/hyperframes/pull/3446)).
+- **Studio:** Apply group creation and edits as one transaction across source files, live DOM state, undo, and expanded sub-compositions ([#3448](https://github.com/heygen-com/hyperframes/pull/3448), [#3449](https://github.com/heygen-com/hyperframes/pull/3449)).
+- **Studio:** Keep preview hydration, selection, reveal requests, group state, and property-panel controls synchronized through HMR and remounts ([#3450](https://github.com/heygen-com/hyperframes/pull/3450), [#3453](https://github.com/heygen-com/hyperframes/pull/3453)).
+- **Studio:** Prevent self-carve, reciprocal carve, and duplicate analysis. Repeated FX reveal requests now reopen the intended control ([f575bdadc](https://github.com/heygen-com/hyperframes/commit/f575bdadcbc9461df038a9fa84092ba22da9b18a), [#3452](https://github.com/heygen-com/hyperframes/pull/3452)).
+- **Studio:** Align group rows, track headers, and automation lanes. Audition starts where selected audio is actually playing ([4ea018a4a](https://github.com/heygen-com/hyperframes/commit/4ea018a4a7ccdfee4e77538c336c37d366876779), [#3451](https://github.com/heygen-com/hyperframes/pull/3451)).
+
+## Docs & Examples
+
+- **Audio:** Document submix buses, group attributes, routing rules, and carve guardrails in the HyperFrames skills and contributor guidance ([2685c8f22](https://github.com/heygen-com/hyperframes/commit/2685c8f2231e39da31871f25b2e4609551a78c76), [#3455](https://github.com/heygen-com/hyperframes/pull/3455)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.11...v0.8.12).
+</Update>
+
+<Update
   label="HyperFrames v0.8.11"
   description="Released - 2026-08-23"
   tags={["Release", "Engine", "Studio", "Sdk"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.12.md
+++ b/releases/v0.8.12.md
@@ -1,0 +1,31 @@
+# HyperFrames v0.8.12
+
+Released on 2026-08-24.
+
+Grouped audio now stays consistent from Studio preview through export, with safer edits, carve analysis, and validation. This release also removes the unfinished solo and group meter controls.
+
+## Breaking Changes
+
+- **Studio:** Remove the session-only “Hear only this” control and live group meter. Existing compositions need no migration because neither wrote project data ([05affaae2](https://github.com/heygen-com/hyperframes/commit/05affaae2175a6dde0e2eafa5e702b67863d721c), [#3454](https://github.com/heygen-com/hyperframes/pull/3454)).
+- **Core:** Remove `window.__hf.setAudioSolo`. Custom Studio integrations must stop calling this preview bridge ([05affaae2](https://github.com/heygen-com/hyperframes/commit/05affaae2175a6dde0e2eafa5e702b67863d721c), [#3454](https://github.com/heygen-com/hyperframes/pull/3454)).
+
+## Features
+
+- **Lint:** Report invalid group timing, misplaced carve settings, and membership problems without rejecting valid cross-file groups ([54091b501](https://github.com/heygen-com/hyperframes/commit/54091b5015aa0d45ca61275e75567701daf6e2b2), [#3447](https://github.com/heygen-com/hyperframes/pull/3447)).
+
+## Fixes
+
+- **Core, Engine:** Keep group identity, mute state, gain, automation, and FX routing consistent across inlined previews and FFmpeg exports ([#3444](https://github.com/heygen-com/hyperframes/pull/3444), [#3445](https://github.com/heygen-com/hyperframes/pull/3445), [#3446](https://github.com/heygen-com/hyperframes/pull/3446)).
+- **Engine:** Preserve bus headroom and clean temporary files when grouped mixes fail. Render errors now retain structured context ([1aec3b4a0](https://github.com/heygen-com/hyperframes/commit/1aec3b4a09ea99e35b8d082b329fd3152d088e78), [#3446](https://github.com/heygen-com/hyperframes/pull/3446)).
+- **Studio:** Apply group creation and edits as one transaction across source files, live DOM state, undo, and expanded sub-compositions ([#3448](https://github.com/heygen-com/hyperframes/pull/3448), [#3449](https://github.com/heygen-com/hyperframes/pull/3449)).
+- **Studio:** Keep preview hydration, selection, reveal requests, group state, and property-panel controls synchronized through HMR and remounts ([#3450](https://github.com/heygen-com/hyperframes/pull/3450), [#3453](https://github.com/heygen-com/hyperframes/pull/3453)).
+- **Studio:** Prevent self-carve, reciprocal carve, and duplicate analysis. Repeated FX reveal requests now reopen the intended control ([f575bdadc](https://github.com/heygen-com/hyperframes/commit/f575bdadcbc9461df038a9fa84092ba22da9b18a), [#3452](https://github.com/heygen-com/hyperframes/pull/3452)).
+- **Studio:** Align group rows, track headers, and automation lanes. Audition starts where selected audio is actually playing ([4ea018a4a](https://github.com/heygen-com/hyperframes/commit/4ea018a4a7ccdfee4e77538c336c37d366876779), [#3451](https://github.com/heygen-com/hyperframes/pull/3451)).
+
+## Docs & Examples
+
+- **Audio:** Document submix buses, group attributes, routing rules, and carve guardrails in the HyperFrames skills and contributor guidance ([2685c8f22](https://github.com/heygen-com/hyperframes/commit/2685c8f2231e39da31871f25b2e4609551a78c76), [#3455](https://github.com/heygen-com/hyperframes/pull/3455)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.11...v0.8.12


### PR DESCRIPTION
## Summary

- release all publishable packages and plugin manifests as 0.8.12
- add reviewed GitHub and docs changelogs for the grouped-audio reliability work
- document the Studio solo, group meter, and runtime bridge removal

## Validation

- bun run build
- bun run lint
- bun run format:check
- bun run test:scripts (184 Node tests and 42 Vitest tests)
- bun run verify:packed-manifests
- stable release-channel validation

## Publish

Merge after approval and CI. The protected release workflow will tag the merge commit, publish npm packages, and create the GitHub release. The local stable tag was intentionally not pushed.