### PR TITLE
chore(studio): typecheck on TypeScript 7 via an aliased devDependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/aws-lambda": {
       "name": "@hyperframes/aws-lambda",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/client-sfn": "^3.700.0",
@@ -57,7 +57,7 @@
     },
     "packages/cli": {
       "name": "@hyperframes/cli",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "bin": {
         "hyperframes": "./bin/hyperframes.mjs",
       },
@@ -108,7 +108,7 @@
     },
     "packages/core": {
       "name": "@hyperframes/core",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@chenglou/pretext": "^0.0.5",
         "@hyperframes/lint": "workspace:*",
@@ -133,7 +133,7 @@
     },
     "packages/engine": {
       "name": "@hyperframes/engine",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@hono/node-server": "^2.0.5",
         "@hyperframes/core": "workspace:^",
@@ -152,7 +152,7 @@
     },
     "packages/gcp-cloud-run": {
       "name": "@hyperframes/gcp-cloud-run",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@google-cloud/storage": "^7.14.0",
         "@google-cloud/workflows": "^4.2.0",
@@ -173,7 +173,7 @@
     },
     "packages/lint": {
       "name": "@hyperframes/lint",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@hyperframes/parsers": "workspace:*",
         "htmlparser2": "^10.1.0",
@@ -191,7 +191,7 @@
     },
     "packages/parsers": {
       "name": "@hyperframes/parsers",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@babel/parser": "^7.27.0",
         "acorn": "^8.17.0",
@@ -211,7 +211,7 @@
     },
     "packages/player": {
       "name": "@hyperframes/player",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
       },
@@ -226,7 +226,7 @@
     },
     "packages/producer": {
       "name": "@hyperframes/producer",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@fontsource/archivo-black": "^5.2.8",
         "@fontsource/eb-garamond": "^5.2.7",
@@ -271,7 +271,7 @@
     },
     "packages/sdk": {
       "name": "@hyperframes/sdk",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "@hyperframes/parsers": "workspace:*",
@@ -301,7 +301,7 @@
     },
     "packages/shader-transitions": {
       "name": "@hyperframes/shader-transitions",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "html2canvas": "^1.4.1",
       },
@@ -313,7 +313,7 @@
     },
     "packages/studio": {
       "name": "@hyperframes/studio",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.3",
@@ -353,6 +353,7 @@
         "tailwindcss": "^3.4.0",
         "tsup": "^8.0.0",
         "typescript": "^5.0.0",
+        "typescript-native": "npm:typescript@7.0.2",
         "vite": "^6.4.2",
         "vitest": "^3.2.4",
         "zustand": "^5.0.0",
@@ -365,7 +366,7 @@
     },
     "packages/studio-server": {
       "name": "@hyperframes/studio-server",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "@hyperframes/parsers": "workspace:*",
@@ -1199,6 +1200,46 @@
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -2093,6 +2134,8 @@
     "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-native": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,7 +32,7 @@ pre-commit:
         git add registry/registry.json registry/catalog-artifact/local-vectors.json registry/catalog-artifact/local-vectors.bin
     typecheck:
       glob: "*.{ts,tsx}"
-      run: cd packages/core && bunx tsc --noEmit && cd ../studio && bunx tsc --noEmit && cd ../.. && bunx tsc --noEmit -p scripts/tsconfig.json
+      run: cd packages/core && bunx tsc --noEmit && cd ../studio && bun run typecheck && cd ../.. && bunx tsc --noEmit -p scripts/tsconfig.json
     # Mirrors the CI gate (same `--base origin/main` so the local hook can't
     # pass on a branch CI would fail). Audits the working tree, which means
     # unstaged WIP in `packages/**` is part of the diff — stash before

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "dev": "bun --bun ./node_modules/.bin/vite --host 127.0.0.1",
     "build": "vite build && tsup",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "node ./node_modules/typescript-native/bin/tsc --noEmit",
     "test": "vitest run",
     "test:webmcp-edit-loop": "node tests/e2e/webmcp-edit-loop.mjs",
     "test:timeline-virtualization": "TIMELINE_ROW_VIRTUALIZATION=on TIMELINE_ELEMENT_COUNT=50000 node tests/e2e/timeline-virtualization.mjs",
@@ -94,6 +94,7 @@
     "tailwindcss": "^3.4.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
+    "typescript-native": "npm:typescript@7.0.2",
     "vite": "^6.4.2",
     "vitest": "^3.2.4",
     "zustand": "^5.0.0"

--- a/packages/studio/src/player/components/Timeline.tsx
+++ b/packages/studio/src/player/components/Timeline.tsx
@@ -62,7 +62,7 @@ export {
   getTimelineScrollTopForGeometryChange,
   getTimelineVisibleTimeRange,
 } from "./timelineViewportGeometry";
-export const Timeline = memo(function Timeline({
+export const Timeline = memo<TimelineProps>(function Timeline({
   onSeek,
   onDrillDown,
   renderClipContent,

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
     "paths": {
       "@hyperframes/player": ["../player/src/hyperframes-player.ts"]
     },


### PR DESCRIPTION
Lands unit U15 (toolchain) of the Studio design-system foundation. No color literals touched; no ratchet yet.

## What

Studio's `typecheck` script now runs on TypeScript 7.0.2 (the native compiler), while every other package, and Studio's own build tooling, stays on TypeScript 5.x.

## Why

TypeScript 7 typechecks Studio noticeably faster than 5.x with an identical result (same zero errors, same file). It was blocked, though: Studio's `build` script uses `tsup` to bundle a `.d.ts` for the published package, and `tsup` vendors an internal copy of `rollup-plugin-dts` that calls `ts.sys.useCaseSensitiveFileNames` at load time. TypeScript 7's public JS entry point does not populate `ts.sys` at all, so as soon as Studio's own `typescript` devDependency became 7.x, `tsup`'s declaration build threw and the package failed to build. Keeping `typescript` itself at `^5.0.0` avoids that regression while still getting the typecheck speedup by resolving 7.0.2 under a separate name that only the typecheck script touches.

## How

- Added `"typescript-native": "npm:typescript@7.0.2"` as a second devDependency in `packages/studio/package.json`, alongside the unchanged `"typescript": "^5.0.0"`. Bun accepts the `npm:` alias form directly and installs the aliased package's own platform-specific native binary correctly (verified the darwin-arm64 optional dependency resolves and `tsc --version` runs).
- Changed the `typecheck` script to `node ./node_modules/typescript-native/bin/tsc --noEmit`, invoking the aliased binary explicitly rather than the ambient `tsc` (which still resolves the 5.x package).
- `packages/studio/tsconfig.json`: removed `baseUrl`, which TypeScript 7 rejects outright (`TS5102: Option 'baseUrl' has been removed`). Verified the config is equally valid under TypeScript 5.9 (its own typecheck stays clean) so this isn't a version-gated option.
- `packages/studio/src/player/components/Timeline.tsx`: added an explicit `memo<TimelineProps>(...)` generic argument. This is a real TypeScript 7 inference regression, reproduced in isolation: `memo()` wrapping a function whose destructured parameter has a default (`{ ... }: Props = {}`) loses its prop type under TypeScript 7's inference, so `React.createElement(Timeline, { sessionEpoch: ... })` failed with "Object literal may only specify known properties" in a test file. The explicit annotation is a no-op under TypeScript 5 and restores the identical (zero-error) result under 7.

Timing, three runs each, same machine:
- Before (`tsc` at 5.9.3): 2.93s / 2.91s / 1.88s — median 2.91s
- After (`typescript-native` at 7.0.2): 1.79s / 0.66s / 0.81s — median 0.81s

No other workspace changed: `bunx tsc --version` still prints 5.9.3 at the repo root and inside `packages/core` and `packages/cli`. `bun run build` from the repo root (all workspace packages, including Studio's `tsup` step) succeeds.

Two invocation paths worth knowing about, since they don't agree:
- CI's Typecheck job (`.github/workflows/ci.yml`, job `typecheck`) runs `bun run --filter '*' typecheck`, which invokes each package's own `typecheck` script — this picks up TypeScript 7 for Studio.
- The local `lefthook.yml` pre-commit `typecheck` step does not call the package script; it runs `cd packages/core && bunx tsc --noEmit && cd ../studio && bunx tsc --noEmit && cd ../.. && bunx tsc --noEmit -p scripts/tsconfig.json` directly, so it type checks Studio with the ambient `tsc` (still 5.x), not the aliased 7.0.2 binary. Local pre-commit and CI are checking Studio with two different compilers as a result; both currently agree on the same (zero-error) result, so nothing is broken, but the speed win only shows up in CI, not locally, until lefthook is updated to call the package script instead.

## Test plan

- [x] `bun run typecheck` in `packages/studio` — clean on TypeScript 7.0.2 (via the aliased binary)
- [x] `bunx tsc --noEmit` in `packages/studio` — clean on TypeScript 5.9.3 (unaffected path)
- [x] `bunx tsc --noEmit` in `packages/core`, and `bunx tsc --noEmit -p scripts/tsconfig.json` at the repo root — both clean, both still on 5.9.3
- [x] `bun run build` from the repo root — succeeds, including Studio's `tsup` declaration bundling step
- [x] `bunx vitest run --poolOptions.forks.maxForks=4` in `packages/studio` — 427 test files, 4743 tests passed (includes the test file that exercised the Timeline typing regression)
- [x] `bunx oxlint` / `bunx oxfmt --check` on the changed files — clean
- [x] `bunx fallow audit --base origin/main --fail-on-issues` — one non-blocking finding (see Not covered)

## Not covered

- `fallow audit` flags `typescript-native` as an unused devDependency, since its only reference is inside the `typecheck` script string in `package.json`, not an import statement. Fallow's dependency-usage scan doesn't see script-only usage. This doesn't fail the audit (dependency findings are warn-level here) and Fallow isn't a required check on `main`, but it's worth knowing the finding is a false positive rather than real dead weight.
- `lefthook.yml`'s local `typecheck` step still runs Studio's typecheck on TypeScript 5.x rather than the new aliased binary (see How); updating it to call `bun run --filter ... typecheck` so local pre-commit matches CI is a follow-up, not part of this change.
- Studio's `tsup`-based `.d.ts` build staying on TypeScript 5 is a workaround, not a fix: it's blocked on `tsup` shipping a release that bundles a `rollup-plugin-dts` built against TypeScript 7's new API surface. Moving that build step onto TypeScript 7 waits on tsup upstream.

Also points the lefthook typecheck step at the package script so local pre-commit and CI use the same compiler.
