### PR TITLE
chore: release v0.8.21

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,39 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.21"
+  description="Released - 2026-08-31"
+  tags={["Release", "Studio", "Changelog", "Studio Server"]}
+>
+Studio agents can now see the current frame, select and inspect elements, edit content, transform layouts, and author motion through WebMCP.
+Preview assets refresh reliably, hidden sub-composition layers can be restored, and player failures now surface instead of stalling silently.
+
+## Features
+
+- **Studio:** Let an agent author motion ([2d6b055f3](https://github.com/heygen-com/hyperframes/commit/2d6b055f310ef076ce812912e8d2c469ba6f2795), [#3520](https://github.com/heygen-com/hyperframes/pull/3520)).
+- **Studio:** Let an agent edit text and styles, guarded ([f84b4c23d](https://github.com/heygen-com/hyperframes/commit/f84b4c23dcc8b4acbb597e3ad1d293788eaa379b), [#3518](https://github.com/heygen-com/hyperframes/pull/3518)).
+- **Studio:** Give an agent eyes with studio_frame ([3337cc899](https://github.com/heygen-com/hyperframes/commit/3337cc899071c40e0bf3c6bc030d91c499c639d0), [#3516](https://github.com/heygen-com/hyperframes/pull/3516)).
+- **Studio:** Let an agent drive Studio's selection and playhead ([0e558d591](https://github.com/heygen-com/hyperframes/commit/0e558d591658afcba59a84d53d75112b963a9f0a), [#3515](https://github.com/heygen-com/hyperframes/pull/3515)).
+
+## Fixes
+
+- **Studio Server:** Revalidate preview assets on every request ([44c90dd7f](https://github.com/heygen-com/hyperframes/commit/44c90dd7ff79d0564d676a295d6198e3974774d1), [#3565](https://github.com/heygen-com/hyperframes/pull/3565)).
+- **Studio:** Let a hidden sub-composition child be shown again ([f18964de0](https://github.com/heygen-com/hyperframes/commit/f18964de0c3a90b8f8cf155fd2eefda5f47654b6), [#3559](https://github.com/heygen-com/hyperframes/pull/3559)).
+- **Player/runtime:** Rebind timelines and bound paused seeks ([61ba800a5](https://github.com/heygen-com/hyperframes/commit/61ba800a5db0825afb40f061fb6df5498dfdb37d), [#3489](https://github.com/heygen-com/hyperframes/pull/3489)).
+- **Player:** Report and fail closed on runtime delivery errors ([859ac622c](https://github.com/heygen-com/hyperframes/commit/859ac622c2991250ed28fbdcee4b6d2a8efea6ff), [#3472](https://github.com/heygen-com/hyperframes/pull/3472)).
+
+## Docs & Examples
+
+- **Changelog:** Weekly digest 2026-08-24–2026-08-31 ([1cb3c749c](https://github.com/heygen-com/hyperframes/commit/1cb3c749c88d2fa44211d69a8950d36dd4fe81bf), [#3563](https://github.com/heygen-com/hyperframes/pull/3563)).
+
+## Catalog
+
+- **Registry:** Hw write-on wave — hw-write-title block + control surfaces for the handwritten family ([5b45bcc16](https://github.com/heygen-com/hyperframes/commit/5b45bcc16ddc1308fdbadef81f436e56bbc1d559), [#3557](https://github.com/heygen-com/hyperframes/pull/3557)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.20...v0.8.21).
+</Update>
+
+<Update
   label="HyperFrames v0.8.20"
   description="Released - 2026-08-30"
   tags={["Release", "Studio"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.21.md
+++ b/releases/v0.8.21.md
@@ -1,0 +1,32 @@
+# HyperFrames v0.8.21
+
+Released on 2026-08-31.
+
+Studio agents can now see the current frame, select and inspect elements, edit content, transform layouts, and author motion through WebMCP.
+Preview assets refresh reliably, hidden sub-composition layers can be restored, and player failures now surface instead of stalling silently.
+
+## Features
+
+- **Studio:** Let an agent author motion ([2d6b055f3](https://github.com/heygen-com/hyperframes/commit/2d6b055f310ef076ce812912e8d2c469ba6f2795), [#3520](https://github.com/heygen-com/hyperframes/pull/3520)).
+- **Studio:** Let an agent edit text and styles, guarded ([f84b4c23d](https://github.com/heygen-com/hyperframes/commit/f84b4c23dcc8b4acbb597e3ad1d293788eaa379b), [#3518](https://github.com/heygen-com/hyperframes/pull/3518)).
+- **Studio:** Give an agent eyes with studio_frame ([3337cc899](https://github.com/heygen-com/hyperframes/commit/3337cc899071c40e0bf3c6bc030d91c499c639d0), [#3516](https://github.com/heygen-com/hyperframes/pull/3516)).
+- **Studio:** Let an agent drive Studio's selection and playhead ([0e558d591](https://github.com/heygen-com/hyperframes/commit/0e558d591658afcba59a84d53d75112b963a9f0a), [#3515](https://github.com/heygen-com/hyperframes/pull/3515)).
+
+## Fixes
+
+- **Studio Server:** Revalidate preview assets on every request ([44c90dd7f](https://github.com/heygen-com/hyperframes/commit/44c90dd7ff79d0564d676a295d6198e3974774d1), [#3565](https://github.com/heygen-com/hyperframes/pull/3565)).
+- **Studio:** Let a hidden sub-composition child be shown again ([f18964de0](https://github.com/heygen-com/hyperframes/commit/f18964de0c3a90b8f8cf155fd2eefda5f47654b6), [#3559](https://github.com/heygen-com/hyperframes/pull/3559)).
+- **Player/runtime:** Rebind timelines and bound paused seeks ([61ba800a5](https://github.com/heygen-com/hyperframes/commit/61ba800a5db0825afb40f061fb6df5498dfdb37d), [#3489](https://github.com/heygen-com/hyperframes/pull/3489)).
+- **Player:** Report and fail closed on runtime delivery errors ([859ac622c](https://github.com/heygen-com/hyperframes/commit/859ac622c2991250ed28fbdcee4b6d2a8efea6ff), [#3472](https://github.com/heygen-com/hyperframes/pull/3472)).
+
+## Docs & Examples
+
+- **Changelog:** Weekly digest 2026-08-24–2026-08-31 ([1cb3c749c](https://github.com/heygen-com/hyperframes/commit/1cb3c749c88d2fa44211d69a8950d36dd4fe81bf), [#3563](https://github.com/heygen-com/hyperframes/pull/3563)).
+
+## Catalog
+
+- **Registry:** Hw write-on wave — hw-write-title block + control surfaces for the handwritten family ([5b45bcc16](https://github.com/heygen-com/hyperframes/commit/5b45bcc16ddc1308fdbadef81f436e56bbc1d559), [#3557](https://github.com/heygen-com/hyperframes/pull/3557)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.20...v0.8.21


### PR DESCRIPTION
## Summary

- bump all 13 published packages and 3 plugin manifests to `0.8.21`
- add reviewed GitHub release notes and the matching docs changelog entry
- ship the complete WebMCP Studio agent toolset plus preview, sub-composition visibility, and player reliability fixes merged since `v0.8.20`

## Verification

- 35/35 release preparation, versioning, and release-channel tests pass
- 4/4 immutable publish-workflow tests pass
- stable channel guard accepts `0.8.21` from `release/v0.8.21` with npm tag `latest`
- all package and plugin manifests report `0.8.21`
- release notes and docs contain no generated review TODO markers
- branch push excluded the local `v0.8.21` tag, as required

Code review: skipped (mechanical diff) �w^~)�t fixed-version metadata plus generated/reviewed changelog artifacts; this PR is the required review gate.

## Post-Deploy Monitoring & Validation

- **Owner/window:** Miguel/Magi, from merge through 15 minutes after the publish workflow completes.
- **Watch:** the `Publish to npm` workflow triggered by this merged release PR.
- **Healthy:** workflow checks out the exact merge SHA; creates `v0.8.21`; all 13 packages publish or idempotently report already published; GitHub Release is created; npm `latest` resolves to `0.8.21` for `hyperframes` and `@hyperframes/core`.
- **Failure:** immutable-SHA/tag validation fails, any package publish fails, the GitHub Release is absent, or npm dist-tags disagree.
- **Mitigation:** rerun the original merged-PR publish workflow only. Do not push the stable tag or manually dispatch a different commit.
