### PR TITLE
fix(studio): fix the caption overrides save protocol and a false-armed autosave

### DIFF
--- a/packages/studio/src/captions/hooks/useCaptionSync.test.tsx
+++ b/packages/studio/src/captions/hooks/useCaptionSync.test.tsx
@@ -219,4 +219,56 @@ describe("useCaptionSync", () => {
 
     expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(true);
   });
+  it("serializes overlapping saves so the newest body lands last", async () => {
+    vi.useFakeTimers();
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const putBodies: string[] = [];
+    const releases: Array<() => void> = [];
+
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method !== "PUT") return new Response(null, { status: 404 });
+      putBodies.push(String(init.body));
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise<void>((resolve) => releases.push(resolve));
+      inFlight--;
+      return jsonResponse({ ok: true, version: `"sha256:v${putBodies.length}"` });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    mountCaptionSync("proj-1");
+    const store = useCaptionStore.getState();
+    store.setSourceFilePath("comp.html");
+    act(() => store.setModel(makeModel()));
+    act(() => store.setEditMode(true));
+
+    // First edit: its PUT starts and then hangs, still in flight.
+    act(() => store.setModel(makeModel({ x: 5 })));
+    await flushDebounce();
+    expect(putBodies).toHaveLength(1);
+
+    // A second edit arrives before the first PUT has come back. It must be
+    // queued rather than raced against the in-flight one, which is what could
+    // let the older body win and lose this edit.
+    act(() => store.setModel(makeModel({ x: 9 })));
+    await flushDebounce();
+    expect(putBodies).toHaveLength(1);
+    expect(maxInFlight).toBe(1);
+
+    // Releasing the first PUT lets the queued newest body go out.
+    await act(async () => {
+      releases.shift()?.();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(putBodies).toHaveLength(2);
+    expect(maxInFlight).toBe(1);
+    expect(putBodies[1]).toContain('"x": 9');
+
+    await act(async () => {
+      releases.shift()?.();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+  });
 });

--- a/packages/studio/src/captions/hooks/useCaptionSync.test.tsx
+++ b/packages/studio/src/captions/hooks/useCaptionSync.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment happy-dom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useCaptionSync } from "./useCaptionSync";
+import { useCaptionStore } from "../store";
+import { DEFAULT_ANIMATION_SET, DEFAULT_CONTAINER, DEFAULT_STYLE } from "../types";
+import type { CaptionModel } from "../types";
+import { resetStudioWriteTokens } from "../../utils/studioFileVersion";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function makeModel(styleOverride: Record<string, unknown> = {}): CaptionModel {
+  return {
+    width: 1920,
+    height: 1080,
+    duration: 5,
+    groupOrder: ["g1"],
+    groups: new Map([
+      [
+        "g1",
+        {
+          id: "g1",
+          segmentIds: ["s1"],
+          style: DEFAULT_STYLE,
+          animation: DEFAULT_ANIMATION_SET,
+          containerStyle: DEFAULT_CONTAINER,
+        },
+      ],
+    ]),
+    segments: new Map([
+      [
+        "s1",
+        {
+          id: "s1",
+          wordId: "w0",
+          text: "hi",
+          start: 0,
+          end: 1,
+          groupIndex: 0,
+          style: styleOverride,
+          animation: {},
+        },
+      ],
+    ]),
+    defaultAnimation: DEFAULT_ANIMATION_SET,
+  };
+}
+
+// Every mounted instance keeps its own live store subscription until
+// unmounted. Tracked here so afterEach can tear them all down — otherwise a
+// prior test's instance keeps reacting to later tests' store writes and
+// double (or triple) fires saves against the same fetch mock.
+const mountedRoots: ReturnType<typeof createRoot>[] = [];
+
+function mountCaptionSync(projectId: string | null) {
+  const captured: { sync: ReturnType<typeof useCaptionSync> | null } = { sync: null };
+  function Probe() {
+    captured.sync = useCaptionSync(projectId);
+    return null;
+  }
+  const root = createRoot(document.createElement("div"));
+  mountedRoots.push(root);
+  act(() => root.render(<Probe />));
+  const sync = captured.sync;
+  if (!sync) throw new Error("useCaptionSync did not render");
+  return { sync, root };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+async function flushDebounce() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(800);
+  });
+}
+
+describe("useCaptionSync", () => {
+  afterEach(() => {
+    for (const root of mountedRoots.splice(0)) {
+      act(() => root.unmount());
+    }
+    resetStudioWriteTokens();
+    useCaptionStore.getState().reset();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("sends If-None-Match on the first save of a new overrides file", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") return jsonResponse({ ok: true, version: '"sha256:v1"' });
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    mountCaptionSync("proj-1");
+    const store = useCaptionStore.getState();
+    store.setSourceFilePath("comp.html");
+    act(() => store.setModel(makeModel()));
+    act(() => store.setEditMode(true));
+    act(() => store.setModel(makeModel({ x: 5 })));
+
+    await flushDebounce();
+
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
+    expect(putCall).toBeDefined();
+    const headers = putCall?.[1]?.headers as Record<string, string>;
+    expect(headers["If-None-Match"]).toBe("*");
+    expect(headers["If-Match"]).toBeUndefined();
+  });
+
+  it("sends If-Match with the version captured by loadOverrides", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") return jsonResponse({ ok: true, version: '"sha256:v2"' });
+      return jsonResponse({ content: "[]", version: '"sha256:v1"' });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { sync } = mountCaptionSync("proj-1");
+    const store = useCaptionStore.getState();
+    store.setSourceFilePath("comp.html");
+    // Matches useCaptionDetection's real order: setModel, then setEditMode,
+    // then loadOverrides. loadOverrides setting the model again while
+    // suppressSaveRef is armed relies on isEditMode already being true, or
+    // that model update never gets treated as "no user edit happened".
+    act(() => store.setModel(makeModel()));
+    act(() => store.setEditMode(true));
+    await act(async () => {
+      await sync.loadOverrides();
+    });
+
+    act(() => store.setModel(makeModel({ x: 5 })));
+    await flushDebounce();
+
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === "PUT");
+    const headers = putCall?.[1]?.headers as Record<string, string>;
+    expect(headers["If-Match"]).toBe('"sha256:v1"');
+  });
+
+  it("retries once with the adopted version on a 409 conflict", async () => {
+    vi.useFakeTimers();
+    let putAttempts = 0;
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method !== "PUT") return new Response(null, { status: 404 });
+      putAttempts++;
+      if (putAttempts === 1) {
+        return jsonResponse(
+          { error: "file conflict", currentVersion: '"sha256:fresh"', currentContent: "[]" },
+          { status: 409 },
+        );
+      }
+      expect((init.headers as Record<string, string>)["If-Match"]).toBe('"sha256:fresh"');
+      return jsonResponse({ ok: true, version: '"sha256:v3"' });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    mountCaptionSync("proj-1");
+    const store = useCaptionStore.getState();
+    store.setSourceFilePath("comp.html");
+    act(() => store.setModel(makeModel()));
+    act(() => store.setEditMode(true));
+    act(() => store.setModel(makeModel({ x: 5 })));
+
+    await flushDebounce();
+
+    expect(putAttempts).toBe(2);
+    expect(useCaptionStore.getState().syncError).toBeNull();
+  });
+
+  it("does not arm a save when edit mode activates without a prior edit", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(
+      async (_url: string, _init?: RequestInit) => new Response(null, { status: 404 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    mountCaptionSync("proj-1");
+    const store = useCaptionStore.getState();
+    store.setSourceFilePath("comp.html");
+
+    // Mirrors useCaptionDetection's activation order: setModel() while still
+    // out of edit mode, THEN setEditMode(true) with no further model change.
+    act(() => store.setModel(makeModel()));
+    act(() => store.setEditMode(true));
+
+    await flushDebounce();
+
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(false);
+    expect(useCaptionStore.getState().hasPendingSave).toBe(false);
+  });
+
+  it("still arms a save for a genuine edit made while already in edit mode", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === "PUT") return jsonResponse({ ok: true, version: '"sha256:v1"' });
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    mountCaptionSync("proj-1");
+    const store = useCaptionStore.getState();
+    store.setSourceFilePath("comp.html");
+    act(() => store.setModel(makeModel()));
+    act(() => store.setEditMode(true));
+
+    // The activation settles (see the test above); now a real edit happens.
+    act(() => store.setModel(makeModel({ x: 5 })));
+    expect(useCaptionStore.getState().hasPendingSave).toBe(true);
+
+    await flushDebounce();
+
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(true);
+  });
+});

--- a/packages/studio/src/captions/hooks/useCaptionSync.ts
+++ b/packages/studio/src/captions/hooks/useCaptionSync.ts
@@ -4,6 +4,18 @@ import { useMountEffect } from "../../hooks/useMountEffect";
 import { trackEvent } from "../../telemetry/client";
 import type { CaptionStyle } from "../types";
 import { studioWriteHeaders } from "../../utils/studioFileVersion";
+import {
+  StudioFileConflictError,
+  createStudioSaveHttpError,
+  retryStudioSave,
+} from "../../utils/studioSaveDiagnostics";
+
+const CAPTION_OVERRIDES_PATH = "caption-overrides.json";
+const ENCODED_CAPTION_OVERRIDES_PATH = encodeURIComponent(CAPTION_OVERRIDES_PATH);
+
+function captionOverridesUrl(projectId: string): string {
+  return `/api/projects/${encodeURIComponent(projectId)}/files/${ENCODED_CAPTION_OVERRIDES_PATH}`;
+}
 
 interface CaptionOverrideEntry {
   wordId?: string;
@@ -69,10 +81,74 @@ export function useCaptionSync(projectId: string | null) {
   const suppressSaveRef = useRef(false);
 
   // True while an edit is debounced or a PUT is in flight — guards tab close.
+  // Mirrored into the store so useCaptionDetection can skip a flush that has
+  // nothing to send, instead of firing a PUT on every composition switch.
   const pendingRef = useRef(false);
   // Bumped on every new edit: a PUT's success may only clear the pending flag
   // when no newer edit re-armed the debounce while it was in flight.
   const editSeqRef = useRef(0);
+  // caption-overrides.json's content version. undefined = unknown (preflight
+  // before the first write), null = confirmed not to exist yet (send
+  // If-None-Match instead of If-Match).
+  const versionRef = useRef<string | null | undefined>(undefined);
+
+  const setPending = (pending: boolean) => {
+    pendingRef.current = pending;
+    useCaptionStore.getState().setHasPendingSave(pending);
+  };
+
+  const putOverrides = useCallback(async (pid: string, body: string) => {
+    const url = captionOverridesUrl(pid);
+    await retryStudioSave(async () => {
+      const expectedVersion = versionRef.current;
+      let response: Response;
+      try {
+        response = await fetch(url, {
+          method: "PUT",
+          headers: {
+            "Content-Type": "text/plain",
+            ...studioWriteHeaders(),
+            ...(expectedVersion ? { "If-Match": expectedVersion } : { "If-None-Match": "*" }),
+          },
+          body,
+        });
+      } catch (error) {
+        throw new Error(`Failed to save ${CAPTION_OVERRIDES_PATH}: network error`, {
+          cause: error,
+        });
+      }
+      if (response.status === 409) {
+        const conflict = (await response.json().catch(() => null)) as {
+          currentVersion?: string | null;
+          currentContent?: string | null;
+        } | null;
+        const currentVersion = conflict?.currentVersion ?? null;
+        // Another writer already saved identical content: adopt its version,
+        // nothing left to send.
+        if (currentVersion && conflict?.currentContent === body) {
+          versionRef.current = currentVersion;
+          return;
+        }
+        // caption-overrides.json has exactly one writer in the whole app (this
+        // hook), so a real conflict means our own cached version went stale —
+        // a manual file edit, or a second tab. Adopt the fresh version and let
+        // the caller retry once with it; there is no conflict UI for captions
+        // to surface a StudioFileConflictError to.
+        versionRef.current = currentVersion;
+        throw new StudioFileConflictError({
+          filePath: CAPTION_OVERRIDES_PATH,
+          currentVersion,
+          currentContent: conflict?.currentContent ?? null,
+          attemptedContent: body,
+        });
+      }
+      if (!response.ok) {
+        throw await createStudioSaveHttpError(response, `Failed to save ${CAPTION_OVERRIDES_PATH}`);
+      }
+      const result = (await response.json()) as { version?: string };
+      versionRef.current = result.version ?? response.headers.get("etag") ?? null;
+    });
+  }, []);
 
   const save = useCallback(() => {
     const state = useCaptionStore.getState();
@@ -80,28 +156,35 @@ export function useCaptionSync(projectId: string | null) {
     // path that fires the flush) must still write the last edits; the model
     // survives exit, and after a store reset it is null anyway.
     if (!state.model || !state.sourceFilePath) {
-      pendingRef.current = false;
+      setPending(false);
       return;
     }
     const pid = projectIdRef.current;
     if (!pid) {
-      pendingRef.current = false;
+      setPending(false);
       return;
     }
 
     const seqAtSave = editSeqRef.current;
-    const overrides = buildOverrides(state.model);
+    const body = JSON.stringify(buildOverrides(state.model), null, 2);
 
-    fetch(`/api/projects/${pid}/files/${encodeURIComponent("caption-overrides.json")}`, {
-      method: "PUT",
-      headers: { "Content-Type": "text/plain", ...studioWriteHeaders() },
-      body: JSON.stringify(overrides, null, 2),
-    })
-      .then((res) => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    (async () => {
+      try {
+        await putOverrides(pid, body);
+      } catch (error) {
+        if (error instanceof StudioFileConflictError) {
+          // versionRef was already refreshed by putOverrides; one retry with
+          // it is enough for a single-writer file.
+          await putOverrides(pid, body);
+        } else {
+          throw error;
+        }
+      }
+    })()
+      .then(() => {
         // A newer edit may have re-armed the debounce while this PUT was in
         // flight — its beforeunload/unmount flush still needs pending=true.
-        if (editSeqRef.current === seqAtSave) pendingRef.current = false;
+        if (editSeqRef.current === seqAtSave) setPending(false);
         const s = useCaptionStore.getState();
         if (s.syncError) s.setSyncError(null);
       })
@@ -111,15 +194,23 @@ export function useCaptionSync(projectId: string | null) {
         trackEvent("studio_caption_autosave_failed", { error: String(error) });
         useCaptionStore.getState().setSyncError("Caption changes couldn't be saved");
       });
-  }, []);
+  }, [putOverrides]);
 
   // Auto-save on model changes with 800ms debounce
   useMountEffect(() => {
     let prevModel = useCaptionStore.getState().model;
 
     const unsub = useCaptionStore.subscribe((state) => {
-      if (!state.isEditMode || state.model === prevModel || !state.model) return;
+      // Track the latest model on every tick, even before edit mode is
+      // entered. useCaptionDetection calls setModel() BEFORE setEditMode(true)
+      // when it activates caption editing; without this, that setModel() is
+      // skipped here (isEditMode still false) and prevModel is left stale, so
+      // the very next tick (setEditMode(true), same model) sees
+      // `state.model !== prevModel` and arms a save for an edit that never
+      // happened.
+      const modelChanged = state.model !== prevModel;
       prevModel = state.model;
+      if (!modelChanged || !state.isEditMode || !state.model) return;
 
       // Skip save when loadOverrides just updated the model
       if (suppressSaveRef.current) {
@@ -128,7 +219,7 @@ export function useCaptionSync(projectId: string | null) {
       }
 
       if (debounceRef.current) clearTimeout(debounceRef.current);
-      pendingRef.current = true;
+      setPending(true);
       editSeqRef.current++;
       debounceRef.current = setTimeout(save, 800);
     });
@@ -168,13 +259,19 @@ export function useCaptionSync(projectId: string | null) {
     const pid = projectIdRef.current;
     if (!pid) return;
 
-    let data: { content?: string };
+    let data: { content?: string; version?: string };
     try {
-      const res = await fetch(
-        `/api/projects/${pid}/files/${encodeURIComponent("caption-overrides.json")}`,
-      );
-      if (!res.ok) return; // no overrides file yet — normal
+      const res = await fetch(captionOverridesUrl(pid));
+      if (!res.ok) {
+        // Treated as "no overrides file yet" below. If that guess is wrong
+        // (a transient error rather than a real 404), the save path's
+        // 409-conflict retry recovers: it adopts the server's real version
+        // and retries once.
+        versionRef.current = null;
+        return;
+      }
       data = await res.json();
+      versionRef.current = data.version ?? res.headers.get("etag") ?? null;
     } catch {
       return; // network failure fetching an optional file — nothing to restore
     }

--- a/packages/studio/src/captions/hooks/useCaptionSync.ts
+++ b/packages/studio/src/captions/hooks/useCaptionSync.ts
@@ -6,6 +6,7 @@ import type { CaptionStyle } from "../types";
 import { studioWriteHeaders } from "../../utils/studioFileVersion";
 import {
   StudioFileConflictError,
+  StudioSaveNetworkError,
   createStudioSaveHttpError,
   retryStudioSave,
 } from "../../utils/studioSaveDiagnostics";
@@ -91,6 +92,15 @@ export function useCaptionSync(projectId: string | null) {
   // before the first write), null = confirmed not to exist yet (send
   // If-None-Match instead of If-Match).
   const versionRef = useRef<string | null | undefined>(undefined);
+  // Saves are serialized. Two PUTs in flight at once race on versionRef: the
+  // usual ordering self-heals (the older lands first, the newer 409s, adopts
+  // and retries), but if they reorder — or the older one's adopt-and-retry
+  // lands last — the older body wins and the newer edit is silently lost.
+  // Only one attempt runs at a time, and a save requested while one is in
+  // flight replaces any already-queued attempt rather than stacking, so the
+  // next PUT always carries the newest body.
+  const savingRef = useRef(false);
+  const queuedSaveRef = useRef<{ pid: string; body: string; seq: number } | null>(null);
 
   const setPending = (pending: boolean) => {
     pendingRef.current = pending;
@@ -113,9 +123,14 @@ export function useCaptionSync(projectId: string | null) {
           body,
         });
       } catch (error) {
-        throw new Error(`Failed to save ${CAPTION_OVERRIDES_PATH}: network error`, {
-          cause: error,
-        });
+        // StudioSaveNetworkError, not a plain Error, so retryStudioSave's
+        // network-retry path applies here the way it does in useFileManager.
+        throw new StudioSaveNetworkError(
+          `Failed to save ${CAPTION_OVERRIDES_PATH}: network error`,
+          {
+            cause: error,
+          },
+        );
       }
       if (response.status === 409) {
         const conflict = (await response.json().catch(() => null)) as {
@@ -165,35 +180,47 @@ export function useCaptionSync(projectId: string | null) {
       return;
     }
 
-    const seqAtSave = editSeqRef.current;
-    const body = JSON.stringify(buildOverrides(state.model), null, 2);
+    queuedSaveRef.current = {
+      pid,
+      body: JSON.stringify(buildOverrides(state.model), null, 2),
+      seq: editSeqRef.current,
+    };
+    if (savingRef.current) return;
+    savingRef.current = true;
 
-    (async () => {
+    void (async () => {
       try {
-        await putOverrides(pid, body);
-      } catch (error) {
-        if (error instanceof StudioFileConflictError) {
-          // versionRef was already refreshed by putOverrides; one retry with
-          // it is enough for a single-writer file.
-          await putOverrides(pid, body);
-        } else {
-          throw error;
+        // Drains whatever is queued, including edits that arrive mid-PUT, so
+        // the last write to land is always the newest body.
+        while (queuedSaveRef.current) {
+          const attempt = queuedSaveRef.current;
+          queuedSaveRef.current = null;
+          try {
+            await putOverrides(attempt.pid, attempt.body);
+          } catch (error) {
+            if (error instanceof StudioFileConflictError) {
+              // versionRef was already refreshed by putOverrides; one retry
+              // with it is enough for a single-writer file.
+              await putOverrides(attempt.pid, attempt.body);
+            } else {
+              throw error;
+            }
+          }
+          // A newer edit may have re-armed the debounce while this PUT was in
+          // flight — its beforeunload/unmount flush still needs pending=true.
+          if (editSeqRef.current === attempt.seq) setPending(false);
+          const s = useCaptionStore.getState();
+          if (s.syncError) s.setSyncError(null);
         }
-      }
-    })()
-      .then(() => {
-        // A newer edit may have re-armed the debounce while this PUT was in
-        // flight — its beforeunload/unmount flush still needs pending=true.
-        if (editSeqRef.current === seqAtSave) setPending(false);
-        const s = useCaptionStore.getState();
-        if (s.syncError) s.setSyncError(null);
-      })
-      .catch((error: unknown) => {
+      } catch (error: unknown) {
         // Caption auto-save is a data-loss path: surface it to the user, not
         // just telemetry. pendingRef stays true so beforeunload still warns.
         trackEvent("studio_caption_autosave_failed", { error: String(error) });
         useCaptionStore.getState().setSyncError("Caption changes couldn't be saved");
-      });
+      } finally {
+        savingRef.current = false;
+      }
+    })();
   }, [putOverrides]);
 
   // Auto-save on model changes with 800ms debounce

--- a/packages/studio/src/captions/store.ts
+++ b/packages/studio/src/captions/store.ts
@@ -25,6 +25,10 @@ interface CaptionState {
   syncError: string | null;
   /** Registered by useCaptionSync so error banners can retry the save. */
   retrySave: (() => void) | null;
+  /** True while an edit is debounced or a save PUT is in flight. Lets a
+   *  composition-switch flush skip retrySave() when there is nothing to
+   *  flush, instead of firing a PUT on every switch. */
+  hasPendingSave: boolean;
 
   // Undo/redo (in-memory model snapshots)
   past: CaptionModel[];
@@ -39,6 +43,7 @@ interface CaptionState {
   setSourceFilePath: (path: string | null) => void;
   setSyncError: (error: string | null) => void;
   setRetrySave: (fn: (() => void) | null) => void;
+  setHasPendingSave: (pending: boolean) => void;
 
   // Selection
   selectSegment: (id: string, additive?: boolean) => void;
@@ -79,6 +84,7 @@ const initialState = {
   sourceFilePath: null,
   syncError: null,
   retrySave: null,
+  hasPendingSave: false,
   past: [] as CaptionModel[],
   future: [] as CaptionModel[],
 };
@@ -118,6 +124,7 @@ export const useCaptionStore = create<CaptionState>((set, get) => ({
   setSourceFilePath: (path) => set({ sourceFilePath: path }),
   setSyncError: (error) => set({ syncError: error }),
   setRetrySave: (fn) => set({ retrySave: fn }),
+  setHasPendingSave: (pending) => set({ hasPendingSave: pending }),
 
   // Undo/redo
   undo: () => {

--- a/packages/studio/src/hooks/useCaptionDetection.flushGate.test.tsx
+++ b/packages/studio/src/hooks/useCaptionDetection.flushGate.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useCaptionDetection } from "./useCaptionDetection";
+import { useCaptionStore } from "../captions/store";
+import type { useCaptionSync } from "../captions/hooks/useCaptionSync";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// projectId: null keeps this to the composition-switch flush effect only —
+// the caption-activation effect bails immediately without a project id, so
+// no iframe/DOM mocking is needed for it.
+function mountDetection(initialCompPath: string | null) {
+  let setActiveCompPath: (path: string | null) => void = () => {};
+  function Probe({ activeCompPath }: { activeCompPath: string | null }) {
+    useCaptionDetection({
+      projectId: null,
+      activeCompPath,
+      compIdToSrc: new Map(),
+      captionEditMode: false,
+      captionHasSelection: false,
+      previewIframeRef: { current: null },
+      captionSync: {} as ReturnType<typeof useCaptionSync>,
+      setRightCollapsed: () => {},
+    });
+    return null;
+  }
+
+  const root = createRoot(document.createElement("div"));
+  function render(path: string | null) {
+    act(() => root.render(<Probe activeCompPath={path} />));
+  }
+  setActiveCompPath = render;
+  render(initialCompPath);
+  return { root, setActiveCompPath };
+}
+
+describe("useCaptionDetection composition-switch flush", () => {
+  afterEach(() => {
+    useCaptionStore.getState().reset();
+    vi.restoreAllMocks();
+  });
+
+  it("does not call retrySave when there is no pending edit", () => {
+    const retrySave = vi.fn();
+    const store = useCaptionStore.getState();
+    store.setModel({} as never);
+    store.setRetrySave(retrySave);
+    store.setHasPendingSave(false);
+
+    const { root, setActiveCompPath } = mountDetection("comp-a.html");
+    setActiveCompPath("comp-b.html");
+
+    expect(retrySave).not.toHaveBeenCalled();
+    act(() => root.unmount());
+  });
+
+  it("calls retrySave when an edit is pending", () => {
+    const retrySave = vi.fn();
+    const store = useCaptionStore.getState();
+    store.setModel({} as never);
+    store.setRetrySave(retrySave);
+    store.setHasPendingSave(true);
+
+    const { root, setActiveCompPath } = mountDetection("comp-a.html");
+    setActiveCompPath("comp-b.html");
+
+    expect(retrySave).toHaveBeenCalledTimes(1);
+    act(() => root.unmount());
+  });
+
+  it("still resets caption state on switch even when nothing was pending", () => {
+    const store = useCaptionStore.getState();
+    store.setModel({} as never);
+    store.setEditMode(true);
+    store.setHasPendingSave(false);
+
+    const { root, setActiveCompPath } = mountDetection("comp-a.html");
+    setActiveCompPath("comp-b.html");
+
+    expect(useCaptionStore.getState().model).toBeNull();
+    expect(useCaptionStore.getState().isEditMode).toBe(false);
+    act(() => root.unmount());
+  });
+});

--- a/packages/studio/src/hooks/useCaptionDetection.ts
+++ b/packages/studio/src/hooks/useCaptionDetection.ts
@@ -37,7 +37,10 @@ export function useCaptionDetection({
       if (store.model || store.isEditMode) {
         // Flush the last debounced caption edit before the reset destroys the
         // model — otherwise a save landing after the switch writes nothing.
-        store.retrySave?.();
+        // Gated on hasPendingSave: without it, every switch out of a
+        // composition that ever entered caption mode fired a PUT, even when
+        // nothing had been edited.
+        if (store.hasPendingSave) store.retrySave?.();
         store.reset();
       }
     }


### PR DESCRIPTION
## What

Fixes #3501. `useCaptionSync`'s save path now follows the same conditional-write protocol `useFileManager.ts` already uses for the main composition file, and a false-armed autosave on edit-mode activation is fixed.

## Why

`caption-overrides.json` was `PUT` without an `If-Match`/`If-None-Match` header at all, so the server's 428 (Precondition Required) response was never satisfied and every save failed, surfacing as a toast even when the user hadn't edited anything.

That second half traced to a bug in the autosave subscription's own change tracking, separate from the missing headers: `prevModel` was only updated inside the `!state.isEditMode` early-return's guarded branch. The real activation order (`useCaptionDetection.ts`: `setModel()`, then `setEditMode(true)`) calls `setModel()` *before* entering edit mode, so that call was invisible to `prevModel`. The next tick's `setEditMode(true)` then looked like a model change against the stale `prevModel` and armed a save nobody asked for.

## How

- Added a `versionRef` to `useCaptionSync` (`undefined` = unknown, `null` = confirmed absent, string = known ETag), mirroring `useFileManager.ts`. `loadOverrides()` captures the version from the GET response.
- `putOverrides()` sends `If-None-Match: "*"` when no version is known yet, `If-Match: <version>` once one is, via the existing `retryStudioSave`/`StudioFileConflictError` machinery. On a 409, adopts the server's `currentVersion` and retries once.
- Fixed `prevModel` tracking: compute `modelChanged`/update `prevModel` unconditionally at the top of every subscription tick, before the `isEditMode` early return, so a `setModel()` that happens before `setEditMode(true)` is no longer invisible.
- Added `hasPendingSave` to the caption store, set whenever a real edit arms a save, cleared once it's sent. Gated `useCaptionDetection.ts`'s composition-switch flush behind it, since it previously called `retrySave?.()` unconditionally on every switch, not just when there was something to save.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

`useCaptionSync.test.tsx` (5 cases): first save sends `If-None-Match: "*"`; a save after `loadOverrides()` sends `If-Match` with the captured version; a 409 retries once with the adopted version; edit-mode activation with no prior edit does not arm a save (regression test for the `prevModel` bug); a genuine edit still arms one. `useCaptionDetection.flushGate.test.tsx` (3 cases) covers the gated flush directly.

Ran the full studio suite before and after: same 56 pre-existing failures both times (401→403 files affected, 3984→3992 tests passing), so this branch doesn't touch anything outside its own scope. `lefthook run pre-commit` (lint, format, fallow, typecheck, filesize, largefiles, tracked-artifacts, commitlint) all green on the actual commit.
