### PR TITLE
fix(producer): enforce video extraction failures by default

### DIFF
--- a/packages/producer/src/services/render/stages/extractVideosStage.test.ts
+++ b/packages/producer/src/services/render/stages/extractVideosStage.test.ts
@@ -205,14 +205,14 @@ describe("shouldCopyExtractedFrames", () => {
 });
 
 describe("resolveVideoExtractionPolicy", () => {
-  it("preserves stable behavior by default", () => {
+  it("enforces extraction failures by default (#3372)", () => {
     expect(resolveVideoExtractionPolicy({})).toEqual({
-      failureMode: "off",
+      failureMode: "enforce",
       maxTransientRetries: 0,
     });
   });
 
-  it("allows only the bounded candidate rollout values", () => {
+  it("allows explicit opt-out or observe mode", () => {
     expect(
       resolveVideoExtractionPolicy({
         HF_VIDEO_EXTRACTION_FAILURE_MODE: "observe",
@@ -221,10 +221,15 @@ describe("resolveVideoExtractionPolicy", () => {
     ).toEqual({ failureMode: "observe", maxTransientRetries: 1 });
     expect(
       resolveVideoExtractionPolicy({
-        HF_VIDEO_EXTRACTION_FAILURE_MODE: "unexpected",
-        HF_VIDEO_EXTRACTION_MAX_RETRIES: "1",
+        HF_VIDEO_EXTRACTION_FAILURE_MODE: "off",
       }),
     ).toEqual({ failureMode: "off", maxTransientRetries: 0 });
+    expect(
+      resolveVideoExtractionPolicy({
+        HF_VIDEO_EXTRACTION_FAILURE_MODE: "enforce",
+        HF_VIDEO_EXTRACTION_MAX_RETRIES: "1",
+      }),
+    ).toEqual({ failureMode: "enforce", maxTransientRetries: 1 });
   });
 });
 

--- a/packages/producer/src/services/render/stages/extractVideosStage.ts
+++ b/packages/producer/src/services/render/stages/extractVideosStage.ts
@@ -131,15 +131,17 @@ export interface VideoExtractionPolicy {
 }
 
 /**
- * Candidate-lane rollout controls. Stable behavior remains unchanged unless
- * explicitly enabled in the producer environment.
+ * Extraction failure policy. Defaults to `enforce` so per-source errors
+ * surface as render failures instead of being silently swallowed (#3372).
+ * Set `HF_VIDEO_EXTRACTION_FAILURE_MODE=off` to restore the old silent
+ * behavior, or `observe` to log without failing.
  */
 export function resolveVideoExtractionPolicy(
   env: Readonly<Record<string, string | undefined>> = process.env,
 ): VideoExtractionPolicy {
   const rawMode = env.HF_VIDEO_EXTRACTION_FAILURE_MODE?.trim().toLowerCase();
   const failureMode: VideoExtractionFailureMode =
-    rawMode === "observe" || rawMode === "enforce" ? rawMode : "off";
+    rawMode === "observe" || rawMode === "off" ? rawMode : "enforce";
   const maxTransientRetries =
     failureMode !== "off" && env.HF_VIDEO_EXTRACTION_MAX_RETRIES?.trim() === "1" ? 1 : 0;
   return { failureMode, maxTransientRetries };


### PR DESCRIPTION
## Summary

Flips the video extraction failure policy default from `off` to `enforce` so per-source extraction errors fail the render instead of being silently swallowed.

The error handling infrastructure was fully built — typed errors, retryable classification, caller throw — but gated behind `HF_VIDEO_EXTRACTION_FAILURE_MODE=enforce`. With the default at `off`, extraction failures (e.g. ffmpeg exiting 0 with zero frames from an audio-only tail) were collected into an `errors` array but never surfaced, leading to misleading coverage aborts downstream.

Opt-out: `HF_VIDEO_EXTRACTION_FAILURE_MODE=off` restores the old silent behavior.

Closes #3372

— Miga