### PR TITLE
fix(producer): degrade gracefully when font cache directory is unwritable

### DIFF
--- a/packages/producer/src/services/deterministicFonts.ts
+++ b/packages/producer/src/services/deterministicFonts.ts
@@ -746,14 +746,22 @@ function fontSlug(familyName: string): string {
     .replace(/^-|-$/g, "");
 }
 
+let ephemeralFontCacheRoot: string | undefined;
+
 function fontCacheDir(slug: string): string {
   const dir = join(resolveFontCacheRoot(), slug);
   if (!existsSync(dir)) {
     try {
       mkdirSync(dir, { recursive: true });
     } catch {
-      const fallback = join(tmpdir(), `hyperframes-fonts-fallback`, slug);
+      ephemeralFontCacheRoot ??= mkdtempSync(join(tmpdir(), "hyperframes-fonts-"));
+      const fallback = join(ephemeralFontCacheRoot, slug);
       mkdirSync(fallback, { recursive: true });
+      defaultLogger.warn(
+        `Font cache directory is unwritable (${dir}). ` +
+          `Using temporary fallback — fonts will re-download each run. ` +
+          `Fix with: chmod 755 ${resolveFontCacheRoot()}`,
+      );
       return fallback;
     }
   }

--- a/packages/producer/src/services/deterministicFonts.ts
+++ b/packages/producer/src/services/deterministicFonts.ts
@@ -749,7 +749,13 @@ function fontSlug(familyName: string): string {
 function fontCacheDir(slug: string): string {
   const dir = join(resolveFontCacheRoot(), slug);
   if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+    try {
+      mkdirSync(dir, { recursive: true });
+    } catch {
+      const fallback = join(tmpdir(), `hyperframes-fonts-fallback`, slug);
+      mkdirSync(fallback, { recursive: true });
+      return fallback;
+    }
   }
   return dir;
 }

--- a/packages/producer/src/services/deterministicFonts.ts
+++ b/packages/producer/src/services/deterministicFonts.ts
@@ -754,14 +754,17 @@ function fontCacheDir(slug: string): string {
     try {
       mkdirSync(dir, { recursive: true });
     } catch {
+      const firstFallback = ephemeralFontCacheRoot === undefined;
       ephemeralFontCacheRoot ??= mkdtempSync(join(tmpdir(), "hyperframes-fonts-"));
       const fallback = join(ephemeralFontCacheRoot, slug);
       mkdirSync(fallback, { recursive: true });
-      defaultLogger.warn(
-        `Font cache directory is unwritable (${dir}). ` +
-          `Using temporary fallback — fonts will re-download each run. ` +
-          `Fix with: chmod 755 ${resolveFontCacheRoot()}`,
-      );
+      if (firstFallback) {
+        defaultLogger.warn(
+          `Font cache directory is unwritable (${dir}). ` +
+            `Using temporary fallback — fonts will re-download each run. ` +
+            `Fix with: chmod 755 ${resolveFontCacheRoot()}`,
+        );
+      }
       return fallback;
     }
   }


### PR DESCRIPTION
## Summary

When the font cache directory can't be created (`EPERM`/`EACCES` on `mkdirSync`), the render aborted with a raw filesystem error. The cache is an optimization — it stores Google Fonts downloads between runs — so an unwritable cache should degrade, not crash.

The fix wraps `mkdirSync` in `fontCacheDir` with a try/catch. On failure, it falls back to a temp directory (`mkdtempSync`) for the process lifetime, mirroring the existing Lambda fallback pattern. A warning is logged so users know fonts are cached to a temp location.

## Root cause

`fontCacheDir` in `deterministicFonts.ts` called `mkdirSync` unguarded. When `~/.cache/hyperframes/fonts/` was unwritable (permissions, read-only filesystem, corporate policy), the throw propagated through compile and failed the render.

Fixes #3412.

## Test plan

- [x] All 7 `deterministicFonts.test.ts` tests pass
- [x] No type errors in `deterministicFonts.ts`
- [ ] CI green

— Miga