### PR TITLE
fix(fonts): unify preview and render font resolution

### DIFF
--- a/packages/cli/bin/hyperframes-localize-fonts.mjs
+++ b/packages/cli/bin/hyperframes-localize-fonts.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+import { runtimeVersionError } from "../dist/runtimeVersion.js";
+
+const error = runtimeVersionError(process.versions.node);
+if (error) {
+  console.error(error);
+  process.exitCode = 1;
+} else {
+  await import("../dist/fontLocalizeCli.js");
+}

--- a/packages/cli/bin/hyperframes-localize-fonts.mjs
+++ b/packages/cli/bin/hyperframes-localize-fonts.mjs
@@ -7,5 +7,6 @@ if (error) {
   console.error(error);
   process.exitCode = 1;
 } else {
-  await import("../dist/fontLocalizeCli.js");
+  const { main } = await import("../dist/fontLocalizeCli.js");
+  process.exitCode = await main();
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,8 @@
     "directory": "packages/cli"
   },
   "bin": {
-    "hyperframes": "./bin/hyperframes.mjs"
+    "hyperframes": "./bin/hyperframes.mjs",
+    "hyperframes-localize-fonts": "./bin/hyperframes-localize-fonts.mjs"
   },
   "files": [
     "bin",

--- a/packages/cli/src/fontLocalize.test.ts
+++ b/packages/cli/src/fontLocalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { runFontLocalize, type FontLocalizeIo } from "./fontLocalize.js";
+import { runFontLocalize, stampFontCompilerVersion, type FontLocalizeIo } from "./fontLocalize.js";
 
 function makeIo(input: string): {
   io: FontLocalizeIo;
@@ -68,5 +68,19 @@ describe("runFontLocalize", () => {
     expect(exitCode).toBe(1);
     expect(harness.output).toEqual([]);
     expect(harness.errors.join(" ")).toContain("empty output");
+  });
+});
+
+describe("stampFontCompilerVersion", () => {
+  it("records the compiler version inside the document head", () => {
+    const stamped = stampFontCompilerVersion(
+      "<!doctype html><html><head><title>x</title></head><body></body></html>",
+      "0.8.15",
+    );
+
+    expect(stamped).toContain('<meta name="hyperframes-font-compiler-version" content="0.8.15">');
+    expect(stamped.indexOf("hyperframes-font-compiler-version")).toBeLessThan(
+      stamped.indexOf("</head>"),
+    );
   });
 });

--- a/packages/cli/src/fontLocalize.test.ts
+++ b/packages/cli/src/fontLocalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { runFontLocalize, stampFontCompilerVersion, type FontLocalizeIo } from "./fontLocalize.js";
+import { runFontLocalize, stampFontVersions, type FontLocalizeIo } from "./fontLocalize.js";
 
 function makeIo(input: string): {
   io: FontLocalizeIo;
@@ -71,16 +71,39 @@ describe("runFontLocalize", () => {
   });
 });
 
-describe("stampFontCompilerVersion", () => {
-  it("records the compiler version inside the document head", () => {
-    const stamped = stampFontCompilerVersion(
+describe("stampFontVersions", () => {
+  it("records producer and localizer versions inside the document head", () => {
+    const stamped = stampFontVersions(
       "<!doctype html><html><head><title>x</title></head><body></body></html>",
-      "0.8.15",
+      { producer: "0.8.15", localizer: "0.8.16" },
     );
 
     expect(stamped).toContain('<meta name="hyperframes-font-compiler-version" content="0.8.15">');
+    expect(stamped).toContain('<meta name="hyperframes-font-localizer-version" content="0.8.16">');
     expect(stamped.indexOf("hyperframes-font-compiler-version")).toBeLessThan(
       stamped.indexOf("</head>"),
+    );
+  });
+
+  it("inserts both diagnostic stamps after a doctype when no head close exists", () => {
+    const stamped = stampFontVersions("<!doctype html><main>x</main>", {
+      producer: "0.8.15",
+      localizer: "0.8.16",
+    });
+
+    expect(stamped).toMatch(
+      /^<!doctype html><meta name="hyperframes-font-compiler-version" content="0\.8\.15"><meta name="hyperframes-font-localizer-version" content="0\.8\.16">/,
+    );
+  });
+
+  it("inserts both diagnostic stamps at the start when no head or doctype exists", () => {
+    const stamped = stampFontVersions("<main>x</main>", {
+      producer: "0.8.15<script>",
+      localizer: "0.8.16<script>",
+    });
+
+    expect(stamped).toBe(
+      '<meta name="hyperframes-font-compiler-version" content="0.8.15script"><meta name="hyperframes-font-localizer-version" content="0.8.16script"><main>x</main>',
     );
   });
 });

--- a/packages/cli/src/fontLocalize.test.ts
+++ b/packages/cli/src/fontLocalize.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { runFontLocalize, type FontLocalizeIo } from "./fontLocalize.js";
+
+function makeIo(input: string): {
+  io: FontLocalizeIo;
+  output: string[];
+  errors: string[];
+} {
+  const output: string[] = [];
+  const errors: string[] = [];
+  return {
+    io: {
+      readInput: async () => input,
+      writeOutput: (value) => output.push(value),
+      writeError: (value) => errors.push(value),
+    },
+    output,
+    errors,
+  };
+}
+
+describe("runFontLocalize", () => {
+  it("writes only the localized document to stdout", async () => {
+    const harness = makeIo("<html>source</html>");
+    const localize = vi.fn(async () => "<html>localized</html>");
+
+    const exitCode = await runFontLocalize(harness.io, localize);
+
+    expect(exitCode).toBe(0);
+    expect(localize).toHaveBeenCalledWith("<html>source</html>");
+    expect(harness.output).toEqual(["<html>localized</html>"]);
+    expect(harness.errors).toEqual([]);
+  });
+
+  it("rejects blank input without calling the resolver", async () => {
+    const harness = makeIo("  \n");
+    const localize = vi.fn(async (html: string) => html);
+
+    const exitCode = await runFontLocalize(harness.io, localize);
+
+    expect(exitCode).toBe(2);
+    expect(localize).not.toHaveBeenCalled();
+    expect(harness.output).toEqual([]);
+    expect(harness.errors.join(" ")).toContain("input is empty");
+  });
+
+  it("fails without echoing source HTML or resolver details", async () => {
+    const source = '<html><img src="https://signed.example/secret"></html>';
+    const harness = makeIo(source);
+    const localize = vi.fn(async () => {
+      throw new Error(`fetch failed for ${source}`);
+    });
+
+    const exitCode = await runFontLocalize(harness.io, localize);
+
+    expect(exitCode).toBe(1);
+    expect(harness.output).toEqual([]);
+    expect(harness.errors.join(" ")).toContain("font localization failed (Error)");
+    expect(harness.errors.join(" ")).not.toContain("signed.example");
+    expect(harness.errors.join(" ")).not.toContain("<html>");
+  });
+
+  it("fails closed when the resolver returns an empty document", async () => {
+    const harness = makeIo("<html>source</html>");
+
+    const exitCode = await runFontLocalize(harness.io, async () => "\n");
+
+    expect(exitCode).toBe(1);
+    expect(harness.output).toEqual([]);
+    expect(harness.errors.join(" ")).toContain("empty output");
+  });
+});

--- a/packages/cli/src/fontLocalize.ts
+++ b/packages/cli/src/fontLocalize.ts
@@ -1,0 +1,39 @@
+export interface FontLocalizeIo {
+  readInput(): Promise<string>;
+  writeOutput(value: string): void;
+  writeError(value: string): void;
+}
+
+function safeErrorName(error: unknown): string {
+  const name = error instanceof Error ? error.name : "UnknownError";
+  return /^[A-Za-z][A-Za-z0-9]*$/.test(name) ? name : "Error";
+}
+
+/**
+ * Machine-only stdin/stdout boundary for deterministic font localization.
+ * Source HTML and resolver messages can contain signed URLs, so failures emit
+ * only a fixed category plus a sanitized error class.
+ */
+export async function runFontLocalize(
+  io: FontLocalizeIo,
+  localize: (html: string) => Promise<string>,
+): Promise<number> {
+  const html = await io.readInput();
+  if (!html.trim()) {
+    io.writeError("font localization input is empty\n");
+    return 2;
+  }
+
+  try {
+    const localized = await localize(html);
+    if (!localized.trim()) {
+      io.writeError("font localization failed (Error): empty output\n");
+      return 1;
+    }
+    io.writeOutput(localized);
+    return 0;
+  } catch (error) {
+    io.writeError(`font localization failed (${safeErrorName(error)})\n`);
+    return 1;
+  }
+}

--- a/packages/cli/src/fontLocalize.ts
+++ b/packages/cli/src/fontLocalize.ts
@@ -4,15 +4,29 @@ export interface FontLocalizeIo {
   writeError(value: string): void;
 }
 
-export function stampFontCompilerVersion(html: string, version: string): string {
-  const safeVersion = version.replace(/[^A-Za-z0-9.+-]/g, "") || "unknown";
-  const tag = `<meta name="hyperframes-font-compiler-version" content="${safeVersion}">`;
+export interface FontVersions {
+  producer: string;
+  localizer: string;
+}
+
+function safeVersion(version: string): string {
+  return version.replace(/[^A-Za-z0-9.+-]/g, "") || "unknown";
+}
+
+/**
+ * Add post-hoc diagnostics for the producer resolver and the CLI wrapper that ran it.
+ * These stamps are traceability metadata, not an enforcement mechanism.
+ */
+export function stampFontVersions(html: string, versions: FontVersions): string {
+  const tags =
+    `<meta name="hyperframes-font-compiler-version" content="${safeVersion(versions.producer)}">` +
+    `<meta name="hyperframes-font-localizer-version" content="${safeVersion(versions.localizer)}">`;
   const headClose = html.search(/<\/head\s*>/i);
-  if (headClose >= 0) return `${html.slice(0, headClose)}${tag}${html.slice(headClose)}`;
+  if (headClose >= 0) return `${html.slice(0, headClose)}${tags}${html.slice(headClose)}`;
   const doctype = /^\s*<!doctype[^>]*>/i.exec(html);
-  if (!doctype) return `${tag}${html}`;
+  if (!doctype) return `${tags}${html}`;
   const insertAt = doctype.index + doctype[0].length;
-  return `${html.slice(0, insertAt)}${tag}${html.slice(insertAt)}`;
+  return `${html.slice(0, insertAt)}${tags}${html.slice(insertAt)}`;
 }
 
 function safeErrorName(error: unknown): string {

--- a/packages/cli/src/fontLocalize.ts
+++ b/packages/cli/src/fontLocalize.ts
@@ -4,6 +4,17 @@ export interface FontLocalizeIo {
   writeError(value: string): void;
 }
 
+export function stampFontCompilerVersion(html: string, version: string): string {
+  const safeVersion = version.replace(/[^A-Za-z0-9.+-]/g, "") || "unknown";
+  const tag = `<meta name="hyperframes-font-compiler-version" content="${safeVersion}">`;
+  const headClose = html.search(/<\/head\s*>/i);
+  if (headClose >= 0) return `${html.slice(0, headClose)}${tag}${html.slice(headClose)}`;
+  const doctype = /^\s*<!doctype[^>]*>/i.exec(html);
+  if (!doctype) return `${tag}${html}`;
+  const insertAt = doctype.index + doctype[0].length;
+  return `${html.slice(0, insertAt)}${tag}${html.slice(insertAt)}`;
+}
+
 function safeErrorName(error: unknown): string {
   const name = error instanceof Error ? error.name : "UnknownError";
   return /^[A-Za-z][A-Za-z0-9]*$/.test(name) ? name : "Error";

--- a/packages/cli/src/fontLocalizeCli.ts
+++ b/packages/cli/src/fontLocalizeCli.ts
@@ -1,6 +1,7 @@
 // fallow-ignore-file unused-file
 import { injectDeterministicFontFaces } from "@hyperframes/producer";
-import { runFontLocalize } from "./fontLocalize.js";
+import { runFontLocalize, stampFontCompilerVersion } from "./fontLocalize.js";
+import { VERSION } from "./version.js";
 
 async function readStdin(): Promise<string> {
   const chunks: Buffer[] = [];
@@ -18,10 +19,12 @@ export async function main(): Promise<number> {
       writeOutput: (value) => process.stdout.write(value),
       writeError: (value) => process.stderr.write(value),
     },
-    (html) =>
-      injectDeterministicFontFaces(html, {
+    async (html) => {
+      const localized = await injectDeterministicFontFaces(html, {
         failClosedFontFetch: true,
         allowSystemFontCapture: false,
-      }),
+      });
+      return stampFontCompilerVersion(localized, VERSION);
+    },
   );
 }

--- a/packages/cli/src/fontLocalizeCli.ts
+++ b/packages/cli/src/fontLocalizeCli.ts
@@ -1,0 +1,23 @@
+import { injectDeterministicFontFaces } from "@hyperframes/producer";
+import { runFontLocalize } from "./fontLocalize.js";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+process.exitCode = await runFontLocalize(
+  {
+    readInput: readStdin,
+    writeOutput: (value) => process.stdout.write(value),
+    writeError: (value) => process.stderr.write(value),
+  },
+  (html) =>
+    injectDeterministicFontFaces(html, {
+      failClosedFontFetch: true,
+      allowSystemFontCapture: false,
+    }),
+);

--- a/packages/cli/src/fontLocalizeCli.ts
+++ b/packages/cli/src/fontLocalizeCli.ts
@@ -1,7 +1,7 @@
 // fallow-ignore-file unused-file
 import { injectDeterministicFontFaces } from "@hyperframes/producer";
-import { runFontLocalize, stampFontCompilerVersion } from "./fontLocalize.js";
-import { VERSION } from "./version.js";
+import { runFontLocalize, stampFontVersions } from "./fontLocalize.js";
+import { PRODUCER_VERSION, VERSION } from "./version.js";
 
 async function readStdin(): Promise<string> {
   const chunks: Buffer[] = [];
@@ -24,7 +24,10 @@ export async function main(): Promise<number> {
         failClosedFontFetch: true,
         allowSystemFontCapture: false,
       });
-      return stampFontCompilerVersion(localized, VERSION);
+      return stampFontVersions(localized, {
+        producer: PRODUCER_VERSION,
+        localizer: VERSION,
+      });
     },
   );
 }

--- a/packages/cli/src/fontLocalizeCli.ts
+++ b/packages/cli/src/fontLocalizeCli.ts
@@ -1,3 +1,4 @@
+// fallow-ignore-file unused-file
 import { injectDeterministicFontFaces } from "@hyperframes/producer";
 import { runFontLocalize } from "./fontLocalize.js";
 
@@ -9,15 +10,18 @@ async function readStdin(): Promise<string> {
   return Buffer.concat(chunks).toString("utf8");
 }
 
-process.exitCode = await runFontLocalize(
-  {
-    readInput: readStdin,
-    writeOutput: (value) => process.stdout.write(value),
-    writeError: (value) => process.stderr.write(value),
-  },
-  (html) =>
-    injectDeterministicFontFaces(html, {
-      failClosedFontFetch: true,
-      allowSystemFontCapture: false,
-    }),
-);
+/** Standalone-entry main; the bin wrapper owns the actual process exit code. */
+export async function main(): Promise<number> {
+  return runFontLocalize(
+    {
+      readInput: readStdin,
+      writeOutput: (value) => process.stdout.write(value),
+      writeError: (value) => process.stderr.write(value),
+    },
+    (html) =>
+      injectDeterministicFontFaces(html, {
+        failClosedFontFetch: true,
+        allowSystemFontCapture: false,
+      }),
+  );
+}

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,2 +1,5 @@
 declare const __CLI_VERSION__: string | undefined;
+declare const __PRODUCER_VERSION__: string | undefined;
 export const VERSION = typeof __CLI_VERSION__ !== "undefined" ? __CLI_VERSION__ : "0.0.0-dev";
+export const PRODUCER_VERSION =
+  typeof __PRODUCER_VERSION__ !== "undefined" ? __PRODUCER_VERSION__ : "0.0.0-dev";

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -6,6 +6,9 @@ import { sourceAliases } from "../../scripts/package-subpaths.mjs";
 const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf-8")) as {
   version: string;
 };
+const producerPkg = JSON.parse(
+  readFileSync(new URL("../producer/package.json", import.meta.url), "utf-8"),
+) as { version: string };
 
 export default defineConfig({
   entry: {
@@ -80,6 +83,7 @@ var __dirname = __hf_dirname(__filename);`,
   ],
   define: {
     __CLI_VERSION__: JSON.stringify(pkg.version),
+    __PRODUCER_VERSION__: JSON.stringify(producerPkg.version),
   },
   esbuildOptions(options) {
     options.alias = {

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -10,6 +10,7 @@ const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), 
 export default defineConfig({
   entry: {
     cli: "src/cli.ts",
+    fontLocalizeCli: "src/fontLocalizeCli.ts",
     runtimeVersion: "src/runtimeVersion.ts",
     shaderTransitionWorker: "../producer/src/services/shaderTransitionWorker.ts",
   },

--- a/packages/producer/src/services/deterministicFonts-failClosed.test.ts
+++ b/packages/producer/src/services/deterministicFonts-failClosed.test.ts
@@ -198,6 +198,31 @@ describe("injectDeterministicFontFaces — failClosedFontFetch: true", () => {
     expect((caught as FontFetchError).code).toBe(FONT_FETCH_FAILED);
   });
 
+  it("fails closed when a secondary family in the authored cascade is unresolved", async () => {
+    const html = `<!doctype html><html><head><style>
+      body { font-family: "Inter", "Author Custom Fallback", sans-serif; }
+    </style></head><body><p>hello</p></body></html>`;
+    const fetchImpl = (async (input: string | URL | Request) => {
+      const family = new URL(input instanceof Request ? input.url : String(input)).searchParams.get(
+        "family",
+      );
+      return family?.startsWith("Inter:")
+        ? new Response("/* bundled Inter is sufficient */", { status: 200 })
+        : new Response("", { status: 400 });
+    }) as unknown as typeof fetch;
+
+    const caught = await rejectedError(
+      injectDeterministicFontFaces(html, {
+        failClosedFontFetch: true,
+        allowSystemFontCapture: false,
+        fetchImpl,
+      }),
+    );
+
+    expect(caught).toBeInstanceOf(FontFetchError);
+    expect((caught as FontFetchError).familyName).toContain("Author Custom Fallback");
+  });
+
   it("throws FontFetchUnavailableError on an exhausted 5xx response", async () => {
     const caught = await rejectedError(
       injectDeterministicFontFaces(HTML_REQUESTING_UNRESOLVED_FONT, {

--- a/packages/producer/src/services/deterministicFonts-textSubset.test.ts
+++ b/packages/producer/src/services/deterministicFonts-textSubset.test.ts
@@ -39,4 +39,47 @@ describe("Google Fonts text subsetting", () => {
 
     expect(new URL(requestedUrl).searchParams.get("text")).toContain("旅行");
   });
+
+  it("includes case variants for transformed supplemental alias weights", async () => {
+    let requestedUrl = "";
+    const fetchImpl = (async (input: unknown) => {
+      requestedUrl = String(input);
+      return new Response("", { status: 400 });
+    }) as unknown as typeof fetch;
+
+    await injectDeterministicFontFaces(
+      `<!doctype html><html><head><style>
+        h1 { font-family: "Inter", sans-serif; font-weight: 800; text-transform: uppercase; }
+      </style></head><body><h1>Your Kidney Transplant:<br/>What Happens Next</h1></body></html>`,
+      { fetchImpl, allowSystemFontCapture: false },
+    );
+
+    const text = new URL(requestedUrl).searchParams.get("text") ?? "";
+    for (const character of new Set("YOUR KIDNEY TRANSPLANT:WHAT HAPPENS NEXT")) {
+      expect(text).toContain(character);
+    }
+  });
+
+  it("falls back to the full font when case closure exceeds the text URL budget", async () => {
+    let requestedUrl = "";
+    const fetchImpl = (async (input: unknown) => {
+      requestedUrl = String(input);
+      return new Response("", { status: 400 });
+    }) as unknown as typeof fetch;
+    const caseChangingCharacters = Array.from({ length: 0x500 }, (_, index) =>
+      String.fromCodePoint(index),
+    )
+      .filter((character) => character.toUpperCase() !== character.toLowerCase())
+      .slice(0, 300)
+      .join("");
+
+    await injectDeterministicFontFaces(
+      `<!doctype html><html><head><style>
+        p { font-family: "Inter", sans-serif; font-weight: 800; text-transform: uppercase; }
+      </style></head><body><p>${caseChangingCharacters}</p></body></html>`,
+      { fetchImpl, allowSystemFontCapture: false },
+    );
+
+    expect(new URL(requestedUrl).searchParams.has("text")).toBe(false);
+  });
 });

--- a/packages/producer/src/services/deterministicFonts-textSubset.test.ts
+++ b/packages/producer/src/services/deterministicFonts-textSubset.test.ts
@@ -47,9 +47,22 @@ describe("Google Fonts text subsetting", () => {
     );
 
     const text = url.searchParams.get("text") ?? "";
+    expect(encodeURIComponent(text).length).toBeLessThan(700);
     for (const character of new Set("YOUR KIDNEY TRANSPLANT:WHAT HAPPENS NEXT")) {
       expect(text).toContain(character);
     }
+  });
+
+  it("covers capitalized words through the same case closure", async () => {
+    const url = await requestedGoogleFontUrl(
+      `<!doctype html><html><head><style>
+        h1 { font-family: "Inter", sans-serif; font-weight: 800; text-transform: capitalize; }
+      </style></head><body><h1>hello world</h1></body></html>`,
+    );
+
+    const text = url.searchParams.get("text") ?? "";
+    expect(text).toContain("H");
+    expect(text).toContain("W");
   });
 
   it("falls back to the full font when case closure exceeds the text URL budget", async () => {

--- a/packages/producer/src/services/deterministicFonts-textSubset.test.ts
+++ b/packages/producer/src/services/deterministicFonts-textSubset.test.ts
@@ -1,22 +1,28 @@
 import { describe, expect, it } from "bun:test";
 import { injectDeterministicFontFaces } from "./deterministicFonts.js";
 
+async function requestedGoogleFontUrl(html: string): Promise<URL> {
+  let requestedUrl = "";
+  const fetchImpl = (async (input: unknown) => {
+    requestedUrl = String(input);
+    return new Response("", { status: 400 });
+  }) as unknown as typeof fetch;
+
+  await injectDeterministicFontFaces(html, {
+    fetchImpl,
+    allowSystemFontCapture: false,
+  });
+  return new URL(requestedUrl);
+}
+
 describe("Google Fonts text subsetting", () => {
   it("sends the composition character set to the CSS API", async () => {
-    let requestedUrl = "";
-    const fetchImpl = (async (input: unknown) => {
-      requestedUrl = String(input);
-      return new Response("", { status: 400 });
-    }) as unknown as typeof fetch;
-
-    await injectDeterministicFontFaces(
+    const url = await requestedGoogleFontUrl(
       `<!doctype html><html><head><style>
         h1 { font-family: "Noto Performance Test", sans-serif; }
       </style></head><body><h1>旅行ランキング</h1></body></html>`,
-      { fetchImpl, allowSystemFontCapture: false },
     );
 
-    const url = new URL(requestedUrl);
     const text = url.searchParams.get("text") ?? "";
     for (const character of new Set("旅行ランキング")) {
       expect(text).toContain(character);
@@ -24,48 +30,29 @@ describe("Google Fonts text subsetting", () => {
   });
 
   it("includes decoded HTML entities from visible composition text", async () => {
-    let requestedUrl = "";
-    const fetchImpl = (async (input: unknown) => {
-      requestedUrl = String(input);
-      return new Response("", { status: 400 });
-    }) as unknown as typeof fetch;
-
-    await injectDeterministicFontFaces(
+    const url = await requestedGoogleFontUrl(
       `<!doctype html><html><head><style>
         h1 { font-family: "Noto Performance Test", sans-serif; }
       </style></head><body><h1>&#x65C5;&#34892;</h1></body></html>`,
-      { fetchImpl, allowSystemFontCapture: false },
     );
 
-    expect(new URL(requestedUrl).searchParams.get("text")).toContain("旅行");
+    expect(url.searchParams.get("text")).toContain("旅行");
   });
 
   it("includes case variants for transformed supplemental alias weights", async () => {
-    let requestedUrl = "";
-    const fetchImpl = (async (input: unknown) => {
-      requestedUrl = String(input);
-      return new Response("", { status: 400 });
-    }) as unknown as typeof fetch;
-
-    await injectDeterministicFontFaces(
+    const url = await requestedGoogleFontUrl(
       `<!doctype html><html><head><style>
         h1 { font-family: "Inter", sans-serif; font-weight: 800; text-transform: uppercase; }
       </style></head><body><h1>Your Kidney Transplant:<br/>What Happens Next</h1></body></html>`,
-      { fetchImpl, allowSystemFontCapture: false },
     );
 
-    const text = new URL(requestedUrl).searchParams.get("text") ?? "";
+    const text = url.searchParams.get("text") ?? "";
     for (const character of new Set("YOUR KIDNEY TRANSPLANT:WHAT HAPPENS NEXT")) {
       expect(text).toContain(character);
     }
   });
 
   it("falls back to the full font when case closure exceeds the text URL budget", async () => {
-    let requestedUrl = "";
-    const fetchImpl = (async (input: unknown) => {
-      requestedUrl = String(input);
-      return new Response("", { status: 400 });
-    }) as unknown as typeof fetch;
     const caseChangingCharacters = Array.from({ length: 0x500 }, (_, index) =>
       String.fromCodePoint(index),
     )
@@ -73,13 +60,12 @@ describe("Google Fonts text subsetting", () => {
       .slice(0, 300)
       .join("");
 
-    await injectDeterministicFontFaces(
+    const url = await requestedGoogleFontUrl(
       `<!doctype html><html><head><style>
         p { font-family: "Inter", sans-serif; font-weight: 800; text-transform: uppercase; }
       </style></head><body><p>${caseChangingCharacters}</p></body></html>`,
-      { fetchImpl, allowSystemFontCapture: false },
     );
 
-    expect(new URL(requestedUrl).searchParams.has("text")).toBe(false);
+    expect(url.searchParams.has("text")).toBe(false);
   });
 });

--- a/packages/producer/src/services/deterministicFonts.ts
+++ b/packages/producer/src/services/deterministicFonts.ts
@@ -1201,11 +1201,15 @@ const GOOGLE_FONTS_TEXT_MAX_ENCODED_LENGTH = 1_700;
 function extractGoogleFontsText(html: string): string | undefined {
   const { document } = parseHTML(html);
   const decodedBodyText = document.body?.textContent ?? "";
+  // Source + decoded text is an intentional over-approximation: base64, scripts, and class names
+  // collapse in the Set, while decoded entities contribute the glyphs the browser actually paints.
   const characters = [...Array.from(html), ...Array.from(decodedBodyText)];
   const uniqueCharacters = new Set<string>();
   for (const character of characters) {
     uniqueCharacters.add(character);
-    // CSS text-transform can render glyphs absent from the authored source.
+    // This closes locale-independent Unicode casing, including multi-code-point expansions such as
+    // ß -> SS. Locale/context transforms (for example Turkish İ) and CSS full-width/full-size-kana
+    // need a transform-aware follow-up rather than pretending this code-point closure is exhaustive.
     for (const variant of `${character.toUpperCase()}${character.toLowerCase()}`) {
       uniqueCharacters.add(variant);
     }

--- a/packages/producer/src/services/deterministicFonts.ts
+++ b/packages/producer/src/services/deterministicFonts.ts
@@ -1193,18 +1193,26 @@ export interface InjectDeterministicFontFacesOptions {
 }
 
 // Keep the complete CSS request under the broadly supported ~2 KB URL limit.
-// Using unique source characters covers static text plus strings authored in
-// scripts, while collapsing repeated prose and base64 assets to a tiny set.
+// Using unique source/decoded characters plus deterministic case variants covers
+// static text, strings authored in scripts, and CSS case transforms while
+// collapsing repeated prose and base64 assets to a tiny set.
 const GOOGLE_FONTS_TEXT_MAX_ENCODED_LENGTH = 1_700;
 
 function extractGoogleFontsText(html: string): string | undefined {
   const { document } = parseHTML(html);
   const decodedBodyText = document.body?.textContent ?? "";
-  const uniqueCharacters = [...new Set([...Array.from(html), ...Array.from(decodedBodyText)])].join(
-    "",
-  );
-  return encodeURIComponent(uniqueCharacters).length <= GOOGLE_FONTS_TEXT_MAX_ENCODED_LENGTH
-    ? uniqueCharacters
+  const characters = [...Array.from(html), ...Array.from(decodedBodyText)];
+  const uniqueCharacters = new Set<string>();
+  for (const character of characters) {
+    uniqueCharacters.add(character);
+    // CSS text-transform can render glyphs absent from the authored source.
+    for (const variant of `${character.toUpperCase()}${character.toLowerCase()}`) {
+      uniqueCharacters.add(variant);
+    }
+  }
+  const fontText = [...uniqueCharacters].join("");
+  return encodeURIComponent(fontText).length <= GOOGLE_FONTS_TEXT_MAX_ENCODED_LENGTH
+    ? fontText
     : undefined;
 }
 


### PR DESCRIPTION
## What

Studio previews can now be compiled with the same deterministic font resolver as final HyperFrames renders. Locale-independent CSS case variants are included in Google Fonts `text=` subsets, while broader locale/context and non-case transforms are explicitly tracked in #3496.

This PR adds a pipe-safe `hyperframes-localize-fonts` executable so downstream preview publishers can reuse the exact renderer font pipeline. The downstream integration will land after this version is released.

## Why

A production report exposed two connected failures. Authored HTML requested Inter 800 with `text-transform: uppercase` but carried no font resource, so a streamed preview used the browser's system sans. Final compilation resolved Inter 800, but its subset was derived from mixed-case source; some uppercase glyphs existed only after CSS transformed the text and fell back glyph-by-glyph in the rendered output.

| Reproduction evidence | Before | With the coordinated fix |
| --- | --- | --- |
| Streamed-preview font contract | Host-dependent fallback | Deterministic localized HTML |
| Inter 800 transformed glyphs | Missing from the subset | Present in decoded cmap |
| Preview/render font bytes | Different effective faces | Byte-identical resolved face |

Fixing only the subset would remove the mixed glyphs but leave preview/render parity broken. Fixing only this title, this weight, or these three letters would hide the architectural issue.

## How

- Keep `injectDeterministicFontFaces` as the single resolver. The new executable is only a stdin/stdout adapter and owns no alias, weight, fetch, or fallback policy.
- Close the subset character set over locale-independent Unicode upper- and lower-case variants before the existing URL-length gate. This covers the reported `uppercase` contract and the same code-point closure used by `lowercase` / `capitalize`; locale/context-sensitive casing and `full-width` / `full-size-kana` remain scoped in #3496 rather than being over-claimed here.
- Preserve the existing full-font request when case closure exceeds the URL budget.
- Bundle the producer into the published CLI package, so the executable requires no browser, project filesystem, or separately installed producer package.
- Fail closed on every unresolved non-generic family in an authored cascade, write only localized HTML to stdout, and keep compiler diagnostics on stderr. This intentionally prevents a secondary face from varying when the primary lacks a glyph.
- Stamp the exact producer/compiler version and the CLI localizer version separately into localized HTML. The stamps are traceability metadata; the downstream publisher owns pin enforcement.

Rollout order: land/release this PR, update the downstream package pin, then run this executable after streamed-preview bundling and immediately before upload. Until that integration lands, final-render subset correctness is fixed but external streamed previews remain host-font-dependent.

## Test plan

- [x] Unit tests added/updated
  - 51 focused producer tests across subset, alias-supplement, multi-subset, retry, and fail-closed behavior
  - 7 executable stdin/stdout, failure-contract, and dual-version-stamp tests
- [x] Manual testing performed
  - Full monorepo build passed in canonical dependency order
  - CLI and producer typechecks passed
  - Formatting and targeted Oxlint passed
  - A minimized CSS-uppercase fixture exits `0`, keeps stdout HTML-only, stamps the compiler version, embeds Inter 800, and includes every transformed glyph in its cmap
- [x] Documentation updated (if applicable)
  - Not applicable: this is an internal machine-only executable with no public usage surface

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6-000000)
