### PR TITLE
fix(studio): update WebMCP test for polyfill fallback

### DIFF
--- a/packages/studio/src/webmcp/useStudioAgentTools.test.tsx
+++ b/packages/studio/src/webmcp/useStudioAgentTools.test.tsx
@@ -149,16 +149,16 @@ describe("useStudioAgentTools", () => {
     expect(signal?.aborted).toBe(true);
   });
 
-  it("registers nothing when the browser has no WebMCP", async () => {
+  it("boots cleanly when the browser has no native WebMCP", async () => {
     removeModelContext();
 
     await act(async () => {
       mountTools({ getSnapshot: () => snapshot() });
     });
 
-    // The assertion is that mounting did not throw; a browser without the API
-    // must still boot Studio.
-    expect(document).not.toHaveProperty("modelContext");
+    // The assertion is that mounting did not throw; a browser without the
+    // native API must still boot Studio. The polyfill may install
+    // document.modelContext as a fallback — that is expected.
   });
 
   it("registers nothing when the preference is turned off", async () => {


### PR DESCRIPTION
## Summary

- The `useStudioAgentTools` test "registers nothing when the browser has no WebMCP" asserted `document.modelContext` was absent after mount
- Since #3514 added the `@mcp-b/global` polyfill, the hook installs `document.modelContext` even without native browser support — that's the polyfill's purpose
- Updated the test to verify that mounting doesn't throw (the real contract), without asserting polyfill absence

This fixes the `CI / Test` failure on `main`.

## Other main CI failures (not ours)

- **Docs / Validate docs** — `npm error notarget No matching version found for mint@4.2.837` (docs tool dependency)
- **Windows / Tests on windows-latest** — `ECONNREFUSED ::1:3000` (Windows network test infra)
- **regression** — cancelled, not failing

## Test plan

- [x] All 9 `useStudioAgentTools` tests pass with `NODE_ENV=development`
- [x] Pre-commit hooks: lint, format, fallow, typecheck all green

— Miga

🤖 Generated with [Claude Code](https://claude.com/claude-code)