### PR TITLE
fix(cli): score apple-touch-icon-precomposed at the 180px default

### DIFF
--- a/packages/cli/src/capture/faviconRanker.test.ts
+++ b/packages/cli/src/capture/faviconRanker.test.ts
@@ -108,6 +108,24 @@ describe("rankIconCandidates", () => {
     expect(hrefs([{ rel: "icon", href: "" }, ...NOTION])).toHaveLength(2);
   });
 
+  it("scores apple-touch-icon-precomposed at the same 180px default as apple-touch-icon", () => {
+    // Precomposed is one token longer, not a different rel: it must win against a small
+    // sized png the same way a plain apple-touch-icon would.
+    const precomposed: IconCandidate[] = [
+      {
+        rel: "apple-touch-icon-precomposed",
+        href: "https://x.test/apple-touch-icon-precomposed.png",
+        sizes: null,
+        type: null,
+      },
+      { rel: "icon", href: "https://x.test/favicon-32.png", sizes: "32x32", type: "image/png" },
+    ];
+    expect(hrefs(precomposed)).toEqual([
+      "https://x.test/apple-touch-icon-precomposed.png",
+      "https://x.test/favicon-32.png",
+    ]);
+  });
+
   it("keeps DOM order between candidates of equal rank", () => {
     const same: IconCandidate[] = [
       { rel: "icon", href: "https://x.test/a.png", sizes: "32x32" },

--- a/packages/cli/src/capture/faviconRanker.ts
+++ b/packages/cli/src/capture/faviconRanker.ts
@@ -68,7 +68,15 @@ function isIco(c: IconCandidate): boolean {
 function declaredSize(c: IconCandidate): number {
   const parsed = parseSizes(c.sizes);
   if (parsed > 0) return parsed;
-  return c.rel.toLowerCase().split(/\s+/).includes("apple-touch-icon") ? APPLE_TOUCH_DEFAULT_PX : 0;
+  // `startsWith`, not an exact-token match: `apple-touch-icon-precomposed` is the same
+  // 180px default, one spelling later. Exact match is right for `mask-icon` (isMaskIcon),
+  // where a longer rel really would be a different asset.
+  return c.rel
+    .toLowerCase()
+    .split(/\s+/)
+    .some((t) => t.startsWith("apple-touch-icon"))
+    ? APPLE_TOUCH_DEFAULT_PX
+    : 0;
 }
 
 function tierOf(c: IconCandidate): number {


### PR DESCRIPTION
## What changed

The favicon ranker's `declaredSize()` matches the rel token `apple-touch-icon`
exactly. `rel="apple-touch-icon-precomposed"` is one token, not two, so it
fell through to a score of 0 instead of the 180px Apple default — even though
the selector (`link[rel*="icon"]`) already collects it. Same page, one
spelling apart, opposite winner inside tier 1: it never drops a candidate and
never beats the `.ico` tier, so it only mis-orders within the middle tier.

Fix: `startsWith("apple-touch-icon")` on the token instead of an exact match.
`mask-icon` keeps its own exact-token check (`isMaskIcon`), where a longer
rel really would be a different asset.

## What I measured

Reverted the fix locally (exact-token match) and reran the new test:

```
FAIL  src/capture/faviconRanker.test.ts > rankIconCandidates > scores apple-touch-icon-precomposed at the same 180px default as apple-touch-icon
AssertionError: expected [ …(2) ] to deeply equal [ …(2) ]
- Expected
+ Received
  [
-   "https://x.test/apple-touch-icon-precomposed.png",
    "https://x.test/favicon-32.png",
+   "https://x.test/apple-touch-icon-precomposed.png",
  ]
```

With the fix restored:

```
✓ src/capture/faviconRanker.test.ts (12 tests) 3ms
Test Files  1 passed (1)
     Tests  12 passed (12)
```

`bunx tsc --noEmit` in `packages/cli`: same three pre-existing errors on both
`origin/main` and this branch (missing generated runtime files, unrelated to
this change) — no new errors introduced.

## What I did NOT exercise

- The live capture path end to end (no headless browser run against a real
  page declaring `apple-touch-icon-precomposed`). This is a pure ranking-unit
  change; the download loop and page-evaluate extraction it feeds into are
  untouched.
- `<link rel="manifest">` icons and `data:` URI hrefs, both called out as
  pre-existing gaps in the original PR's review and out of scope here.