### PR TITLE
fix(producer): skip HDR layers outside their sub-composition window

### DIFF
--- a/packages/producer/src/services/hdrCompositor.test.ts
+++ b/packages/producer/src/services/hdrCompositor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ElementStackingInfo } from "@hyperframes/engine";
-import { selectDomLayerShowIds } from "./hdrCompositor.js";
+import { isHdrLayerBlittable, selectDomLayerShowIds } from "./hdrCompositor.js";
 
 function makeEl(id: string, overrides?: Partial<ElementStackingInfo>): ElementStackingInfo {
   return {
@@ -24,6 +24,41 @@ function makeEl(id: string, overrides?: Partial<ElementStackingInfo>): ElementSt
     ...overrides,
   };
 }
+
+describe("isHdrLayerBlittable", () => {
+  it("skips HDR video elements outside their sub-composition window", () => {
+    // Native videos are hidden during capture (visible=false), so
+    // renderFrameVisible tracks the replacement <img>'s paintability.
+    // When the scene's time window has ended, both are false.
+    expect(isHdrLayerBlittable(makeEl("v1", { visible: false, renderFrameVisible: false }))).toBe(
+      false,
+    );
+  });
+
+  it("keeps HDR video elements within their sub-composition window", () => {
+    // During capture the video itself is hidden, but the replacement frame is visible.
+    expect(isHdrLayerBlittable(makeEl("v1", { visible: false, renderFrameVisible: true }))).toBe(
+      true,
+    );
+  });
+
+  it("keeps visible HDR image elements", () => {
+    // Images are not hidden by the frame injector — visible tracks the time window.
+    expect(isHdrLayerBlittable(makeEl("img1", { visible: true, renderFrameVisible: false }))).toBe(
+      true,
+    );
+  });
+
+  it("skips HDR image elements outside their time window", () => {
+    expect(isHdrLayerBlittable(makeEl("img1", { visible: false, renderFrameVisible: false }))).toBe(
+      false,
+    );
+  });
+
+  it("skips zero-opacity elements regardless of visibility", () => {
+    expect(isHdrLayerBlittable(makeEl("v1", { opacity: 0, renderFrameVisible: true }))).toBe(false);
+  });
+});
 
 describe("selectDomLayerShowIds", () => {
   it("does not re-show hidden DOM elements while preserving visible injected video frames", () => {

--- a/packages/producer/src/services/hdrCompositor.test.ts
+++ b/packages/producer/src/services/hdrCompositor.test.ts
@@ -96,4 +96,17 @@ describe("selectDomLayerShowIds", () => {
       ),
     ).toEqual(["active-overlay"]);
   });
+
+  it("excludes HDR elements whose sub-composition window has ended during a transition scene", () => {
+    expect(
+      selectDomLayerShowIds(
+        ["hdr-video-ended", "hdr-video-active", "visible-replacement"],
+        [
+          makeEl("hdr-video-ended", { visible: false, renderFrameVisible: false }),
+          makeEl("hdr-video-active", { visible: false, renderFrameVisible: true }),
+          makeEl("visible-replacement"),
+        ],
+      ),
+    ).toEqual(["hdr-video-active", "visible-replacement"]);
+  });
 });

--- a/packages/producer/src/services/hdrCompositor.ts
+++ b/packages/producer/src/services/hdrCompositor.ts
@@ -434,6 +434,10 @@ export function resolveCompositeTransfer(
   return hasHdrContent && effectiveHdr ? effectiveHdr.transfer : "srgb";
 }
 
+export function isHdrLayerBlittable(el: ElementStackingInfo): boolean {
+  return el.opacity > 0 && (el.visible || el.renderFrameVisible === true);
+}
+
 export function selectDomLayerShowIds(
   layerElementIds: string[],
   fullStacking: ElementStackingInfo[],
@@ -559,8 +563,7 @@ export async function compositeHdrFrame(
 
   for (const [layerIdx, layer] of layers.entries()) {
     if (layer.type === "hdr") {
-      // Skip zero-opacity HDR elements — their parent scene may have faded out.
-      if (layer.element.opacity <= 0) continue;
+      if (!isHdrLayerBlittable(layer.element)) continue;
       const before = shouldLog ? countNonZeroRgb48(canvas) : 0;
       const isHdrImage = nativeHdrImageIds.has(layer.element.id);
       const hdrTargetTransfer = compositeTransfer === "srgb" ? undefined : compositeTransfer;

--- a/packages/producer/src/services/hdrCompositor.ts
+++ b/packages/producer/src/services/hdrCompositor.ts
@@ -445,7 +445,7 @@ export function selectDomLayerShowIds(
   const byId = new Map(fullStacking.map((el) => [el.id, el]));
   return layerElementIds.filter((id) => {
     const el = byId.get(id);
-    return !!el && el.opacity > 0 && (el.visible || el.renderFrameVisible === true);
+    return !!el && isHdrLayerBlittable(el);
   });
 }
 

--- a/packages/producer/src/services/render/stages/captureHdrFrameShared.ts
+++ b/packages/producer/src/services/render/stages/captureHdrFrameShared.ts
@@ -27,6 +27,7 @@ import {
   type TransitionRange,
   blitHdrImageLayer,
   blitHdrVideoLayer,
+  isHdrLayerBlittable,
   selectDomLayerShowIds,
 } from "../../hdrCompositor.js";
 import { cleanupHdrVideoFrameSource } from "./captureHdrResources.js";
@@ -204,7 +205,7 @@ export async function captureSceneIntoBuffer(a: CaptureSceneArgs): Promise<void>
     "domLayerInjectMs",
   );
   for (const el of stackingInfo) {
-    if (!el.isHdr || !sceneIds.has(el.id)) continue;
+    if (!el.isHdr || !sceneIds.has(el.id) || !isHdrLayerBlittable(el)) continue;
     if (nativeHdrImageIds.has(el.id)) {
       blitHdrImageLayer(
         sceneBuf,

--- a/packages/producer/tests/hdr-regression/output/output.mp4
+++ b/packages/producer/tests/hdr-regression/output/output.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5808c1d2d8e794568deb36ff8c727066d3c6846bd764f4dc10b154c8c329e717
-size 3689447
+oid sha256:c043fe0dcd91d1e39ebe1e4d03ab59ba1b3de5f7f5975ee62237909899907c7c
+size 3772220


### PR DESCRIPTION
## Summary

- The HDR blit loop only checked `opacity <= 0` when deciding whether to skip a layer — it ignored the sub-composition time window entirely, so when a scene ended, its HDR video/image elements kept painting the last captured frame over all subsequent scenes
- Extracted `isHdrLayerBlittable()` predicate that gates on `(visible || renderFrameVisible)`, matching the existing DOM layer rule in `selectDomLayerShowIds`
- Native videos are deliberately hidden during capture (`visibility: hidden`), so `el.visible` is always false for them — `renderFrameVisible` tracks the replacement `<img>` whose paintability follows the scene's GSAP timeline state
- The same gate protects transition-scene capture, and the HDR regression golden now records the corrected visibility windows

This PR does not change documented auto-HDR codec/transfer selection, Windows temp placement, or black-level behavior.

## Test plan

- [x] 5 unit tests cover HDR video/image in and out of window, native replacement visibility, and zero opacity
- [x] 7/7 HDR compositor tests pass
- [x] 15/15 transition/shared HDR-frame tests pass
- [x] Producer typecheck plus changed-file lint and format pass
- [x] `hdr-regression` re-render passes all 100 visual checkpoints with zero failed frames against the refreshed LFS golden
- [ ] CI required checks rerunning

Closes #3591

— Miga

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
