### PR TITLE
chore: release v0.8.15

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,32 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.15"
+  description="Released - 2026-08-26"
+  tags={["Release", "Fonts", "CLI", "Producer"]}
+>
+Preview publishers can now use the same deterministic font resolver as final renders, preventing CSS case transforms from changing typography between preview and export. Rendering now exits stalled parallel capture paths, while template editing and JSON attribute linting handle promoted media and encoded values more safely.
+
+## Features
+
+- **CLI:** Stamp font compiler version in localized HTML ([d6de08341](https://github.com/heygen-com/hyperframes/commit/d6de083411d76a0819768b21d30a305500a92048)).
+- **CLI:** Expose deterministic font localization ([38f8f9250](https://github.com/heygen-com/hyperframes/commit/38f8f9250a3f2a551a2e0a5f685ac4f64109e218)).
+
+## Fixes
+
+- **Fonts:** Harden localizer release diagnostics ([7c40efbc6](https://github.com/heygen-com/hyperframes/commit/7c40efbc62bd7bd70bcfdb80cd55aef4bafb39d6)).
+- **CLI:** Keep font localizer process ownership explicit ([ec68d40cc](https://github.com/heygen-com/hyperframes/commit/ec68d40cc617272943069123383e7a9f6e463e93)).
+- **Fonts:** Cover rendered case variants in subsets ([744146eb6](https://github.com/heygen-com/hyperframes/commit/744146eb6e71f3c108091fe981a7d63859a6287b)).
+- **Producer:** Trip DE parallel-router circuit breaker on stalls and hangs ([3202f3fb8](https://github.com/heygen-com/hyperframes/commit/3202f3fb87e0f7babfdfe0a9d62703b293abfd80), [#3479](https://github.com/heygen-com/hyperframes/pull/3479)).
+- **Lint:** Decode JSON attribute entities ([3cacac5bd](https://github.com/heygen-com/hyperframes/commit/3cacac5bdc405b808e74df3da14e6c1595357325)).
+- Document safe template default editing ([71e8e92ae](https://github.com/heygen-com/hyperframes/commit/71e8e92ae940584a2be5a82c5a3d102187043dea)).
+- Expose promoted template media slots ([1e11608d4](https://github.com/heygen-com/hyperframes/commit/1e11608d443d0cadeb64b5b005d72763f1a6dccd)).
+- **Scripts:** Stop the large-file guard firing on text ([a562946e1](https://github.com/heygen-com/hyperframes/commit/a562946e11538a87ac2a0766fdad7833b2798696), [#3475](https://github.com/heygen-com/hyperframes/pull/3475)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.14...v0.8.15).
+</Update>
+
+<Update
   label="HyperFrames v0.8.14"
   description="Released - 2026-08-24"
   tags={["Release", "CLI", "Skills,lint"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.15.md
+++ b/releases/v0.8.15.md
@@ -1,0 +1,25 @@
+# HyperFrames v0.8.15
+
+Released on 2026-08-26.
+
+Preview publishers can now use the same deterministic font resolver as final renders, preventing CSS case transforms from changing typography between preview and export. Rendering now exits stalled parallel capture paths, while template editing and JSON attribute linting handle promoted media and encoded values more safely.
+
+## Features
+
+- **CLI:** Stamp font compiler version in localized HTML ([d6de08341](https://github.com/heygen-com/hyperframes/commit/d6de083411d76a0819768b21d30a305500a92048)).
+- **CLI:** Expose deterministic font localization ([38f8f9250](https://github.com/heygen-com/hyperframes/commit/38f8f9250a3f2a551a2e0a5f685ac4f64109e218)).
+
+## Fixes
+
+- **Fonts:** Harden localizer release diagnostics ([7c40efbc6](https://github.com/heygen-com/hyperframes/commit/7c40efbc62bd7bd70bcfdb80cd55aef4bafb39d6)).
+- **CLI:** Keep font localizer process ownership explicit ([ec68d40cc](https://github.com/heygen-com/hyperframes/commit/ec68d40cc617272943069123383e7a9f6e463e93)).
+- **Fonts:** Cover rendered case variants in subsets ([744146eb6](https://github.com/heygen-com/hyperframes/commit/744146eb6e71f3c108091fe981a7d63859a6287b)).
+- **Producer:** Trip DE parallel-router circuit breaker on stalls and hangs ([3202f3fb8](https://github.com/heygen-com/hyperframes/commit/3202f3fb87e0f7babfdfe0a9d62703b293abfd80), [#3479](https://github.com/heygen-com/hyperframes/pull/3479)).
+- **Lint:** Decode JSON attribute entities ([3cacac5bd](https://github.com/heygen-com/hyperframes/commit/3cacac5bdc405b808e74df3da14e6c1595357325)).
+- Document safe template default editing ([71e8e92ae](https://github.com/heygen-com/hyperframes/commit/71e8e92ae940584a2be5a82c5a3d102187043dea)).
+- Expose promoted template media slots ([1e11608d4](https://github.com/heygen-com/hyperframes/commit/1e11608d443d0cadeb64b5b005d72763f1a6dccd)).
+- **Scripts:** Stop the large-file guard firing on text ([a562946e1](https://github.com/heygen-com/hyperframes/commit/a562946e11538a87ac2a0766fdad7833b2798696), [#3475](https://github.com/heygen-com/hyperframes/pull/3475)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.14...v0.8.15


### PR DESCRIPTION
## What

Stable HyperFrames v0.8.15. All package/plugin manifests are bumped together, with reviewed release notes in `releases/v0.8.15.md` and `docs/changelog.mdx`.

## Why

This release ships deterministic preview font localization and CSS case-variant subset coverage from #3492. It also includes the parallel-capture stall breaker, safer template editing, and JSON attribute lint fixes landed since v0.8.14.

## How

- Generated the full `v0.8.14...main` changelog and replaced the draft marker with reviewed copy.
- Bumped every fixed-version package and plugin manifest to `0.8.15`.
- Kept the release to the repository release-allowlist; no production source changed.

The stable publish workflow will create tag `v0.8.15` at this PR's immutable merge commit and publish npm `latest` after merge.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated (if applicable)

Verified release-script/channel tests (47/47), full formatting/lint, canonical monorepo build, packed-manifest consumer validation, and the built `hyperframes-localize-fonts` binary stamping producer/localizer `0.8.15`.
