### PR TITLE
feat(lint): flag CSS transition as seek-unsafe

### DIFF
--- a/packages/engine/src/utils/ffprobe.test.ts
+++ b/packages/engine/src/utils/ffprobe.test.ts
@@ -832,6 +832,96 @@ describe("ffprobe missing-binary fallback", () => {
     expect(basename(calls[0]?.command ?? "")).toMatch(/^ffprobe(?:\.exe)?$/);
   });
 
+  it("analyzeKeyframeIntervals treats a single keyframe as the whole stream duration", async () => {
+    // A 10s single-GOP video: exactly one keyframe at t=0. Every seek past
+    // it lands inside that one GOP, so the effective interval is the whole
+    // stream, not zero.
+    const { spawn, calls } = createSpawnSpy([
+      { kind: "exit", code: 0, stdout: "0.000000\n" },
+      {
+        kind: "exit",
+        code: 0,
+        stdout: JSON.stringify({
+          streams: [
+            {
+              codec_type: "video",
+              codec_name: "h264",
+              width: 640,
+              height: 360,
+              r_frame_rate: "30/1",
+              avg_frame_rate: "30/1",
+              duration: "10.0",
+            },
+          ],
+          format: { duration: "10.0" },
+        }),
+      },
+    ]);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { analyzeKeyframeIntervals } = await import("./ffprobe.js");
+    const result = await analyzeKeyframeIntervals("/tmp/single-gop.mp4");
+
+    expect(result).toEqual({
+      avgIntervalSeconds: 10,
+      maxIntervalSeconds: 10,
+      keyframeCount: 1,
+      isProblematic: true,
+    });
+    expect(calls.length).toBe(2);
+  });
+
+  it("analyzeKeyframeIntervals does not flag a single keyframe under the threshold", async () => {
+    const { spawn } = createSpawnSpy([
+      { kind: "exit", code: 0, stdout: "0.000000\n" },
+      {
+        kind: "exit",
+        code: 0,
+        stdout: JSON.stringify({
+          streams: [
+            {
+              codec_type: "video",
+              codec_name: "h264",
+              width: 640,
+              height: 360,
+              r_frame_rate: "30/1",
+              avg_frame_rate: "30/1",
+              duration: "1.0",
+            },
+          ],
+          format: { duration: "1.0" },
+        }),
+      },
+    ]);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { analyzeKeyframeIntervals } = await import("./ffprobe.js");
+    const result = await analyzeKeyframeIntervals("/tmp/short-single-gop.mp4");
+
+    expect(result.keyframeCount).toBe(1);
+    expect(result.isProblematic).toBe(false);
+  });
+
+  it("analyzeKeyframeIntervals reports no keyframes as not problematic", async () => {
+    const { spawn, calls } = createSpawnSpy([{ kind: "exit", code: 0, stdout: "" }]);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { analyzeKeyframeIntervals } = await import("./ffprobe.js");
+    const result = await analyzeKeyframeIntervals("/tmp/no-keyframes.mp4");
+
+    expect(result).toEqual({
+      avgIntervalSeconds: 0,
+      maxIntervalSeconds: 0,
+      keyframeCount: 0,
+      isProblematic: false,
+    });
+    // Only the keyframe probe should run — no metadata lookup for zero timestamps.
+    expect(calls.length).toBe(1);
+  });
+
   it("ffprobe-missing error message includes install hint", async () => {
     const { spawn } = createSpawnSpy([{ kind: "missing" }]);
     hidePathBinaries();

--- a/packages/engine/src/utils/ffprobe.ts
+++ b/packages/engine/src/utils/ffprobe.ts
@@ -1050,12 +1050,28 @@ async function analyzeKeyframeIntervalsUncached(filePath: string): Promise<Keyfr
     .map((line) => parseFloat(line.trim()))
     .filter((t) => Number.isFinite(t));
 
-  if (timestamps.length < 2) {
+  if (timestamps.length === 0) {
     return {
       avgIntervalSeconds: 0,
       maxIntervalSeconds: 0,
-      keyframeCount: timestamps.length,
+      keyframeCount: 0,
       isProblematic: false,
+    };
+  }
+
+  if (timestamps.length === 1) {
+    // A single keyframe means every seek past it lands inside one GOP that
+    // spans the whole stream, which is the worst case the multi-keyframe
+    // branch below reports on. The interval is the stream duration, not
+    // zero — the video-stream duration, not the container's, since they can
+    // disagree (e.g. an audio-only tail past the last video frame).
+    const { videoStreamDurationSeconds } = await extractMediaMetadata(filePath);
+    const duration = Math.round(videoStreamDurationSeconds * 100) / 100;
+    return {
+      avgIntervalSeconds: duration,
+      maxIntervalSeconds: duration,
+      keyframeCount: 1,
+      isProblematic: duration > 2,
     };
   }
 

--- a/packages/lint/src/rules/core.test.ts
+++ b/packages/lint/src/rules/core.test.ts
@@ -793,4 +793,73 @@ describe("core rules", () => {
       expect(finding?.message).toContain("Missed semicolon");
     });
   });
+
+  describe("css_transition_used", () => {
+    const withStyle = (css: string, body = "") => `
+<html><head><style>${css}</style></head><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080" data-start="0" data-duration="5">
+${body}
+  </div>
+  <script>window.__timelines = {};</script>
+</body></html>`;
+
+    it("flags a shorthand transition in a <style> block", async () => {
+      const result = await lintHyperframeHtml(withStyle(".card { transition: all .2s; }"));
+      const finding = result.findings.find((f) => f.code === "css_transition_used");
+      expect(finding).toBeDefined();
+      expect(finding?.severity).toBe("error");
+      expect(finding?.selector).toBe(".card");
+    });
+
+    it("flags a longhand transition-* property", async () => {
+      const result = await lintHyperframeHtml(
+        withStyle(".card { transition-property: opacity; transition-duration: .3s; }"),
+      );
+      const codes = result.findings.filter((f) => f.code === "css_transition_used");
+      expect(codes).toHaveLength(2);
+    });
+
+    it("flags a -webkit- prefixed transition", async () => {
+      const result = await lintHyperframeHtml(
+        withStyle(".card { -webkit-transition: opacity .2s; }"),
+      );
+      expect(result.findings.find((f) => f.code === "css_transition_used")).toBeDefined();
+    });
+
+    it('flags an inline style="" transition and reports the element id', async () => {
+      const result = await lintHyperframeHtml(
+        withStyle("", '<div id="hero" style="transition: opacity .2s;"></div>'),
+      );
+      const finding = result.findings.find((f) => f.code === "css_transition_used");
+      expect(finding).toBeDefined();
+      expect(finding?.selector).toBe("#hero");
+      expect(finding?.elementId).toBe("hero");
+    });
+
+    it("does not flag transition: none", async () => {
+      const result = await lintHyperframeHtml(withStyle(".card { transition: none; }"));
+      expect(result.findings.find((f) => f.code === "css_transition_used")).toBeUndefined();
+    });
+
+    it("does not flag transition-property: none", async () => {
+      const result = await lintHyperframeHtml(withStyle(".card { transition-property: none; }"));
+      expect(result.findings.find((f) => f.code === "css_transition_used")).toBeUndefined();
+    });
+
+    it("does not flag a --transition-* custom property", async () => {
+      const result = await lintHyperframeHtml(
+        withStyle(".card { --transition-speed: .2s; color: red; }"),
+      );
+      expect(result.findings.find((f) => f.code === "css_transition_used")).toBeUndefined();
+    });
+
+    it("does not flag a class named transition-like or a transition inside a comment", async () => {
+      const result = await lintHyperframeHtml(
+        withStyle(
+          ".transition-card { color: red; } /* transition: all 1s; */ .other { color: blue; }",
+        ),
+      );
+      expect(result.findings.find((f) => f.code === "css_transition_used")).toBeUndefined();
+    });
+  });
 });

--- a/packages/lint/src/rules/core.ts
+++ b/packages/lint/src/rules/core.ts
@@ -518,4 +518,78 @@ export const coreRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
     }
     return findings;
   },
+
+  // css_transition_used
+  ({ styles, tags }) => {
+    const findings: HyperframeLintFinding[] = [];
+    // Matches the shorthand and every longhand (-property, -duration, -delay,
+    // -timing-function, -behavior), with or without -webkit-. Anchored at both
+    // ends so a custom property (--transition-speed) never matches: its name
+    // starts with "--", not "transition" or "-webkit-".
+    const transitionProperty = /^(-webkit-)?transition(-[a-z-]+)?$/i;
+
+    const report = (
+      prop: string,
+      value: string,
+      selector: string | undefined,
+      elementId: string | undefined,
+    ) => {
+      findings.push({
+        code: "css_transition_used",
+        severity: "error",
+        message:
+          `CSS \`${prop}\` runs on the browser clock, not the render's frame clock. A GSAP class/attr ` +
+          "swap driven by it looks correct in preview and --workers 1, but a fresh page (parallel chunk " +
+          "workers, snapshot --at past the settle time) restarts the transition from scratch, so the " +
+          "export can flash or land on the wrong visual state.",
+        selector,
+        elementId,
+        fixHint:
+          "Keep the class/attribute swap for state, and put the visual change on the paused GSAP " +
+          `timeline instead. Set \`${prop.startsWith("transition-") ? prop : "transition"}: none\` if a ` +
+          "non-animated state change is intended.",
+        snippet: truncateSnippet(`${prop}: ${value};`),
+      });
+    };
+
+    const scanDecls = (root: postcss.Root, inlineSelector?: string, inlineElementId?: string) => {
+      root.walkDecls((decl) => {
+        if (!transitionProperty.test(decl.prop)) return;
+        if (decl.value.trim().toLowerCase() === "none") return;
+        const parent = decl.parent;
+        const selector =
+          inlineSelector ??
+          (parent?.type === "rule" ? (parent as postcss.Rule).selector : undefined);
+        report(decl.prop, decl.value, selector, inlineElementId);
+      });
+    };
+
+    for (const style of styles) {
+      let root: postcss.Root;
+      try {
+        root = postcss.parse(style.content);
+      } catch {
+        continue;
+      }
+      scanDecls(root);
+    }
+
+    for (const tag of tags) {
+      const inlineStyle = readAttr(tag.raw, "style");
+      if (!inlineStyle) continue;
+      let root: postcss.Root;
+      try {
+        // Wrapped in a dummy rule: postcss.parse expects a full stylesheet, and
+        // an inline style="" value is a bare declaration list.
+        root = postcss.parse(`__hf_inline__{${inlineStyle}}`);
+      } catch {
+        continue;
+      }
+      const id = readAttr(tag.raw, "id");
+      const firstClass = readAttr(tag.raw, "class")?.split(/\s+/).filter(Boolean)[0];
+      scanDecls(root, id ? `#${id}` : firstClass ? `.${firstClass}` : undefined, id ?? undefined);
+    }
+
+    return findings;
+  },
 ];


### PR DESCRIPTION
Fixes #3493

### Problem

CSS `transition` runs on the browser clock. A GSAP class/attr swap that relies on it looks correct in preview and `--workers 1`, since the browser is running continuously and the transition plays out normally. Parallel chunk workers, and `snapshot --at` past the settle time, restore the class on a fresh page instead, so the transition restarts from its initial state and the export flashes or shows the wrong frame.

The CSS runtime adapter only discovers `animation-name`, since finite `@keyframes` are seekable and `transition` is not, but `hyperframes check` did not flag `transition` itself, so nothing catches the mistake before render.

### Fix

A new lint finding, `css_transition_used`, in the same family as `non_deterministic_code` and `gsap_infinite_repeat`:

- flags `transition` and every `transition-*` longhand (`-property`, `-duration`, `-delay`, `-timing-function`, `-behavior`), with or without `-webkit-`
- scans both `<style>` blocks and inline `style=""` attributes
- allows `transition: none` / `transition-property: none`
- ignores custom properties (`--transition-speed`), since the property-name regex is anchored at both ends and a custom property's name starts with `--`, not `transition` or `-webkit-`

Uses `postcss` to parse declarations, matching how `repeated_id_descendant_selector` elsewhere in `core.ts` already parses `<style>` blocks, rather than a hand-rolled regex over raw CSS text. That gets comment-stripping and string handling for free, and keeps a selector like `.transition-card` from ever being mistaken for the property (postcss separates selector from declaration, so the property-name regex only ever sees `decl.prop`).

Reuses the `css_transition_used` code name already referenced in `skills/hyperframes-core/references/frame-worker-core.md`, per the issue.

### Testing

Eight cases in `core.test.ts`:

- shorthand `transition` in a `<style>` block, selector reported
- two `transition-*` longhands flagged as two separate findings
- `-webkit-transition`
- inline `style=""`, with the element id reported
- `transition: none` and `transition-property: none` both allowed
- a `--transition-speed` custom property not flagged
- a `.transition-card` selector name, plus a commented-out `transition:` declaration, neither flagged

Reverting the source while keeping the tests fails exactly the four positive cases and leaves the four negative (allow) cases passing, so the tests cover the change rather than restating current behaviour.

`bunx vitest run packages/lint/src` passes at 507 (up from 499 with the 8 added), with the same 35 pre-existing failures in `project.test.ts` and `snippetFragment.test.ts` on a clean checkout of `main`, so they look unrelated to this change. `oxlint` and `oxfmt --check` are clean on both files.
