### PR TITLE
chore: release v0.8.25

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,26 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.25"
+  description="Released - 2026-09-02"
+  tags={["Release", "Studio", "Registry"]}
+>
+Studio now shows agent intent and applies accepted edits live across preview, source, thumbnails, reloads, and Undo.
+Catalog adds Kinetic Center Build, while Flowchart selection clears after click-away.
+
+## Features
+
+- **Studio:** Make agent edits live and explicit ([6b5b4cb988](https://github.com/heygen-com/hyperframes/commit/6b5b4cb9889084594b9fd8ee9fd29adbd5e69227), [#3581](https://github.com/heygen-com/hyperframes/pull/3581)).
+
+## Catalog
+
+- **Registry:** Add kinetic center build component ([f498be94c2](https://github.com/heygen-com/hyperframes/commit/f498be94c24e2bb66538f1f9447ae32935587c42), [#3269](https://github.com/heygen-com/hyperframes/pull/3269)).
+- **Registry:** Clear flowchart selection after click-away ([aab3bfcd10](https://github.com/heygen-com/hyperframes/commit/aab3bfcd1021995fabd36f3f603ed148067f4fb8), [#3262](https://github.com/heygen-com/hyperframes/pull/3262)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.24...v0.8.25).
+</Update>
+
+<Update
   label="HyperFrames v0.8.24"
   description="Released - 2026-09-02"
   tags={["Release", "Producer", "Catalog", "Engine"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.24",
+  "version": "0.8.25",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.25.md
+++ b/releases/v0.8.25.md
@@ -1,0 +1,19 @@
+# HyperFrames v0.8.25
+
+Released on 2026-09-02.
+
+Studio now shows agent intent and applies accepted edits live across preview, source, thumbnails, reloads, and Undo.
+Catalog adds Kinetic Center Build, while Flowchart selection clears after click-away.
+
+## Features
+
+- **Studio:** Make agent edits live and explicit ([6b5b4cb988](https://github.com/heygen-com/hyperframes/commit/6b5b4cb9889084594b9fd8ee9fd29adbd5e69227), [#3581](https://github.com/heygen-com/hyperframes/pull/3581)).
+
+## Catalog
+
+- **Registry:** Add kinetic center build component ([f498be94c2](https://github.com/heygen-com/hyperframes/commit/f498be94c24e2bb66538f1f9447ae32935587c42), [#3269](https://github.com/heygen-com/hyperframes/pull/3269)).
+- **Registry:** Clear flowchart selection after click-away ([aab3bfcd10](https://github.com/heygen-com/hyperframes/commit/aab3bfcd1021995fabd36f3f603ed148067f4fb8), [#3262](https://github.com/heygen-com/hyperframes/pull/3262)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.24...v0.8.25


### PR DESCRIPTION
## Summary

Release HyperFrames 0.8.25 with live, proof-carrying Studio agent edits, Kinetic Center Build, and corrected Flowchart deselection.

Merging this reviewed `release/v0.8.25` PR publishes all 13 public packages from the immutable merge SHA and creates the matching tag and GitHub release.

## Included changes

- **Studio:** show agent intent before targeted edits, then keep accepted text, style, transform, and animation changes live through persistence, thumbnails, reloads, and Undo (#3581).
- **Catalog:** add the native, seek-safe Kinetic Center Build component (#3269).
- **Catalog:** clear Flowchart selection outlines after click-away in both horizontal and vertical blocks (#3262).

## Release surface

- 13 public packages move from 0.8.24 to 0.8.25.
- 3 plugin manifests move from 0.8.24 to 0.8.25.
- `@hyperframes/sdk-playground` remains private at 0.6.106.
- Release notes cover the complete `v0.8.24...main` range with no review TODO markers.

## Validation

- 63 focused release, publish-workflow, changelog, versioning, workspace-contract, package-subpath, and packed-manifest tests pass locally.
- Stable release-channel validation passes for `release/v0.8.25` with npm dist-tag `latest`.
- All 13 package versions and all 3 plugin versions are aligned at 0.8.25.
- Changed release files pass `oxfmt --check`; workspace and package-subpath contract checks pass.

## Post-Deploy Monitoring & Validation

- **Workflow/logs:** inspect the immutable publish run triggered by this merged PR. Require `Create release tag`, build, npm publish, and GitHub release steps to succeed.
- **Expected healthy signals:** `v0.8.25` and its GitHub release point to the merge SHA; all 13 public npm packages report `0.8.25` with `latest=0.8.25`.
- **Failure signals:** any package remains on 0.8.24, `latest` diverges, the tag points elsewhere, or the GitHub release is missing/draft.
- **Mitigation:** do not cut a replacement release or move the tag. Rerun the original immutable publish workflow so its idempotent tag check and package publishes recover the same merge SHA.
- **Window/owner:** validate for 30 minutes after merge; owner is the HyperFrames release owner.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
