### PR TITLE
fix(studio): let a hidden sub-composition child be shown again

### DIFF
--- a/packages/studio/src/player/hooks/timelineSyncHydration.test.ts
+++ b/packages/studio/src/player/hooks/timelineSyncHydration.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from "vitest";
+import {
+  collectSubCompositionDomChildren,
+  collectSubCompositionHostState,
+} from "./timelineSyncHydration";
+import type { ClipManifestClip } from "../lib/playbackTypes";
+
+const clip = (over: Partial<ClipManifestClip>): ClipManifestClip => ({
+  id: "x",
+  label: "x",
+  start: 0,
+  duration: 1,
+  track: 0,
+  kind: "element",
+  tagName: "div",
+  compositionId: null,
+  parentCompositionId: null,
+  compositionSrc: null,
+  assetUrl: null,
+  ...over,
+});
+
+/**
+ * The shape a storyboard scene actually publishes: the clip that carries
+ * `data-hidden` is a `<video>` one level BELOW an id'd region wrapper.
+ */
+function mountScene(): Document {
+  document.body.innerHTML = `
+    <div id="scene-2-slot" data-composition-id="scene-2" data-composition-src="scene-2.html">
+      <div data-hf-inner-root>
+        <div id="scene-2-video-region" class="hf-region">
+          <video id="scene-2-video" class="clip" data-start="0" data-hidden></video>
+        </div>
+        <div id="scene-2-title" class="clip" data-start="0" data-hidden></div>
+        <div id="scene-2-caption" class="clip" data-start="0" data-timeline-locked
+             data-timeline-role="caption" data-fx-chain="blur" data-automation="opacity"></div>
+      </div>
+    </div>`;
+  return document;
+}
+
+// A composition clip is keyed by its ELEMENT id, not its `data-composition-id`
+// (the runtime's clip tree publishes `scene-2-slot`), so the collector resolves
+// the host with getElementById(clip.id) exactly as the sibling walk does.
+const sceneClips = [clip({ id: "scene-2-slot", kind: "composition", compositionId: "scene-2" })];
+
+describe("collectSubCompositionHostState", () => {
+  it("reaches a clip nested below an id'd wrapper, which the sibling walk cannot", () => {
+    const doc = mountScene();
+
+    // The walk that defines rows stops at the first id'd descendant, so the
+    // video inside the region wrapper is never recorded there. That is why the
+    // eye on a hidden scene video had no state to read.
+    const siblings = collectSubCompositionDomChildren(doc, sceneClips, new Map());
+    expect(siblings.map((child) => child.id)).toEqual([
+      "scene-2-video-region",
+      "scene-2-title",
+      "scene-2-caption",
+    ]);
+
+    const state = collectSubCompositionHostState(doc, sceneClips);
+    expect(state.get("scene-2-video")?.hidden).toBe(true);
+  });
+
+  it("records every data-* attribute an expanded child row needs", () => {
+    const state = collectSubCompositionHostState(mountScene(), sceneClips);
+
+    expect(state.get("scene-2-title")).toEqual({ hidden: true });
+    expect(state.get("scene-2-caption")).toEqual({
+      timelineLocked: true,
+      timelineRole: "caption",
+      fxChain: "blur",
+      automation: "opacity",
+    });
+  });
+
+  it("omits elements carrying no state, so a visible child reads as visible", () => {
+    const state = collectSubCompositionHostState(mountScene(), sceneClips);
+
+    expect(state.has("scene-2-video-region")).toBe(false);
+    expect(state.get("scene-2-video")?.hidden).toBe(true);
+  });
+
+  it("returns empty without a document, rather than throwing", () => {
+    expect(collectSubCompositionHostState(null, sceneClips).size).toBe(0);
+  });
+
+  it("ignores clips that are not compositions", () => {
+    const doc = mountScene();
+    const state = collectSubCompositionHostState(doc, [clip({ id: "scene-2-slot" })]);
+
+    expect(state.size).toBe(0);
+  });
+});

--- a/packages/studio/src/player/hooks/timelineSyncHydration.ts
+++ b/packages/studio/src/player/hooks/timelineSyncHydration.ts
@@ -10,7 +10,7 @@
  */
 
 import { usePlayerStore } from "../store/playerStore";
-import type { TimelineElement, DomClipChild } from "../store/playerStore";
+import type { TimelineElement, DomClipChild, SubCompositionHostState } from "../store/playerStore";
 import { resolveCssStackingContextId } from "@hyperframes/core/runtime/stacking-context";
 import type { ClipTree } from "@hyperframes/core/runtime/clipTree";
 import { HF_AUDIO_GROUP_ATTR } from "@hyperframes/core/audio-groups";
@@ -133,6 +133,52 @@ export function collectSubCompositionDomChildren(
     if (!hostEl) continue;
     const innerRoot = hostEl.querySelector("[data-hf-inner-root]") ?? hostEl;
     collectHostDomChildren(clip.id, innerRoot, clip.id, parentMap, out);
+  }
+  return out;
+}
+
+/** The host-element `data-*` state one element carries, or null when it has none. */
+function readSubCompositionHostState(el: Element): SubCompositionHostState | null {
+  const state: SubCompositionHostState = {};
+  if (el.hasAttribute("data-hidden")) state.hidden = true;
+  if (el.hasAttribute("data-timeline-locked")) state.timelineLocked = true;
+  const timelineRole = el.getAttribute("data-timeline-role");
+  if (timelineRole) state.timelineRole = timelineRole;
+  const fxChain = el.getAttribute("data-fx-chain");
+  if (fxChain) state.fxChain = fxChain;
+  const automation = el.getAttribute("data-automation");
+  if (automation) state.automation = automation;
+  return Object.keys(state).length > 0 ? state : null;
+}
+
+/**
+ * Host-element state for every id'd element inside every sub-composition.
+ *
+ * This walk exists because nothing else in the pipeline can see these
+ * attributes. A clip whose parent composition is itself in the manifest is
+ * filtered out before the flat store is built, so an expanded child has no twin
+ * to inherit from, and the manifest carries timing rather than attributes.
+ *
+ * Deliberately separate from {@link collectSubCompositionDomChildren}: that walk
+ * defines which rows exist and writes `parentMap`, and it stops at the first
+ * id'd descendant. Scene footage commonly sits one level below an id'd region
+ * wrapper, so it is never reached there. This one descends the whole subtree and
+ * touches neither rows nor parentage.
+ */
+export function collectSubCompositionHostState(
+  iframeDoc: Document | null,
+  clips: readonly ClipManifestClip[],
+): Map<string, SubCompositionHostState> {
+  const out = new Map<string, SubCompositionHostState>();
+  if (!iframeDoc) return out;
+  for (const clip of clips) {
+    if (clip.kind !== "composition" || !clip.id) continue;
+    const hostEl = iframeDoc.getElementById(clip.id);
+    if (!hostEl) continue;
+    for (const el of Array.from(hostEl.querySelectorAll("[id]"))) {
+      const state = readSubCompositionHostState(el);
+      if (state) out.set(el.id, state);
+    }
   }
   return out;
 }

--- a/packages/studio/src/player/hooks/useExpandedTimelineElements.test.ts
+++ b/packages/studio/src/player/hooks/useExpandedTimelineElements.test.ts
@@ -270,6 +270,49 @@ describe("buildExpandedElements", () => {
     expect(child.timelineLocked).toBe(true);
   });
 
+  // The test above only covers a host with no compositionSrc, where the child's
+  // key falls back to the `index.html` scope and a flat store twin can exist. A
+  // REAL sub-composition scopes the child key to the sub-comp file, and clips
+  // whose parent composition is itself in the manifest are filtered out of the
+  // flat store before it is built (`processTimelineMessage`). So the twin never
+  // exists there and the inheritance above is dead code for the one case it was
+  // written for: the eye reported every hidden child visible, clicking it
+  // rewrote data-hidden, and nothing could be shown again.
+  it("reads hidden and locked off the live element when the child has no flat twin", () => {
+    // Only the host is in the flat store — exactly what the manifest filter leaves.
+    const elements = [
+      el({
+        id: "scene-2",
+        domId: "scene-2",
+        start: 3.25,
+        duration: 3.5,
+        compositionSrc: "scene-2.html",
+      }),
+    ];
+    const manifest = [
+      clip({ id: "scene-2", start: 3.25, duration: 3.5, compositionSrc: "scene-2.html" }),
+      clip({ id: "scene-2-video", start: 3.25, duration: 3.5, parentCompositionId: "scene-2" }),
+    ];
+    const parentMap = new Map([["scene-2-video", "scene-2"]]);
+    const hostState = new Map([["scene-2-video", { hidden: true, timelineLocked: true }]]);
+
+    const out = buildExpandedElements(
+      elements,
+      manifest,
+      parentMap,
+      "scene-2",
+      "scene-2",
+      [],
+      hostState,
+    );
+    const child = out.find((e) => e.domId === "scene-2-video")!;
+    // The child key is scoped to the sub-comp file, so no store element can match it.
+    expect(child.key).toBe("scene-2.html#scene-2-video");
+    expect(elements.some((element) => element.key === child.key)).toBe(false);
+    expect(child.hidden).toBe(true);
+    expect(child.timelineLocked).toBe(true);
+  });
+
   // Sub-comp internals (group + pills) have no data-start, so they're not in the
   // manifest. They arrive as DOM children and must still expand under their host.
   it("expands DOM-only sub-comp children (no manifest clip) under the host", () => {

--- a/packages/studio/src/player/hooks/useExpandedTimelineElements.ts
+++ b/packages/studio/src/player/hooks/useExpandedTimelineElements.ts
@@ -1,5 +1,10 @@
 import { useMemo } from "react";
-import { usePlayerStore, type TimelineElement, type DomClipChild } from "../store/playerStore";
+import {
+  usePlayerStore,
+  type TimelineElement,
+  type DomClipChild,
+  type SubCompositionHostState,
+} from "../store/playerStore";
 import type { ClipManifestClip } from "../lib/playbackTypes";
 import { createTimelineElementFromManifestClip } from "../lib/timelineDOM";
 import { buildTimelineElementKey, splitTimelineElementKey } from "../lib/timelineElementHelpers";
@@ -132,18 +137,6 @@ interface DisplayBounds {
 }
 
 /**
- * State that lives on the live host element, not in the clip manifest:
- * `data-hidden`, `data-timeline-locked`, `data-timeline-role`. A child row is
- * built from a manifest clip with no hostEl to read, so
- * createTimelineElementFromManifestClip cannot see any of it. The flat store
- * element for the same child WAS built with one, so it is inherited from there.
- *
- * Without this the eye on an expanded child always reported the row visible, so
- * clicking it wrote data-hidden again instead of removing it, and a hidden child
- * could never be shown again (not even after a reload, since the attribute is in
- * the source).
- */
-/**
  * Audio-group membership for an expanded child, from whichever source has it.
  *
  * The flat store twin when there is one; otherwise the `DomClipChild` record,
@@ -169,20 +162,34 @@ function childGroupState(
   };
 }
 
-function hostElementState(flat: TimelineElement | undefined): Partial<TimelineElement> {
-  if (!flat) return {};
-  return {
-    hidden: flat.hidden,
-    timelineLocked: flat.timelineLocked,
-    timelineRole: flat.timelineRole,
-    // Same reason as the three above: these are read off the host element, which
-    // an expanded child is built without. Missing them, an audio child inside a
-    // sub-composition reserved no automation height and drew no lanes, while the
-    // property panel — reading the live DOM selection rather than this row —
-    // still showed the chain and its toggles.
-    fxChain: flat.fxChain,
-    automation: flat.automation,
-  };
+/**
+ * State that lives on the live host element, not in the clip manifest:
+ * `data-hidden`, `data-timeline-locked`, `data-timeline-role`, `data-fx-chain`,
+ * `data-automation`. A child row is built from a manifest clip with no hostEl to
+ * read, so createTimelineElementFromManifestClip cannot see any of it.
+ *
+ * `live` is the reading taken off the element itself and is authoritative. For a
+ * child of a REAL sub-composition it is also the only source: such a clip is
+ * filtered out of the manifest before the flat store is built, so no twin exists
+ * to inherit from. The flat twin still covers the phantom-wrapper case, where
+ * the child does keep a store entry of its own.
+ *
+ * Without a reading of the element, the eye on an expanded child always reported
+ * the row visible, so clicking it wrote data-hidden again instead of removing
+ * it, and a hidden child could never be shown again (not even after a reload,
+ * since the attribute is in the source). Missing fxChain and automation, an
+ * audio child inside a sub-composition reserved no automation height and drew no
+ * lanes, while the property panel, which reads the live DOM selection rather
+ * than this row, still showed the chain and its toggles.
+ */
+function hostElementState(
+  flat: TimelineElement | undefined,
+  live: SubCompositionHostState | undefined,
+): Partial<TimelineElement> {
+  if (!flat) return { ...live };
+  const { hidden, timelineLocked, timelineRole, fxChain, automation } = flat;
+  // `live` last: it is the reading off the element, so it wins wherever it has one.
+  return { hidden, timelineLocked, timelineRole, fxChain, automation, ...live };
 }
 
 // `display` bounds come from the top-level scene clip (where the expanded row is
@@ -196,6 +203,7 @@ function buildChildElements(
   expandedHostKey: string,
   elements: readonly TimelineElement[],
   domChildrenById: ReadonlyMap<string, DomClipChild>,
+  hostStateById: ReadonlyMap<string, SubCompositionHostState>,
 ): TimelineElement[] {
   const result: TimelineElement[] = [];
   for (const child of siblings) {
@@ -223,7 +231,10 @@ function buildChildElements(
     });
     result.push({
       ...base,
-      ...hostElementState(elements.find((element) => element.key === key)),
+      ...hostElementState(
+        elements.find((element) => element.key === key),
+        domId ? hostStateById.get(domId) : undefined,
+      ),
       ...childGroupState(
         elements.find((element) => element.key === key),
         domId ? domChildrenById.get(domId) : undefined,
@@ -309,6 +320,7 @@ export function buildExpandedElements(
   topLevelId: string,
   siblingParentId: string,
   domClipChildren: DomClipChild[] = [],
+  subCompositionHostState: ReadonlyMap<string, SubCompositionHostState> = new Map(),
 ): TimelineElement[] {
   const topLevelElement = elements.find((el) => el.id === topLevelId || el.domId === topLevelId);
   if (!topLevelElement) return filterToTopLevel(elements, parentMap);
@@ -348,6 +360,7 @@ export function buildExpandedElements(
     parentKey,
     elements,
     domChildrenById,
+    subCompositionHostState,
   );
   if (expanded.length === 0) return filterToTopLevel(elements, parentMap);
 
@@ -391,6 +404,7 @@ export function useExpandedTimelineElements(): TimelineElement[] {
   const clipManifest = usePlayerStore((s) => s.clipManifest);
   const clipParentMap = usePlayerStore((s) => s.clipParentMap);
   const domClipChildren = usePlayerStore((s) => s.domClipChildren);
+  const subCompositionHostState = usePlayerStore((s) => s.subCompositionHostState);
   const selectedElementId = usePlayerStore((s) => s.selectedElementId);
   const currentTime = usePlayerStore((s) => s.currentTime);
 
@@ -432,6 +446,15 @@ export function useExpandedTimelineElements(): TimelineElement[] {
       topLevel,
       immediateParent,
       domClipChildren,
+      subCompositionHostState,
     );
-  }, [elements, clipManifest, clipParentMap, domClipChildren, rawId, selectedRawId]);
+  }, [
+    elements,
+    clipManifest,
+    clipParentMap,
+    domClipChildren,
+    subCompositionHostState,
+    rawId,
+    selectedRawId,
+  ]);
 }

--- a/packages/studio/src/player/hooks/useTimelineSyncCallbacks.ts
+++ b/packages/studio/src/player/hooks/useTimelineSyncCallbacks.ts
@@ -19,6 +19,7 @@ import {
   buildTimelineElementsFromClips,
   clipTreeParentMap,
   collectSubCompositionDomChildren,
+  collectSubCompositionHostState,
   hydrateTimelineFromPreview,
   isPreviewReadinessMessage,
   safeContentDocument,
@@ -131,6 +132,9 @@ export function useTimelineSyncCallbacks({
         const domClipChildren = collectSubCompositionDomChildren(iframeDoc, data.clips, parentMap);
         usePlayerStore.getState().setClipParentMap(parentMap);
         usePlayerStore.getState().setDomClipChildren(domClipChildren);
+        usePlayerStore
+          .getState()
+          .setSubCompositionHostState(collectSubCompositionHostState(iframeDoc, data.clips));
       } catch {
         // cross-origin or __clipTree not available — maps stay empty
       }

--- a/packages/studio/src/player/store/playerStore.ts
+++ b/packages/studio/src/player/store/playerStore.ts
@@ -23,9 +23,13 @@ import { createThumbnailSlice, type ThumbnailSlice } from "./thumbnailSlice";
 export type { KeyframeCacheEntry } from "./keyframeSlice";
 export { liveTime } from "./liveTime";
 
-import type { TimelineElement, TimelineElementPatch } from "./timelineElement";
+import type {
+  TimelineElement,
+  TimelineElementPatch,
+  SubCompositionHostState,
+} from "./timelineElement";
 
-export type { TimelineElement };
+export type { TimelineElement, SubCompositionHostState };
 export type ZoomMode = "fit" | "manual";
 type TimelineTool = "select" | "razor";
 
@@ -212,6 +216,14 @@ interface PlayerState
    */
   domClipChildren: DomClipChild[];
   setDomClipChildren: (children: DomClipChild[]) => void;
+  /**
+   * Host-element state for every id'd element inside a sub-composition, keyed by
+   * dom id. Collected from the live preview because it is the only place that
+   * sees it: these elements are filtered out of `elements` before the flat store
+   * is built, and the clip manifest carries timing, not attributes.
+   */
+  subCompositionHostState: Map<string, SubCompositionHostState>;
+  setSubCompositionHostState: (state: Map<string, SubCompositionHostState>) => void;
 }
 
 /** A sub-comp DOM-only timeline child (no data-start) and its nesting context. */
@@ -284,6 +296,7 @@ export function createTimelineResetState() {
     clipManifest: null,
     clipParentMap: new Map<string, string>(),
     domClipChildren: [],
+    subCompositionHostState: new Map<string, SubCompositionHostState>(),
   };
 }
 
@@ -430,6 +443,8 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
   setClipParentMap: (map) => set({ clipParentMap: map }),
   domClipChildren: [],
   setDomClipChildren: (children) => set({ domClipChildren: children }),
+  subCompositionHostState: new Map(),
+  setSubCompositionHostState: (state) => set({ subCompositionHostState: state }),
 
   setIsPlaying: (playing) => {
     if (get().isPlaying === playing) return;

--- a/packages/studio/src/player/store/timelineElement.ts
+++ b/packages/studio/src/player/store/timelineElement.ts
@@ -118,3 +118,24 @@ export type TimelineElementPatch = Partial<
     | "audioGroupAutomation"
   >
 >;
+
+/**
+ * The `data-*` state an expanded sub-composition child needs but cannot reach.
+ *
+ * A child row is synthesized from a manifest clip with no element to read, and
+ * for a real sub-composition it has no flat store twin either: such clips are
+ * dropped before the flat store is built. Read off the live preview instead
+ * (`collectSubCompositionHostState`) and carried on the store by dom id.
+ *
+ * Without it the eye reported every hidden child visible, so clicking it wrote
+ * `data-hidden` a second time instead of removing it, and the element could
+ * never be shown again, not even after a reload, since the attribute is in the
+ * source.
+ */
+export interface SubCompositionHostState {
+  hidden?: boolean;
+  timelineLocked?: boolean;
+  timelineRole?: string;
+  fxChain?: string;
+  automation?: string;
+}


### PR DESCRIPTION
## Summary

Hiding anything that lives inside a sub-composition is a one-way trip in Studio. The eye on an expanded child row always renders as **Hide**, whatever the source file says, so the first click writes `data-hidden` and every click after it rewrites the same attribute and changes nothing. The element can never be shown again from the UI, not even after a reload, because the attribute is in the file.

Top-level clips are unaffected. Their eye flips to **Show** and toggles correctly. That contrast is the whole bug: same attribute, same file format, different row type.

---

## The bug, from a user's point of view

A user pressed the eye on a timeline track, decided they wanted it back, and pressed it again. One scene never came back. Its clip in the timeline went from a thumbnail to an empty box, and the scene would have rendered as several seconds of nothing.

Recovering it needed a text editor. In the UI there was no path back:

- The child row's eye still says "Hide", so it offers the action that is already done.
- Clicking it is a silent no-op. No error, no toast, no file change.
- Selecting the row does nothing either, because a hidden element is not selectable on the canvas, so the property panel never opens for it.

Affected rows lose four more pieces of state through the same gap: `timelineLocked`, `timelineRole`, `fxChain` and `automation`.

---

## How it got caught

I clicked on the "hide" eye in the UI for a particular track, it hid my track, then I clicked again and it didn't undo the action.

Working backwards from the file was what pinned it. Studio's own `.hyperframes/backup` chain holds a pre-write snapshot per save, so the sequence was recoverable exactly:

| Time | File | `data-hidden` before → after |
|---|---|---|
| 01:55:44 | `compositions/scene-2.html` | 0 → 1 (the title) |
| 01:56:01 | `compositions/scene-2.html` | 1 → 2 (the video) |
| 09:48:13–09:48:18 | `index.html` | 0 → 9 → 0 → 9 → 0 |

Two observations did the work. The sub-composition file only ever gained attributes, never lost one, across every save in its history. And `index.html` in the same session toggled 0 ↔ 9 perfectly, four times in a row, which ruled out the write path and the track-level toggle and left only the read path for one class of row.

The existing regression test never fired, and that turned out to be part of the story. See **Why the existing test passes** below.

---

## Root cause

`buildChildElements` synthesizes an expanded child row from a manifest clip. It calls `createTimelineElementFromManifestClip` with no `doc` and no `hostEl`, so it cannot read `data-hidden`, `data-timeline-locked`, `data-timeline-role`, `data-fx-chain` or `data-automation` off the element. It compensated by inheriting them from the child's flat store twin:

```ts
// useExpandedTimelineElements.ts:226
...hostElementState(elements.find((element) => element.key === key)),
```

For a real sub-composition that twin cannot exist. `processTimelineMessage` filters the manifest to root-level clips before building the flat store, and drops any clip whose parent composition is itself in the manifest:

```ts
// useTimelineSyncCallbacks.ts:122-138
// Show root-level clips: no parentCompositionId, OR parent is a "phantom wrapper"
const clipCompositionIds = new Set(data.clips.map((c) => c.compositionId).filter(Boolean));
const filtered = data.clips.filter(
  (clip) => !clip.parentCompositionId || !clipCompositionIds.has(clip.parentCompositionId),
);
...
const els = buildTimelineElementsFromClips(filtered, iframeDoc);
```

So `elements.find(...)` always returns `undefined`, `hostElementState` returns `{}`, and the child row carries `hidden: undefined`. `TimelineLanes` then computes:

```ts
// TimelineLanes.tsx:208
const isTrackHidden = els.length > 0 && els.every((element) => element.hidden === true);
```

which is `false`, so the button renders as "Hide" and dispatches `hidden: true`. The patch writes `data-hidden` onto an element that already has it. Same bytes, no change, no error.

The inheritance is therefore dead code for the case its own docstring describes. It works only when the parent is a phantom wrapper, where the child does keep a store entry of its own.

---

## Reproducing it

Four files, no assets, about a minute. Verified on `f84b4c23d` (this PR's base).

```
repro/
  hyperframes.json
  index.html
  compositions/scene-a.html
  compositions/scene-b.html
```

`index.html` — two scene slots:

```html
<div id="main" data-composition-id="main" data-start="0.000" data-duration="6.000"
     data-width="720" data-height="1280" data-fps="24">
  <div id="scene-a-slot" class="clip" data-composition-id="scene-a"
       data-composition-src="compositions/scene-a.html"
       data-start="0.000" data-duration="3.000" data-track-index="0"
       data-covers-frame="true" data-width="720" data-height="1280"></div>
  <div id="scene-b-slot" class="clip" data-composition-id="scene-b"
       data-composition-src="compositions/scene-b.html"
       data-start="3.000" data-duration="3.000" data-track-index="0"
       data-covers-frame="true" data-width="720" data-height="1280"></div>
</div>
```

`compositions/scene-a.html` — note that the clip sits one level **below** an id'd wrapper, which is what a generated scene looks like:

```html
<div id="scene-a" data-composition-id="scene-a" data-start="0.000" data-duration="3.000"
     data-width="720" data-height="1280" data-fps="24">
  <div id="scene-a-region" class="fill" style="background:#123">
    <div id="scene-a-body" class="clip fill" data-start="0.000" data-duration="3.000"
         data-track-index="0" style="background:#3a7"></div>
  </div>
  <div id="scene-a-title" class="clip" data-start="0.000" data-duration="3.000"
       data-track-index="1" style="position:absolute;top:40%;width:100%;text-align:center;color:#fff;font:700 64px sans-serif">Scene A</div>
</div>
```

(`scene-b.html` is the same with `b` substituted. It only exists so `scene-a` is a sub-composition among siblings rather than the whole timeline.)

Then:

1. `hyperframes preview` in `repro/`.
2. Put the playhead inside Scene A, around `t=1`, so its children expand. Rows appear for **Scene A Body** and **Scene A Title** under the scene track.
3. Click the eye on **Scene A Body**.

**On `main`:**

| Step | `data-hidden` in `scene-a.html` | Button label |
|---|---|---|
| start | 0 | Hide track 2 |
| after click 1 | 1 | **Hide track 2** |
| after click 2 | **1** | **Hide track 2** |

The row is now unrecoverable from the UI.

**With this PR:**

| Step | `data-hidden` in `scene-a.html` | Button label |
|---|---|---|
| start | 0 | Hide track 2 |
| after click 1 | 1 | Show track 2 |
| after click 2 | 0 | Hide track 2 |

---

## The fix

Read the state off the live element instead of hoping a store twin exists.

`collectSubCompositionHostState` walks each sub-composition host in the preview document and records the `data-*` state of every id'd descendant, keyed by dom id. It runs in `processTimelineMessage` beside the existing DOM walk, lands on the player store, and `hostElementState` now takes that reading. The flat twin stays as the fallback, so the phantom-wrapper case is unchanged.

### Why it is a second walk and not an extension of the existing one

`collectSubCompositionDomChildren` looks like the natural home for this, and it is the wrong one for two independent reasons.

**It cannot reach the element.** It stops at the first id'd descendant and only recurses into groups:

```ts
// timelineSyncHydration.ts:97-111
if (!child.id) {
  collectHostDomChildren(hostId, child, parentId, parentMap, out); // id-less wrapper
  continue;
}
...
if (isGroup) collectHostDomChildren(hostId, child, child.id, parentMap, out);
```

Scene footage commonly sits below an id'd region wrapper, so it is never visited:

```
(no-id) <div data-hf-inner-root>
  scene-a-region <div>                    ← walk stops here (id'd, not a group)
    scene-a-body <div data-hidden>        ← never collected
  scene-a-title <div data-hidden>         ← collected
```

That asymmetry is why the two child rows in the original report behaved identically despite only one being reachable by that walk: neither had a store twin, so both were broken for the same reason.

**Making it reach the element would break rows.** That walk also writes `parentMap`. Recursing into `scene-a-region` would set `parentMap.set('scene-a-body', 'scene-a-region')`, overwriting the entry the runtime clip tree already published (`scene-a-body → scene-a-slot`). `buildExpandedElements` filters siblings on exactly that map:

```ts
const fromManifest = manifest.filter((c) => c.id != null && parentMap.get(c.id) === siblingParentId);
```

so the body row would stop matching its host and disappear from the timeline entirely.

The new walk descends the whole subtree with `querySelectorAll("[id]")` and touches neither rows nor parentage. It returns a plain map, and elements carrying no state are omitted so a visible child still reads as visible.

---

## Why the existing test passes

`useExpandedTimelineElements.test.ts` has a test named "inherits hidden and locked state from the flat store element", added as a regression guard for this exact symptom. It is green on `main` and green with the bug present.

Its fixture does two things production cannot:

```ts
const elements = [
  el({ id: "s1", domId: "s1", start: 0, duration: 14 }),
  el({ id: "eyebrow", key: "index.html#eyebrow", ..., hidden: true, timelineLocked: true }),
];
```

It hands the child a flat store twin carrying `hidden: true`, and it gives the host no `compositionSrc`. Without a `compositionSrc` the child key falls back to the `index.html` scope, which is the one scope where a twin can exist. So the test asserts that a spread copies a field, never that the field can be obtained.

The added test models a real sub-composition: host with `compositionSrc`, no twin in the store, and an explicit assertion that no store element can match the child's key.

```ts
expect(child.key).toBe("scene-2.html#scene-2-video");
expect(elements.some((element) => element.key === child.key)).toBe(false);
expect(child.hidden).toBe(true);
```

On `main` it fails with `expected undefined to be true`.

---

## Tests

**`timelineSyncHydration.test.ts`** (new) covers the collector. It includes a positive control that asserts the existing sibling walk returns `["scene-2-video-region", "scene-2-title", "scene-2-caption"]` and not the nested video, so the "cannot reach it" claim above is measured in the suite rather than asserted in a comment. Also covers the full `data-*` set, omission of stateless elements, a null document, and non-composition clips.

**`useExpandedTimelineElements.test.ts`** gains the real-sub-composition case described above.

Gates, all clean:

- `packages/studio`: 415 files, 4621 tests pass on this branch.
- `bun run lint`, `bun run format:check`, `tsc --noEmit`.

Two things the repo's own gates caught in this change and that are worth noting rather than hiding: `hostElementState` first landed as a `??` chain at cyclomatic 18 and was flagged, so it is now a destructure plus one spread; and `playerStore.ts` crossed the 600-line cap, so `SubCompositionHostState` lives in `timelineElement.ts` next to `TimelineElement` and is re-exported, matching how `TimelineElement` itself is surfaced.

---

## Scope

Studio only. No change to `core`, `engine`, `parsers`, `player`, `producer` or `shader-transitions`, so rendering is untouched.

Found while running a generated storyboard project: one root `index.html` of scene slots plus one `compositions/scene-N.html` per scene. In that shape every scene's footage and title is a sub-composition child, so the broken case is the normal case rather than an edge.
