### PR TITLE
feat(studio): add design:shots screenshot and computed-style capture

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -1,6 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/config-schema.json",
   "entry": [
+    // Vitest collects .test.mjs, but fallow's default test-entry detection only
+    // knows the .ts/.tsx spellings, so this one reads as an unreachable file.
+    "packages/studio/scripts/*.test.mjs",
     "packages/producer/src/**/*.test.ts",
     "packages/aws-lambda/src/**/*.test.ts",
     "packages/gcp-cloud-run/src/**/*.test.ts",

--- a/packages/studio/.gitignore
+++ b/packages/studio/.gitignore
@@ -2,3 +2,4 @@ dist/
 node_modules/
 data/projects/
 tests/e2e/evidence/
+.design-shots/

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -49,6 +49,7 @@
     "build": "vite build && tsup",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "design:shots": "node scripts/design-shots.mjs",
     "test:webmcp-edit-loop": "node tests/e2e/webmcp-edit-loop.mjs",
     "test:timeline-virtualization": "TIMELINE_ROW_VIRTUALIZATION=on TIMELINE_ELEMENT_COUNT=50000 node tests/e2e/timeline-virtualization.mjs",
     "test:watch": "vitest",

--- a/packages/studio/scripts/design-shots.mjs
+++ b/packages/studio/scripts/design-shots.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+/**
+ * Design review capture: boots Studio from source on a free port, walks it
+ * through six review states, screenshots each one, and prints a computed-style
+ * table for a fixed selector list.
+ *
+ * The table is the point. Screenshots show that two controls look different;
+ * only the measured height / radius / font-size / background says by how much,
+ * and that is what a before/after pair of runs compares.
+ *
+ *   bun run --cwd packages/studio design:shots
+ *   bun run --cwd packages/studio design:shots -- --out /tmp/before
+ *   bun run --cwd packages/studio design:shots -- --storybook-url http://localhost:6006
+ *
+ * Server discipline: the run starts its own Vite dev server on a port nobody is
+ * listening on, and kills that one pid on exit. It never touches a server it
+ * did not start, so it is safe to run while another Studio session is up.
+ */
+import { spawn } from "node:child_process";
+import { cpSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const STUDIO_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * The controls the sweep is judged on. Every entry is measured wherever it is
+ * first visible across the six states, so a control that only exists inside a
+ * menu still gets a row.
+ *
+ * Selectors prefer an attribute the component owns (aria-label, role,
+ * data-testid) over a class, because a reskin rewrites
+ * every class in this package and a table that stops resolving is a table that
+ * silently reports "not found" instead of a regression.
+ */
+export const DESIGN_SHOT_SELECTORS = [
+  { key: "header-export", label: "Header Export", selector: '[data-testid="header-export"]' },
+  { key: "renders-export", label: "Renders Export", selector: '[data-testid="renders-export"]' },
+  {
+    key: "inspector-input",
+    label: "Inspector metric input",
+    selector: '[data-testid="inspector-field"]',
+  },
+  {
+    key: "timeline-toolbar-button",
+    label: "Timeline toolbar button",
+    selector: '[aria-label="Selection tool"]',
+  },
+  { key: "menu-item", label: "Menu item", selector: '[role="menuitemradio"]' },
+];
+
+const TABLE_COLUMNS = ["Control", "Selector", "Height", "Radius", "Font size", "Background"];
+
+/**
+ * One row per selector, in declaration order, whether or not it resolved. A
+ * dropped row would read as "the control is unchanged"; `not found` reads as
+ * what it is.
+ */
+export function formatTable(measurements) {
+  const cell = (value) => String(value ?? "not found").replaceAll("|", "\\|");
+  const rows = DESIGN_SHOT_SELECTORS.map((entry) => {
+    const m = measurements[entry.key] ?? {};
+    return [
+      entry.label,
+      `\`${entry.selector}\``,
+      cell(m.height),
+      cell(m.radius),
+      cell(m.fontSize),
+      cell(m.background),
+    ];
+  });
+  return [
+    `| ${TABLE_COLUMNS.join(" | ")} |`,
+    `| ${TABLE_COLUMNS.map(() => "---").join(" | ")} |`,
+    ...rows.map((row) => `| ${row.join(" | ")} |`),
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const args = { out: join(STUDIO_DIR, ".design-shots"), storybookUrl: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--out") args.out = resolve(argv[++i]);
+    else if (argv[i] === "--storybook-url") args.storybookUrl = argv[++i];
+  }
+  return args;
+}
+
+/** Ask the OS for a port nobody holds, then hand it to Vite with --strictPort. */
+function freePort() {
+  return new Promise((res, rej) => {
+    const server = createServer();
+    server.on("error", rej);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      server.close(() => res(port));
+    });
+  });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function waitForServer(url, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return true;
+    } catch {
+      // not up yet
+    }
+    await sleep(500);
+  }
+  return false;
+}
+
+/**
+ * Studio resolves projects out of data/projects, which is gitignored. The
+ * fixture is tracked under tests/e2e, so copy it into place per run under a
+ * name that belongs to this script and cannot collide with a real project.
+ */
+function installFixture() {
+  const projectId = "design-shots";
+  const target = join(STUDIO_DIR, "data", "projects", projectId);
+  rmSync(target, { recursive: true, force: true });
+  mkdirSync(dirname(target), { recursive: true });
+  cpSync(join(STUDIO_DIR, "tests", "e2e", "fixtures", "design-panel-qa"), target, {
+    recursive: true,
+  });
+  return projectId;
+}
+
+function startStudio(port) {
+  const child = spawn(
+    "bun",
+    ["run", "dev", "--", "--port", String(port), "--strictPort", "--host", "127.0.0.1"],
+    { cwd: STUDIO_DIR, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  let log = "";
+  child.stdout.on("data", (d) => (log += d));
+  child.stderr.on("data", (d) => (log += d));
+  return { child, readLog: () => log };
+}
+
+async function measureAll(page, into) {
+  const measured = await page.evaluate((entries) => {
+    const out = {};
+    for (const entry of entries) {
+      const el = document.querySelector(entry.selector);
+      if (!el) continue;
+      const style = getComputedStyle(el);
+      out[entry.key] = {
+        height: `${Math.round(el.getBoundingClientRect().height)}px`,
+        radius: style.borderRadius,
+        fontSize: style.fontSize,
+        background: style.backgroundColor,
+      };
+    }
+    return out;
+  }, DESIGN_SHOT_SELECTORS);
+  // First sighting wins: a control measured in the state built to show it is
+  // more trustworthy than the same selector matching something else later.
+  for (const [key, value] of Object.entries(measured)) into[key] ??= value;
+}
+
+async function shoot(page, outDir, name) {
+  const file = join(outDir, `${name}.png`);
+  await page.screenshot({ path: file });
+  console.log(`captured ${name}.png`);
+}
+
+async function gotoState(page, baseUrl, projectId, params) {
+  const query = new URLSearchParams({ v: "1", ...params }).toString();
+  // Not networkidle: the dev server holds an HMR socket open and the fixture
+  // pulls GSAP from a CDN, so "the network went quiet" never reliably fires.
+  // The app's own header is the readiness signal.
+  await page.goto(`${baseUrl}/#project/${projectId}?${query}`, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector('[data-testid="header-export"]', { timeout: 30_000 });
+}
+
+async function selectFixtureElement(page) {
+  await page.waitForFunction(() => typeof window.__studioTest?.selectByDomId === "function", {
+    timeout: 30_000,
+  });
+  // The preview iframe has to have painted before selectByDomId can resolve the
+  // node; polling the hook's own return value is the only honest ready signal.
+  await page.waitForFunction(
+    async () => (await window.__studioTest.selectByDomId("qa-headline")) === true,
+    { timeout: 30_000, polling: 500 },
+  );
+}
+
+async function capture(page, baseUrl, projectId, outDir, measurements) {
+  // 1. Fresh boot, header visible.
+  await gotoState(page, baseUrl, projectId, { tv: "1" });
+  await measureAll(page, measurements);
+  await shoot(page, outDir, "1-fresh-boot");
+
+  // 2. Element selected, inspector on its Design tab.
+  await selectFixtureElement(page);
+  await page.waitForSelector('[data-testid="inspector-field"]', { timeout: 30_000 });
+  await measureAll(page, measurements);
+  await shoot(page, outDir, "2-inspector-design");
+
+  // 3. Renders tab. The Export control is the panel header, not a per-job
+  //    action, so it renders with an empty queue and needs no render to exist.
+  await gotoState(page, baseUrl, projectId, { tab: "renders", rc: "0", tv: "1" });
+  await page.waitForSelector('[data-testid="renders-export"]', { timeout: 30_000 });
+  await measureAll(page, measurements);
+  await shoot(page, outDir, "3-renders-panel");
+
+  // 4. Context menu over the canvas. The overlay opens it from a real
+  //    contextmenu event, and only once a selection is settled.
+  await gotoState(page, baseUrl, projectId, { tv: "1" });
+  await selectFixtureElement(page);
+  const overlay = await page.$('[aria-label="Composition canvas"]');
+  const box = await overlay.boundingBox();
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2, { button: "right" });
+  await page.waitForSelector("body > div.fixed", { timeout: 10_000 }).catch(() => {});
+  await measureAll(page, measurements);
+  await shoot(page, outDir, "4-canvas-context-menu");
+  await page.keyboard.press("Escape");
+
+  // 5. Timeline toolbar.
+  await page.waitForSelector('[aria-label="Selection tool"]', { timeout: 30_000 });
+  await measureAll(page, measurements);
+  await shoot(page, outDir, "5-timeline-toolbar");
+
+  // 6. Speed menu, the reachable timeline popover.
+  await page.click('[aria-label="Playback speed"]');
+  await page.waitForSelector('[role="menuitemradio"]', { timeout: 10_000 });
+  await measureAll(page, measurements);
+  await shoot(page, outDir, "6-timeline-speed-menu");
+}
+
+async function captureStorybook(page, storybookUrl, outDir) {
+  if (!storybookUrl) {
+    console.log("7-storybook-index.png skipped: no storybook url");
+    return;
+  }
+  await page.goto(storybookUrl, { waitUntil: "domcontentloaded" });
+  await shoot(page, outDir, "7-storybook-index");
+}
+
+async function main() {
+  const { default: puppeteer } = await import("puppeteer-core");
+  const { resolveChromeExecutable } = await import("../tests/e2e/chrome-executable.mjs");
+  const args = parseArgs(process.argv.slice(2));
+  const executablePath = resolveChromeExecutable();
+  if (!executablePath) throw new Error("no Chrome found; set PUPPETEER_EXECUTABLE_PATH");
+
+  mkdirSync(args.out, { recursive: true });
+  const projectId = installFixture();
+  const port = await freePort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const { child, readLog } = startStudio(port);
+
+  let browser;
+  const shutdown = () => {
+    // Exact pid only. Another Studio dev server may be running for a human.
+    if (child.pid) {
+      try {
+        process.kill(child.pid, "SIGTERM");
+      } catch {
+        // already gone
+      }
+    }
+  };
+  process.on("exit", shutdown);
+
+  try {
+    if (!(await waitForServer(baseUrl))) {
+      throw new Error(`studio dev server did not start on ${port}\n${readLog()}`);
+    }
+    browser = await puppeteer.launch({
+      executablePath,
+      headless: true,
+      args: ["--no-sandbox", "--window-size=1600,1000"],
+      defaultViewport: { width: 1600, height: 1000 },
+    });
+    const page = await browser.newPage();
+    const measurements = {};
+    await capture(page, baseUrl, projectId, args.out, measurements);
+    await captureStorybook(page, args.storybookUrl, args.out);
+
+    const table = formatTable(measurements);
+    writeFileSync(join(args.out, "table.md"), `${table}\n`);
+    console.log(`\n${table}\n`);
+    console.log(`wrote ${args.out}`);
+  } finally {
+    if (browser) await browser.close();
+    shutdown();
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith("design-shots.mjs")) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/studio/scripts/design-shots.test.mjs
+++ b/packages/studio/scripts/design-shots.test.mjs
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { DESIGN_SHOT_SELECTORS, formatTable } from "./design-shots.mjs";
+
+describe("design-shots selector list", () => {
+  it("covers the five controls the sweep is judged on", () => {
+    expect(DESIGN_SHOT_SELECTORS.map((entry) => entry.key)).toEqual([
+      "header-export",
+      "renders-export",
+      "inspector-input",
+      "timeline-toolbar-button",
+      "menu-item",
+    ]);
+  });
+});
+
+describe("formatTable", () => {
+  it("emits one row per selector plus a header and a rule", () => {
+    const lines = formatTable({}).split("\n");
+    expect(lines).toHaveLength(DESIGN_SHOT_SELECTORS.length + 2);
+    expect(lines[0]).toContain("Height");
+    expect(lines[1]).toBe("| --- | --- | --- | --- | --- | --- |");
+  });
+
+  it("puts each measured value in its own column", () => {
+    const table = formatTable({
+      "header-export": {
+        height: "28px",
+        radius: "6px",
+        fontSize: "11px",
+        background: "rgb(0, 0, 0)",
+      },
+    });
+    const row = table.split("\n").find((line) => line.startsWith("| Header Export"));
+    expect(row).toBe(
+      '| Header Export | `[data-testid="header-export"]` | 28px | 6px | 11px | rgb(0, 0, 0) |',
+    );
+  });
+
+  it("reports an unresolved selector rather than dropping its row", () => {
+    const row = formatTable({})
+      .split("\n")
+      .find((line) => line.startsWith("| Menu item"));
+    expect(row).toContain("not found");
+  });
+});

--- a/packages/studio/src/components/StudioHeader.tsx
+++ b/packages/studio/src/components/StudioHeader.tsx
@@ -393,6 +393,7 @@ export function StudioHeader({
         >
           <button
             type="button"
+            data-testid="header-export"
             disabled={isRendering}
             onClick={() => {
               if (isRendering) return;

--- a/packages/studio/src/components/editor/propertyPanelCommitField.tsx
+++ b/packages/studio/src/components/editor/propertyPanelCommitField.tsx
@@ -184,6 +184,10 @@ export function CommitField({
     <input
       ref={inputRef}
       type="text"
+      // Stable hook for the design-shots computed-style capture: the inspector
+      // metric field is the one control the sweep measures that has no label,
+      // role or aria-label of its own.
+      data-testid="inspector-field"
       value={draft}
       disabled={disabled}
       onFocus={() => {

--- a/packages/studio/src/components/renders/RenderQueue.tsx
+++ b/packages/studio/src/components/renders/RenderQueue.tsx
@@ -396,6 +396,7 @@ function FormatExportButton({
       <Button
         variant="primary"
         size="md"
+        data-testid="renders-export"
         loading={isRendering}
         disabled={missingFfmpeg !== null}
         title={missingFfmpeg ? "Install FFmpeg to export. See the note above." : undefined}


### PR DESCRIPTION
Lands unit U8 (capture tooling) of the Studio design-system foundation. No ratchet yet; this PR adds no color literals.

## What

Adds `bun run --cwd packages/studio design:shots`: one command that boots Studio from source on a free port, walks it through six review states, screenshots each one, and prints a computed-style table (height, radius, font size, background) for a fixed list of five controls.

Output (default `packages/studio/.design-shots/`, override with `--out <dir>`):

- `1-fresh-boot.png`, `2-inspector-design.png`, `3-renders-panel.png`, `4-canvas-context-menu.png`, `5-timeline-toolbar.png`, `6-timeline-speed-menu.png`
- `table.md`
- `7-storybook-index.png` only when `--storybook-url` is passed; without it the run prints `skipped: no storybook url` and still exits 0.

Also adds a `data-testid` to the two Export buttons and the inspector metric field. Those are the three measured controls that carry no `role` or `aria-label` of their own, so there was no attribute-based selector to point at.

## Why

This lands the design-system unit that produces the before/after evidence every later sweep PR attaches. Screenshots alone show that two controls look different; only the measured numbers say by how much, and only numbers can be compared across two branches.

Running it on `main` today reproduces the known Export mismatch:

| Control | Selector | Height | Radius | Font size | Background |
| --- | --- | --- | --- | --- | --- |
| Header Export | `[data-testid="header-export"]` | 28px | 6px | 11px | rgb(60, 230, 172) |
| Renders Export | `[data-testid="renders-export"]` | 32px | 0px | 14px | rgb(255, 255, 255) |
| Inspector metric input | `[data-testid="inspector-field"]` | 17px | 0px | 11px | rgba(0, 0, 0, 0) |
| Timeline toolbar button | `[aria-label="Selection tool"]` | 28px | 6px | 16px | rgba(255, 255, 255, 0.08) |
| Menu item | `[role="menuitemradio"]` | 29px | 0px | 11px | rgba(0, 0, 0, 0) |

Two buttons that read as the same action differ on all four measured properties. The Renders Export radius is `0px` because its size class asks for a `rounded-button` utility the stylesheet never emits, so that control has been square-cornered rather than rounded the whole time.

## How

- Reuses the boot path the timeline CI job already uses: the Studio Vite dev server started from source, with the tracked `design-panel-qa` fixture copied into `data/projects` under a name that belongs to the script.
- Picks a port the OS reports as free and hands it to Vite with `--strictPort`, so the run never binds to or disturbs a server it did not start. On exit it signals its own child pid only.
- Drives Chrome through `puppeteer-core`, resolving the binary with the existing `resolveChromeExecutable` helper shared by the other Studio browser checks.
- Reaches each state the way the app itself offers: the right panel tab and timeline visibility come from URL hash params, selection comes from the dev-only `window.__studioTest.selectByDomId` hook, the canvas menu comes from a real right-click on the overlay, and the speed menu from a click on its trigger.
- Measures every selector after each state and keeps the first sighting, so a control that only exists inside a menu still gets a row.
- Navigation waits on the app's own header rather than network idle: the dev server holds an HMR socket open, so "the network went quiet" never reliably fires.
- The unit test covers the pure parts only, the selector list and the table formatter, including that an unresolved selector keeps its row and reads `not found` instead of disappearing.
- One `.fallowrc.jsonc` entry: Vitest collects `.test.mjs`, but fallow's default test-entry detection only knows the `.ts`/`.tsx` spellings, so the new test file otherwise reads as unreachable.

## Test plan

- `bunx vitest run scripts/design-shots.test.mjs` from `packages/studio`: 4 passed. Proved non-vacuous by corrupting an expected key and watching the assertion fail.
- Full Studio suite, `bunx vitest run --poolOptions.forks.maxForks=4`: 428 files passed, 1 skipped; 4747 tests passed, 18 todo.
- `bun run typecheck` and `bun run --filter @hyperframes/studio build`: both clean.
- `bunx oxlint` and `bunx oxfmt --check` on the changed files: clean.
- `bunx fallow audit --base origin/main --fail-on-issues`: no issues in 8 changed files.
- The script itself run end to end on this branch: six PNGs plus `table.md` written, Storybook shot reported as skipped, exit 0. Also verified with `--out` pointing outside the package.

## Not covered

- Storybook does not exist yet, so `7-storybook-index.png` is only ever a skip line here. Nothing in this PR builds Storybook.
- No unit coverage of the driver itself (boot, navigation, screenshotting). Per the plan this unit is tooling, and the end-to-end run is the check.
- The script is not wired into CI. It is a local before/after capture that a PR author runs and attaches.
- The `data-testid` additions are selector hooks only. No control's look or behavior changes in this PR; fixing the Export mismatch belongs to the later sweep units.
- The capture is local Chrome-for-Testing on macOS/Linux; it has not been exercised on Windows.
