### PR TITLE
chore: release v0.8.13

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,31 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.13"
+  description="Released - 2026-08-24"
+  tags={["Release", "Studio", "Changelog", "Skills"]}
+>
+Automation is easier to shape in Studio: drag a segment to move both endpoints, and click lanes to reveal their controls. Audio bus selection now reliably clears clip selection, while CLI and skill fixes keep validation scoped and project previews attached.
+
+## Features
+
+- **Studio:** Drag between automation points to move both endpoints together. Segments thicken on hover and preserve their shape within lane bounds ([7caf4b887](https://github.com/heygen-com/hyperframes/commit/7caf4b887192d90e53fe08460b1e79554b8fe37e), [#3465](https://github.com/heygen-com/hyperframes/pull/3465)).
+
+## Fixes
+
+- **Studio:** Keep audio bus selection authoritative, even when an earlier clip selection resolves late. Group automation labels now reveal the exact rack control ([7caf4b887](https://github.com/heygen-com/hyperframes/commit/7caf4b887192d90e53fe08460b1e79554b8fe37e), [#3465](https://github.com/heygen-com/hyperframes/pull/3465)).
+- **Skills:** Keep seam-gate project previews attached, preventing false early-exit failures and leaked preview servers ([ac00560d7](https://github.com/heygen-com/hyperframes/commit/ac00560d7d9778b7e7a1f29701b66a83e39248af), [#3463](https://github.com/heygen-com/hyperframes/pull/3463)).
+- **CLI:** Restrict overlap waivers to marked text so parent markers cannot hide descendant collisions or caption-zone intrusions ([e5a5e6b15](https://github.com/heygen-com/hyperframes/commit/e5a5e6b151aaf0dd489456c2681da6d664983de4), [#3464](https://github.com/heygen-com/hyperframes/pull/3464)).
+- **Skills:** Avoid duplicate Pi skill discovery by skipping per-agent mirrors when the agent already reads the universal skill store ([95e1ac9f0](https://github.com/heygen-com/hyperframes/commit/95e1ac9f041ded5cd5c2a034de1dbd16c499bd04), [#3325](https://github.com/heygen-com/hyperframes/pull/3325)).
+
+## Docs & Examples
+
+- **Changelog:** Weekly digest 2026-08-17–2026-08-24 ([21dc4aed0](https://github.com/heygen-com/hyperframes/commit/21dc4aed0cef3cdaf328cb3f84a8d8029bf6d6d6), [#3462](https://github.com/heygen-com/hyperframes/pull/3462)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.12...v0.8.13).
+</Update>
+
+<Update
   label="HyperFrames v0.8.12"
   description="Released - 2026-08-24"
   tags={["Release", "Audio", "Studio", "Core", "Engine", "Lint"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.13.md
+++ b/releases/v0.8.13.md
@@ -1,0 +1,24 @@
+# HyperFrames v0.8.13
+
+Released on 2026-08-24.
+
+Automation is easier to shape in Studio: drag a segment to move both endpoints, and click lanes to reveal their controls. Audio bus selection now reliably clears clip selection, while CLI and skill fixes keep validation scoped and project previews attached.
+
+## Features
+
+- **Studio:** Drag between automation points to move both endpoints together. Segments thicken on hover and preserve their shape within lane bounds ([7caf4b887](https://github.com/heygen-com/hyperframes/commit/7caf4b887192d90e53fe08460b1e79554b8fe37e), [#3465](https://github.com/heygen-com/hyperframes/pull/3465)).
+
+## Fixes
+
+- **Studio:** Keep audio bus selection authoritative, even when an earlier clip selection resolves late. Group automation labels now reveal the exact rack control ([7caf4b887](https://github.com/heygen-com/hyperframes/commit/7caf4b887192d90e53fe08460b1e79554b8fe37e), [#3465](https://github.com/heygen-com/hyperframes/pull/3465)).
+- **Skills:** Keep seam-gate project previews attached, preventing false early-exit failures and leaked preview servers ([ac00560d7](https://github.com/heygen-com/hyperframes/commit/ac00560d7d9778b7e7a1f29701b66a83e39248af), [#3463](https://github.com/heygen-com/hyperframes/pull/3463)).
+- **CLI:** Restrict overlap waivers to marked text so parent markers cannot hide descendant collisions or caption-zone intrusions ([e5a5e6b15](https://github.com/heygen-com/hyperframes/commit/e5a5e6b151aaf0dd489456c2681da6d664983de4), [#3464](https://github.com/heygen-com/hyperframes/pull/3464)).
+- **Skills:** Avoid duplicate Pi skill discovery by skipping per-agent mirrors when the agent already reads the universal skill store ([95e1ac9f0](https://github.com/heygen-com/hyperframes/commit/95e1ac9f041ded5cd5c2a034de1dbd16c499bd04), [#3325](https://github.com/heygen-com/hyperframes/pull/3325)).
+
+## Docs & Examples
+
+- **Changelog:** Weekly digest 2026-08-17–2026-08-24 ([21dc4aed0](https://github.com/heygen-com/hyperframes/commit/21dc4aed0cef3cdaf328cb3f84a8d8029bf6d6d6), [#3462](https://github.com/heygen-com/hyperframes/pull/3462)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.12...v0.8.13


### PR DESCRIPTION
## Summary

- bump all published packages and plugins to 0.8.13
- add reviewed release notes for automation segment dragging, authoritative audio bus selection, and CLI/skill fixes
- prepend the 0.8.13 documentation changelog entry

## Validation

- release preparation tests: 33 passed
- release pre-commit gates passed
- version manifests verified at 0.8.13

Merging this release PR triggers the stable npm publish workflow and creates the v0.8.13 GitHub release.