### PR TITLE
feat(cli): snapshot --against pairs each frame with a reference video

### DIFF
--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -722,6 +722,7 @@ Capture specific frames as PNGs, without waiting for a full render.
 npx hyperframes snapshot my-project --at 2.9,10.4,18.7
 npx hyperframes snapshot my-project --frames 10
 npx hyperframes snapshot my-project --zoom '#headline'
+npx hyperframes snapshot my-project --at 1.5,4.3 --against ref.mp4
 ```
 
 ```
@@ -740,6 +741,7 @@ npx hyperframes snapshot my-project --zoom '#headline'
 | `--output, -o`          | Where the PNGs go (default `<project>/snapshots`)                                                                                                                   |
 | `--end` / `--no-end`    | Always add a readable end-of-timeline frame (default: on). `--no-end` captures only your `--at` times.                                                              |
 | `--zoom`                | Crop to a CSS selector or an exact `x,y,w,h` region, using a raised device scale factor. Layout is untouched — never CSS zoom or a resized viewport. A selector that matches nothing is an error. |
+| `--against`             | A reference video, such as footage you are rebuilding. For every captured time also saves its frame-exact frame (`ref-XX-…png`) and a labelled render / reference pair (`pair-XX-…jpg`). |
 | `--zoom-scale`          | Pixel density for `--zoom` crops (default 3)                                                                                                                        |
 | `--angle`               | Orthogonal 3D camera for depth and occlusion checks: `front`, `iso`, `top`, `side`, or `yaw,pitch` in degrees. Tilts the whole stage, so you get real pixels.        |
 | `--describe`            | Gemini vision analysis of each frame. Runs by default when `GEMINI_API_KEY` is set. Pass a question to override the prompt, or `--describe false` to opt out.        |

--- a/packages/cli/src/commands/snapshot.test.ts
+++ b/packages/cli/src/commands/snapshot.test.ts
@@ -77,6 +77,17 @@ describe("transparent snapshot capture", () => {
     expect(source).toContain("opts.autoProxy");
   });
 
+  it("pairs every frame with the frame-exact reference frame under --against", () => {
+    const source = readFileSync(new URL("./snapshot.ts", import.meta.url), "utf8");
+    expect(source).toContain("against: {");
+    expect(source).toContain("extractVideoFrameToBuffer(opts.against, time, false, true)");
+    expect(source).toContain('labels: ["render", "reference"]');
+    // accurate seek = `-ss` after `-i`, never the keyframe-snap fast path
+    expect(source).toContain(
+      'accurateSeek ? ["-i", videoPath, ...seek] : [...seek, "-i", videoPath]',
+    );
+  });
+
   it("resolves and forwards the shared local browser GPU policy", () => {
     const source = readFileSync(new URL("./snapshot.ts", import.meta.url), "utf8");
     expect(source).toContain("resolveLocalBrowserGpuMode");

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -593,7 +593,6 @@ async function captureSnapshots(
         } else {
           await page.screenshot({ path: framePath, type: "png", omitBackground: true });
         }
-        const saved = [framePath];
         if (opts.against) {
           // Frame-exact reference frame beside the render, so a rebuild can be
           // checked against its footage without hand-rolled ffmpeg + montage.
@@ -614,13 +613,13 @@ async function captureSnapshots(
               labelMode: "custom",
               labels: ["render", "reference"],
             });
-            saved.push(pairPath);
           }
         }
-        for (const path of saved) {
-          const rel = relative(projectDir, path);
-          savedPaths.push(rel.startsWith("..") || isAbsolute(rel) ? path : rel);
-        }
+        // Only the capture itself is a "snapshot": the reference frame and the
+        // pair sheet are derived artifacts, like contact-sheet.jpg, so they stay
+        // out of savedPaths (count, listing, and --describe all read it).
+        const rel = relative(projectDir, framePath);
+        savedPaths.push(rel.startsWith("..") || isAbsolute(rel) ? framePath : rel);
       }
     } finally {
       await chromeBrowser.close();
@@ -802,6 +801,11 @@ export default defineCommand({
       );
       for (const p of paths) {
         console.log(`   ${p}`);
+      }
+      if (against) {
+        console.log(
+          `   ${c.dim("ref-*.png + pair-*.jpg")} beside each frame (reference frame, render | reference sheet)`,
+        );
       }
 
       // Generate contact sheet for quick AI review

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -137,6 +137,7 @@ async function extractVideoFrameToBuffer(
   videoPath: string,
   timeSeconds: number,
   useVp9AlphaDecoder = false,
+  accurateSeek = false,
 ): Promise<Buffer | null> {
   const tmp = mkdtempSync(join(tmpdir(), "hf-snapshot-frame-"));
   const outPath = join(tmp, "frame.png");
@@ -144,15 +145,15 @@ async function extractVideoFrameToBuffer(
     const ffmpegPath = requireSnapshotFfmpeg(findFFmpeg());
     // `-ss` before `-i` performs a fast keyframe seek; adequate for snapshot accuracy
     // (±1 frame) and orders of magnitude faster than the decode-and-scan alternative.
+    // `accurateSeek` puts `-ss` after `-i` (decode from the start) for frame-exact
+    // reference pairs, where ±1 frame would read as a real mismatch.
     const args = ["-hide_banner", "-loglevel", "error"];
     if (useVp9AlphaDecoder) {
       args.push("-c:v", "libvpx-vp9");
     }
+    const seek = ["-ss", String(Math.max(0, timeSeconds))];
     args.push(
-      "-ss",
-      String(Math.max(0, timeSeconds)),
-      "-i",
-      videoPath,
+      ...(accurateSeek ? ["-i", videoPath, ...seek] : [...seek, "-i", videoPath]),
       "-frames:v",
       "1",
       "-q:v",
@@ -180,6 +181,10 @@ export const examples: Example[] = [
   [
     "Zoom into an exact pixel region at 2x density",
     "snapshot --zoom 100,50,400,300 --zoom-scale 2",
+  ],
+  [
+    "Pair each frame with the reference footage at the same time",
+    "snapshot --at 1.5,4.3,8.1 --against ref.mp4",
   ],
 ];
 
@@ -264,6 +269,8 @@ async function captureSnapshots(
     zoomScale?: number;
     autoProxy?: boolean;
     browserGpuMode?: BrowserGpuMode;
+    /** Reference video: save its frame at each captured time plus a render|reference pair. */
+    against?: string;
   },
 ): Promise<string[]> {
   const { bundleWithLocalizedFonts } = await import("../utils/bundleWithLocalizedFonts.js");
@@ -559,7 +566,8 @@ async function captureSnapshots(
         }
 
         const timeLabel = formatSnapshotTimestamp(time);
-        const filename = `frame-${String(i).padStart(2, "0")}-at-${timeLabel}.png`;
+        const index = String(i).padStart(2, "0");
+        const filename = `frame-${index}-at-${timeLabel}.png`;
         const framePath = join(snapshotDir, filename);
 
         if (opts.zoom) {
@@ -585,8 +593,34 @@ async function captureSnapshots(
         } else {
           await page.screenshot({ path: framePath, type: "png", omitBackground: true });
         }
-        const rel = relative(projectDir, framePath);
-        savedPaths.push(rel.startsWith("..") || isAbsolute(rel) ? framePath : rel);
+        const saved = [framePath];
+        if (opts.against) {
+          // Frame-exact reference frame beside the render, so a rebuild can be
+          // checked against its footage without hand-rolled ffmpeg + montage.
+          const refPng = await extractVideoFrameToBuffer(opts.against, time, false, true);
+          if (!refPng) {
+            console.error(
+              `   ${c.warn("⚠")} --against has no frame at ${timeLabel} — reference pair skipped`,
+            );
+          } else {
+            const refPath = join(snapshotDir, `ref-${index}-at-${timeLabel}.png`);
+            writeFileSync(refPath, refPng);
+            const pairPath = join(snapshotDir, `pair-${index}-at-${timeLabel}.jpg`);
+            const { createContactSheet } = await import("../capture/contactSheet.js");
+            await createContactSheet([framePath, refPath], pairPath, {
+              cols: 2,
+              maxImages: 2,
+              cellWidth: 960,
+              labelMode: "custom",
+              labels: ["render", "reference"],
+            });
+            saved.push(pairPath);
+          }
+        }
+        for (const path of saved) {
+          const rel = relative(projectDir, path);
+          savedPaths.push(rel.startsWith("..") || isAbsolute(rel) ? path : rel);
+        }
       }
     } finally {
       await chromeBrowser.close();
@@ -648,6 +682,11 @@ export default defineCommand({
       type: "string",
       description: "Device-scale-factor density for --zoom crops (default: 3)",
       default: "3",
+    },
+    against: {
+      type: "string",
+      description:
+        "Reference video (e.g. footage being rebuilt): also save its frame at each captured time and a render|reference pair sheet",
     },
     describe: {
       type: "string",
@@ -718,6 +757,11 @@ export default defineCommand({
     const camera = args.angle ? parseAngle(String(args.angle)) : undefined;
     const zoomTarget = args.zoom ? parseZoomTarget(String(args.zoom)) : undefined;
     const zoomScale = parseZoomScale(args["zoom-scale"]);
+    const against = args.against ? resolve(String(args.against)) : undefined;
+    if (against && !existsSync(against)) {
+      console.log(`${c.error("✗")} --against video not found: ${against}`);
+      failCommand();
+    }
 
     const label = atTimestamps
       ? `${atTimestamps.length} frames at [${atTimestamps.map(formatSnapshotTimestamp).join(", ")}]`
@@ -743,6 +787,7 @@ export default defineCommand({
         zoomScale,
         autoProxy: args.proxy as boolean | undefined,
         browserGpuMode: resolveLocalBrowserGpuMode(args["browser-gpu"] as boolean | undefined),
+        against,
       });
 
       if (paths.length === 0) {


### PR DESCRIPTION
## What

`hyperframes snapshot --against <video>`: for every captured time, also save the reference video's frame at that time and a labelled render | reference pair sheet.

```
npx hyperframes snapshot my-project --at 1.5,4.3,8.1 --against ref.mp4
   snapshots/frame-01-at-4.3s.png
   snapshots/ref-01-at-4.3s.png
   snapshots/pair-01-at-4.3s.jpg
```

## Why

Rebuilding footage (a 1:1 recreation, a re-cut, a re-render of a reference) means checking the render against the source at the same timestamps. Until now that was hand-rolled every time: ffmpeg frame grabs, an image tool for the side-by-side sheet, a fresh script per round. `compare` only puts projects next to each other; nothing in the CLI compared a composition to a video.

## How

- Reference frames come from the existing `extractVideoFrameToBuffer`, with a new `accurateSeek` option that puts `-ss` after `-i`. The fast keyframe seek is ±1 frame, which would read as a real mismatch in a pair sheet.
- The pair sheet reuses `createContactSheet` (2 columns, 960 px cells, labels `render` / `reference`). No new dependencies.
- The reference PNG and the pair JPG land next to the frame; the pair path is listed in the summary. The existing `contact-sheet.jpg` still only picks up `frame-*.png`.
- `--against` pointing at a missing file fails the command up front.

## Test plan

- [x] Unit test added (`snapshot.test.ts`, source contract for the flag, the accurate seek and the pair labels). Two pre-existing "snapshot lint preflight" failures in that suite are unchanged on `main`.
- [x] Manual: a 24 s 1080p rebuild against its source footage at three timestamps produced 3 frames, 3 reference frames, 3 pair sheets; pairs render with correct labels and aspect
- [x] Documentation updated (`docs/packages/cli.mdx`)