### PR TITLE
fix(engine): preserve nested sibling video layout

### DIFF
--- a/packages/engine/src/services/screenshotService.test.ts
+++ b/packages/engine/src/services/screenshotService.test.ts
@@ -518,6 +518,23 @@ describe("video-frame injection respects ancestor visibility", () => {
     expect(seededImg.style.visibility).toBe("hidden");
   });
 
+  it("preserves display:none on an inactive in-flow video so its sibling keeps the same box", async () => {
+    const { teardown, setup } = withGlobals(setupHostHiddenScenario({}));
+    setup.video.style.display = "none";
+    const seededImg = setup.document.createElement("img");
+    seededImg.classList.add("__render_frame__");
+    setup.video.parentNode?.insertBefore(seededImg, setup.video.nextSibling);
+
+    try {
+      await syncVideoFrameVisibility(passthroughPage(), []);
+    } finally {
+      teardown();
+    }
+
+    expect(setup.video.style.display).toBe("none");
+    expect(seededImg.style.visibility).toBe("hidden");
+  });
+
   it("still injects when a plain [data-start] host is visibility:hidden (CSS-escapable)", async () => {
     // Regression guard for the style-9-prod symptom: a regular
     // `[data-start]` container whose GSAP timeline is shorter than its

--- a/packages/engine/src/services/screenshotService.ts
+++ b/packages/engine/src/services/screenshotService.ts
@@ -901,7 +901,6 @@ export async function syncVideoFrameVisibility(
           // cannot revive a stale frame when the sub-comp host lands in the
           // active layer's `show` set — same mask-defense reasoning as the
           // `isVisualAncestorHidden` branch in `injectVideoFramesBatch`.
-          video.style.removeProperty("display");
           video.style.setProperty("visibility", "hidden", "important");
           video.style.setProperty("pointer-events", "none", "important");
           if (hasImg) {


### PR DESCRIPTION
## What

Sequential in-flow sibling videos now keep the same nested scene box during export, so later siblings no longer render outside the capture surface as black frames.

## Why

The runtime intentionally applies `display:none` to inactive in-flow leaf clips. The frame-injection visibility sync removed that runtime-owned value, restoring the inactive sibling’s layout box and pushing the active replacement frame down in document flow.

## How

Keep `display` ownership in the runtime while the injector continues to manage native-video and replacement-frame visibility. The change removes one conflicting style reset and adds a regression for inactive sibling layout preservation.

## Test plan

- [x] Unit tests added/updated: targeted RED reproduced the lost `display:none`; GREEN passed with 1 test, 0 failures
- [ ] Manual testing performed
- [ ] Documentation updated (not applicable)

The full screenshot-service file reached 30 passing tests; two existing LinkeDOM/Bun `setProperty` spy assertions failed even though their visibility value assertions passed. Engine typecheck was blocked by missing generated/published dependency payloads in the clean worktree. `git diff --check` passed.
