### PR TITLE
test(engine): give the 150-track audio mix test a Windows-sized budget

### DIFF
--- a/packages/engine/src/services/audioMixer.test.ts
+++ b/packages/engine/src/services/audioMixer.test.ts
@@ -107,7 +107,7 @@ describe("processCompositionAudio", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    runFfmpegMock.mockClear();
+    runFfmpegMock.mockReset();
     extractAudioMetadataMock.mockReset();
     extractAudioMetadataMock.mockResolvedValue({
       durationSeconds: 2,
@@ -1098,7 +1098,9 @@ describe("processCompositionAudio", () => {
     // indefinite `apad` to cap the padded stream at composition duration.
     expect((filter?.match(/atrim=/g) ?? []).length).toBe(trackCount * 2);
     expect((filter?.match(/apad,/g) ?? []).length).toBe(trackCount);
-  });
+    // 150 real files + 150 existence checks: ~60ms on Linux, but well past the 5s
+    // default on the Windows lane, where each file create is orders slower.
+  }, 30_000);
 
   it("renumbers timestamps between apad and atrim on every mixed branch", async () => {
     // Regression: `apad` then `atrim` is the portable pad-to-length shape --


### PR DESCRIPTION
## What

Two changes to `packages/engine/src/services/audioMixer.test.ts`:

1. An explicit `30_000` timeout on the 150-track ENAMETOOLONG regression test.
2. `afterEach` now calls `runFfmpegMock.mockReset()` instead of `mockClear()`.

## Why

The Windows lane on #3586 failed two tests in this file:

- `keeps the ffmpeg command line short with a large track count (regression for spawn ENAMETOOLONG)` — `Test timed out in 5000ms` (`audioMixer.test.ts:1050`)
- `retries with the current file-valued filter option when a nightly removes the legacy alias` — `expected "spy" to be called 3 times, but got 5 times` (`audioMixer.test.ts:1199`)

Only the first is a real problem. The second is caused by it.

**Why it times out.** The test writes 150 real clip files, and `processCompositionAudio` existence-checks every one (`audioMixer.ts:1144`). That measures ~58ms on Linux and goes past vitest's 5s default on Windows, where each file create costs orders more. `packages/engine/vitest.config.ts` sets no `testTimeout`, so every engine test runs on the 5s default — which is why the heavy tests here already carry an explicit one (`videoFrameExtractor.test.ts:1282` at `30_000`, `audioFxRender.test.ts:239` at `180_000`). This one didn't.

**Why the sibling fails too.** `runFfmpegMock` is a module-level hoisted mock shared by all 61 tests in the file. When the 150-track test times out, vitest abandons it but its async work keeps running — and keeps calling that mock after `afterEach` has cleared it. Those calls land inside the *next* test: 3 expected + 2 leaked = 5. Worse, the leaked calls consume that test's queued `mockImplementationOnce` handlers, so its `mock.calls[1]` / `[2]` assertions read the wrong invocations.

Reproduced in isolation, with the same `afterEach(mockClear)` shape:

| Scenario | test A | innocent test B |
| --- | --- | --- |
| A times out at 300ms | `Test timed out` | count 1 → 2, and B's own call returned `ONCE_2` because the leak had consumed `ONCE_1` |
| A given an adequate budget | passes | count 1, returns `ONCE_1` |

So one slow test produces two failures, and the second one reads as an unrelated flake. Removing the timeout removes both.

## How

The timeout is the fix, and it follows the existing convention in this directory rather than introducing a new one.

`mockReset()` is hardening, and to be precise it does **not** fix the leak above — calls arriving mid-test are unaffected by a hook that already ran. What it fixes is the adjacent case: a test that queues `mockImplementationOnce` and dies before consuming them currently hands those leftovers to the next test. Verified against this repo's vitest 3.2.4 that `mockReset()` restores the original `vi.fn(impl)`, so the file's default mock behaviour is unchanged.

Two alternatives I did not take, in case a maintainer prefers one:

- Set `testTimeout` in `packages/engine/vitest.config.ts`, as `packages/cli` does at 20s. That fixes the whole class, but raises the budget for all 70 engine test files and would make genuine hangs slower to surface.
- Parallelise the 150 `writeFileSync` calls. A real cost reduction on Windows, but it reshapes the test's setup for a problem the budget already solves.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

- `bun run vitest run src/services/audioMixer.test.ts --root packages/engine` → 61/61 pass, both before and after (so `mockReset` changes no existing expectation).
- `oxfmt --check`, `oxlint`, and `bun run --cwd packages/engine typecheck` all clean.
- Cascade reproduced and then confirmed gone, per the table above.
- I can't reproduce the Windows timing locally, so `30_000` is headroom sizing rather than a measurement: roughly 500x the observed Linux runtime, and the same value a sibling test in this directory already uses.

— Rames Jusso
