### PR TITLE
fix(cli): stop promising a claim link to signed-in publishers

### DIFF
--- a/packages/cli/src/commands/publish.test.ts
+++ b/packages/cli/src/commands/publish.test.ts
@@ -138,7 +138,20 @@ describe("publish consent notice", () => {
   it("tells a signed-in publisher there is no claim link", async () => {
     const output = await runConsent({ type: "api_key", key: "k", source: "env" });
 
-    expect(output).toContain("owned by your account");
+    expect(output).toContain("you own it on publish and there is no claim link");
     expect(output).not.toContain("claim it after authenticating");
+  });
+
+  it.each([
+    ["anonymous", null],
+    ["signed in", { type: "api_key", key: "k", source: "env" }],
+  ])("discloses the exposure before uploading (%s)", async (_label, credential) => {
+    // The consent prompt is the only place the user is told the artifact is world-readable:
+    // the result block prints no exposure line on the owned branch. Dropping it from either
+    // branch means someone approves an upload without being told who can reach it.
+    const output = await runConsent(credential);
+
+    expect(output).toContain("creates a stable public URL");
+    expect(output).toContain("Anyone with the URL can open the published project");
   });
 });

--- a/packages/cli/src/commands/publish.test.ts
+++ b/packages/cli/src/commands/publish.test.ts
@@ -4,10 +4,22 @@ import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 
 const publishState = vi.hoisted(() => ({ publish: vi.fn() }));
+const authState = vi.hoisted(() => ({ tryResolveCredential: vi.fn().mockResolvedValue(null) }));
+const clackState = vi.hoisted(() => ({ confirm: vi.fn() }));
 
 vi.mock("../utils/publishProject.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../utils/publishProject.js")>()),
   publishProjectArchive: publishState.publish,
+}));
+
+vi.mock("../auth/index.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../auth/index.js")>()),
+  tryResolveCredential: authState.tryResolveCredential,
+}));
+
+vi.mock("@clack/prompts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@clack/prompts")>()),
+  confirm: clackState.confirm,
 }));
 
 import publishCommand, { parseUpdateTarget } from "./publish.js";
@@ -88,5 +100,45 @@ describe("publish default-entry preflight", () => {
     expect(output).toContain("compositions/card.html");
     expect(output).not.toContain("hyperframes publish <project>/compositions");
     expect(output).toContain("publish accepts project directories, not individual HTML files");
+  });
+});
+
+describe("publish consent notice", () => {
+  async function runConsent(credential: unknown): Promise<string> {
+    const project = mkdtempSync(join(tmpdir(), "hf-publish-consent-"));
+    writeFileSync(
+      join(project, "index.html"),
+      `<html><body><div data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="5"><div class="clip" data-start="0" data-duration="5">Visible</div></div></body></html>`,
+    );
+    publishState.publish.mockReset();
+    authState.tryResolveCredential.mockReset().mockResolvedValue(credential);
+    // Declining the prompt stops the run right after the notice — no network, no upload.
+    clackState.confirm.mockReset().mockResolvedValue(false);
+    const lines: string[] = [];
+    const log = vi.spyOn(console, "log").mockImplementation((...parts: unknown[]) => {
+      lines.push(parts.map(String).join(" "));
+    });
+
+    try {
+      await publishCommand.run?.({ args: { dir: project, proxy: false } } as never);
+      expect(publishState.publish).not.toHaveBeenCalled();
+      return lines.join("\n");
+    } finally {
+      log.mockRestore();
+      rmSync(project, { recursive: true, force: true });
+    }
+  }
+
+  it("offers the claim step when publishing anonymously", async () => {
+    const output = await runConsent(null);
+
+    expect(output).toContain("claim it after authenticating");
+  });
+
+  it("tells a signed-in publisher there is no claim link", async () => {
+    const output = await runConsent({ type: "api_key", key: "k", source: "env" });
+
+    expect(output).toContain("owned by your account");
+    expect(output).not.toContain("claim it after authenticating");
   });
 });

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -119,13 +119,22 @@ export default defineCommand({
       }
     }
 
+    // Resolved once: the consent notice and the --update/--space gate must agree on
+    // whether this publish is authenticated.
+    const credential = await tryResolveCredential();
+
     if (args.yes !== true) {
       console.log();
       console.log(
-        `  ${c.bold("hyperframes publish uploads this project and creates a stable public URL.")}`,
+        `  ${c.bold("hyperframes publish uploads this project and creates a stable URL.")}`,
       );
+      // Only an anonymous publish gets a claim token; an authenticated one is owned on
+      // creation. Promising a claim step to a signed-in user sends them looking for a
+      // token the server never issued.
       console.log(
-        `  ${c.dim("Anyone with the URL can open the published project and claim it after authenticating.")}`,
+        credential === null
+          ? `  ${c.dim("Anyone with the URL can open the published project and claim it after authenticating.")}`
+          : `  ${c.dim("You are signed in, so the project is owned by your account on publish. There is no claim link.")}`,
       );
       console.log();
       const approved = await clack.confirm({ message: "Publish this project?" });
@@ -147,7 +156,6 @@ export default defineCommand({
     // --update / --space only take effect for an authenticated owner. Fail loudly rather
     // than silently minting a fresh URL — the exact failure mode this feature removes.
     if (updateTarget || spaceOverride) {
-      const credential = await tryResolveCredential();
       if (!credential) {
         console.log();
         console.log(

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -126,15 +126,17 @@ export default defineCommand({
     if (args.yes !== true) {
       console.log();
       console.log(
-        `  ${c.bold("hyperframes publish uploads this project and creates a stable URL.")}`,
+        `  ${c.bold("hyperframes publish uploads this project and creates a stable public URL.")}`,
       );
-      // Only an anonymous publish gets a claim token; an authenticated one is owned on
-      // creation. Promising a claim step to a signed-in user sends them looking for a
-      // token the server never issued.
+      // Both branches must state the exposure — the published project is readable by anyone
+      // holding the URL whether or not it is owned. Only the claim half differs: an
+      // anonymous publish gets a claim token, an authenticated one is owned on creation, so
+      // promising a claim step to a signed-in user sends them looking for a token the server
+      // never issued.
       console.log(
         credential === null
           ? `  ${c.dim("Anyone with the URL can open the published project and claim it after authenticating.")}`
-          : `  ${c.dim("You are signed in, so the project is owned by your account on publish. There is no claim link.")}`,
+          : `  ${c.dim("Anyone with the URL can open the published project. You are signed in, so you own it on publish and there is no claim link.")}`,
       );
       console.log();
       const approved = await clack.confirm({ message: "Publish this project?" });


### PR DESCRIPTION
## What

`hyperframes publish` no longer tells a signed-in user their project can be claimed. The consent notice now branches on whether a credential resolves, and both branches keep the exposure disclosure.

Before (every publish, signed in or not):

```
  hyperframes publish uploads this project and creates a stable public URL.
  Anyone with the URL can open the published project and claim it after authenticating.
```

After, when a credential resolves:

```
  hyperframes publish uploads this project and creates a stable public URL.
  Anyone with the URL can open the published project. You are signed in, so you own it on publish and there is no claim link.
```

The signed-out output is byte-identical to `main`, bold line included. Only the claim clause varies between branches.

## Why

The notice described the anonymous path only. An authenticated publish comes back `claimed: true` with an empty `claim_token` (`packages/cli/src/utils/publishProject.ts:69-76`), and the result block prints no claim URL in that branch (`packages/cli/src/commands/publish.ts:214-247`) because there is nothing to claim. So a signed-in user read a promise of a claim link, then went looking through the output for a claim token that the server never issued.

The docs already get this right (`docs/packages/cli.mdx`: "You can publish while signed out. The printed URL then carries a claim token"). The CLI prompt was the one surface asserting it unconditionally.

## How

Hoist the credential resolution above the consent block and pick the claim clause from it. The `--update` / `--space` authentication gate now reuses that same value instead of calling `tryResolveCredential()` a second time, so one resolution owns "is this publish authenticated".

Resolution moves earlier for a plain publish, which previously only resolved credentials inside `publishProjectArchive`. Same call, same failure surface; a broken credential store now fails before the upload starts rather than during it.

The exposure sentence stays on both branches. It is load-bearing, not boilerplate: `GET /v1/hyperframes/projects/<id>/public` carries no `@HeyGenAPI` decorator (the `/claim` route directly below it does), and its handler does not filter on `is_public`, so any published project is readable by anyone holding its id. `--public` governs whether the *claimed session* is public in the web app, not whether the link is readable. Ownership is not privacy here.

## Review history

An earlier head (`710a58ea`) dropped "public" from the shared bold line and replaced rather than supplemented the signed-in dim line, which left a signed-in publisher approving an upload with no exposure disclosure anywhere in the flow. Caught in review and fixed at `f86f39ef2`. The description above describes the current head.

## Test plan

- [x] Unit tests added/updated in `packages/cli/src/commands/publish.test.ts`: two cases drive the real command with a declined prompt and assert the claim clause per auth state, plus a parameterised case asserting **both** branches print `creates a stable public URL` and `Anyone with the URL can open the published project`. That last one exists because the first version of this PR regressed the disclosure and no test caught it.
- [x] Verified non-vacuous: forcing the branch back to the anonymous string fails the signed-in case; removing the disclosure from either branch fails the parameterised case.
- [x] Manual testing performed: ran the actual CLI signed in against a scratch project and read the printed notice.

```
$ echo n | bun packages/cli/src/cli.ts publish /tmp/hf-consent-demo

  hyperframes publish uploads this project and creates a stable public URL.
  Anyone with the URL can open the published project. You are signed in, so you own it on publish and there is no claim link.

◆  Publish this project?
```

- `bun run --filter @hyperframes/cli test -- src/commands/publish.test.ts` → 11 passed.
- `bunx tsc --noEmit -p packages/cli/tsconfig.json` → clean. oxlint + oxfmt clean.

Not covered: the signed-out prompt was not re-run against a real logged-out machine. The unit test covers that branch, and its output is byte-identical to `main`.
