### PR TITLE
fix(cli): hide detached Windows spawns

### DIFF
--- a/packages/cli/src/commands/previewLifecycle.test.ts
+++ b/packages/cli/src/commands/previewLifecycle.test.ts
@@ -355,6 +355,11 @@ describe("background preview lifecycle", () => {
 
     expect(result).toMatchObject({ type: "started", port: 3210, pid: 4321 });
     expect(unref).toHaveBeenCalledOnce();
+    expect(spawn).toHaveBeenCalledWith(
+      "/usr/bin/node",
+      expect.any(Array),
+      expect.objectContaining({ detached: true, windowsHide: true }),
+    );
     expect(existsSync(previewSessionPath(projectDir, stateHome))).toBe(true);
   });
 

--- a/packages/cli/src/commands/previewLifecycle.ts
+++ b/packages/cli/src/commands/previewLifecycle.ts
@@ -33,6 +33,7 @@ type SpawnPreview = (
     detached: boolean;
     stdio: ["ignore", number, number];
     env: NodeJS.ProcessEnv;
+    windowsHide: boolean;
   },
 ) => SpawnResult;
 
@@ -219,6 +220,7 @@ function spawnDetachedPreview(
         detached: true,
         stdio: ["ignore", logFd, logFd],
         env: process.env,
+        windowsHide: true,
       },
     );
   } finally {

--- a/packages/cli/src/telemetry/client.test.ts
+++ b/packages/cli/src/telemetry/client.test.ts
@@ -140,13 +140,14 @@ describe("telemetry queue delivery", () => {
     const [execPath, args, opts] = spawnMock.mock.calls[0] as unknown as [
       string,
       string[],
-      { detached: boolean },
+      { detached: boolean; windowsHide?: boolean },
     ];
     expect(execPath).toBe(process.execPath);
     expect(args[0]).toBe("-e");
     expect(args[1]).toContain("render_complete");
     expect(args[1]).toMatch(/[0-9a-f-]{36}/); // event uuid rides along
     expect(opts.detached).toBe(true);
+    expect(opts.windowsHide).toBe(true);
 
     // Queue handed to the child — nothing left for a regular flush.
     const fetchMock = vi.fn(() => Promise.resolve(new Response("")));

--- a/packages/cli/src/telemetry/transport.ts
+++ b/packages/cli/src/telemetry/transport.ts
@@ -155,7 +155,7 @@ export function flushSync(): void {
         "-e",
         `fetch(${JSON.stringify(`${POSTHOG_HOST}/batch/`)},{method:"POST",headers:{"Content-Type":"application/json"},body:${JSON.stringify(payload)},signal:AbortSignal.timeout(${FLUSH_TIMEOUT_MS})}).catch(()=>{})`,
       ],
-      { detached: true, stdio: "ignore" },
+      { detached: true, stdio: "ignore", windowsHide: true },
     );
     // Let the parent exit without waiting for the child
     child.unref();

--- a/packages/cli/src/utils/openBrowser.test.ts
+++ b/packages/cli/src/utils/openBrowser.test.ts
@@ -1,9 +1,31 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    on: vi.fn(),
+    unref: vi.fn(),
+  })),
+);
+vi.mock("node:child_process", () => ({ spawn: spawnMock }));
+
 import {
   buildBrowserArgs,
+  openBrowser,
   parseRemoteDebuggingPort,
   validateRemoteDebuggingPortDeps,
 } from "./openBrowser.js";
+
+describe("openBrowser", () => {
+  it("hides the console window when spawning a detached browser", () => {
+    openBrowser("http://localhost:3002", { browserPath: "C:\\Browser\\browser.exe" });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "C:\\Browser\\browser.exe",
+      ["http://localhost:3002"],
+      expect.objectContaining({ detached: true, windowsHide: true }),
+    );
+  });
+});
 
 describe("buildBrowserArgs", () => {
   it("returns only the URL when no options are given", () => {

--- a/packages/cli/src/utils/openBrowser.ts
+++ b/packages/cli/src/utils/openBrowser.ts
@@ -81,6 +81,7 @@ export function openBrowser(url: string, options: OpenBrowserOptions = {}): void
     const child = spawn(options.browserPath, args, {
       detached: true,
       stdio: "ignore",
+      windowsHide: true,
     });
     child.on("error", () => {});
     child.unref();


### PR DESCRIPTION
## Summary

- pass `windowsHide: true` to telemetry exit flush, custom browser launch, and background preview detached spawns
- cover each real spawn path with a behavior regression test
- match the existing auto-update spawn behavior

Fixes #3476

## Verification

- `bun run --filter @hyperframes/cli test -- src/telemetry/client.test.ts src/utils/openBrowser.test.ts src/commands/previewLifecycle.test.ts` (61 passed)
- `bun run --filter @hyperframes/cli typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run build`
- `git diff --check`
- sabotage check: removing `windowsHide` from `openBrowser` made its new regression test fail

The full `bun run test` is not clean in this environment. Studio has 97 failures caused primarily by unavailable `localStorage`, and the full CLI run has 3 unrelated `skillsManifest.test.ts` lock-pruning failures. The focused tests for all changed paths pass.

Windows real-device validation has not been performed.

## Scope

This does not change ffmpeg handling from #3379 or chrome-headless-shell handling from #3430. It does not add a shared spawn helper or lint rule.

## AI assistance

Implemented and verified with Hermes Agent using Codex. I reviewed the resulting diff and test evidence.