### PR TITLE
chore: release v0.8.23

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,31 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.23"
+  description="Released - 2026-09-01"
+  tags={["Release", "Registry", "Capture", "CLI"]}
+>
+Server deployments can now caption captured assets with Vertex credentials, and promoted templates identify the brand each slot represents.
+Caption-zone checks catch overlapping text, while safer timeline lint prevents a class of broken template playback.
+
+## Fixes
+
+- **Capture:** Authenticate vision captioning with Vertex service accounts and keep SVG rasterization safe ([8eea3c913](https://github.com/heygen-com/hyperframes/commit/8eea3c913f1584b769cc38e8a91bd70f600f352a), [#3561](https://github.com/heygen-com/hyperframes/pull/3561)).
+- **CLI:** Flag text whenever its DOM box overlaps the reserved caption zone ([45cc34352](https://github.com/heygen-com/hyperframes/commit/45cc3435254c44abe7b21bc8e996bbef32365fe6), [#3580](https://github.com/heygen-com/hyperframes/pull/3580)).
+- **Lint:** Reject timeline return values used as child tweens before they can detach template playback ([254fe4bd8](https://github.com/heygen-com/hyperframes/commit/254fe4bd8a3f00c1e70ac5e38a1bce25060f7590), [#3562](https://github.com/heygen-com/hyperframes/pull/3562)).
+
+## Catalog
+
+- **Registry:** Mark identity-bearing slots across eight promoted templates and keep long prompts visible in exchange composers ([254fe4bd8](https://github.com/heygen-com/hyperframes/commit/254fe4bd8a3f00c1e70ac5e38a1bce25060f7590), [#3562](https://github.com/heygen-com/hyperframes/pull/3562)).
+
+## Internal
+
+- Optimize Windows test lanes ([f42b5ce86](https://github.com/heygen-com/hyperframes/commit/f42b5ce86c23268a533217e012cd228434c84e02), [#3579](https://github.com/heygen-com/hyperframes/pull/3579)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.22...v0.8.23).
+</Update>
+
+<Update
   label="HyperFrames v0.8.22"
   description="Released - 2026-09-01"
   tags={["Release", "Rendering", "CLI"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.22",
+  "version": "0.8.23",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.23.md
+++ b/releases/v0.8.23.md
@@ -1,0 +1,24 @@
+# HyperFrames v0.8.23
+
+Released on 2026-09-01.
+
+Server deployments can now caption captured assets with Vertex credentials, and promoted templates identify the brand each slot represents.
+Caption-zone checks catch overlapping text, while safer timeline lint prevents a class of broken template playback.
+
+## Fixes
+
+- **Capture:** Authenticate vision captioning with Vertex service accounts and keep SVG rasterization safe ([8eea3c913](https://github.com/heygen-com/hyperframes/commit/8eea3c913f1584b769cc38e8a91bd70f600f352a), [#3561](https://github.com/heygen-com/hyperframes/pull/3561)).
+- **CLI:** Flag text whenever its DOM box overlaps the reserved caption zone ([45cc34352](https://github.com/heygen-com/hyperframes/commit/45cc3435254c44abe7b21bc8e996bbef32365fe6), [#3580](https://github.com/heygen-com/hyperframes/pull/3580)).
+- **Lint:** Reject timeline return values used as child tweens before they can detach template playback ([254fe4bd8](https://github.com/heygen-com/hyperframes/commit/254fe4bd8a3f00c1e70ac5e38a1bce25060f7590), [#3562](https://github.com/heygen-com/hyperframes/pull/3562)).
+
+## Catalog
+
+- **Registry:** Mark identity-bearing slots across eight promoted templates and keep long prompts visible in exchange composers ([254fe4bd8](https://github.com/heygen-com/hyperframes/commit/254fe4bd8a3f00c1e70ac5e38a1bce25060f7590), [#3562](https://github.com/heygen-com/hyperframes/pull/3562)).
+
+## Internal
+
+- Optimize Windows test lanes ([f42b5ce86](https://github.com/heygen-com/hyperframes/commit/f42b5ce86c23268a533217e012cd228434c84e02), [#3579](https://github.com/heygen-com/hyperframes/pull/3579)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.22...v0.8.23


### PR DESCRIPTION
## Summary

Release HyperFrames 0.8.23 with server-ready Vertex vision captioning, explicit brand semantics for promoted templates, stricter caption-zone checks, and safer GSAP timeline linting.

This release unblocks the coordinated Experiment Framework rollout: EF #48887 passes `HYPERFRAMES_VERTEX_PROJECT_ID` and `HYPERFRAMES_VERTEX_SERVICE_ACCOUNT`, but its current HyperFrames 0.8.15 pin cannot read them. Publish 0.8.23 first, then move the eight EF pins together.

## Included changes

- **Capture:** Vertex service-account authentication, zero-thinking factual captions, serialized SVG rasterization, and restoration of Sharp's process-global worker pool (#3561).
- **Registry and lint:** machine-readable identity semantics across eight promoted templates, complete `notes-reveal` attribution, long-prompt caret scrolling, and a guard against treating `Timeline.to()` returns as child tweens (#3562).
- **CLI:** caption-zone detection now uses DOM-box intersection, so partially overlapping text cannot pass a center-point test (#3580).
- **CI:** two balanced Windows test lanes preserve the existing required-check name while reducing the measured critical path (#3579).

## Release surface

- 13 public packages move from 0.8.22 to 0.8.23.
- 3 plugin manifests move from 0.8.22 to 0.8.23.
- `@hyperframes/sdk-playground` remains private at 0.6.106.
- No package name is new, and npm currently has no 0.8.23 version for any publish target.
- Merging this `release/v0.8.23` branch triggers the stable publish from the immutable merge SHA.

## Validation

- 65 focused release, publish-workflow, changelog, versioning, workspace-contract, and packed-manifest tests passed locally.
- Stable release-channel validation passed for `release/v0.8.23` with dist-tag `latest`.
- Publish workflow coverage matches all 13 public packages, including the unscoped `hyperframes` CLI rewrite.
- Changelog generation covers the complete v0.8.22...main range and contains no review TODO markers.
- All four included PRs merged after their exact-head required checks passed; the release branch CI reruns the full suite.

## Post-deploy validation

- Confirm tag `v0.8.23` and the GitHub release point to the release merge SHA.
- Confirm all 13 npm packages report both version and `latest` as 0.8.23.
- Then bump `EXPECTED_HYPERFRAMES_VERSION` and all eight EF worker/compiler pins in one change.
- If publishing is partial, rerun the idempotent publish job before moving the EF pins.

Validation window: 30 minutes after merge. Owner: Magi.
