### PR TITLE
fix(cli): respect timeline-free static compositions

### DIFF
--- a/packages/cli/src/commands/check.test.ts
+++ b/packages/cli/src/commands/check.test.ts
@@ -145,6 +145,7 @@ function fakeDriver(overrides: Partial<CheckAuditDriver> = {}): CheckAuditDriver
   return {
     initialize: vi.fn(async (_contrast: boolean) => undefined),
     getDuration: vi.fn(async () => 9),
+    hasNoTimelineDeclaration: vi.fn(async () => false),
     getTransitionBoundaries: vi.fn(async () => []),
     getCanvas: vi.fn(async () => ({ width: 1920, height: 1080 })),
     findAmbiguousSelectors: vi.fn(async (_selectors: string[]) => []),
@@ -1220,6 +1221,18 @@ describe("check pipeline", () => {
             finding.message.includes("did not advance"),
         ),
       ).toBe(true);
+    });
+
+    it("does not flag intentional static content declared with data-no-timeline", async () => {
+      const driver = fakeDriver({
+        getDuration: vi.fn(async () => 6),
+        hasNoTimelineDeclaration: vi.fn(async () => true),
+        collectLayoutGeometry: vi.fn(async () => "frozen"),
+      });
+
+      const { report } = await runScenario(driver);
+
+      expect(report.layout.findings.some((finding) => finding.code === "sweep_static")).toBe(false);
     });
 
     it("does not flag a 1.5s static title card — too short for the guard to apply", async () => {

--- a/packages/cli/src/utils/checkBrowser.ts
+++ b/packages/cli/src/utils/checkBrowser.ts
@@ -395,6 +395,7 @@ function createPageDriver(page: Page, setTime: (time: number) => void): CheckAud
   return {
     initialize: (contrast) => injectAuditScripts(page, contrast),
     getDuration: () => getCompositionDuration(page),
+    hasNoTimelineDeclaration: () => hasNoTimelineDeclaration(page),
     getTransitionBoundaries: () => collectTweenBoundaries(page),
     getCanvas: () =>
       page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight })),
@@ -418,6 +419,13 @@ function createPageDriver(page: Page, setTime: (time: number) => void): CheckAud
     anchorMotionIssues: (issues) => anchorLayoutIssues(page, issues),
     collectContrast: (time, annotations) => collectContrast(page, time, annotations),
   };
+}
+
+async function hasNoTimelineDeclaration(page: Page): Promise<boolean> {
+  return page.evaluate(
+    () =>
+      document.querySelector("[data-composition-id]")?.hasAttribute("data-no-timeline") ?? false,
+  );
 }
 
 async function injectAuditScripts(page: Page, contrast: boolean): Promise<void> {

--- a/packages/cli/src/utils/checkPipeline.ts
+++ b/packages/cli/src/utils/checkPipeline.ts
@@ -492,7 +492,9 @@ function detectSweepStatic(
   duration: number,
   geometrySignatures: string[],
   motionIssues: AnchoredLayoutIssue[],
+  hasNoTimelineDeclaration: boolean,
 ): AnchoredLayoutIssue[] {
+  if (hasNoTimelineDeclaration) return [];
   if (duration < SWEEP_STATIC_MIN_DURATION_SEC) return [];
   if (geometrySignatures.length < 2) return [];
   if (motionIssues.some((issue) => issue.code === "motion_frozen")) return [];
@@ -1071,6 +1073,7 @@ export async function runAuditGrid(
     grid.duration,
     collected.geometrySignatures,
     motionIssues,
+    await driver.hasNoTimelineDeclaration(),
   );
   const rotationFindings = detectRotationPivotDrift(
     collected.rotationSamples,

--- a/packages/cli/src/utils/checkTypes.ts
+++ b/packages/cli/src/utils/checkTypes.ts
@@ -179,6 +179,8 @@ export type MotionSpecResolution =
 export interface CheckAuditDriver {
   initialize(contrast: boolean): Promise<void>;
   getDuration(): Promise<number>;
+  /** True when the root composition explicitly declares that it is intentionally timeline-free. */
+  hasNoTimelineDeclaration(): Promise<boolean>;
   getTransitionBoundaries(): Promise<number[]>;
   getCanvas(): Promise<Canvas>;
   findAmbiguousSelectors(selectors: string[]): Promise<AnchoredLayoutIssue[]>;


### PR DESCRIPTION
## Summary

Intentional static voiceover and page compositions marked `data-no-timeline` no longer fail `hyperframes check` with a misleading `sweep_static` error. The frozen-sweep guard still rejects unchanged seek results for normal timeline-backed compositions, while the explicit timeline-free contract now suppresses only that diagnostic and leaves all other checks intact.

## Test plan

- `bun run --cwd packages/cli test -- src/commands/check.test.ts src/utils/checkBrowser.test.ts` (67 passed)
- `bun run --cwd packages/cli typecheck`
- `bunx oxlint` and `bunx oxfmt --check` on changed files
- `bun run --cwd packages/cli dev -- check /tmp/hf-sweep-static-TZTuys --json --no-contrast` (exact Terra fixture: exit 0, zero layout findings)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--Sol-000000)
