### PR TITLE
fix(producer): preserve render warning attribution

### DIFF
--- a/packages/producer/src/services/render/renderEventPublisher.test.ts
+++ b/packages/producer/src/services/render/renderEventPublisher.test.ts
@@ -126,6 +126,35 @@ describe("OrderedRenderEventPublisher", () => {
   });
 });
 
+describe("RenderQualityError", () => {
+  it("includes the warning message that identifies the failing audio element", () => {
+    const error = new RenderQualityError([
+      {
+        code: "audio_processing_failed",
+        message: "Audio processing failed for element bgm-bed: Automation is not valid JSON",
+        stage: "capture-readiness",
+      },
+    ]);
+
+    expect(error.message).toContain(
+      "audio_processing_failed: Audio processing failed for element bgm-bed: Automation is not valid JSON",
+    );
+  });
+
+  it("redacts URL query secrets from warning messages", () => {
+    const error = new RenderQualityError([
+      {
+        code: "audio_processing_failed",
+        message: "Audio processing failed for https://cdn.example.com/track.wav?token=secret",
+        stage: "capture-readiness",
+      },
+    ]);
+
+    expect(error.message).toContain("https://cdn.example.com/track.wav?…");
+    expect(error.message).not.toContain("secret");
+  });
+});
+
 describe("updateJobStatus", () => {
   it("keeps one bounded monotonic integer-percent representation", () => {
     const job = createRenderJob({ fps: 30, quality: "high" });

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -50,6 +50,7 @@ import {
   type Fps,
   type FpsInput,
   fpsToNumber,
+  redactTelemetryString,
   toFps,
 } from "@hyperframes/core";
 import {
@@ -639,8 +640,10 @@ export type ProgressCallback = (job: RenderJob, message: string) => void | Promi
 export class RenderQualityError extends Error {
   constructor(readonly warnings: readonly RenderWarning[]) {
     super(
-      `Render blocked by ${warnings.length} correctness warning${warnings.length === 1 ? "" : "s"}: ` +
-        warnings.map((warning) => warning.code).join(", "),
+      `Render blocked by ${warnings.length} correctness warning${warnings.length === 1 ? "" : "s"}:\n` +
+        warnings
+          .map((warning) => `- ${warning.code}: ${redactTelemetryString(warning.message)}`)
+          .join("\n"),
     );
     this.name = "RenderQualityError";
   }


### PR DESCRIPTION
## What

Fatal render warnings now preserve their actionable message in the terminal error, so users can identify the failing track and cause without project archaeology.

## Why

`RenderQualityError` previously emitted only warning codes even though the mixer and structured warning already retained the element ID and automation parse reason.

## How

Format each blocking warning as its code plus a redacted message. Existing URL-query and path redaction prevents diagnostic attribution from exposing secrets.

## Test plan

- [x] Unit tests added/updated: focused warning/error suite passes 15/15
- [x] Manual testing performed: exact malformed-automation attribution shape asserted at the terminal error boundary
- [x] Documentation updated (not applicable; diagnostic-only behavior)
- [x] Producer typecheck, oxlint, and oxfmt checks pass
