### PR TITLE
fix(engine): treat a single keyframe as the worst sparse-keyframe case

### DIFF
--- a/packages/engine/src/utils/ffprobe.test.ts
+++ b/packages/engine/src/utils/ffprobe.test.ts
@@ -832,6 +832,96 @@ describe("ffprobe missing-binary fallback", () => {
     expect(basename(calls[0]?.command ?? "")).toMatch(/^ffprobe(?:\.exe)?$/);
   });
 
+  it("analyzeKeyframeIntervals treats a single keyframe as the whole stream duration", async () => {
+    // A 10s single-GOP video: exactly one keyframe at t=0. Every seek past
+    // it lands inside that one GOP, so the effective interval is the whole
+    // stream, not zero.
+    const { spawn, calls } = createSpawnSpy([
+      { kind: "exit", code: 0, stdout: "0.000000\n" },
+      {
+        kind: "exit",
+        code: 0,
+        stdout: JSON.stringify({
+          streams: [
+            {
+              codec_type: "video",
+              codec_name: "h264",
+              width: 640,
+              height: 360,
+              r_frame_rate: "30/1",
+              avg_frame_rate: "30/1",
+              duration: "10.0",
+            },
+          ],
+          format: { duration: "10.0" },
+        }),
+      },
+    ]);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { analyzeKeyframeIntervals } = await import("./ffprobe.js");
+    const result = await analyzeKeyframeIntervals("/tmp/single-gop.mp4");
+
+    expect(result).toEqual({
+      avgIntervalSeconds: 10,
+      maxIntervalSeconds: 10,
+      keyframeCount: 1,
+      isProblematic: true,
+    });
+    expect(calls.length).toBe(2);
+  });
+
+  it("analyzeKeyframeIntervals does not flag a single keyframe under the threshold", async () => {
+    const { spawn } = createSpawnSpy([
+      { kind: "exit", code: 0, stdout: "0.000000\n" },
+      {
+        kind: "exit",
+        code: 0,
+        stdout: JSON.stringify({
+          streams: [
+            {
+              codec_type: "video",
+              codec_name: "h264",
+              width: 640,
+              height: 360,
+              r_frame_rate: "30/1",
+              avg_frame_rate: "30/1",
+              duration: "1.0",
+            },
+          ],
+          format: { duration: "1.0" },
+        }),
+      },
+    ]);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { analyzeKeyframeIntervals } = await import("./ffprobe.js");
+    const result = await analyzeKeyframeIntervals("/tmp/short-single-gop.mp4");
+
+    expect(result.keyframeCount).toBe(1);
+    expect(result.isProblematic).toBe(false);
+  });
+
+  it("analyzeKeyframeIntervals reports no keyframes as not problematic", async () => {
+    const { spawn, calls } = createSpawnSpy([{ kind: "exit", code: 0, stdout: "" }]);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { analyzeKeyframeIntervals } = await import("./ffprobe.js");
+    const result = await analyzeKeyframeIntervals("/tmp/no-keyframes.mp4");
+
+    expect(result).toEqual({
+      avgIntervalSeconds: 0,
+      maxIntervalSeconds: 0,
+      keyframeCount: 0,
+      isProblematic: false,
+    });
+    // Only the keyframe probe should run — no metadata lookup for zero timestamps.
+    expect(calls.length).toBe(1);
+  });
+
   it("ffprobe-missing error message includes install hint", async () => {
     const { spawn } = createSpawnSpy([{ kind: "missing" }]);
     hidePathBinaries();

--- a/packages/engine/src/utils/ffprobe.ts
+++ b/packages/engine/src/utils/ffprobe.ts
@@ -1050,12 +1050,28 @@ async function analyzeKeyframeIntervalsUncached(filePath: string): Promise<Keyfr
     .map((line) => parseFloat(line.trim()))
     .filter((t) => Number.isFinite(t));
 
-  if (timestamps.length < 2) {
+  if (timestamps.length === 0) {
     return {
       avgIntervalSeconds: 0,
       maxIntervalSeconds: 0,
-      keyframeCount: timestamps.length,
+      keyframeCount: 0,
       isProblematic: false,
+    };
+  }
+
+  if (timestamps.length === 1) {
+    // A single keyframe means every seek past it lands inside one GOP that
+    // spans the whole stream, which is the worst case the multi-keyframe
+    // branch below reports on. The interval is the stream duration, not
+    // zero — the video-stream duration, not the container's, since they can
+    // disagree (e.g. an audio-only tail past the last video frame).
+    const { videoStreamDurationSeconds } = await extractMediaMetadata(filePath);
+    const duration = Math.round(videoStreamDurationSeconds * 100) / 100;
+    return {
+      avgIntervalSeconds: duration,
+      maxIntervalSeconds: duration,
+      keyframeCount: 1,
+      isProblematic: duration > 2,
     };
   }
 


### PR DESCRIPTION
Fixes #3460

### Problem

`analyzeKeyframeIntervalsUncached` returned `isProblematic: false` whenever a video had fewer than two keyframes:

```js
if (timestamps.length < 2) {
  return { avgIntervalSeconds: 0, maxIntervalSeconds: 0, keyframeCount: timestamps.length, isProblematic: false };
}
```

A video with exactly one keyframe is the worst case for the failure this check exists to catch: every seek past 0 lands inside the single GOP spanning the whole file. The compiler warns loudly about a 5 second GOP and stays silent about a 10 second one.

Two 10s clips, identical except GOP size, confirm it: `five-second-gop.mp4` (keyframes at 0 and 5) gets flagged, `single-gop.mp4` (keyframe at 0 only, effective seek distance 10s) does not.

### Fix

Split the early return into two cases:

- zero keyframes (still images, failed probes) keeps the prior not-problematic result
- one keyframe reports the video stream's own duration as both the average and max interval, flagged past the same 2s threshold as the multi-keyframe path

Stream duration rather than container duration, since they can disagree, which is exactly the class of bug behind #3372.

### Testing

Added three cases to `ffprobe.test.ts`:

- a 10s single-GOP video reports `avgIntervalSeconds: 10, maxIntervalSeconds: 10, isProblematic: true`
- a 1s single-GOP video stays `isProblematic: false`
- zero keyframes still returns the untouched not-problematic result, and skips the metadata probe entirely (asserted via call count)

Reverting `ffprobe.ts` fails the first new test with the old `avgIntervalSeconds: 0`, so it covers the change. Full file passes at 117 tests (1 pre-existing skip), `oxlint` and `oxfmt --check` are clean.

### Note on the issue's side observation

The issue also raises that `hyperframes render` may resolve frames correctly even past a sparse keyframe, since `video_extract` decodes through ffmpeg from the preceding keyframe with `minVideoFrameCoverageRatio: 1` rather than relying on browser seeking. I have not touched the warning's wording or scope here, since that is a question about what the check is actually protecting against and felt like a separate decision from the reported false negative. Happy to follow up if useful.
