### PR TITLE
fix(runtime): align nested activation to export frames

### DIFF
--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -597,6 +597,40 @@ describe("initSandboxRuntimeModular", () => {
     );
   });
 
+  it("activates a nested outro on frame 584 when its authored start rounds just above it", () => {
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-duration", "20");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    const outro = document.createElement("div");
+    outro.setAttribute("data-composition-id", "outro");
+    outro.setAttribute("data-start", "19.466666666667");
+    outro.setAttribute("data-duration", "0.533333333333");
+    root.appendChild(outro);
+
+    const video = document.createElement("video");
+    video.setAttribute("data-start", "0");
+    video.setAttribute("data-duration", "0.533333333333");
+    outro.appendChild(video);
+
+    window.__timelines = {
+      main: createMockTimeline(20),
+      outro: createMockTimeline(0.533333333333),
+    };
+    window.__HF_EXPORT_RENDER_SEEK_CONFIG = { fps: 30, fpsSource: "render-options" };
+
+    initSandboxRuntimeModular();
+    window.__player?.renderSeek(584 / 30);
+
+    expect(outro.style.visibility).toBe("visible");
+    expect(video.style.visibility).toBe("visible");
+  });
+
   it("surfaces unknown export render fps sources without collapsing them to render-options", () => {
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     const root = document.createElement("div");

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -746,8 +746,16 @@ export function initSandboxRuntimeModular(): void {
     }
     const computedEnd =
       duration != null && duration > 0 ? start + duration : Number.POSITIVE_INFINITY;
+    const frameAlignedStart = window.__HF_EXPORT_RENDER_SEEK_CONFIG
+      ? quantizeTimeToFrame(start, state.canonicalFps)
+      : start;
+    const frameAlignedEnd =
+      window.__HF_EXPORT_RENDER_SEEK_CONFIG && Number.isFinite(computedEnd)
+        ? quantizeTimeToFrame(computedEnd, state.canonicalFps)
+        : computedEnd;
     return (
-      currentTime >= start && (Number.isFinite(computedEnd) ? currentTime < computedEnd : true)
+      currentTime >= frameAlignedStart &&
+      (Number.isFinite(frameAlignedEnd) ? currentTime < frameAlignedEnd : true)
     );
   };
 


### PR DESCRIPTION
## What

Nested composition hosts and media now activate on the intended export frame when authored decimal timing lands microscopically above that frame boundary.

## Why

Export seeks were quantized to the render FPS, but timed-element visibility still compared the quantized seek against raw authored seconds. At 30fps, frame 584 is `19.466666666666665s`, which compared below an authored `19.466666666667s` start and delayed the outro by one frame.

## How

Align finite visibility start/end boundaries to the same export frame grid used by render seek. Continuous preview timing remains unchanged because alignment is gated on export render configuration.

## Test plan

- [x] Unit tests added/updated: frame-584 nested host/video regression passed (1 test, 0 failures)
- [x] Quantizer suite passed (10 tests, 0 failures)
- [ ] Manual testing performed
- [ ] Documentation updated (not applicable)

A broader Bun run reached the runtime tests but hit two unrelated runner assumptions (package-relative CWD and unsupported `vi.advanceTimersByTimeAsync`) before its timeout. Core typecheck was blocked by missing `htmlparser2`/`hono` dependency payloads in the clean worktree. `git diff --check` passed.
