### PR TITLE
fix(studio): export the composition the user has selected

### DIFF
--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -84,7 +84,7 @@ export function StudioApp() {
   const activeCompPathRef = useRef(activeCompPath);
   activeCompPathRef.current = activeCompPath;
   const leftSidebarRef = useRef<LeftSidebarHandle>(null);
-  const renderQueue = useRenderQueue(projectId);
+  const renderQueue = useRenderQueue(projectId, activeCompPathRef);
   const captionEditMode = useCaptionStore((s) => s.isEditMode);
   const captionHasSelection = useCaptionStore((s) => s.selectedSegmentIds.size > 0);
   const captionSync = useCaptionSync(projectId);

--- a/packages/studio/src/components/renders/RenderQueuePanel.tsx
+++ b/packages/studio/src/components/renders/RenderQueuePanel.tsx
@@ -12,13 +12,8 @@ import { usePreviewVariablesStore } from "../../hooks/previewVariablesStore";
  * without giving anything a second reader.
  */
 export const RenderQueuePanel = memo(function RenderQueuePanel() {
-  const {
-    projectId,
-    activeCompPath,
-    compositionDimensions,
-    waitForPendingDomEditSaves,
-    renderQueue,
-  } = useStudioShellContext();
+  const { projectId, compositionDimensions, waitForPendingDomEditSaves, renderQueue } =
+    useStudioShellContext();
 
   return (
     <RenderQueue
@@ -36,14 +31,12 @@ export const RenderQueuePanel = memo(function RenderQueuePanel() {
       onRecheckFfmpeg={renderQueue.recheckFfmpeg}
       onStartRender={async (format, quality, resolution, fps) => {
         await waitForPendingDomEditSaves();
-        const composition =
-          activeCompPath && activeCompPath !== "index.html" ? activeCompPath : undefined;
+        // No `composition`: startRender targets the active one by default.
         await renderQueue.startRender({
           fps,
           quality,
           format,
           resolution,
-          composition,
           // Render what the user is previewing: active variable overrides
           // from the Variables panel ride along (undefined = defaults).
           variables: usePreviewVariablesStore.getState().values ?? undefined,

--- a/packages/studio/src/components/renders/renderQueueTestHarness.tsx
+++ b/packages/studio/src/components/renders/renderQueueTestHarness.tsx
@@ -49,13 +49,39 @@ export interface MountedQueue {
   unmount: () => void;
 }
 
+/**
+ * Mounts the hook, starts one render, and returns the body of the POST it
+ * made — the only place Studio states what to render and who to attribute it
+ * to, so it is what the tests around it assert on. The caller keeps the
+ * returned queue to unmount it.
+ */
+export async function startRenderAndReadBody(
+  useRenderQueueHook: UseRenderQueue,
+  {
+    activeCompPath = null,
+    opts,
+  }: { activeCompPath?: string | null; opts?: Parameters<RenderQueueApi["startRender"]>[0] } = {},
+): Promise<{ body: Record<string, unknown>; queue: MountedQueue }> {
+  const fetchMock = stubRenderFetch();
+  const queue = mountRenderQueue(useRenderQueueHook, "demo", activeCompPath);
+  await act(async () => {
+    await queue.api().startRender(opts);
+  });
+  const [post] = renderPosts(fetchMock) as [undefined | [string, RequestInit]];
+  const body = post?.[1]?.body;
+  if (body === undefined || body === null) throw new Error("hook made no POST with a body");
+  return { body: JSON.parse(String(body)) as Record<string, unknown>, queue };
+}
+
 export function mountRenderQueue(
   useRenderQueueHook: UseRenderQueue,
   projectId = "demo",
+  activeCompPath: string | null = null,
 ): MountedQueue {
   let current: RenderQueueApi | null = null;
+  const activeCompPathRef = { current: activeCompPath };
   function Harness(): null {
-    current = useRenderQueueHook(projectId);
+    current = useRenderQueueHook(projectId, activeCompPathRef);
     return null;
   }
   const host = document.createElement("div");

--- a/packages/studio/src/components/renders/useRenderQueue.ts
+++ b/packages/studio/src/components/renders/useRenderQueue.ts
@@ -30,7 +30,11 @@ export interface StartRenderOptions {
   format?: "mp4" | "webm" | "mov";
   /** `"auto"` (default) renders at the composition's authored dimensions. */
   resolution?: ResolutionPreset | "auto";
-  /** Render a specific composition file instead of index.html. */
+  /**
+   * Render a specific composition file. Omit it to render the composition the
+   * user currently has open — only the sidebar's per-composition Render button
+   * names one, because it renders a card the user is not looking at.
+   */
   composition?: string;
   /**
    * Composition-variable overrides ({variableId: value}), forwarded to the
@@ -66,7 +70,13 @@ function writeHiddenIds(projectId: string, ids: Set<string>): void {
   }
 }
 
-export function useRenderQueue(projectId: string | null) {
+export function useRenderQueue(
+  projectId: string | null,
+  // A ref, not the value: the render target has to be read at click time, and
+  // threading the value through would rebuild every callback below on each
+  // composition switch.
+  activeCompPathRef: { current: string | null },
+) {
   const [jobs, setJobs] = useState<RenderJob[]>([]);
   // History fetch failure — distinguished from "no renders yet" so the panel
   // never shows a false empty state.
@@ -185,7 +195,13 @@ export function useRenderQueue(projectId: string | null) {
       const quality = opts.quality ?? "standard";
       const format = opts.format ?? "mp4";
       const resolution = opts.resolution;
-      const composition = opts.composition;
+      // Which composition a render targets belongs here, with the same
+      // argument the FFmpeg gate above makes: Studio starts renders from three
+      // controls, and a default living in one of them leaves the others
+      // exporting a file the user is not looking at. The header's Export
+      // passed no options at all, so every render it started went to
+      // index.html no matter which composition was selected (#3549).
+      const composition = opts.composition ?? activeCompPathRef.current ?? undefined;
 
       trackStudioRenderStart({
         fps,
@@ -344,7 +360,7 @@ export function useRenderQueue(projectId: string | null) {
 
       return jobId;
     },
-    [projectId, closeActiveEventSource, addSessionJob, ffmpeg, ffmpegMissing],
+    [projectId, activeCompPathRef, closeActiveEventSource, addSessionJob, ffmpeg, ffmpegMissing],
   );
 
   // Cancel an in-flight render. The job row stays (as "cancelled") so the

--- a/packages/studio/src/components/renders/useRenderQueueComposition.test.tsx
+++ b/packages/studio/src/components/renders/useRenderQueueComposition.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+
+// The render POST is the only place Studio says WHICH file to render. When it
+// says nothing the server falls back to index.html, so a caller that forgets
+// the field does not fail — it silently exports the wrong video (#3549). The
+// default therefore lives in startRender, which every control routes through.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startRenderAndReadBody, type MountedQueue } from "./renderQueueTestHarness";
+
+vi.mock("../../telemetry/policy", () => ({ browserTelemetryAllowed: () => false }));
+vi.mock("../../telemetry/config", () => ({ getAnonymousId: () => "unused" }));
+vi.mock("../../telemetry/events", () => ({ trackStudioRenderStart: vi.fn() }));
+
+const { useRenderQueue } = await import("./useRenderQueue");
+
+let queue: MountedQueue | null = null;
+
+/** Body of the render POST, started with `opts` while `activeCompPath` is open. */
+async function renderBody(
+  activeCompPath: string | null,
+  opts?: Parameters<ReturnType<typeof useRenderQueue>["startRender"]>[0],
+): Promise<Record<string, unknown>> {
+  const started = await startRenderAndReadBody(useRenderQueue, { activeCompPath, opts });
+  queue = started.queue;
+  return started.body;
+}
+
+afterEach(() => {
+  queue?.unmount();
+  queue = null;
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});
+
+describe("render target composition", () => {
+  it("renders the composition the user has selected when the caller names none", async () => {
+    // The header's Export button: no options at all.
+    const body = await renderBody("parts/part-1.html", undefined);
+    expect(body["composition"]).toBe("parts/part-1.html");
+  });
+
+  it("keeps the caller's composition when one is named", async () => {
+    // The sidebar's per-composition Render button renders a card the user is
+    // not looking at, so its argument must win over the active composition.
+    const body = await renderBody("parts/part-1.html", { composition: "parts/part-4.html" });
+    expect(body["composition"]).toBe("parts/part-4.html");
+  });
+
+  it("omits the composition when nothing is selected", async () => {
+    // Master view. The server's index.html fallback is the right answer here.
+    const body = await renderBody(null, { format: "mp4" });
+    expect(body["composition"]).toBeUndefined();
+  });
+});

--- a/packages/studio/src/components/renders/useRenderQueueTelemetry.test.tsx
+++ b/packages/studio/src/components/renders/useRenderQueueTelemetry.test.tsx
@@ -7,9 +7,8 @@
 // install id rather than the user's, which is worse than attributing it
 // correctly.
 
-import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mountRenderQueue, renderPosts, stubRenderFetch } from "./renderQueueTestHarness";
+import { startRenderAndReadBody, type MountedQueue } from "./renderQueueTestHarness";
 
 const policyState = { allowed: true };
 const mintCalls = vi.fn(() => "browser-user-123");
@@ -26,20 +25,15 @@ vi.mock("../../telemetry/events", () => ({
 
 const { useRenderQueue } = await import("./useRenderQueue");
 
-let queue: ReturnType<typeof mountRenderQueue> | null = null;
+let queue: MountedQueue | null = null;
 
 /** Body of the POST the hook makes when a render is started. */
 async function startRenderBody(): Promise<Record<string, unknown>> {
-  const fetchMock = stubRenderFetch();
-  queue = mountRenderQueue(useRenderQueue);
-  await act(async () => {
-    await queue?.api().startRender({ fps: 30, quality: "standard", format: "mp4" });
+  const started = await startRenderAndReadBody(useRenderQueue, {
+    opts: { fps: 30, quality: "standard", format: "mp4" },
   });
-
-  const [post] = renderPosts(fetchMock) as [undefined | [string, RequestInit]];
-  const body = post?.[1]?.body;
-  if (body === undefined || body === null) throw new Error("hook made no POST with a body");
-  return JSON.parse(String(body)) as Record<string, unknown>;
+  queue = started.queue;
+  return started.body;
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## What

Exporting from Studio now renders the composition the user currently has selected, instead of always falling back to `index.html`.

## Why

Reported in #3549: in a project with a root `index.html` plus `parts/part-N.html` sub-compositions, selecting a part in the Comps panel correctly showed that part's canvas and timeline, but clicking **Export** rendered the full-length root file. `hyperframes render -c parts/part-1.html` from the CLI produced the right file, so the gap was Studio-side only.

The server already honours the request: `POST /api/projects/:id/render` reads `body.composition`, validates it resolves inside the project, and forwards it to the render adapter (`packages/studio-server/src/routes/render.ts:93-101`). It falls back to `index.html` when the field is absent, which is the correct behaviour for a request that names nothing. No server change was needed.

## How

The render target had three owners, one per control that can start a render:

- the Renders panel resolved it from the active composition,
- the header's Export button passed no options at all, so the field was simply missing,
- the sidebar's per-composition Render button named one explicitly.

Only the middle one was wrong, but patching it would have left the same decision duplicated in two places, free to drift again. Instead the default now lives in `startRender`, which all three controls route through, next to the FFmpeg gate that is there for the same reason:

```ts
const composition = opts.composition ?? activeCompPathRef.current ?? undefined;
```

An explicit argument still wins, so the sidebar keeps rendering the card the user clicked rather than the one on screen. With nothing selected (master view) the field stays absent and the server's `index.html` fallback still applies. `useRenderQueue` takes the active composition as a ref so the target is read at click time without rebuilding every callback on each composition switch. The panel's now-redundant copy of the logic is deleted.

No composition picker was added: defaulting to the active composition is the fix, and a picker would be new surface for a problem the selection already answers.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

**Unit** — new `useRenderQueueComposition.test.tsx` asserts the POST body directly: it carries the active composition when the caller names none, keeps an explicit argument when one is given, and omits the field entirely when nothing is selected. Verified non-vacuous by reverting the one-line default, which fails the first case with `expected undefined to be 'parts/part-1.html'`.

Full package suite: `bun run --filter @hyperframes/studio test` → 409 files, 4553 tests passing.

**End to end** — scaffolded a project matching the report's shape (root `index.html` at 20s, `parts/part-1.html` at 4s), ran the real `preview` server against it, drove Studio in Puppeteer, selected `parts/part-1` in the Comps panel, clicked the header's Export, and let the render finish.

Before, with the default removed:

```
RENDER POST BODY: {"fps":30,"quality":"standard","format":"mp4",...}
$ ffprobe ... renders/<job>.mp4
duration=20.000000        # the root, not the part
```

After:

```
RENDER POST BODY: {"fps":30,"quality":"standard","format":"mp4",...,"composition":"parts/part-1.html"}
$ ffprobe ... renders/<job>.mp4
duration=4.000000         # the selected part
```

Fixes #3549
