### PR TITLE
chore: release v0.8.16

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,36 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.16"
+  description="Released - 2026-08-27"
+  tags={["Release", "Media Use", "Engine", "CLI"]}
+>
+Rendering is more reliable across audio, embedded sources, long sequences, and empty caches, while CJK and Thai captions keep phrase boundaries. Local video generation now avoids dead model tiers, and the player can retain runtime data channels for richer integrations.
+
+## Features
+
+- **Player:** Add retained runtime data channels ([4f00336c9](https://github.com/heygen-com/hyperframes/commit/4f00336c92f6418aab82c060853da604dd832197), [#3471](https://github.com/heygen-com/hyperframes/pull/3471)).
+
+## Fixes
+
+- **Media Use:** Repoint the dead videogen tier, demote past unusable local models ([8392e84a1](https://github.com/heygen-com/hyperframes/commit/8392e84a1839dbe083b74d093cb441f4610389c4), [#3509](https://github.com/heygen-com/hyperframes/pull/3509)).
+- **Engine:** Stop destroying the AAC priming edit list when muxing ([ee64c3b11](https://github.com/heygen-com/hyperframes/commit/ee64c3b1168a3466269344197ba6774f9eb15e14), [#3505](https://github.com/heygen-com/hyperframes/pull/3505)).
+- **CLI:** Keep phrase-level CJK and Thai transcripts as separate cues ([18409c9f2](https://github.com/heygen-com/hyperframes/commit/18409c9f2742e491ef7ff6a1454675a295e5d0a0), [#3436](https://github.com/heygen-com/hyperframes/pull/3436)).
+- **Engine,producer,lint:** Resolve \<source\> children for media extract and localize ([97991bbd3](https://github.com/heygen-com/hyperframes/commit/97991bbd3566a70f857412739dfa6ca9acfcaf27), [#3238](https://github.com/heygen-com/hyperframes/pull/3238)).
+- **Engine:** Preserve source frame identity above 99,999 ([c9f43ebcf](https://github.com/heygen-com/hyperframes/commit/c9f43ebcfbc05a83b18f46007f31a5cbd973ebb9), [#3503](https://github.com/heygen-com/hyperframes/pull/3503)).
+- **Studio:** Dedupe repeated selection telemetry ([9aaa7552f](https://github.com/heygen-com/hyperframes/commit/9aaa7552fc7a41d479e4b4638cd0c47472652ddc), [#3498](https://github.com/heygen-com/hyperframes/pull/3498)).
+- **Engine:** Treat a sentineled cache entry with no frames as a miss ([dae5b7b90](https://github.com/heygen-com/hyperframes/commit/dae5b7b90b7eefceffc9e64cc532b5cc74eeeedd), [#3434](https://github.com/heygen-com/hyperframes/pull/3434)).
+- **Producer,core:** Honor relative data-start id-refs in render media scheduling ([f52ec1c25](https://github.com/heygen-com/hyperframes/commit/f52ec1c25f3af20fcceefad24acb06f37feab24c), [#3252](https://github.com/heygen-com/hyperframes/pull/3252)).
+- **Producer:** Fall back to screenshot capture on drawElement canvas-not-initialized ([a7e867475](https://github.com/heygen-com/hyperframes/commit/a7e86747586b5aad0263b6b00bbd9d32c51ff7e6), [#3480](https://github.com/heygen-com/hyperframes/pull/3480)).
+- **Core:** Evict cached MediaElementSource on src mutation, soften enforcement-point claims ([f7fc0017a](https://github.com/heygen-com/hyperframes/commit/f7fc0017a6a6f31a4ae725f9f391d8dc63e3d9cc)).
+- **Core:** Correct web-audio-route subpath export resolution ([32ef37cfc](https://github.com/heygen-com/hyperframes/commit/32ef37cfc31975afbeae85a3f6805e575a43e87a)).
+- **Core:** Address review — gate early diagnostic, fix empty crossOrigin, document gaps ([acc689825](https://github.com/heygen-com/hyperframes/commit/acc689825543942939bbef14ccd2844b7f13298d)).
+- **Core:** Prevent cross-origin Web Audio capture from silencing audio ([cce17da5a](https://github.com/heygen-com/hyperframes/commit/cce17da5a9eb1c6efa21db084d786a1d34b5d8f9)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.15...v0.8.16).
+</Update>
+
+<Update
   label="HyperFrames v0.8.15"
   description="Released - 2026-08-26"
   tags={["Release", "Fonts", "CLI", "Producer"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.15",
+  "version": "0.8.16",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.16.md
+++ b/releases/v0.8.16.md
@@ -1,0 +1,29 @@
+# HyperFrames v0.8.16
+
+Released on 2026-08-27.
+
+Rendering is more reliable across audio, embedded sources, long sequences, and empty caches, while CJK and Thai captions keep phrase boundaries. Local video generation now avoids dead model tiers, and the player can retain runtime data channels for richer integrations.
+
+## Features
+
+- **Player:** Add retained runtime data channels ([4f00336c9](https://github.com/heygen-com/hyperframes/commit/4f00336c92f6418aab82c060853da604dd832197), [#3471](https://github.com/heygen-com/hyperframes/pull/3471)).
+
+## Fixes
+
+- **Media Use:** Repoint the dead videogen tier, demote past unusable local models ([8392e84a1](https://github.com/heygen-com/hyperframes/commit/8392e84a1839dbe083b74d093cb441f4610389c4), [#3509](https://github.com/heygen-com/hyperframes/pull/3509)).
+- **Engine:** Stop destroying the AAC priming edit list when muxing ([ee64c3b11](https://github.com/heygen-com/hyperframes/commit/ee64c3b1168a3466269344197ba6774f9eb15e14), [#3505](https://github.com/heygen-com/hyperframes/pull/3505)).
+- **CLI:** Keep phrase-level CJK and Thai transcripts as separate cues ([18409c9f2](https://github.com/heygen-com/hyperframes/commit/18409c9f2742e491ef7ff6a1454675a295e5d0a0), [#3436](https://github.com/heygen-com/hyperframes/pull/3436)).
+- **Engine,producer,lint:** Resolve <source> children for media extract and localize ([97991bbd3](https://github.com/heygen-com/hyperframes/commit/97991bbd3566a70f857412739dfa6ca9acfcaf27), [#3238](https://github.com/heygen-com/hyperframes/pull/3238)).
+- **Engine:** Preserve source frame identity above 99,999 ([c9f43ebcf](https://github.com/heygen-com/hyperframes/commit/c9f43ebcfbc05a83b18f46007f31a5cbd973ebb9), [#3503](https://github.com/heygen-com/hyperframes/pull/3503)).
+- **Studio:** Dedupe repeated selection telemetry ([9aaa7552f](https://github.com/heygen-com/hyperframes/commit/9aaa7552fc7a41d479e4b4638cd0c47472652ddc), [#3498](https://github.com/heygen-com/hyperframes/pull/3498)).
+- **Engine:** Treat a sentineled cache entry with no frames as a miss ([dae5b7b90](https://github.com/heygen-com/hyperframes/commit/dae5b7b90b7eefceffc9e64cc532b5cc74eeeedd), [#3434](https://github.com/heygen-com/hyperframes/pull/3434)).
+- **Producer,core:** Honor relative data-start id-refs in render media scheduling ([f52ec1c25](https://github.com/heygen-com/hyperframes/commit/f52ec1c25f3af20fcceefad24acb06f37feab24c), [#3252](https://github.com/heygen-com/hyperframes/pull/3252)).
+- **Producer:** Fall back to screenshot capture on drawElement canvas-not-initialized ([a7e867475](https://github.com/heygen-com/hyperframes/commit/a7e86747586b5aad0263b6b00bbd9d32c51ff7e6), [#3480](https://github.com/heygen-com/hyperframes/pull/3480)).
+- **Core:** Evict cached MediaElementSource on src mutation, soften enforcement-point claims ([f7fc0017a](https://github.com/heygen-com/hyperframes/commit/f7fc0017a6a6f31a4ae725f9f391d8dc63e3d9cc)).
+- **Core:** Correct web-audio-route subpath export resolution ([32ef37cfc](https://github.com/heygen-com/hyperframes/commit/32ef37cfc31975afbeae85a3f6805e575a43e87a)).
+- **Core:** Address review — gate early diagnostic, fix empty crossOrigin, document gaps ([acc689825](https://github.com/heygen-com/hyperframes/commit/acc689825543942939bbef14ccd2844b7f13298d)).
+- **Core:** Prevent cross-origin Web Audio capture from silencing audio ([cce17da5a](https://github.com/heygen-com/hyperframes/commit/cce17da5a9eb1c6efa21db084d786a1d34b5d8f9)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.15...v0.8.16


### PR DESCRIPTION
## What

Publishes HyperFrames `0.8.16` from the current stable `main` snapshot. Rendering is more reliable across audio, embedded sources, long sequences, and empty caches, while CJK and Thai captions keep phrase boundaries.

Local video generation now avoids dead model tiers, and the player can retain runtime data channels for richer integrations.

## Why

Packages on npm `latest` remain at `0.8.15`. This reviewed release PR is the only supported path for creating the stable tag and publishing `0.8.16`.

## How

`bun run release:prepare 0.8.16` generated reviewed release notes, synchronized 13 package versions and three plugin manifests, and created the release commit. The local tag was deliberately not pushed; the stable publish workflow creates it from the immutable merge SHA.

## Test plan

- [x] 47 release, changelog, version, publish-workflow, and channel-validation tests pass
- [x] `oxfmt --check` passes for all 18 changed files
- [x] Release commit is based exactly on current `origin/main`
- [x] Documentation updated

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
