### PR TITLE
chore: declare Apache-2.0 on every published package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,6 +175,9 @@ jobs:
               pkg.name = 'hyperframes';
               fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
             "
+            # pnpm copies the workspace-root LICENSE into each tarball; plain
+            # npm publish does not, so place it in the package first.
+            cp LICENSE packages/cli/LICENSE
             echo "📦 Publishing hyperframes@${VERSION}..."
             if (cd packages/cli && npm publish --access public --tag "$DIST_TAG"); then
               echo "✅ hyperframes@${VERSION} published"

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/aws-lambda",
   "version": "0.8.14",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/core",
   "version": "0.8.14",
   "description": "",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/engine",
   "version": "0.8.14",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/gcp-cloud-run",
   "version": "0.8.14",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hyperframes/lint",
   "version": "0.8.14",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hyperframes/parsers",
   "version": "0.8.14",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/player",
   "version": "0.8.14",
   "description": "Embeddable web component for HyperFrames compositions",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/producer",
   "version": "0.8.14",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/sdk",
   "version": "0.8.14",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/shader-transitions",
   "version": "0.8.14",
   "description": "WebGL shader transitions for HyperFrames compositions",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hyperframes/studio-server",
   "version": "0.8.14",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -2,6 +2,7 @@
   "name": "@hyperframes/studio",
   "version": "0.8.14",
   "description": "",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",


### PR DESCRIPTION
## What

Declare `"license": "Apache-2.0"` on the twelve published packages that omit it, and copy the root `LICENSE` into `packages/cli` before it is published.

## Why

The repo is Apache-2.0 and `LICENSE` at the root covers the whole monorepo, but the two publish paths in `publish.yml` lose that signal on npm in opposite ways:

| | `license` field | `LICENSE` in tarball |
| --- | --- | --- |
| `@hyperframes/core`, `engine`, `producer`, + 9 more | ❌ missing | ✅ present |
| `hyperframes` (CLI) | ✅ `Apache-2.0` | ❌ missing |

The split follows the publisher. The twelve scoped packages go out via `pnpm publish`, and [pnpm packs the workspace-root LICENSE when a package has none of its own](https://pnpm.io/cli/publish) — so the licence text lands in the tarball even though no package declares the field. The CLI is published with plain `npm publish` (the workflow explains why: `pnpm --filter` cannot match the rewritten unscoped name), and npm has no equivalent root-copy behaviour, so `hyperframes` ships with the field but without the text.

Neither gap changes what the licence *is* — the grant is unambiguous either way. They do cost downstream users:

- Registry metadata, `npm view <pkg> license`, `pnpm licenses list`, SBOM generators (SPDX/CycloneDX) and scanners like FOSSA/Snyk read the **field**, so the twelve scoped packages surface as `UNLICENSED`/`NOASSERTION` and trip license gates in CI and vendor review.
- Tools that build attribution bundles by collecting `LICENSE` files out of `node_modules` read the **file**, so they silently produce no attribution entry for the CLI — the package most likely to be redistributed inside an image.

Declaring both in both places removes the discrepancy without changing any licence terms.

## Notes

- `packages/sdk-playground` is `private: true` and never published, so it is left alone.
- No `files` change is needed for the CLI: npm always packs `LICENSE` regardless of the `files` allowlist. Verified locally with a scratch package (`files: ["bin"]` + a `LICENSE` → `npm pack --dry-run` lists `LICENSE`).
- The field is inserted after `description` (after `version` where there is none), matching `packages/cli/package.json`, the one package that already declares it.
- Happy to follow up with a guard in `scripts/verify-packed-manifests.mjs` asserting that every published package declares a licence and packs the text, so this cannot regress silently — left out here to keep the diff mechanical. Say the word and I will add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
