### PR TITLE
fix(producer): scale frame coverage by playback rate

### DIFF
--- a/packages/producer/src/services/render/videoFrameCoverage.test.ts
+++ b/packages/producer/src/services/render/videoFrameCoverage.test.ts
@@ -19,6 +19,7 @@ function makeVideo(overrides: Partial<VideoElement> & { id: string }): VideoElem
     start: overrides.start ?? 0,
     end: overrides.end ?? 1,
     mediaStart: overrides.mediaStart ?? 0,
+    playbackRate: overrides.playbackRate,
     loop: overrides.loop ?? false,
     hasAudio: overrides.hasAudio ?? false,
   };
@@ -133,6 +134,16 @@ describe("resolveVideoCoverageThreshold", () => {
 });
 
 describe("computeVideoFrameCoverage", () => {
+  it("expects only the source frames consumed by a slowed authored slot", () => {
+    const videos = [makeVideo({ id: "slow", start: 0, end: 4, playbackRate: 0.5 })];
+    const extracted = [makeExtracted("slow", 60, { durationSeconds: 4 })];
+
+    const reports = computeVideoFrameCoverage(videos, extracted, 30);
+
+    expect(reports[0]).toMatchObject({ expectedFrames: 60, capturedFrames: 60, ratio: 1 });
+    expect(() => assertVideoFrameCoverage(reports, 0.95)).not.toThrow();
+  });
+
   it("reports 1.0 ratio when every video delivered its authored window", () => {
     const videos = [
       makeVideo({ id: "a", start: 0, end: 1 }),

--- a/packages/producer/src/services/render/videoFrameCoverage.ts
+++ b/packages/producer/src/services/render/videoFrameCoverage.ts
@@ -45,7 +45,7 @@
  */
 
 import { parseHTML } from "linkedom";
-import { fpsToNumber, toFps, type FpsInput } from "@hyperframes/core";
+import { fpsToNumber, normalizePlaybackRate, toFps, type FpsInput } from "@hyperframes/core";
 import {
   extractionFrameCountForDuration,
   resolvePlayableVideoDuration,
@@ -166,7 +166,9 @@ function expectedFramesForVideo(
   fps: FpsInput,
 ): number {
   const rounding = entry && !entry.metadata.isVFR ? "nearest" : "ceil";
-  const slotFrames = expectedFramesForClip(video.start, video.end, fps, rounding);
+  const playbackRate = normalizePlaybackRate(video.playbackRate ?? 1);
+  const slotSourceDuration = Math.max(0, video.end - video.start) * playbackRate;
+  const slotFrames = expectedFramesForClip(0, slotSourceDuration, fps, rounding);
   if (!entry) return slotFrames;
 
   // A short source in a longer slot has a legitimate delivery ceiling of


### PR DESCRIPTION
## Summary

Valid slow-playback clips no longer fail the extracted-frame coverage gate. Coverage now compares delivered frames against the unique source-frame window consumed by the authored slot, using the same normalized playback rate as extraction, while retaining the existing source-duration ceiling and incomplete-extraction protection.

Fixes `reported:1787952018.741109`.

- https://slack.com/archives/C0BGC335AQY/p1787952018741109
- Related: https://slack.com/archives/C0BGC335AQY/p1787865428565129
- Related: https://slack.com/archives/C0BGC335AQY/p1787902069198369

## Test plan

- `packages/producer/src/services/render/videoFrameCoverage.test.ts` (39 passed)
- Producer typecheck
- `oxlint` and `oxfmt --check` on changed files
- Exact Terra fixture with the default 95% gate: extracts 60 frames, expects 60, reports minimum coverage `1`, and produces a valid `4.000s` MP4 without `HF_VIDEO_COVERAGE_THRESHOLD=0`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--Sol-000000)
