### PR TITLE
fix(studio): activate a composition at any path, not just compositions/

### DIFF
--- a/packages/studio/src/components/nle/useCompositionStack.test.tsx
+++ b/packages/studio/src/components/nle/useCompositionStack.test.tsx
@@ -42,3 +42,72 @@ describe("useCompositionStack — project scoping", () => {
     });
   }
 });
+
+describe("useCompositionStack — activating a composition by path", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function mountStack(activeCompositionPath: string | null) {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const root = createRoot(host);
+    const seen: { stack: ReturnType<typeof useCompositionStack>["compositionStack"] } = {
+      stack: [],
+    };
+
+    function Harness(props: { activeCompositionPath: string | null }) {
+      seen.stack = useCompositionStack({ projectId: "p", ...props }).compositionStack;
+      return null;
+    }
+
+    return { root, seen, Harness, activeCompositionPath };
+  }
+
+  // The root stays on the master level; everything else pushes a second level.
+  for (const path of [
+    "compositions/scene-a.html",
+    "parts/part-1.html",
+    "chapter-2.html",
+    "a/b/c/deep.html",
+  ]) {
+    it(`pushes a level for ${path}`, async () => {
+      const { root, seen, Harness } = mountStack(path);
+
+      await act(async () => {
+        root.render(<Harness activeCompositionPath={path} />);
+      });
+
+      expect(seen.stack).toHaveLength(2);
+      expect(seen.stack[1]?.id).toBe(path);
+      expect(seen.stack[1]?.previewUrl).toBe(`/api/projects/p/preview/comp/${path}`);
+
+      act(() => root.unmount());
+    });
+  }
+
+  it("labels a non-compositions/ path without mangling it", async () => {
+    const { root, seen, Harness } = mountStack("parts/part-1.html");
+
+    await act(async () => {
+      root.render(<Harness activeCompositionPath="parts/part-1.html" />);
+    });
+
+    expect(seen.stack[1]?.label).toBe("parts/part-1");
+
+    act(() => root.unmount());
+  });
+
+  it("keeps the master alone for the root composition", async () => {
+    const { root, seen, Harness } = mountStack("index.html");
+
+    await act(async () => {
+      root.render(<Harness activeCompositionPath="index.html" />);
+    });
+
+    expect(seen.stack).toHaveLength(1);
+    expect(seen.stack[0]?.id).toBe("master");
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/studio/src/components/nle/useCompositionStack.ts
+++ b/packages/studio/src/components/nle/useCompositionStack.ts
@@ -108,7 +108,13 @@ export function useCompositionStack({
     if (activeCompositionPath === "index.html") {
       usePlayerStore.getState().setElements([]);
       updateCompositionStack([master]);
-    } else if (activeCompositionPath && activeCompositionPath.startsWith("compositions/")) {
+    } else if (activeCompositionPath) {
+      // Any composition file that isn't the root, wherever it lives. Gating
+      // this on a `compositions/` prefix meant a project laying its comps out
+      // anywhere else (`parts/part-1.html`, generated multi-part builds) hit
+      // no branch at all: the stack kept the master mounted while the Comps
+      // panel highlighted the row, so the canvas and timeline stayed on
+      // index.html and edits landed in the root file.
       const label = activeCompositionPath.replace(/^compositions\//, "").replace(/\.html$/, "");
       const previewUrl = `/api/projects/${projectId}/preview/comp/${encodePreviewPath(activeCompositionPath)}`;
       usePlayerStore.getState().setElements([]);
@@ -116,7 +122,7 @@ export function useCompositionStack({
         if (prev[prev.length - 1]?.id === activeCompositionPath) return prev;
         return [master, { id: activeCompositionPath, label, previewUrl }];
       });
-    } else if (!activeCompositionPath) {
+    } else {
       usePlayerStore.getState().setElements([]);
       updateCompositionStack([master]);
     }


### PR DESCRIPTION
## What

Fixes #3543. Selecting a composition in the Comps panel now actually switches the canvas and timeline to it, for any path, not only files under `compositions/`.

## Why

`useCompositionStack`'s activation effect ran an if/else-if chain:

```ts
if (activeCompositionPath === "index.html") { /* master */ }
else if (activeCompositionPath && activeCompositionPath.startsWith("compositions/")) { /* push level */ }
else if (!activeCompositionPath) { /* master */ }
```

A path like `parts/part-1.html` is not `index.html`, does not start with `compositions/`, and is not falsy, so it matched no branch at all and the effect did nothing. The Comps panel still highlighted the row and the URL hash still updated, but the stack kept the master mounted: the canvas and timeline stayed on `index.html`, and, as the issue notes, any edit made there landed in the root file instead of the part.

The reporter's setup is the case that exposes it, a generated multi-part build with `index.html` plus `parts/part-1.html` through `parts/part-4.html`. Nothing requires a project's compositions to live under `compositions/`; the server already serves any of them (`GET /api/projects/<id>/preview/comp/parts/part-1.html` returns the right page, per the issue).

## How

Replaced the prefix test with a plain truthiness check, so the root composition stays on the master level and every other path pushes its own level. The final `else` now covers null/empty.

Label derivation is unchanged (`replace(/^compositions\//, "").replace(/\.html$/, "")`), which is the same expression `CompositionsTab` uses for the panel's own card labels, so a `compositions/`-relative project's labels are byte-identical to before and `parts/part-1.html` reads as `parts/part-1`.

## Test plan

- [x] Unit tests added/updated
- [ ] Manual testing performed (see note)
- [ ] Documentation updated (if applicable)

Extended `useCompositionStack.test.tsx` with 6 cases: a parameterised set asserting a level is pushed with the right `id` and `previewUrl` for `compositions/scene-a.html` (the previously-working case, as a regression guard), `parts/part-1.html` (the issue's case), a bare `chapter-2.html`, and a deep `a/b/c/deep.html`; plus a label assertion and a guard that `index.html` still leaves the master alone.

Mutation-tested: reverting only `useCompositionStack.ts` and keeping the tests fails the three non-`compositions/` cases (stack length 1 instead of 2), while the `compositions/` and `index.html` cases still pass, which is exactly the reported split. 8/8 pass with the fix.

I did not reproduce this in a running Studio: it needs a multi-part project and a live preview server, and the mechanism is fully determined by this effect's branch conditions, which the tests cover directly. The issue author already confirmed the runtime symptom headlessly with puppeteer.

`lefthook run pre-commit` all green (lint, format, fallow, typecheck, filesize, largefiles, tracked-artifacts, commitlint).
