### PR TITLE
fix(studio-server): revalidate preview assets on every request

### DIFF
--- a/packages/studio-server/src/routes/preview.ts
+++ b/packages/studio-server/src/routes/preview.ts
@@ -576,7 +576,7 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
     const cacheHeaders: Record<string, string> = isText
       ? { "Cache-Control": "no-store" }
       : {
-          "Cache-Control": "private, max-age=3600, must-revalidate",
+          "Cache-Control": "private, no-cache",
           ETag: etag,
         };
 


### PR DESCRIPTION
## Summary

Project preview assets (images, videos) were served with `Cache-Control: private, max-age=3600, must-revalidate`. The 1-hour `max-age` let browsers serve stale images from disk cache without revalidating the ETag, even after the file changed on disk. Hard refresh (Ctrl+Shift+R) didn't recover because it doesn't bypass iframe sub-resource caches — only incognito (empty CacheStorage) showed the updated file.

## Root cause

The preview route at `packages/studio-server/src/routes/preview.ts` serves binary project assets with a 1-hour cache window. During that window, browsers are allowed to use the cached response without checking with the server. Since Studio renders compositions in an iframe, and hard refresh only bypasses the top-level document cache, sub-resources (images) inside the iframe remained stale.

## Fix

Switch from `max-age=3600, must-revalidate` to `no-cache`. This tells browsers to always revalidate before using a cached response. The existing `mtime+size` ETag ensures unchanged assets still get efficient 304 (Not Modified) responses — no bandwidth wasted re-downloading unchanged files.

Fixes #3564

— Miga