### PR TITLE
feat(studio): add Base UI and prove menu dismissal over the canvas overlay

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -4,6 +4,10 @@
     // Vitest collects .test.mjs, but fallow's default test-entry detection only
     // knows the .ts/.tsx spellings, so this one reads as an unreachable file.
     "packages/studio/scripts/*.test.mjs",
+    // The KTD6 dismiss-spike fixture. scripts/menu-dismiss-spike.mjs injects it
+    // into a running Studio by importing it from the Vite dev server by URL, so
+    // no TypeScript import reaches its mount function.
+    "packages/studio/src/components/ui/menuDismissSpikeMount.tsx",
     "packages/producer/src/**/*.test.ts",
     "packages/aws-lambda/src/**/*.test.ts",
     "packages/gcp-cloud-run/src/**/*.test.ts",

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "packages/aws-lambda": {
       "name": "@hyperframes/aws-lambda",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.700.0",
         "@aws-sdk/client-sfn": "^3.700.0",
@@ -57,7 +57,7 @@
     },
     "packages/cli": {
       "name": "@hyperframes/cli",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "bin": {
         "hyperframes": "./bin/hyperframes.mjs",
       },
@@ -108,7 +108,7 @@
     },
     "packages/core": {
       "name": "@hyperframes/core",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@chenglou/pretext": "^0.0.5",
         "@hyperframes/lint": "workspace:*",
@@ -133,7 +133,7 @@
     },
     "packages/engine": {
       "name": "@hyperframes/engine",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@hono/node-server": "^2.0.5",
         "@hyperframes/core": "workspace:^",
@@ -152,7 +152,7 @@
     },
     "packages/gcp-cloud-run": {
       "name": "@hyperframes/gcp-cloud-run",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@google-cloud/storage": "^7.14.0",
         "@google-cloud/workflows": "^4.2.0",
@@ -173,7 +173,7 @@
     },
     "packages/lint": {
       "name": "@hyperframes/lint",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@hyperframes/parsers": "workspace:*",
         "htmlparser2": "^10.1.0",
@@ -191,7 +191,7 @@
     },
     "packages/parsers": {
       "name": "@hyperframes/parsers",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@babel/parser": "^7.27.0",
         "acorn": "^8.17.0",
@@ -211,7 +211,7 @@
     },
     "packages/player": {
       "name": "@hyperframes/player",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
       },
@@ -226,7 +226,7 @@
     },
     "packages/producer": {
       "name": "@hyperframes/producer",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@fontsource/archivo-black": "^5.2.8",
         "@fontsource/eb-garamond": "^5.2.7",
@@ -271,7 +271,7 @@
     },
     "packages/sdk": {
       "name": "@hyperframes/sdk",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "@hyperframes/parsers": "workspace:*",
@@ -301,7 +301,7 @@
     },
     "packages/shader-transitions": {
       "name": "@hyperframes/shader-transitions",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "html2canvas": "^1.4.1",
       },
@@ -313,8 +313,9 @@
     },
     "packages/studio": {
       "name": "@hyperframes/studio",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
+        "@base-ui/react": "1.7.0",
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-css": "^6.3.1",
@@ -365,7 +366,7 @@
     },
     "packages/studio-server": {
       "name": "@hyperframes/studio-server",
-      "version": "0.8.14",
+      "version": "0.8.27",
       "dependencies": {
         "@hyperframes/core": "workspace:*",
         "@hyperframes/parsers": "workspace:*",
@@ -515,6 +516,10 @@
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@balena/dockerignore": ["@balena/dockerignore@1.0.2", "", {}, "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="],
+
+    "@base-ui/react": ["@base-ui/react@1.7.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.3.2", "@floating-ui/react-dom": "^2.1.9", "@floating-ui/utils": "^0.2.12", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug=="],
+
+    "@base-ui/utils": ["@base-ui/utils@0.3.2", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.12", "reselect": "^5.2.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
@@ -675,6 +680,14 @@
     "@fallow-cli/win32-arm64-msvc": ["@fallow-cli/win32-arm64-msvc@2.75.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-HbIXLbte8pzNX0XlbyRlRQA2+y8kfJ4O6XxB2VR2dE6q5LrNhG4fl0QRR/P9x8r3CNn9fw/25kk+WxULfbHu1w=="],
 
     "@fallow-cli/win32-x64-msvc": ["@fallow-cli/win32-x64-msvc@2.75.0", "", { "os": "win32", "cpu": "x64" }, "sha512-h8W+qEOPvyolBQO2Y0H4/pz2XXw/1yHA8/XRPo3/tYRovmN2zoNjDrvaGjjodzFt6fBVLus+T0uo+U4pMgOu/w=="],
+
+    "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.8.0", "", { "dependencies": { "@floating-ui/core": "^1.8.0", "@floating-ui/utils": "^0.2.12" } }, "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg=="],
+
+    "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
 
     "@fontsource/archivo-black": ["@fontsource/archivo-black@5.2.8", "", {}, "sha512-3zNj/o9LzWyDl/UEpY5IOHpAQyUtFr3hQaFS7NSKwCLLkXOfH/CMCt1L2b2Z+OF25OURtOYenCadgAebALz7/A=="],
 
@@ -1924,6 +1937,8 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "reselect": ["reselect@5.3.0", "", {}, "sha512-XGoLeRAVzUTcJ1qkxPQhDJyIZ5d6zzZD9nT7AEZOaaU9UbWclhycElmhO+VD5bFeLuzhPBaOV2oXC8uG35ZSpg=="],
+
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
@@ -2111,6 +2126,8 @@
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -50,6 +50,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "design:shots": "node scripts/design-shots.mjs",
+    "spike:menu-dismiss": "node scripts/menu-dismiss-spike.mjs",
     "test:webmcp-edit-loop": "node tests/e2e/webmcp-edit-loop.mjs",
     "test:timeline-virtualization": "TIMELINE_ROW_VIRTUALIZATION=on TIMELINE_ELEMENT_COUNT=50000 node tests/e2e/timeline-virtualization.mjs",
     "test:watch": "vitest",
@@ -57,6 +58,7 @@
     "test:timeline-default": "bun run test:timeline-virtualization"
   },
   "dependencies": {
+    "@base-ui/react": "1.7.0",
     "@codemirror/autocomplete": "^6.20.1",
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-css": "^6.3.1",

--- a/packages/studio/scripts/design-shots.mjs
+++ b/packages/studio/scripts/design-shots.mjs
@@ -169,7 +169,62 @@ async function shoot(page, outDir, name) {
   console.log(`captured ${name}.png`);
 }
 
-async function gotoState(page, baseUrl, projectId, params) {
+/**
+ * Boot Studio from source and open a browser on it. Shared with
+ * scripts/menu-dismiss-spike.mjs so both runs prove things against the same
+ * app, the same fixture and the same Chrome. Call `shutdown()` when done: it
+ * kills only the pid this call started.
+ */
+export async function bootStudio() {
+  const { default: puppeteer } = await import("puppeteer-core");
+  const { resolveChromeExecutable } = await import("../tests/e2e/chrome-executable.mjs");
+  const executablePath = resolveChromeExecutable();
+  if (!executablePath) throw new Error("no Chrome found; set PUPPETEER_EXECUTABLE_PATH");
+
+  const projectId = installFixture();
+  const port = await freePort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const { child, readLog } = startStudio(port);
+
+  let browser = null;
+  const shutdown = async () => {
+    if (browser) {
+      const closing = browser;
+      browser = null;
+      await closing.close().catch(() => {});
+    }
+    // Exact pid only. Another Studio dev server may be running for a human.
+    if (child.pid) {
+      try {
+        process.kill(child.pid, "SIGTERM");
+      } catch {
+        // already gone
+      }
+    }
+  };
+  process.on("exit", () => {
+    void shutdown();
+  });
+
+  try {
+    if (!(await waitForServer(baseUrl))) {
+      throw new Error(`studio dev server did not start on ${port}\n${readLog()}`);
+    }
+    browser = await puppeteer.launch({
+      executablePath,
+      headless: true,
+      args: ["--no-sandbox", "--window-size=1600,1000"],
+      defaultViewport: { width: 1600, height: 1000 },
+    });
+    const page = await browser.newPage();
+    return { page, baseUrl, projectId, shutdown };
+  } catch (error) {
+    await shutdown();
+    throw error;
+  }
+}
+
+export async function gotoState(page, baseUrl, projectId, params) {
   const query = new URLSearchParams({ v: "1", ...params }).toString();
   // Not networkidle: the dev server holds an HMR socket open and the fixture
   // pulls GSAP from a CDN, so "the network went quiet" never reliably fires.
@@ -178,7 +233,7 @@ async function gotoState(page, baseUrl, projectId, params) {
   await page.waitForSelector('[data-testid="header-export"]', { timeout: 30_000 });
 }
 
-async function selectFixtureElement(page) {
+export async function selectFixtureElement(page) {
   await page.waitForFunction(() => typeof window.__studioTest?.selectByDomId === "function", {
     timeout: 30_000,
   });
@@ -243,42 +298,11 @@ async function captureStorybook(page, storybookUrl, outDir) {
 }
 
 async function main() {
-  const { default: puppeteer } = await import("puppeteer-core");
-  const { resolveChromeExecutable } = await import("../tests/e2e/chrome-executable.mjs");
   const args = parseArgs(process.argv.slice(2));
-  const executablePath = resolveChromeExecutable();
-  if (!executablePath) throw new Error("no Chrome found; set PUPPETEER_EXECUTABLE_PATH");
-
   mkdirSync(args.out, { recursive: true });
-  const projectId = installFixture();
-  const port = await freePort();
-  const baseUrl = `http://127.0.0.1:${port}`;
-  const { child, readLog } = startStudio(port);
 
-  let browser;
-  const shutdown = () => {
-    // Exact pid only. Another Studio dev server may be running for a human.
-    if (child.pid) {
-      try {
-        process.kill(child.pid, "SIGTERM");
-      } catch {
-        // already gone
-      }
-    }
-  };
-  process.on("exit", shutdown);
-
+  const { page, baseUrl, projectId, shutdown } = await bootStudio();
   try {
-    if (!(await waitForServer(baseUrl))) {
-      throw new Error(`studio dev server did not start on ${port}\n${readLog()}`);
-    }
-    browser = await puppeteer.launch({
-      executablePath,
-      headless: true,
-      args: ["--no-sandbox", "--window-size=1600,1000"],
-      defaultViewport: { width: 1600, height: 1000 },
-    });
-    const page = await browser.newPage();
     const measurements = {};
     await capture(page, baseUrl, projectId, args.out, measurements);
     await captureStorybook(page, args.storybookUrl, args.out);
@@ -288,8 +312,7 @@ async function main() {
     console.log(`\n${table}\n`);
     console.log(`wrote ${args.out}`);
   } finally {
-    if (browser) await browser.close();
-    shutdown();
+    await shutdown();
   }
 }
 

--- a/packages/studio/scripts/menu-dismiss-spike.mjs
+++ b/packages/studio/scripts/menu-dismiss-spike.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * KTD6 dismiss spike, browser half.
+ *
+ * Boots Studio through the same helper design-shots.mjs uses, selects the
+ * fixture element, mounts a Base UI ContextMenu and Menu INSIDE the real
+ * canvas overlay, and drives real Chrome input at them.
+ *
+ * The question it answers: DomEditOverlay calls stopPropagation() on its own
+ * bubble-phase pointer handlers, which is why Studio's useContextMenuDismiss
+ * listens in the capture phase. Does Base UI's own outside-press dismiss
+ * survive that, or does a shared Menu need Studio's capture-phase hook driving
+ * its open state?
+ *
+ * happy-dom cannot answer it: no layout, no real hit testing, no portal
+ * placement. src/components/ui/menuDismiss.spike.test.tsx is the regression
+ * guard; this run is the verdict.
+ *
+ *   bun run --cwd packages/studio node scripts/menu-dismiss-spike.mjs
+ *
+ * Exit code 0 means every check passed. Every check prints its own line either
+ * way, so a partial pass is readable rather than a single "failed".
+ */
+import { bootStudio, gotoState, selectFixtureElement } from "./design-shots.mjs";
+
+const CONTEXT_POPUP = '[data-testid="spike-context-popup"]';
+const CONTEXT_TRIGGER = '[data-testid="spike-context-trigger"]';
+const MENU_POPUP = '[data-testid="spike-menu-popup"]';
+const MENU_TRIGGER = '[data-testid="spike-menu-trigger"]';
+
+const results = [];
+
+function record(name, ok, detail) {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? ` — ${detail}` : ""}`);
+}
+
+/**
+ * The fixture is a source module, not inline script text, so Vite compiles its
+ * JSX and resolves Base UI exactly as it does for the app. The URL is passed in
+ * rather than written inline because the app never imports this module and a
+ * literal import specifier here would read to static analysis as a broken one.
+ */
+const MOUNT_MODULE_URL = ["", "src", "components", "ui", "menuDismissSpikeMount.tsx"].join("/");
+
+async function mountSpike(page) {
+  const mounted = await page.evaluate(async (url) => {
+    const mod = await import(/* @vite-ignore */ url);
+    return mod.mountMenuDismissSpike();
+  }, MOUNT_MODULE_URL);
+  if (!mounted) throw new Error("canvas overlay not present; nothing to mount into");
+}
+
+const isOpen = (page, selector) => page.$(selector).then((el) => Boolean(el));
+
+async function rectOf(page, selector) {
+  const handle = await page.$(selector);
+  if (!handle) throw new Error(`${selector} not found`);
+  return handle.boundingBox();
+}
+
+/**
+ * A point on the overlay that is outside both the trigger and the open popup.
+ * Bottom-right of the overlay: the fixture's content sits top-left, so a press
+ * there hits the overlay's empty-canvas branch, the one that calls
+ * stopPropagation to start a marquee.
+ */
+function outsidePoint(overlay) {
+  return { x: overlay.x + overlay.width - 24, y: overlay.y + overlay.height - 24 };
+}
+
+/**
+ * Installs a bubble-phase document listener before the press and reports
+ * whether it ever fired. It must not: that is the overlay swallowing the event,
+ * which is the whole reason this spike exists. If it fires, the press missed
+ * the overlay and any dismissal proves nothing.
+ */
+async function pressWithBubbleWitness(page, point) {
+  await page.evaluate(() => {
+    window.__spikeSawBubblePress = false;
+    window.__spikeWitness = () => {
+      window.__spikeSawBubblePress = true;
+    };
+    document.addEventListener("pointerdown", window.__spikeWitness);
+  });
+  await page.mouse.click(point.x, point.y);
+  return page.evaluate(() => {
+    document.removeEventListener("pointerdown", window.__spikeWitness);
+    return window.__spikeSawBubblePress;
+  });
+}
+
+async function openContextMenu(page) {
+  const trigger = await rectOf(page, CONTEXT_TRIGGER);
+  const at = { x: trigger.x + trigger.width / 2, y: trigger.y + trigger.height / 2 };
+  await page.mouse.click(at.x, at.y, { button: "right" });
+  await page.waitForSelector(CONTEXT_POPUP, { timeout: 5_000 });
+  return at;
+}
+
+async function checkOpensNearPointer(page) {
+  const at = await openContextMenu(page);
+  const popup = await rectOf(page, CONTEXT_POPUP);
+  const dx = Math.round(popup.x - at.x);
+  const dy = Math.round(popup.y - at.y);
+  // Base UI anchors a context menu to the pointer; allow a menu-sized slack for
+  // flipping away from a viewport edge.
+  const near = Math.abs(dx) <= 240 && Math.abs(dy) <= 240;
+  record("context menu opens near the pointer", near, `offset ${dx}px, ${dy}px`);
+}
+
+async function checkOutsidePressDismisses(page) {
+  if (!(await isOpen(page, CONTEXT_POPUP))) await openContextMenu(page);
+  const overlay = await rectOf(page, '[aria-label="Composition canvas"]');
+  const sawBubble = await pressWithBubbleWitness(page, outsidePoint(overlay));
+  await waitClosed(page, CONTEXT_POPUP);
+  const open = await isOpen(page, CONTEXT_POPUP);
+  record(
+    "outside press on the real overlay closes the context menu",
+    !open && !sawBubble,
+    sawBubble
+      ? "the press reached a bubble-phase document listener, so the overlay did not swallow it and this check is vacuous"
+      : "overlay swallowed the bubble-phase press",
+  );
+}
+
+async function checkEscapeDismisses(page) {
+  await openContextMenu(page);
+  await page.keyboard.press("Escape");
+  await waitClosed(page, CONTEXT_POPUP);
+  record("Escape closes the context menu", !(await isOpen(page, CONTEXT_POPUP)));
+}
+
+async function openPanelMenu(page) {
+  await page.click(MENU_TRIGGER);
+  await page.waitForSelector(MENU_POPUP, { timeout: 5_000 });
+}
+
+async function waitClosed(page, selector) {
+  await page
+    .waitForFunction((sel) => !document.querySelector(sel), { timeout: 5_000 }, selector)
+    .catch(() => {});
+}
+
+async function checkPanelMenuDismissesOverOverlay(page) {
+  await openPanelMenu(page);
+  const overlay = await rectOf(page, '[aria-label="Composition canvas"]');
+  const sawBubble = await pressWithBubbleWitness(page, outsidePoint(overlay));
+  await waitClosed(page, MENU_POPUP);
+  const open = await isOpen(page, MENU_POPUP);
+  record(
+    "press on the real overlay closes a panel menu",
+    !open && !sawBubble,
+    sawBubble ? "press reached a bubble-phase document listener; check is vacuous" : undefined,
+  );
+}
+
+async function checkFocusRestoreOnEscape(page) {
+  await openPanelMenu(page);
+  await page.keyboard.press("Escape");
+  await waitClosed(page, MENU_POPUP);
+  const focused = await page.evaluate(
+    (sel) => document.activeElement === document.querySelector(sel),
+    MENU_TRIGGER,
+  );
+  record("Escape returns focus to the menu trigger", focused && !(await isOpen(page, MENU_POPUP)));
+}
+
+async function main() {
+  const { page, baseUrl, projectId, shutdown } = await bootStudio();
+  try {
+    page.on("pageerror", (e) => console.error("[page error]", e.message));
+    page.on("console", (m) => {
+      if (m.type() === "error") console.error("[console]", m.text());
+    });
+    await gotoState(page, baseUrl, projectId, { tv: "1" });
+    await selectFixtureElement(page);
+    await page.waitForSelector('[aria-label="Composition canvas"]', { timeout: 30_000 });
+    await mountSpike(page);
+
+    await checkOpensNearPointer(page);
+    await checkOutsidePressDismisses(page);
+    await checkEscapeDismisses(page);
+    await checkPanelMenuDismissesOverOverlay(page);
+    await checkFocusRestoreOnEscape(page);
+  } finally {
+    await shutdown();
+  }
+
+  const failed = results.filter((r) => !r.ok);
+  console.log(
+    `\n${results.length - failed.length}/${results.length} checks passed on the plain Base UI path (no capture-phase wrapper).`,
+  );
+  if (failed.length) process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/studio/src/components/ui/menuDismiss.spike.test.tsx
+++ b/packages/studio/src/components/ui/menuDismiss.spike.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment happy-dom
+/**
+ * KTD6 dismiss spike (regression guard half).
+ *
+ * Studio's canvas overlay calls `stopPropagation()` on its own bubble-phase
+ * pointer handlers (DomEditOverlay: marquee start, shift-select, inline-text
+ * start), which is why `useContextMenuDismiss` listens in the CAPTURE phase.
+ * Before any menu moves onto Base UI, these tests pin the behaviors a shared
+ * Menu has to keep over that overlay.
+ *
+ * Base UI registers its outside-press listeners on `document` with capture set
+ * (floating-ui-react/hooks/useDismiss), so a bubble-phase `stopPropagation`
+ * upstream cannot swallow them. That is the claim under test here.
+ *
+ * happy-dom has no layout, so nothing asserts on position: only on open/closed
+ * state, the item that ran, and `document.activeElement`. The browser half of
+ * the spike (scripts/menu-dismiss-spike.mjs) is the verdict over the real
+ * overlay; this file is what keeps the verdict from rotting.
+ */
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, expect, it } from "vitest";
+import { SpikeMenu } from "./menuDismissSpikeMount";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let mounted: { root: Root; host: HTMLElement } | null = null;
+
+afterEach(() => {
+  if (!mounted) return;
+  const { root, host } = mounted;
+  mounted = null;
+  act(() => root.unmount());
+  host.remove();
+});
+
+/**
+ * The synthetic stand-in for DomEditOverlay: a pointer surface whose
+ * bubble-phase `onPointerDown`/`onMouseDown` swallow the event, exactly as the
+ * overlay's marquee and shift-select branches do. The menu inside it is the
+ * same component the browser half mounts over the real overlay.
+ */
+function Harness({ activated }: { activated: string[] }): React.JSX.Element {
+  const swallow = (event: React.SyntheticEvent) => event.stopPropagation();
+  return (
+    <div onPointerDown={swallow} onMouseDown={swallow}>
+      <div data-testid="overlay" aria-label="Composition canvas">
+        overlay
+      </div>
+      <SpikeMenu onActivate={(item) => activated.push(item)} />
+    </div>
+  );
+}
+
+/** Base UI moves focus into the popup one task after open, not synchronously. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function press(target: Element): void {
+  // `composed` is what a real browser sets: without it the event never crosses
+  // a shadow boundary and Base UI's document listener never sees it.
+  const init = { bubbles: true, cancelable: true, composed: true };
+  act(() => {
+    target.dispatchEvent(new PointerEvent("pointerdown", init));
+    target.dispatchEvent(new MouseEvent("mousedown", init));
+  });
+}
+
+function key(k: string): void {
+  const target = document.activeElement ?? document.body;
+  const init = { key: k, bubbles: true, cancelable: true, composed: true };
+  act(() => {
+    target.dispatchEvent(new KeyboardEvent("keydown", init));
+    target.dispatchEvent(new KeyboardEvent("keyup", init));
+  });
+}
+
+function trigger(): HTMLElement {
+  const el = document.querySelector<HTMLElement>('[data-testid="spike-menu-trigger"]');
+  if (!el) throw new Error("trigger not rendered");
+  return el;
+}
+
+function popup(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('[data-testid="spike-menu-popup"]');
+}
+
+function required(el: Element | null, what: string): Element {
+  if (!el) throw new Error(`${what} not rendered`);
+  return el;
+}
+
+async function openMenu(activated: string[] = []): Promise<void> {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  mounted = { root, host };
+  act(() => root.render(<Harness activated={activated} />));
+  act(() => trigger().click());
+  await settle();
+  expect(popup()).not.toBeNull();
+}
+
+it("closes on an outside press that a parent stops in the bubble phase", async () => {
+  await openMenu();
+
+  // Witness: a bubble-phase document listener is the thing the overlay starves.
+  // If it ever starts firing, the press stopped being swallowed and this test
+  // would pass for a reason that says nothing about capture-phase dismissal.
+  let sawBubblePress = false;
+  const witness = () => {
+    sawBubblePress = true;
+  };
+  document.addEventListener("pointerdown", witness);
+  press(required(document.querySelector('[data-testid="overlay"]'), "overlay"));
+  document.removeEventListener("pointerdown", witness);
+
+  expect(sawBubblePress).toBe(false);
+  expect(popup()).toBeNull();
+});
+
+it("closes on an outside press inside a shadow root", async () => {
+  await openMenu();
+
+  const shadowHost = document.createElement("div");
+  document.body.append(shadowHost);
+  const inner = document.createElement("button");
+  shadowHost.attachShadow({ mode: "open" }).append(inner);
+  press(inner);
+  shadowHost.remove();
+
+  expect(popup()).toBeNull();
+});
+
+// AE5.
+it("activates the second item with ArrowDown twice then Enter, and closes", async () => {
+  const activated: string[] = [];
+  await openMenu(activated);
+
+  key("ArrowDown");
+  key("ArrowDown");
+  key("Enter");
+
+  expect(activated).toEqual(["second"]);
+  expect(popup()).toBeNull();
+});
+
+it("returns focus to the trigger after Escape", async () => {
+  await openMenu();
+
+  key("Escape");
+  await settle();
+
+  expect(popup()).toBeNull();
+  expect(document.activeElement).toBe(trigger());
+});

--- a/packages/studio/src/components/ui/menuDismissSpikeMount.tsx
+++ b/packages/studio/src/components/ui/menuDismissSpikeMount.tsx
@@ -1,0 +1,119 @@
+/**
+ * KTD6 dismiss spike fixture. One definition of the menus under test, shared by
+ * both halves of the spike so they cannot drift apart: menuDismiss.spike.test.tsx
+ * renders SpikeMenu under happy-dom, and scripts/menu-dismiss-spike.mjs calls
+ * mountMenuDismissSpike() inside a running Studio.
+ *
+ * Nothing in the app imports this. The spike script pulls the module in over
+ * the Vite dev server by URL, which is why it is a source module and not inline
+ * script text: Vite has to compile the JSX and resolve Base UI the same way the
+ * app would, or the run would prove something about a hand-rolled bundle
+ * instead of about Studio.
+ *
+ * mountMenuDismissSpike puts the context menu INSIDE the real canvas overlay so
+ * the outside press lands on DomEditOverlay itself, the element whose
+ * bubble-phase handlers call stopPropagation. A synthetic overlay could not
+ * prove that.
+ */
+import { ContextMenu } from "@base-ui/react/context-menu";
+import { Menu } from "@base-ui/react/menu";
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+const CANVAS_HOST_ID = "menu-dismiss-spike-canvas-host";
+const PANEL_HOST_ID = "menu-dismiss-spike-panel-host";
+
+/**
+ * Right-click surface, inside the overlay: a corner of it, so the rest of the
+ * overlay stays available as the outside-press target.
+ */
+function SpikeContextMenu(): React.JSX.Element {
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger
+        data-testid="spike-context-trigger"
+        tabIndex={-1}
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 0,
+          width: 160,
+          height: 120,
+          pointerEvents: "auto",
+        }}
+      />
+      <ContextMenu.Portal>
+        <ContextMenu.Positioner>
+          <ContextMenu.Popup data-testid="spike-context-popup">
+            <ContextMenu.Item data-testid="spike-context-item">Context one</ContextMenu.Item>
+            <ContextMenu.Item>Context two</ContextMenu.Item>
+          </ContextMenu.Popup>
+        </ContextMenu.Positioner>
+      </ContextMenu.Portal>
+    </ContextMenu.Root>
+  );
+}
+
+/**
+ * Button-triggered menu, OUTSIDE the overlay, which is where Studio's real ones
+ * live (SpeedMenu and the timeline toolbar sit in panel chrome). Its press
+ * target has to stay outside because the overlay's marquee branch calls
+ * preventDefault on an empty-canvas pointerdown, so a trigger placed inside it
+ * never receives the click at all. That is Studio behaving correctly, not a
+ * Base UI failure, and putting the trigger where the shipped menus live keeps
+ * the check about dismissal instead of about the canvas gesture layer.
+ */
+export function SpikeMenu({
+  onActivate,
+}: {
+  onActivate?: (item: string) => void;
+}): React.JSX.Element {
+  return (
+    <Menu.Root>
+      <Menu.Trigger data-testid="spike-menu-trigger">Spike menu</Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner>
+          <Menu.Popup data-testid="spike-menu-popup">
+            <Menu.Item data-testid="spike-menu-item-1" onClick={() => onActivate?.("first")}>
+              First
+            </Menu.Item>
+            <Menu.Item data-testid="spike-menu-item-2" onClick={() => onActivate?.("second")}>
+              Second
+            </Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}
+
+function mountInto(parent: Element, id: string, css: string, node: React.JSX.Element): void {
+  document.getElementById(id)?.remove();
+  const host = document.createElement("div");
+  host.id = id;
+  host.style.cssText = css;
+  parent.append(host);
+  createRoot(host).render(node);
+}
+
+/** Returns false when the canvas overlay is not on screen yet. */
+export function mountMenuDismissSpike(): boolean {
+  const overlay = document.querySelector('[aria-label="Composition canvas"]');
+  if (!overlay) return false;
+
+  // Transparent to the pointer: only the trigger takes presses, so a press
+  // anywhere else on the overlay reaches the overlay's own handlers.
+  mountInto(
+    overlay,
+    CANVAS_HOST_ID,
+    "position:absolute;inset:0;pointer-events:none;z-index:20",
+    <SpikeContextMenu />,
+  );
+  mountInto(
+    document.body,
+    PANEL_HOST_ID,
+    "position:fixed;right:8px;bottom:8px;z-index:9999",
+    <SpikeMenu />,
+  );
+  return true;
+}


### PR DESCRIPTION
Lands unit U3 (Base UI dependency and the dismiss spike) of the Studio design-system foundation. Stacked on the capture-script PR (#3616). No ratchet yet; no color literal added. The lockfile diff also refreshes stale workspace version entries that a plain install rewrites on its own.

Lands U3 of the Studio design-system foundation plan. Stacked on the U8 capture-harness branch.

## What

- Adds `@base-ui/react` at exactly `1.7.0` to `packages/studio`.
- Adds the KTD6 dismiss spike in both halves:
  - `src/components/ui/menuDismiss.spike.test.tsx`, a happy-dom regression test over a synthetic overlay that reproduces `DomEditOverlay`'s bubble-phase `stopPropagation`.
  - `scripts/menu-dismiss-spike.mjs` (`bun run --cwd packages/studio spike:menu-dismiss`), a real-browser run against the actual canvas overlay in a booted Studio.
- Both halves share one fixture, `src/components/ui/menuDismissSpikeMount.tsx`, so the regression test and the browser verdict cannot drift apart.
- Refactors the U8 capture script's boot into an exported `bootStudio()` so the spike reuses the same dev server, fixture project and Chrome resolution instead of copying them. `design:shots` behavior is unchanged.

No menu is migrated and no shared Menu primitive is built here. That is U6.

## Why

The canvas overlay calls `stopPropagation()` on its own bubble-phase pointer handlers (marquee start, shift-select, inline-text start). That is why Studio's `useContextMenuDismiss` listens in the capture phase: a bubble-phase `document` listener never fires for those presses, and menus stayed open. Before any menu moves onto a headless library, KTD6 requires proof that the library's own outside-press dismiss survives the same overlay, or that the capture-phase hook has to wrap it.

## How

**KTD6 outcome: the plain Base UI path passes. No capture-phase wrapper is needed, and `useContextMenuDismiss` is untouched.**

The mechanism, read from the vendored source rather than inferred: Base UI's dismiss hook (`floating-ui-react/hooks/useDismiss`) registers `pointerdown`, `mousedown`, `click`, `pointerup`, `mouseup`, `touchstart`, `touchmove`, `touchend` and `pointercancel` on the owner document with `capture` set to `true`. Capture runs from the document downward, so it executes before any descendant's bubble-phase `stopPropagation` can run. Its default `outsidePressEvent` is `sloppy`, which acts on `pointerdown`/`mousedown` and ignores `click`.

Both halves assert the trap is actually present rather than assuming it: each outside-press check installs a bubble-phase `document` listener and requires that it never fires. If it does, the press missed the overlay and the dismissal would prove nothing, so the check reports itself as vacuous instead of passing.

Because the spike fixture is loaded into the running app by URL from the Vite dev server, no TypeScript import reaches it. It is registered in the fallow `entry` list next to the existing entries that are referenced by path rather than imported.

### Bundle size of a Base UI import

Method: `esbuild --bundle --minify --format=esm` on a scratch entry in `packages/studio`, with `react`, `react-dom` and `react/jsx-runtime` external, piped through `gzip -9`.

| Entry | Gzipped |
| --- | --- |
| `import "@base-ui/react/menu"` (empty, no binding used) | 0 B |
| `Menu` referenced | 51,376 B |
| `Menu` + `ContextMenu` referenced | 52,142 B |
| `Tooltip` alone (for the shared floor) | 33,831 B |

The empty import is 0 B because the package entries are marked side-effect free, so esbuild drops the import entirely. That is the honest answer to the plan's question and it is also the useful one: nothing is paid for reaching the module, only for the parts that are referenced.

The other rows matter for the later budget. Roughly 34 KB of the menu figure is the shared floating layer that any one of Tooltip, Menu, Popover or Select pulls in, so the primitives are not additive: `Menu` adds about 17.5 KB on top of that floor and `ContextMenu` adds under 1 KB more. Worth pricing against the 60 KB gate at U4/U5/U6 before those units start, because the floor lands in whichever unit ships first.

### Peer dependencies

No peer warnings on install under React 19. `date-fns` and `@date-fns/tz` appear in the package's peer list but are recorded as optional peers, so they are not requested.

## Test plan

`packages/studio` unless noted.

- `bunx vitest run --poolOptions.forks.maxForks=4` — 429 files passed, 1 skipped; 4751 tests passed, 18 todo. No Studio dev server was running.
- `bun run spike:menu-dismiss` — 5/5 checks passed, run twice for stability:
  - context menu opens near the pointer (offset 2px, -5px from the press)
  - outside press on the real overlay closes the context menu, with the bubble-phase witness confirming the overlay swallowed the press
  - Escape closes the context menu
  - a press on the real overlay closes a panel-mounted menu
  - Escape returns focus to the menu trigger
- `bun run design:shots` — still produces six PNGs and the computed-style table, and still reproduces the Export mismatch it was built to show (Header Export 28px / 6px / 11px against Renders Export 32px / 0px / 14px).
- `bun run typecheck`, `bun run --filter @hyperframes/studio build` — clean.
- `bunx oxlint` and `bunx oxfmt --check` on the changed paths — clean.
- `bunx fallow audit --base origin/main --fail-on-issues` — no issues in 12 changed files.

The happy-dom test's outside-press case was checked for vacuity by the bubble-phase witness described above, and the file was watched failing before the fix: the shadow-root case failed until the synthetic events were given `composed: true`, and the focus-restore case failed until the assertion waited for Base UI's focus move, which happens one task after open rather than synchronously.

## Not covered

- No existing context menu is migrated and no shared `Menu` primitive is added. Both belong to U6.
- `useContextMenuDismiss` is not moved or renamed. The wrapper path lost, so nothing about the hook changes here and no dead alternative is left behind.
- The browser run drives Chrome only. Safari and Firefox are not exercised.
- Keyboard activation (arrow keys then Enter) is asserted under happy-dom only. The browser run covers dismissal, pointer-anchored placement and focus restore.
- The bundle figures above are measured on an isolated entry, not as a delta against Studio's built bundle. The plan asks for that delta at U4, U5 and U6, where the primitives actually ship.
- The spike fixture is mounted into a dev build over the Vite dev server; it is not reachable from the application and is never bundled.
