### PR TITLE
fix(engine): retry capture screenshot timeouts

### DIFF
--- a/packages/engine/src/services/captureFailure.test.ts
+++ b/packages/engine/src/services/captureFailure.test.ts
@@ -6,6 +6,10 @@ describe("classifyCaptureFailure", () => {
     ["Target closed", "transient_browser"],
     ["Runtime.callFunctionOn timed out after 30000ms", "protocol_timeout"],
     ["Runtime.evaluate timed out", "protocol_timeout"],
+    [
+      "Page.captureScreenshot timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.",
+      "protocol_timeout",
+    ],
     ["drawElement worker encode timed out (frame 42)", "protocol_timeout"],
     ["Waiting failed: 30000ms exceeded", "protocol_timeout"],
     ["JavaScript heap out of memory", "memory_exhaustion"],

--- a/packages/engine/src/services/captureFailure.ts
+++ b/packages/engine/src/services/captureFailure.ts
@@ -57,6 +57,7 @@ const TRANSIENT_BROWSER_ERROR_PATTERNS = [
 const PROTOCOL_TIMEOUT_PATTERNS = [
   /Runtime\.callFunctionOn timed out/i,
   /Runtime\.evaluate timed out/i,
+  /Page\.captureScreenshot timed out/i,
   /HeadlessExperimental\.beginFrame timed out/i,
   /drawElement worker encode timed out \(frame \d+\)/i,
   /Protocol error[\s\S]*tim(?:ed|e) out/i,

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -1526,6 +1526,13 @@ describe("adaptive missing-frame retry helpers", () => {
     expect(
       isRecoverableParallelCaptureError(
         new Error(
+          "[Parallel] Capture failed: Worker 2: Page.captureScreenshot timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isRecoverableParallelCaptureError(
+        new Error(
           "[Parallel] Capture failed: Worker 0: drawElement worker encode timed out (frame 42)",
         ),
       ),


### PR DESCRIPTION
## What

Screenshot protocol timeouts now enter the existing adaptive capture retry, allowing the renderer to reduce worker concurrency instead of hard-failing a valid long render.

## Why

Puppeteer's `Page.captureScreenshot timed out` signature fell through to `authoring`, so parallel capture treated a recoverable CDP timeout as fatal.

## How

Classify the exact screenshot method timeout as `protocol_timeout`. Keep pressure-aware auto worker sizing as separate follow-up scope.

## Test plan

- [x] Unit tests added/updated: engine classifier RED-to-GREEN (14/14)
- [x] Manual testing performed: exact wrapped parallel-worker runtime probe returned `recoverable=true`
- [x] Documentation updated (not applicable; internal failure classification)

The full producer suite could not start in the task worktree because its existing dependency payload omitted generated and package `dist` artifacts; the exact producer recovery assertion is included for CI.
