### PR TITLE
fix(skills): keep the seam gate's preview attached so --project works again

### DIFF
--- a/.agents/skills/motion-doctrine/scripts/seam-gate.mjs
+++ b/.agents/skills/motion-doctrine/scripts/seam-gate.mjs
@@ -71,7 +71,12 @@ async function ensureServer() {
     const port = 5380 + Math.floor(Math.random() * 20);
     const env = { ...process.env };
     delete env.HYPERFRAME_RUNTIME_URL; // wrong value fails silently as 200 HTML
-    const cmd = flag("server-cmd", `npx --yes hyperframes preview --no-open --port ${port}`);
+    // `preview` backgrounds itself when stdin/stdout aren't TTYs, which they never are here: the
+    // launcher would exit 0 before the server is up and detach it out of our process group.
+    const cmd = flag(
+      "server-cmd",
+      `npx --yes hyperframes preview --foreground --no-open --port ${port}`,
+    );
     const child = spawn("sh", ["-c", cmd.replace(/\{port\}/g, String(port))], {
       cwd: project,
       env,

--- a/.claude/skills/motion-doctrine/scripts/seam-gate.mjs
+++ b/.claude/skills/motion-doctrine/scripts/seam-gate.mjs
@@ -71,7 +71,12 @@ async function ensureServer() {
     const port = 5380 + Math.floor(Math.random() * 20);
     const env = { ...process.env };
     delete env.HYPERFRAME_RUNTIME_URL; // wrong value fails silently as 200 HTML
-    const cmd = flag("server-cmd", `npx --yes hyperframes preview --no-open --port ${port}`);
+    // `preview` backgrounds itself when stdin/stdout aren't TTYs, which they never are here: the
+    // launcher would exit 0 before the server is up and detach it out of our process group.
+    const cmd = flag(
+      "server-cmd",
+      `npx --yes hyperframes preview --foreground --no-open --port ${port}`,
+    );
     const child = spawn("sh", ["-c", cmd.replace(/\{port\}/g, String(port))], {
       cwd: project,
       env,


### PR DESCRIPTION
## What

Pass `--foreground` in the seam gate's default preview command, so `seam-gate.mjs verify --project` starts an attached preview again.

## Why

`seam-gate verify --project` has been failing with `preview server exited early` since #3310. The film is fine; the gate is misreading a healthy launch.

#3310 made `hyperframes preview` choose its launch mode from the TTY:

```js
// packages/cli/src/commands/preview.ts:613
if (!options.foreground && !options.interactive) return "background";
```

`seam-gate.mjs` spawns the launcher with `stdio: ["ignore", "pipe", "pipe"]`, so `interactive` is always `false` and it silently takes the background path. Two things then break:

1. The launcher exits `0` as soon as it has handed off to the managed background server, which is *before* the server is serving. The readiness loop's `child.exitCode !== null` check treats that as a dead server and throws.
2. `spawnDetachedPreview` uses `detached: true` + `unref()`, so the server is its own process-group leader. The gate's cleanup kills the *launcher's* group (`process.kill(-child.pid, ...)`), which no longer reaches it — every `--project` run leaks a preview server.

The misdirection is the expensive part: the message says the film's preview died when the launch actually succeeded.

## How

One flag on the default `--server-cmd`. `--foreground` is the CLI's own supported opt-out, added by #3310 for precisely this caller — its help string is *"Force an attached preview in a non-interactive shell."*

That restores both invariants the surrounding code already assumes: a non-null exit code means the server really died, and the server stays inside the process group cleanup kills. So it fixes the false failure and the leak with the same change.

Deliberately **not** doing what looked like the obvious alternative — making `preview` foreground-by-default again. Backgrounding in every launch mode is what #3310 set out to do, and the opt-out for non-interactive callers already exists. The gate was the thing that hadn't been updated.

Both mirrored copies (`.claude/skills/` and `.agents/skills/`) are updated; `scripts/check-skill-mirror.mjs` passes byte-for-byte.

## Test plan

The causal chain is pinned by evidence rather than inference:

- **The gate's spawn really is non-interactive.** Spawned a child with the gate's exact `stdio: ["ignore","pipe","pipe"]` shape: `stdin.isTTY=undefined stdout.isTTY=undefined => interactive=false`.
- **Non-interactive without `--foreground` resolves to background.** Already pinned by this repo's own committed table in `packages/cli/src/commands/preview.test.ts:146` — `{background:false, foreground:false, interactive:false, ...}` → `"background"`.
- **`--foreground` escapes it even when non-interactive.** Same table, `preview.test.ts:166` and `:176` — `{foreground:true, interactive:false, ...}` → `"dev"` / `"local"`, both attached modes.
- `node --check` on both copies, `oxfmt --check` clean, `check-skill-mirror.mjs` passes.

- [ ] Unit tests added/updated — no new test; the behaviour this depends on is already pinned by the existing `previewLaunchMode` table, and the changed line is a default command string with no test harness around it.
- [x] Manual testing performed
- [ ] Documentation updated (if applicable) — the `--project` contract is unchanged, so `references/seam-gate.md` still describes it correctly.

— Rames