### PR TITLE
chore: release v0.8.24

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,29 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.24"
+  description="Released - 2026-09-02"
+  tags={["Release", "Producer", "Catalog", "Engine"]}
+>
+Producer failures now carry bounded extraction evidence across service boundaries without exposing signed URLs.
+Catalog tabs also stay aligned with their active indicator.
+
+## Fixes
+
+- **Producer:** Transport safe extraction failure metadata ([c0887b650](https://github.com/heygen-com/hyperframes/commit/c0887b650d433ecec39a2ea7efa0674b63b103fe), [#3592](https://github.com/heygen-com/hyperframes/pull/3592)).
+
+## Catalog
+
+- **Catalog:** Sync tab labels with the sliding indicator ([305de1543](https://github.com/heygen-com/hyperframes/commit/305de15432730397b23f0c2061b73b48857af6a3), [#3267](https://github.com/heygen-com/hyperframes/pull/3267)).
+
+## Internal
+
+- **Engine:** Give the 150-track audio mix test a Windows-sized budget ([db92f8ab5](https://github.com/heygen-com/hyperframes/commit/db92f8ab592e92571f172e1ba5c9791e002366bb), [#3587](https://github.com/heygen-com/hyperframes/pull/3587)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.23...v0.8.24).
+</Update>
+
+<Update
   label="HyperFrames v0.8.23"
   description="Released - 2026-09-01"
   tags={["Release", "Registry", "Capture", "CLI"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.23",
+  "version": "0.8.24",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.24.md
+++ b/releases/v0.8.24.md
@@ -1,0 +1,22 @@
+# HyperFrames v0.8.24
+
+Released on 2026-09-02.
+
+Producer failures now carry bounded extraction evidence across service boundaries without exposing signed URLs.
+Catalog tabs also stay aligned with their active indicator.
+
+## Fixes
+
+- **Producer:** Transport safe extraction failure metadata ([c0887b650](https://github.com/heygen-com/hyperframes/commit/c0887b650d433ecec39a2ea7efa0674b63b103fe), [#3592](https://github.com/heygen-com/hyperframes/pull/3592)).
+
+## Catalog
+
+- **Catalog:** Sync tab labels with the sliding indicator ([305de1543](https://github.com/heygen-com/hyperframes/commit/305de15432730397b23f0c2061b73b48857af6a3), [#3267](https://github.com/heygen-com/hyperframes/pull/3267)).
+
+## Internal
+
+- **Engine:** Give the 150-track audio mix test a Windows-sized budget ([db92f8ab5](https://github.com/heygen-com/hyperframes/commit/db92f8ab592e92571f172e1ba5c9791e002366bb), [#3587](https://github.com/heygen-com/hyperframes/pull/3587)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.23...v0.8.24


### PR DESCRIPTION
## Summary

Release HyperFrames 0.8.24 with a generic producer metadata boundary for extraction failures, corrected catalog tab indicators, and a Windows-sized audio-mix test budget.

This release unblocks the coordinated internal rollout. After publishing, hyperframes-internal #1022 can pin `@hyperframes/producer` 0.8.24 and preserve safe extraction evidence for Experiment Framework retry decisions.

## Included changes

- **Producer:** transport bounded, query-free extraction failure evidence through generic public error metadata while leaving validation and retry policy to downstream callers (#3592).
- **Catalog:** keep tab labels synchronized with the sliding active indicator (#3267).
- **CI:** give the 150-track audio-mix test enough time on Windows runners (#3587).

## Release surface

- 13 public packages move from 0.8.23 to 0.8.24.
- 3 plugin manifests move from 0.8.23 to 0.8.24.
- `@hyperframes/sdk-playground` remains private at 0.6.106.
- Merging this `release/v0.8.24` branch triggers the stable publish from the immutable merge SHA.

## Validation

- 63 focused release, publish-workflow, changelog, versioning, workspace-contract, package-subpath, and packed-manifest tests passed locally.
- Stable release-channel validation passed for `release/v0.8.24` with dist-tag `latest`.
- Changelog generation covers the complete `v0.8.23...main` range and contains no review TODO markers.
- OSS #3592 merged only after its exact-head required checks passed; this release branch reruns the full suite.

## Post-deploy validation

- Confirm tag `v0.8.24` and the GitHub release point to the release merge SHA.
- Confirm all 13 npm packages report version 0.8.24 and the `latest` dist-tag.
- Then update hyperframes-internal #1022 to `@hyperframes/producer` 0.8.24, rebuild it, and rerun CI.
- If publishing is partial, rerun the idempotent publish job before moving the internal pin.

Validation window: 30 minutes after merge. Owner: Jerry.
