### PR TITLE
fix(engine): stop passing -avoid_negative_ts make_zero in muxVideoWithAudio

### DIFF
--- a/packages/engine/src/services/chunkEncoder.test.ts
+++ b/packages/engine/src/services/chunkEncoder.test.ts
@@ -402,8 +402,6 @@ describe("muxVideoWithAudio audio codec handling", () => {
       "copy",
       "-movflags",
       "+faststart",
-      "-avoid_negative_ts",
-      "make_zero",
       ...renderProvenanceArgs("/tmp/output.mp4"),
       "-r",
       "30",
@@ -424,7 +422,7 @@ describe("muxVideoWithAudio audio codec handling", () => {
     });
   });
 
-  it("keeps negative-timestamp repair for an M4A without a known priming edit list", async () => {
+  it("never repairs negative timestamps for an M4A sidecar (regression #3487)", async () => {
     const { spawn, calls } = createSpawnSpy();
     vi.resetModules();
     vi.doMock("child_process", () => ({ spawn }));
@@ -442,13 +440,15 @@ describe("muxVideoWithAudio audio codec handling", () => {
     await flushMuxCodecResolution();
     expect(calls).toHaveLength(1);
     expect(calls[0]!.args).toContain("copy");
-    expect(calls[0]!.args).toContain("-avoid_negative_ts");
+    // `make_zero` would discard the sidecar's AAC priming edit list, shift
+    // the copied video forward ~21ms and leave an empty video edit at t=0.
+    expect(calls[0]!.args).not.toContain("-avoid_negative_ts");
 
     emitClose(calls[0]!.proc, 0);
     await expect(muxPromise).resolves.toMatchObject({ success: true });
   });
 
-  it("preserves a known M4A priming edit list instead of shifting copied video", async () => {
+  it("ignores the deprecated preserveAudioPrimingEditList option", async () => {
     const { spawn, calls } = createSpawnSpy();
     vi.resetModules();
     vi.doMock("child_process", () => ({ spawn }));
@@ -459,7 +459,7 @@ describe("muxVideoWithAudio audio codec handling", () => {
       "/tmp/audio.duration-normalized.m4a",
       "/tmp/output.mp4",
       undefined,
-      { audioCodec: "aac", preserveAudioPrimingEditList: true },
+      { audioCodec: "aac", preserveAudioPrimingEditList: false },
       { num: 30, den: 1 },
     );
 
@@ -582,6 +582,7 @@ describe("muxVideoWithAudio audio codec handling", () => {
     expect(calls[0]!.args[calls[0]!.args.indexOf("-c:a") + 1]).toBe("aac");
     expect(calls[0]!.args).toContain("-b:a");
     expect(calls[0]!.args).toContain("+faststart");
+    expect(calls[0]!.args).not.toContain("-avoid_negative_ts");
 
     emitClose(calls[0]!.proc, 0);
     await expect(muxPromise).resolves.toMatchObject({ success: true });
@@ -629,6 +630,10 @@ describe("muxVideoWithAudio audio codec handling", () => {
       if (ext !== ".webm") await flushMuxCodecResolution();
       const call = calls[calls.length - 1]!;
       expect(call.args).not.toContain("-shortest");
+      // Same for every container we mux into: ffmpeg's `auto` default is
+      // already `disabled` for mp4/mov, and forcing `make_zero` breaks the
+      // AAC priming edit list (#3487).
+      expect(call.args).not.toContain("-avoid_negative_ts");
       emitClose(call.proc, 0);
       await muxPromise;
     }

--- a/packages/engine/src/services/chunkEncoder.ts
+++ b/packages/engine/src/services/chunkEncoder.ts
@@ -78,7 +78,13 @@ export interface MuxVideoWithAudioOptions extends Partial<
    * depend on the file extension alone.
    */
   audioCodec?: "aac";
-  /** Preserve a priming edit list known to have been created by AAC re-encoding. */
+  /**
+   * @deprecated No longer used. `-avoid_negative_ts` is never passed for
+   * mp4/mov muxing (ffmpeg's `auto` default already resolves to `disabled`
+   * for those containers), so the AAC priming edit list is preserved
+   * unconditionally and this flag has no effect. See issue #3487. Kept for
+   * source compatibility; it will be removed in a future major.
+   */
   preserveAudioPrimingEditList?: boolean;
   /** Hard cap copied audio to the already-encoded video's exact duration. */
 }
@@ -693,14 +699,18 @@ export async function muxVideoWithAudio(
       args.push("-c:a", "aac", "-b:a", "192k", "-movflags", "+faststart");
     }
   }
-  const copiesContainerizedAac =
-    !isWebm && shouldCopyAudio && config?.preserveAudioPrimingEditList === true;
-  // PTS bases can diverge during mux and reintroduce negative DTS. See
-  // buildEncoderArgs for the full reasoning on why that breaks playback.
-  // A freshly encoded M4A is the exception: its edit list already hides the
-  // AAC priming packet. `make_zero` discards that edit and shifts copied video
-  // forward by one AAC frame (~21ms), creating a visible first-frame offset.
-  if (!copiesContainerizedAac) args.push("-avoid_negative_ts", "make_zero");
+  // No `-avoid_negative_ts` here, in any mode. ffmpeg's default is `auto`,
+  // which the mp4/mov muxers (AVFMT_TS_NEGATIVE) already resolve to
+  // `disabled` — the correct behavior for the containers this function
+  // writes. Passing `make_zero` explicitly overrides that default and, on the
+  // dominant audio-copy path, discards the AAC priming edit list the sidecar
+  // encode created: the video start_time shifts forward one AAC frame
+  // (~21ms) and the muxer writes an empty video edit at t=0, which
+  // edit-list-honoring players (QuickTime/Safari) show as a black first
+  // frame. See issue #3487. The video-only encoder args (buildEncoderArgs)
+  // still pass the flag deliberately — those chunks are consumed as raw
+  // elementary output, not as a delivered mp4/mov.
+  //
   // Re-assert provenance here: this stage re-muxes into the delivered
   // container, and the mp4 muxer drops the encode stage's tags without the
   // use_metadata_tags flag that appendRenderProvenanceArgs adds.

--- a/packages/producer/src/services/distributed/assemble.ts
+++ b/packages/producer/src/services/distributed/assemble.ts
@@ -302,10 +302,7 @@ export async function assemble(
     }
 
     // ── 3. Audio: pad-or-trim then mux ────────────────────────────────────
-    let normalizedAudio: {
-      path: string;
-      preserveAudioPrimingEditList: boolean;
-    } | null = null;
+    let normalizedAudioPath: string | null = null;
     if (audioPath !== null && existsSync(audioPath)) {
       const paddedAudioPath = join(workDir, "audio-padded.m4a");
       const padTrimResult = await padOrTrimAudioToVideoFrameCount({
@@ -317,10 +314,7 @@ export async function assemble(
       if (!padTrimResult.success) {
         throw new Error(`[assemble] audio pad/trim failed: ${padTrimResult.error}`);
       }
-      normalizedAudio = {
-        path: paddedAudioPath,
-        preserveAudioPrimingEditList: padTrimResult.operation !== "copy",
-      };
+      normalizedAudioPath = paddedAudioPath;
       log.info("[assemble] audio normalized for mux", {
         operation: padTrimResult.operation,
         targetDurationSeconds: padTrimResult.targetDurationSeconds,
@@ -333,16 +327,17 @@ export async function assemble(
     // because it operates on a `RenderJob` and emits `updateJobStatus`
     // payloads — the distributed activity has no job to thread through.
     const muxOutputPath =
-      normalizedAudio !== null ? join(workDir, `mux.${plan.dimensions.format}`) : postConcatPath;
-    if (normalizedAudio !== null) {
+      normalizedAudioPath !== null
+        ? join(workDir, `mux.${plan.dimensions.format}`)
+        : postConcatPath;
+    if (normalizedAudioPath !== null) {
       const muxResult = await muxVideoWithAudio(
         postConcatPath,
-        normalizedAudio.path,
+        normalizedAudioPath,
         muxOutputPath,
         abortSignal,
         {
           audioCodec: "aac",
-          preserveAudioPrimingEditList: normalizedAudio.preserveAudioPrimingEditList,
         },
         { num: plan.dimensions.fpsNum, den: plan.dimensions.fpsDen },
       );

--- a/packages/producer/src/services/render/stages/assembleStage.test.ts
+++ b/packages/producer/src/services/render/stages/assembleStage.test.ts
@@ -69,7 +69,7 @@ describe("runAssembleStage audio duration parity", () => {
       "/tmp/audio.duration-normalized.m4a",
       "/tmp/output.mp4",
       undefined,
-      { audioCodec: "aac", preserveAudioPrimingEditList: true },
+      { audioCodec: "aac" },
       { num: 30, den: 1 },
     );
   });

--- a/packages/producer/src/services/render/stages/assembleStage.ts
+++ b/packages/producer/src/services/render/stages/assembleStage.ts
@@ -78,7 +78,6 @@ export async function runAssembleStage(input: AssembleStageInput): Promise<Assem
       abortSignal,
       {
         audioCodec: "aac",
-        preserveAudioPrimingEditList: normalizeResult.operation !== "copy",
       },
       job.config.fps,
     );


### PR DESCRIPTION
Fixes #3487

## What

`muxVideoWithAudio` no longer passes `-avoid_negative_ts make_zero` — in any mode, for any container. One flag removed from the mux path; the `preserveAudioPrimingEditList` option that used to gate it is deprecated and ignored rather than deleted.

## Why

The flag is actively harmful on the dominant mux path (an AAC sidecar copied into mp4), and it is not needed on any of the others.

**The defect.** ffmpeg's default is `-avoid_negative_ts auto`, i.e. *"enabled when required by the target format"*. The mp4/mov muxers set `AVFMT_TS_NEGATIVE` (`libavformat/movenc.c`), so `auto` already resolves to **disabled** for the containers this function writes — mp4 expresses an offset start natively through an edit list. Passing `make_zero` explicitly overrides that deliberate per-format opt-out. On the copy path it discards the AAC priming edit list the sidecar encode created, shifts the copied video forward by one AAC frame (~21 ms), and makes the muxer write an **empty video edit at t=0** (`media time: -1`). Players and thumbnailers that honor edit lists — QuickTime, Safari, WhatsApp previews, `requestVideoFrameCallback` — find no video sample at t=0 and render a **black first frame**.

**The regression chain.** The flag was added in v0.4.45 as belt-and-suspenders against negative DTS, a problem the same commit had already fixed at the source with `-bf 0` on the encoder. #1615 (v0.6.116) diagnosed the black-first-frame symptom and fixed it by dropping a second AAC encode. Then:

1. **v0.7.72** narrowed the skip to `config?.preserveAudioPrimingEditList === true`, so the **copy** path — dominant, because the mixer already pads every input to the exact composition duration — ran `make_zero` again. Harmless at the time: the mixer wrote raw ADTS `audio.aac`, which has no edit list to destroy.
2. **v0.7.107** (#3200) changed the mixer artifact from `audio.aac` to `audio.m4a`, precisely so the container would carry the priming edit list — but the v0.7.72 gate was not revisited. The callers still passed `preserveAudioPrimingEditList: operation !== "copy"`, so `make_zero` ran on virtually every render and destroyed the very edit list #3200 had introduced.

**Why omitting the flag is correct rather than merely convenient.** For mp4/mov, omitting it *is* the flag's own documented behavior — `auto` → disabled — so this restores ffmpeg's per-format default instead of imposing a new policy. Genuine leading negative DTS is still handled: the priming interval is carried by the audio track's edit list, and the encoder keeps `-bf 0`, which removes negative DTS at the source. `make_zero` also isn't idempotent — every re-encode pass through it stacks another priming interval (our delivery upscale turned 21 ms into 42 ms, a full frame at 24 fps). And the scenario it was guarding against does not materialize: muxing B-frame video with real leading negative DTS into mp4 comes out correct with the default and broken with `make_zero`.

## How

- `packages/engine/src/services/chunkEncoder.ts` — drop the `copiesContainerizedAac` condition and the `args.push("-avoid_negative_ts", "make_zero")` it guarded. Replaced by a comment recording *why* the flag must not be reintroduced here, so the next person reading the file doesn't re-derive it as a missing safety net.
- `MuxVideoWithAudioOptions.preserveAudioPrimingEditList` is part of the exported engine API, so it stays, marked `@deprecated` and documented as a no-op, rather than being removed. **No breaking change** for external callers; removal can happen in a future major.
- `packages/producer/.../render/stages/assembleStage.ts` and `packages/producer/.../distributed/assemble.ts` — the two internal callers stop passing the option. In `distributed/assemble.ts` the `normalizedAudio` object existed only to carry that boolean alongside the path, so it collapses back to a plain `normalizedAudioPath: string | null`.
- Tests: the case that pinned the buggy behavior (`"keeps negative-timestamp repair for an M4A without a known priming edit list"`, asserting the flag **is** passed) is inverted into `"never repairs negative timestamps for an M4A sidecar (regression #3487)"`. A `not.toContain("-avoid_negative_ts")` assertion is added to the re-encode case and to the per-container loop, so the flag can't come back for any container without a test failing.

**Deliberately left alone:** `buildEncoderArgs` and `streamingEncoder` still pass `-avoid_negative_ts make_zero` for **video-only** output. Those chunks are intermediates consumed by the concat/mux stages, not delivered mp4/mov, they carry no audio priming edit list to destroy, and the flag's original negative-DTS rationale still applies there. Changing them is out of scope for this fix and would need its own evidence.

## Test plan

**1. Caller-shaped ffmpeg repro** — a 30 fps h264 mp4 plus a 48 kHz AAC `.m4a` sidecar, muxed with exactly the argv `muxVideoWithAudio` builds, with and without the flag. `ffprobe`:

| | with `make_zero` (before) | without (this PR) |
| --- | --- | --- |
| video `start_time` | `0.021029` | `0.000000` |
| video `elst` | `media time: -1, dur 323` **+** `media time: 0, dur 30720` | `media time: 0, dur 30720` |
| audio `elst` | `media time: 0` (priming trim destroyed) | `media time: 1024` (priming preserved) |
| audio `duration` | `2.021333` | `2.000000` |

The empty leading video edit and the offset both disappear, and the audio keeps its 1024-sample priming edit.

**2. Minimal repro from the issue** (24 fps, both 44.1 kHz and 48 kHz) — `start_time` `0.023031` / `0.020996` with the flag, `0.000000` without; the `media time: -1` empty edit is present in each broken case and absent in each fixed one.

**3. Full render through the fixed pipeline** — a real 24 fps mp4 with audio out of the producer: video `start_time=0.000000`, audio `start_time=0.000000`, one edit per track (`media time: 0`), no empty edit.

**4. Unit + static checks** (ffmpeg 8.1.2, bun 1.3.14, macOS):

```
bun run --filter @hyperframes/engine test          68 files passed, 1 skipped — 1638 passed, 3 skipped
  └ src/services/chunkEncoder.test.ts              85 passed
bun run --filter @hyperframes/producer test:unit   40 files — 598 passed, 0 failed
bun run --filter @hyperframes/engine typecheck     exit 0
bun run --filter @hyperframes/producer typecheck   exit 0
bun run lint                                       0 warnings, 0 errors (2930 files)
bun run format:check                               all matched files correctly formatted
```

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable) — no docs page covers this flag; the deprecation note lives in the JSDoc on `MuxVideoWithAudioOptions`.

---

*Investigated, written, and tested with Claude Code (Claude Fable 5).*
