### PR TITLE
fix(core): resolve long nested media in local time

### DIFF
--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -1215,11 +1215,13 @@ describe("initSandboxRuntimeModular", () => {
 
     initSandboxRuntimeModular();
 
+    for (const globalTime of [
+      42.353, 49.412, 56.471, 63.529, 70.588, 77.647, 84.706, 91.765, 98.824, 105.882, 112.941,
+    ]) {
+      window.__player?.renderSeek(globalTime);
+      expect(video.style.visibility, `global ${globalTime}s`).toBe("visible");
+    }
     expect(window.__hfResolveMediaStartSeconds?.(video)).toBeCloseTo(39.233);
-    window.__player?.renderSeek(80.4);
-    expect(video.style.visibility).toBe("visible");
-    window.__player?.renderSeek(111);
-    expect(video.style.visibility).toBe("visible");
   });
 
   it("uses the canonical resolver for reference starts, auto-start media, and inline hosts", () => {

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -1187,6 +1187,41 @@ describe("initSandboxRuntimeModular", () => {
     expect(video.style.visibility).toBe("visible");
   });
 
+  it("keeps a long video starting at zero local to its delayed composition host", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-duration", "120");
+    document.body.appendChild(root);
+
+    const host = document.createElement("div");
+    host.setAttribute("data-composition-id", "nested-video");
+    host.setAttribute("data-composition-file", "compositions/nested.html");
+    host.setAttribute("data-start", "39.233");
+    host.setAttribute("data-duration", "80");
+    root.appendChild(host);
+
+    const video = document.createElement("video");
+    video.setAttribute("data-start", "0");
+    video.setAttribute("data-duration", "80");
+    video.load = () => {};
+    host.appendChild(video);
+
+    window.__timelines = {
+      main: createMockTimeline(120),
+      "nested-video": createMockTimeline(80),
+    };
+
+    initSandboxRuntimeModular();
+
+    expect(window.__hfResolveMediaStartSeconds?.(video)).toBeCloseTo(39.233);
+    window.__player?.renderSeek(80.4);
+    expect(video.style.visibility).toBe("visible");
+    window.__player?.renderSeek(111);
+    expect(video.style.visibility).toBe("visible");
+  });
+
   it("uses the canonical resolver for reference starts, auto-start media, and inline hosts", () => {
     const root = document.createElement("div");
     root.setAttribute("data-composition-id", "main");

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -663,22 +663,15 @@ export function initSandboxRuntimeModular(): void {
     // Both timing conventions exist in shipped projects:
     //   - composition-local media, e.g. host@20 + video@0 => root@20
     //   - legacy root-global PIP media, e.g. host@45.4 + video@45.4 => root@45.4
-    // Preserve the global value when its authored window already intersects
-    // the host's absolute window. Otherwise it is unambiguously local and
-    // must inherit the recursively-resolved host start.
-    const authoredDuration = parseStrictFiniteTimingNumber(element.getAttribute("data-duration"));
+    // Preserve the global value when its authored start already falls inside
+    // the host's absolute window. A long local clip can overlap that window
+    // even when its start is local (host@39.233 + video@0/duration=80), so the
+    // duration cannot disambiguate the timing convention.
     const hostDuration = context.inheritedDuration;
     const hostEnd = hostDuration != null && hostDuration > 0 ? inheritedStart + hostDuration : null;
-    const authoredEnd =
-      authoredDuration != null && authoredDuration > 0
-        ? authoredStart + authoredDuration
-        : authoredStart;
-    const overlapsHostWindow =
-      hostEnd == null
-        ? authoredStart >= inheritedStart
-        : authoredStart < hostEnd &&
-          (authoredEnd > inheritedStart || authoredStart === inheritedStart);
-    return overlapsHostWindow ? authoredStart : inheritedStart + authoredStart;
+    const startsInsideHostWindow =
+      authoredStart >= inheritedStart && (hostEnd == null || authoredStart < hostEnd);
+    return startsInsideHostWindow ? authoredStart : inheritedStart + authoredStart;
   };
 
   window.__hfResolveMediaStartSeconds = resolveAbsoluteMediaStartSeconds;


### PR DESCRIPTION
## Summary

Long videos starting at local `0s` inside delayed sub-compositions no longer disappear from late snapshots. Media starts before the host’s absolute window now inherit the host offset even when their long duration overlaps that window; legacy media authored with a start already inside the global host window keeps its existing behavior.

Fixes `reported:1787898835.985789` and `reported:1787908114.998239`.

- https://slack.com/archives/C0BGC335AQY/p1787898835985789
- https://slack.com/archives/C0BGC335AQY/p1787908114998239

## Test plan

- `packages/core/src/runtime/init.test.ts` (91 passed, including legacy global-PIP coverage)
- `packages/cli/src/commands/snapshot.test.ts` (33 passed)
- Core and CLI typechecks
- `oxlint` and `oxfmt --check` on changed files
- Exact Terra point fixture: `40s`, `41s`, `80.4s`, and `111s` snapshots are all non-black
- Exact Terra 18-frame sweep: every in-host sample from `42.353s` through `112.941s` is non-black; only pre-host and post-host samples are black

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--Sol-000000)
