### PR TITLE
fix(render): allow resolution scaling for alpha output

### DIFF
--- a/packages/cli/src/commands/render.test.ts
+++ b/packages/cli/src/commands/render.test.ts
@@ -1283,16 +1283,15 @@ describe("checkRenderResolutionPreflight", () => {
     ).toBeUndefined();
   });
 
-  it("flags alpha output combined with outputResolution", async () => {
+  it("allows alpha output combined with an integer outputResolution scale", async () => {
     const result = await checkRenderResolutionPreflight(landscapeHtml, "landscape-4k", {
       alphaRequested: true,
       hdrRequested: false,
     });
-    expect(result?.message).toContain("alpha output");
-    expect(result?.kind).toBe("alpha-incompatible");
+    expect(result).toBeUndefined();
   });
 
-  // The three remaining kinds share the same rejection sink (→ one emit each);
+  // The remaining kinds share the same rejection sink (→ one emit each);
   // guard their classification so the telemetry dimension stays accurate.
   it("classifies an HDR + outputResolution combination as hdr-incompatible", async () => {
     const result = await checkRenderResolutionPreflight(landscapeHtml, "landscape", {
@@ -1357,16 +1356,13 @@ describe("checkRenderResolutionPreflight", () => {
       ).toBeUndefined();
     });
 
-    it("still flags alpha + aspect-agnostic (orientation isn't the issue)", async () => {
-      // alpha-incompatible is orthogonal to aspect: the alpha capture path
-      // can't apply deviceScaleFactor regardless of orientation. The
-      // aspect-agnostic downgrade must NOT swallow this.
+    it("allows alpha + aspect-agnostic after adapting the orientation", async () => {
       const result = await checkRenderResolutionPreflight(portraitHtml, "landscape", {
         aspectAgnostic: true,
         alphaRequested: true,
         hdrRequested: false,
       });
-      expect(result?.kind).toBe("alpha-incompatible");
+      expect(result).toBeUndefined();
     });
 
     it("still flags HDR + aspect-agnostic", async () => {

--- a/packages/cli/src/telemetry/events.ts
+++ b/packages/cli/src/telemetry/events.ts
@@ -648,10 +648,10 @@ export function identifyUser(distinctId: string): void {
   trackEvent("$identify", { $anon_distinct_id: readConfig().anonymousId }, distinctId);
 }
 
-// A render was rejected by the output-resolution/alpha/HDR pre-flight (P1-3)
+// A render was rejected by the output-resolution/HDR pre-flight (P1-3)
 // before any browser/ffmpeg work. Counts the "caught early" saves on dashboard
 // 1783183, distinct from deep render failures. `kind` is the low-cardinality
-// `OutputResolutionIssueKind` (aspect-mismatch / alpha-incompatible / etc.),
+// `OutputResolutionIssueKind` (aspect-mismatch / hdr-incompatible / etc.),
 // typed to the union so the metric can never carry free text.
 export function trackRenderPreflightRejected(props: { kind: OutputResolutionIssueKind }): void {
   trackEvent("render_preflight_rejected", { kind: props.kind });

--- a/packages/parsers/src/outputResolutionCompatibility.test.ts
+++ b/packages/parsers/src/outputResolutionCompatibility.test.ts
@@ -81,18 +81,15 @@ describe("checkOutputResolutionCompatibility", () => {
     });
   });
 
-  describe("alpha / HDR incompatibility", () => {
-    it("flags alpha output combined with outputResolution", () => {
+  describe("alpha / HDR compatibility", () => {
+    it("allows alpha output to use integer deviceScaleFactor supersampling", () => {
       const result = checkOutputResolutionCompatibility({
         compositionWidth: 1920,
         compositionHeight: 1080,
         outputResolution: "landscape-4k",
         alphaRequested: true,
       });
-      expect(result.ok).toBe(false);
-      expect(result.kind).toBe("alpha-incompatible");
-      expect(result.message).toContain("alpha output");
-      expect(result.message).toContain("--format mp4");
+      expect(result).toEqual({ ok: true });
     });
 
     it("flags HDR combined with outputResolution", () => {

--- a/packages/parsers/src/outputResolutionCompatibility.ts
+++ b/packages/parsers/src/outputResolutionCompatibility.ts
@@ -27,7 +27,6 @@ import { CANVAS_DIMENSIONS, VALID_CANVAS_RESOLUTIONS, type CanvasResolution } fr
 
 export type OutputResolutionIssueKind =
   | "hdr-incompatible"
-  | "alpha-incompatible"
   | "aspect-mismatch"
   | "downsampling"
   | "non-integer-scale";
@@ -124,7 +123,7 @@ function buildAspectMismatch(
 
 /**
  * Check whether rendering a composition of the given dimensions with the given
- * `outputResolution` preset (and alpha/HDR modes) is supported.
+ * `outputResolution` preset (and HDR mode) is supported.
  *
  * Pure and dependency-free — the single source of truth for the constraints
  * `resolveDeviceScaleFactor` enforces, so the CLI can run the exact same check
@@ -151,18 +150,6 @@ export function checkOutputResolutionCompatibility(input: {
         `outputResolution cannot be combined with hdrMode='force-hdr'. ` +
         `HDR rendering composites at composition dimensions and does not yet ` +
         `support supersampling. Pick one or render in two passes.`,
-    };
-  }
-
-  if (input.alphaRequested) {
-    return {
-      ok: false,
-      kind: "alpha-incompatible",
-      message:
-        `outputResolution cannot be combined with alpha output (--format webm|mov|png-sequence). ` +
-        `The alpha screenshot path does not yet apply deviceScaleFactor and would silently ` +
-        `produce composition-resolution frames. Render alpha at composition resolution and ` +
-        `upscale separately, or use --format mp4.`,
     };
   }
 

--- a/packages/producer/src/services/render/shared.ts
+++ b/packages/producer/src/services/render/shared.ts
@@ -119,10 +119,10 @@ export function resolveDeviceScaleFactor(input: {
   alphaRequested: boolean;
 }): number {
   if (!input.outputResolution) return 1;
-  // Single source of truth for the aspect/alpha/HDR/scale constraints, shared
+  // Single source of truth for the aspect/HDR/scale constraints, shared
   // with the CLI render pre-flight so both raise the identical, actionable
   // message. This is the deep defense-in-depth throw; the pre-flight aborts
-  // long before this runs on the common (aspect/alpha) mistakes.
+  // long before this runs on common compatibility mistakes.
   const compat = checkOutputResolutionCompatibility({
     compositionWidth: input.compositionWidth,
     compositionHeight: input.compositionHeight,

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -1598,14 +1598,14 @@ describe("resolveDeviceScaleFactor", () => {
     ).toThrow(/hdrMode='force-hdr'/);
   });
 
-  it("rejects alpha + outputResolution (the alpha capture path doesn't apply DPR yet)", () => {
-    expect(() =>
+  it("returns the requested DPR for alpha + outputResolution", () => {
+    expect(
       resolveDeviceScaleFactor({
         ...defaults,
         outputResolution: "landscape-4k",
         alphaRequested: true,
       }),
-    ).toThrow(/alpha output/);
+    ).toBe(2);
   });
 
   it("rejects orientation mismatch (landscape comp → portrait-4k)", () => {


### PR DESCRIPTION
## What

Alpha WebM, MOV, and PNG-sequence renders can now use `--resolution` supersampling when the requested scale is compatible with the composition.

## Why

The alpha capture path already applies `deviceScaleFactor` through the CDP screenshot clip. A stale shared validator still rejected every alpha and output-resolution combination, forcing callers to stage and downscale frames outside HyperFrames.

## How

Remove the obsolete alpha incompatibility gate while preserving the existing HDR, aspect-ratio, downsampling, and integer-scale checks. Update parser, CLI preflight, and producer regression expectations to cover the supported alpha path.

## Test plan

- [x] Unit tests added/updated: `bun test packages/parsers/src/outputResolutionCompatibility.test.ts` (12 passed, 0 failed)
- [ ] Manual testing performed
- [ ] Documentation updated (not applicable)

The full workspace suites could not start locally because the frozen dependency install omitted published `dist/` payloads for several packages, including Vitest, oxlint, acorn, and pretext. `git diff --check` and a direct Bun bundle of the changed validator passed.
