### PR TITLE
fix(core/bundler): inline fonts and images so a lone bundle renders

### DIFF
--- a/packages/core/src/compiler/htmlBundler.test.ts
+++ b/packages/core/src/compiler/htmlBundler.test.ts
@@ -19,6 +19,16 @@ function makeTempProject(files: Record<string, string>): string {
   return dir;
 }
 
+/**
+ * The data URL a correctly-resolved asset must inline to. Asserting on the
+ * asset's CONTENT, not on the rewritten path string, is what proves rebasing
+ * resolved to the right file: resolving from the wrong base directory finds no
+ * file at all, so nothing is inlined and the assertion fails.
+ */
+function inlinedAs(mime: string, content: string): string {
+  return `data:${mime};base64,${Buffer.from(content, "utf-8").toString("base64")}`;
+}
+
 function makeColorGradingProject(lutSrc: string, files: Record<string, string> = {}): string {
   return makeTempProject({
     "index.html": `<!doctype html>
@@ -1210,7 +1220,7 @@ describe("bundleToSingleHtml", () => {
 
     const bundled = await bundleToSingleHtml(dir);
 
-    expect(bundled).toContain("url('styles/assets/fonts/brand.woff2')");
+    expect(bundled).toContain(`url('${inlinedAs("font/woff2", "fake-font-data")}')`);
     expect(bundled).not.toContain("url('assets/fonts/brand.woff2')");
     expect(bundled).not.toContain("@import");
   });
@@ -1229,7 +1239,7 @@ describe("bundleToSingleHtml", () => {
 
     const bundled = await bundleToSingleHtml(dir);
 
-    expect(bundled).toContain("url('theme/images/grain.png')");
+    expect(bundled).toContain(`url('${inlinedAs("image/png", "fake-image-data")}')`);
     expect(bundled).not.toContain("url('./images/grain.png')");
   });
 
@@ -1248,7 +1258,7 @@ describe("bundleToSingleHtml", () => {
 
     const bundled = await bundleToSingleHtml(dir);
 
-    expect(bundled).toContain("url('assets/bg.png')");
+    expect(bundled).toContain(`url('${inlinedAs("image/png", "fake-image")}')`);
     expect(bundled).not.toContain("url('../../assets/bg.png')");
   });
 
@@ -1272,7 +1282,7 @@ describe("bundleToSingleHtml", () => {
 
     expect(bundled).toContain("url('https://cdn.example.com/font.woff2')");
     expect(bundled).toContain("url('data:image/svg+xml,<svg/>')");
-    expect(bundled).toContain("url('styles/img/bg.png')");
+    expect(bundled).toContain(`url('${inlinedAs("image/png", "fake")}')`);
   });
 
   it("preserves url() query strings and hash fragments during rebasing", async () => {
@@ -1289,7 +1299,70 @@ describe("bundleToSingleHtml", () => {
 
     const bundled = await bundleToSingleHtml(dir);
 
-    expect(bundled).toContain("url('styles/sprite.png?v=2#section')");
+    // The query/hash suffix rides along onto the inlined data URL.
+    expect(bundled).toContain(`url('${inlinedAs("image/png", "fake-sprite")}?v=2#section')`);
+  });
+
+  it("inlines fonts, images and scripts so no relative asset reference survives", async () => {
+    const dir = makeTempProject({
+      "index.html": `<!doctype html>
+<html><head>
+  <style>
+    @font-face { font-family: "Brand"; src: url('assets/fonts/brand.woff2') format('woff2'); }
+    .hero { background: url('assets/hero.jpg'); }
+  </style>
+</head><body>
+  <div data-composition-id="root" data-width="320" data-height="180">
+    <img id="logo" src="assets/logo.png" srcset="assets/logo2x.webp 2x">
+    <video id="clip" poster="assets/poster.gif"></video>
+  </div>
+  <script src="assets/app.js"></script>
+  <script>window.__timelines = window.__timelines || {}; window.__timelines.root = {}</script>
+</body></html>`,
+      "assets/fonts/brand.woff2": "font-bytes",
+      "assets/hero.jpg": "hero-bytes",
+      "assets/logo.png": "logo-bytes",
+      "assets/logo2x.webp": "logo2x-bytes",
+      "assets/poster.gif": "poster-bytes",
+      "assets/app.js": "window.__APP_LOADED__ = true;",
+    });
+
+    const bundled = await bundleToSingleHtml(dir);
+
+    // Each asset arrives as its own bytes, which is what proves its path
+    // resolved to the right file rather than merely being rewritten.
+    expect(bundled).toContain(inlinedAs("font/woff2", "font-bytes"));
+    expect(bundled).toContain(inlinedAs("image/jpeg", "hero-bytes"));
+    expect(bundled).toContain(inlinedAs("image/png", "logo-bytes"));
+    expect(bundled).toContain(inlinedAs("image/webp", "logo2x-bytes"));
+    expect(bundled).toContain(inlinedAs("image/gif", "poster-bytes"));
+    // A local classic script is folded in as source, not as a data: URL.
+    expect(bundled).toContain("window.__APP_LOADED__ = true;");
+
+    // Nothing still points into the sibling assets/ directory that a consumer
+    // storing this bundle as a lone file will not have.
+    expect(bundled).not.toMatch(/["'(]assets\//);
+  });
+
+  it("leaves an oversized asset relative and warns rather than inlining it", async () => {
+    const dir = makeTempProject({
+      "index.html": `<!doctype html>
+<html><body>
+  <div data-composition-id="root" data-width="320" data-height="180">
+    <img id="big" src="assets/huge.png">
+  </div>
+  <script>window.__timelines = window.__timelines || {}; window.__timelines.root = {}</script>
+</body></html>`,
+      "assets/huge.png": "x".repeat(2 * 1024 * 1024 + 1),
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const bundled = await bundleToSingleHtml(dir);
+
+    expect(bundled).toContain('src="assets/huge.png"');
+    expect(bundled).not.toContain("data:image/png");
+    expect(warn.mock.calls.flat().join(" ")).toContain("may not be self-contained");
+    warn.mockRestore();
   });
 
   it("deduplicates diamond @import (same file imported by two parents)", async () => {

--- a/packages/core/src/compiler/htmlBundler.ts
+++ b/packages/core/src/compiler/htmlBundler.ts
@@ -3,7 +3,7 @@ export { FLATTENED_INNER_ROOT_STRIP_ATTRS } from "../runtime/flattenedRoot";
 import { parseHostVariableValues, warnUnknownEnumValues } from "../runtime/getVariables";
 import { sanitizeCssValue } from "../runtime/applyVariableBindings";
 import { cssVariableName } from "../tokenSlug";
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync, statSync } from "fs";
 import { resolve, relative, dirname, isAbsolute, sep } from "path";
 import { CSS_URL_RE, isNonRelativeUrl } from "./assetPaths.js";
 import { transformSync } from "esbuild";
@@ -294,7 +294,53 @@ const INLINE_MIME: Record<string, string> = {
   ".txt": "text/plain",
   ".cube": "text/plain",
   ".xml": "application/xml",
+  // Fonts and raster images. A bundle handed to a consumer that stores it as a
+  // lone object — no sibling `assets/` directory — 404s on every surviving
+  // relative reference, and a missing font silently reflows the whole frame
+  // rather than failing loudly. Media (mp4/webm/mp3/wav) is deliberately absent:
+  // it is large, streamed rather than laid out, and its absence is obvious.
+  ".woff2": "font/woff2",
+  ".woff": "font/woff",
+  ".ttf": "font/ttf",
+  ".otf": "font/otf",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".avif": "image/avif",
 };
+
+/**
+ * Per-asset ceiling on base64 inlining.
+ *
+ * Base64 costs ~33% over the raw bytes, so an unbounded rule turns one careless
+ * 40 MB asset into a bundle no browser should be asked to parse. 2 MiB is
+ * measured against this repo's own assets rather than picked: the largest of
+ * 164 tracked `.woff2` files is 105 KB (p90 75 KB) and the largest of 284
+ * tracked raster images is 2.00 MB (p90 437 KB). So every font and effectively
+ * every image in-tree inlines, while a video-sized file cannot.
+ *
+ * Oversized assets keep their project-relative URL — correct wherever the
+ * bundle is served from its project directory, and warned about because that is
+ * exactly where "self-contained" stops being true.
+ */
+const MAX_INLINE_ASSET_BYTES = 2 * 1024 * 1024;
+
+function safeStatSize(filePath: string): number | null {
+  try {
+    return statSync(filePath).size;
+  } catch {
+    return null;
+  }
+}
+
+function warnAssetTooLargeToInline(assetPath: string, byteLength: number): void {
+  const mb = (byteLength / (1024 * 1024)).toFixed(1);
+  console.warn(
+    `[HyperFrames] Not inlining "${assetPath}" (${mb} MB exceeds the ${MAX_INLINE_ASSET_BYTES / (1024 * 1024)} MB inline limit). The bundle may not be self-contained.`,
+  );
+}
 
 function maybeInlineRelativeAssetUrl(urlValue: string, projectDir: string): string | null {
   if (!urlValue || !isRelativeUrl(urlValue)) return null;
@@ -305,6 +351,13 @@ function maybeInlineRelativeAssetUrl(urlValue: string, projectDir: string): stri
   const ext = filePath.toLowerCase().match(/\.[^.]+$/)?.[0] ?? "";
   const mimeType = INLINE_MIME[ext];
   if (!mimeType) return null;
+  // Size-check before reading: an oversized asset must not be pulled into memory
+  // just to be discarded.
+  const byteLength = safeStatSize(filePath);
+  if (byteLength !== null && byteLength > MAX_INLINE_ASSET_BYTES) {
+    warnAssetTooLargeToInline(basePath, byteLength);
+    return null;
+  }
   const content = safeReadFileBuffer(filePath);
   if (content == null) return null;
   const dataUrl = `data:${mimeType};base64,${content.toString("base64")}`;
@@ -719,7 +772,9 @@ export interface BundleOptions {
  * - Injects the HyperFrames runtime script
  * - Inlines local CSS and JS files
  * - Inlines sub-composition HTML fragments (data-composition-src)
- * - Inlines small textual assets as data URLs
+ * - Inlines textual assets, fonts and raster images as data URLs, up to a
+ *   per-asset size limit; audio/video and oversized assets keep their
+ *   project-relative URL and require the project directory to be served
  */
 
 function ensureExternalScriptTag(doc: Document, src: string): void {


### PR DESCRIPTION
## The gap

`bundleToSingleHtml` documents itself as producing "a single self-contained HTML file", and `BundleOptions.runtime: "inline"` is described as right for "any *ship a single .html file* use case". `INLINE_MIME` covered only `.svg`, `.json`, `.txt`, `.cube` and `.xml`, so **every font and raster image stayed a live project-relative reference**.

This is invisible to every consumer in this repo, because each one serves the bundled string from an HTTP server rooted at the project directory (`serveStaticProjectHtml`, the producer file server), so the relative paths resolve. It breaks as soon as the bundle is stored on its own with no sibling asset directory. A missing image is obvious; a missing **font** is not, because the page silently reflows into a fallback face and still looks plausible.

## Measured, with the real bundler and real binary assets

Each bundle loaded **alone in an empty directory**, which is what a single-object consumer actually has:

| | failed requests | `"Brand"` font usable | `<img>` loaded |
|---|---|---|---|
| before | 3 (`icon.png`, `Brand.woff2`, `gsap.min.js`) | `false` | `false` |
| after | 1 (`gsap.min.js`) | `true` | `true` |

## The change

Widen the inline set to fonts (`woff2`/`woff`/`ttf`/`otf`) and raster images (`png`/`jpg`/`jpeg`/`gif`/`webp`/`avif`), behind a **2 MiB per-asset cap**.

**The cap is measured, not guessed.** Against this repo's own tracked assets: the largest of 164 `.woff2` files is 105 KB (p90 75 KB), and the largest of 284 raster images is 2.00 MB (p90 437 KB). So every font and effectively every image in-tree inlines, while a video-sized file cannot. Base64 costs ~33%, so an unbounded rule would let one careless asset produce a bundle nothing should be asked to parse. Oversized assets keep their relative URL and warn, reusing the existing *"may not be self-contained"* wording.

Deliberately **not** included:

- **Audio and video.** Large, streamed rather than laid out, and their absence is obvious rather than silent.
- **Scripts.** They already have a better path: `script[src]` is folded in as source by the existing "Inline local JS" pass. Adding `.js` to the MIME table would only catch `type="module"` scripts, which are skipped on purpose because a `data:` URL changes their import base URL.

## Known limitation

A `<script src>` written from inside a `document.write` string is invisible to any static rewriter, so a GSAP tag injected that way still 404s. That is the one remaining failed request in the table above. Handling it would mean executing author JS at bundle time; naming it beats pretending it is covered.

## Tests

The new fixture is the point: **the previous asset tests could not contain this bug**, because they asserted that a relative path *survived*. Added a fixture with a font, four image formats, a `srcset`, a `poster` and a script, asserting no reference into `assets/` survives.

The five rebasing tests that asserted a surviving relative path now assert the data URL's **decoded content**. That is a stronger check: resolving from the wrong base directory finds no file at all, so nothing inlines and the assertion fails.

Non-vacuousness proven by reverting the implementation: the new test fails on `expected … to contain 'data:font/woff2;base64,Zm9udC1ieXRlcw…'`.

## Verification

- `packages/core` full suite: **2589 passed (125 files)**, green on `main` beforehand as well
- CLI tests that consume the bundler (`bundleWithLocalizedFonts`, `validate`, `inspect`, `layout`, `registryBlocks`): **37 passed**
- `tsc --noEmit` clean, `oxlint`/`oxfmt`/`fallow` clean

## Worth a reviewer's opinion

`publish` already solves self-containment a different way — it zips the **whole project tree**, assets included. If the intended contract is that a composition always travels with its directory, then a consumer storing one key is the thing to fix, not the bundler. This change is the right one only if a bundle must be able to stand alone, which is what the function's own name and docstring already promise.
