### PR TITLE
fix(producer): guard disk capture capacity

### DIFF
--- a/packages/producer/src/services/render/stages/captureStage.test.ts
+++ b/packages/producer/src/services/render/stages/captureStage.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { shouldAllowAdaptiveCaptureRetry } from "./captureStage.js";
+import {
+  assertDiskCaptureHeadroom,
+  estimateDiskCaptureBytes,
+  shouldAllowAdaptiveCaptureRetry,
+} from "./captureStage.js";
 
 describe("shouldAllowAdaptiveCaptureRetry", () => {
   it("keeps timeout recovery enabled when the initial worker count was explicit", () => {
@@ -8,5 +12,25 @@ describe("shouldAllowAdaptiveCaptureRetry", () => {
 
   it("does not retry an already sequential capture", () => {
     expect(shouldAllowAdaptiveCaptureRetry(1, true)).toBe(false);
+  });
+});
+
+describe("disk capture capacity", () => {
+  const captureOptions = {
+    width: 100,
+    height: 50,
+    fps: { num: 30, den: 1 },
+    deviceScaleFactor: 2,
+    format: "jpeg" as const,
+  };
+
+  it("estimates output-resolution frame storage conservatively", () => {
+    expect(estimateDiskCaptureBytes(10, captureOptions)).toBe(800_000);
+  });
+
+  it("fails before capture when estimated frames exceed available headroom", () => {
+    expect(() =>
+      assertDiskCaptureHeadroom("/render/captured-frames", 10, captureOptions, () => 800_000),
+    ).toThrow(/may need ~0\.8 MB.*0\.8 MB is free.*--low-memory-mode/s);
   });
 });

--- a/packages/producer/src/services/render/stages/captureStage.ts
+++ b/packages/producer/src/services/render/stages/captureStage.ts
@@ -36,6 +36,7 @@
  * the stages can import them without reaching back into the orchestrator.
  */
 
+import { statfsSync } from "node:fs";
 import {
   type BeforeCaptureHook,
   type CaptureOptions,
@@ -136,6 +137,42 @@ export function shouldAllowAdaptiveCaptureRetry(
   return workerCount > 1;
 }
 
+export function estimateDiskCaptureBytes(
+  totalFrames: number,
+  captureOptions: CaptureOptions,
+): number {
+  const scale = captureOptions.deviceScaleFactor ?? 1;
+  const outputWidth = Math.ceil(captureOptions.width * scale);
+  const outputHeight = Math.ceil(captureOptions.height * scale);
+  return Math.ceil(totalFrames) * outputWidth * outputHeight * 4;
+}
+
+export function assertDiskCaptureHeadroom(
+  framesDir: string,
+  totalFrames: number,
+  captureOptions: CaptureOptions,
+  freeDiskBytes: (path: string) => number | null = (path) => {
+    try {
+      const stat = statfsSync(path);
+      return stat.bavail * stat.bsize;
+    } catch {
+      return null;
+    }
+  },
+): void {
+  const freeBytes = freeDiskBytes(framesDir);
+  if (freeBytes === null) return;
+  const estimatedBytes = estimateDiskCaptureBytes(totalFrames, captureOptions);
+  if (estimatedBytes <= freeBytes * 0.9) return;
+  throw new Error(
+    `Disk capture may need ~${(estimatedBytes / 1e6).toFixed(1)} MB of temporary frame storage, ` +
+      `but only ${(freeBytes / 1e6).toFixed(1)} MB is free at ${framesDir}. ` +
+      "Re-run with --low-memory-mode to stream frames, raise " +
+      "PRODUCER_STREAMING_ENCODE_MAX_DURATION_SECONDS if streaming is supported, " +
+      "or free up disk space.",
+  );
+}
+
 export async function runCaptureStage(input: CaptureStageInput): Promise<CaptureStageResult> {
   const {
     fileServer,
@@ -194,6 +231,9 @@ export async function runCaptureStage(input: CaptureStageInput): Promise<Capture
     }
   }
 
+  const captureOptions = buildCaptureOptions();
+  assertDiskCaptureHeadroom(framesDir, totalFrames, captureOptions);
+
   if (workerCount > 1) {
     // Parallel capture. When `frameRange` is set (distributed chunk), pass
     // `frameRangeStart` so workers land on absolute composition frame indices
@@ -206,7 +246,7 @@ export async function runCaptureStage(input: CaptureStageInput): Promise<Capture
       initialWorkerCount: workerCount,
       allowRetry: shouldAllowAdaptiveCaptureRetry(workerCount, job.config.workers !== undefined),
       frameExt: needsAlpha ? "png" : "jpg",
-      captureOptions: buildCaptureOptions(),
+      captureOptions,
       createBeforeCaptureHook: createRenderVideoFrameInjector,
       abortSignal,
       frameRangeStart: frameRange?.startFrame,
@@ -252,7 +292,7 @@ export async function runCaptureStage(input: CaptureStageInput): Promise<Capture
       (await createCaptureSession(
         fileServer.url,
         framesDir,
-        buildCaptureOptions(),
+        captureOptions,
         videoInjector,
         captureCfg,
       ));


### PR DESCRIPTION
## What

Long disk-frame renders now fail before capture when their conservative temporary-storage estimate would consume the available disk headroom.

## Why

The previous preflight checked only a fixed 1 GB floor. A long render could pass that check, select per-frame disk capture, and fill the volume before encoding.

## How

Estimate output-resolution frame storage at four bytes per pixel and reserve 10% of current free capacity. If the estimate exceeds that budget, report required versus available space and direct the user to streaming via `--low-memory-mode`, the duration cap, or more free disk.

The static-frame dedup mismatch remains causally unrelated: disk capture writes one output file per frame whether capture work was deduplicated or not.

## Test plan

- [x] Unit tests added/updated: focused capture-stage suite passes 4/4
- [x] Manual testing performed: injected 0.8 MB capacity reproduces the pre-capture rejection and actionable diagnostic
- [x] Documentation updated (not applicable; runtime guard and error guidance are self-contained)
- [x] Producer typecheck, oxlint, and oxfmt checks pass
