### PR TITLE
test: make published skill checks self-contained

### DIFF
--- a/skills/hyperframes-animation/scripts/package-loader.test.mjs
+++ b/skills/hyperframes-animation/scripts/package-loader.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -22,16 +22,30 @@ test("hyperframesPackageSpec: env override wins", async () => {
   }
 });
 
-// (b) resolvable version (in-repo) pins the bundled hyperframes/@hyperframes/cli version.
-test("hyperframesPackageSpec: resolvable in-repo version pins it", async () => {
-  const prev = process.env[ENV];
-  delete process.env[ENV];
+// (b) a resolvable ancestor package version pins the bundled package version.
+// Published skills do not include the HyperFrames monorepo, so build the
+// ancestor relationship explicitly instead of depending on the install path.
+test("hyperframesPackageSpec: resolvable ancestor version pins it", () => {
+  const dir = mkdtempSync(join(tmpdir(), "hf-pkgloader-version-"));
   try {
-    const { hyperframesPackageSpec } = await import("./package-loader.mjs");
-    const spec = hyperframesPackageSpec("@hyperframes/producer");
-    assert.match(spec, /^@hyperframes\/producer@\d+\.\d+\.\d+/);
+    const scriptsDir = join(dir, "skills", "fixture", "scripts");
+    writeFileSync(join(dir, "package.json"), '{"name":"hyperframes","version":"1.2.3"}\n');
+    mkdirSync(scriptsDir, { recursive: true });
+    copyFileSync(join(HERE, "package-loader.mjs"), join(scriptsDir, "package-loader.mjs"));
+    const probe = join(scriptsDir, "probe.mjs");
+    writeFileSync(
+      probe,
+      [
+        'import { hyperframesPackageSpec } from "./package-loader.mjs";',
+        'process.stdout.write(hyperframesPackageSpec("@hyperframes/producer"));',
+        "",
+      ].join("\n"),
+    );
+    const probeResult = spawnSync(process.execPath, [probe], { cwd: scriptsDir, encoding: "utf8" });
+    assert.equal(probeResult.status, 0, probeResult.stderr);
+    assert.equal(probeResult.stdout.trim(), "@hyperframes/producer@1.2.3");
   } finally {
-    if (prev !== undefined) process.env[ENV] = prev;
+    rmSync(dir, { recursive: true, force: true });
   }
 });
 

--- a/skills/hyperframes-creative/scripts/package-loader.test.mjs
+++ b/skills/hyperframes-creative/scripts/package-loader.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -22,16 +22,30 @@ test("hyperframesPackageSpec: env override wins", async () => {
   }
 });
 
-// (b) resolvable version (in-repo) pins the bundled hyperframes/@hyperframes/cli version.
-test("hyperframesPackageSpec: resolvable in-repo version pins it", async () => {
-  const prev = process.env[ENV];
-  delete process.env[ENV];
+// (b) a resolvable ancestor package version pins the bundled package version.
+// Published skills do not include the HyperFrames monorepo, so build the
+// ancestor relationship explicitly instead of depending on the install path.
+test("hyperframesPackageSpec: resolvable ancestor version pins it", () => {
+  const dir = mkdtempSync(join(tmpdir(), "hf-pkgloader-version-"));
   try {
-    const { hyperframesPackageSpec } = await import("./package-loader.mjs");
-    const spec = hyperframesPackageSpec("@hyperframes/producer");
-    assert.match(spec, /^@hyperframes\/producer@\d+\.\d+\.\d+/);
+    const scriptsDir = join(dir, "skills", "fixture", "scripts");
+    writeFileSync(join(dir, "package.json"), '{"name":"hyperframes","version":"1.2.3"}\n');
+    mkdirSync(scriptsDir, { recursive: true });
+    copyFileSync(join(HERE, "package-loader.mjs"), join(scriptsDir, "package-loader.mjs"));
+    const probe = join(scriptsDir, "probe.mjs");
+    writeFileSync(
+      probe,
+      [
+        'import { hyperframesPackageSpec } from "./package-loader.mjs";',
+        'process.stdout.write(hyperframesPackageSpec("@hyperframes/producer"));',
+        "",
+      ].join("\n"),
+    );
+    const probeResult = spawnSync(process.execPath, [probe], { cwd: scriptsDir, encoding: "utf8" });
+    assert.equal(probeResult.status, 0, probeResult.stderr);
+    assert.equal(probeResult.stdout.trim(), "@hyperframes/producer@1.2.3");
   } finally {
-    if (prev !== undefined) process.env[ENV] = prev;
+    rmSync(dir, { recursive: true, force: true });
   }
 });
 

--- a/skills/media-use/scripts/lib/lut-preset-provider.test.mjs
+++ b/skills/media-use/scripts/lib/lut-preset-provider.test.mjs
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { mkdtempSync, rmSync, existsSync, readFileSync, readdirSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { test } from "node:test";
@@ -12,15 +12,6 @@ import {
 } from "./lut-preset-provider.mjs";
 import { buildCube } from "./cube-build.mjs";
 import { validateCube, validateCubeFile } from "./cube-validate.mjs";
-
-const REPO_ROOT = join(import.meta.dirname, "..", "..", "..", "..");
-
-function corePresetIdsFromSource() {
-  const src = readFileSync(join(REPO_ROOT, "packages/core/src/colorGrading.ts"), "utf8");
-  const match = src.match(/export type HfColorGradingPresetId =([\s\S]*?);/);
-  assert.ok(match, "core preset union should be readable");
-  return [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
-}
 
 test("warm daylight and warm natural light resolve to the core warm-daylight preset", () => {
   assert.deepEqual(matchColorLook("warm daylight"), {
@@ -65,12 +56,7 @@ test("library look freezes a validated cube from params offline (--local-only)",
   }
 });
 
-test("every resolver preset exists in packages/core/src/colorGrading.ts", () => {
-  const corePresetIds = corePresetIdsFromSource();
-  assert.deepEqual(
-    RESOLVABLE_PRESET_IDS.filter((id) => !corePresetIds.includes(id)),
-    [],
-  );
+test("every resolver preset round-trips through the published matcher", () => {
   for (const id of RESOLVABLE_PRESET_IDS) {
     const match = matchColorLook(id);
     assert.equal(match.kind, "preset");


### PR DESCRIPTION
## Summary

- make package-loader version tests use an explicit temporary HyperFrames ancestor fixture
- validate LUT preset IDs through the published matcher contract
- remove published-skill test dependencies on monorepo-only files

## Tests

- isolated published fixture: 16/16 passed
- full skill helper suite: 553/553 passed
- oxfmt check: passed
- oxlint on changed files: passed
- quick_validate.py for all three affected skills: passed