### PR TITLE
fix(producer): preserve nested entry asset base

### DIFF
--- a/packages/producer/src/services/htmlCompiler.test.ts
+++ b/packages/producer/src/services/htmlCompiler.test.ts
@@ -633,6 +633,32 @@ describe("detectRenderModeHints", () => {
     }
   });
 
+  it("rebases a direct nested entry's sibling assets without changing project-root assets", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "hf-direct-entry-base-"));
+    const compositionsDir = join(projectDir, "compositions");
+    mkdirSync(compositionsDir, { recursive: true });
+    writeFileSync(join(compositionsDir, "sibling.png"), "sibling");
+    writeFileSync(join(projectDir, "root.png"), "root");
+    const entryPath = join(compositionsDir, "scene.html");
+    writeFileSync(
+      entryPath,
+      `<!doctype html><html><body>
+  <div data-composition-id="scene" data-width="100" data-height="100" data-duration="1">
+    <img id="sibling" src="sibling.png" />
+    <img id="root" src="root.png" />
+  </div>
+</body></html>`,
+    );
+
+    const compiled = await compileForRender(projectDir, entryPath, projectDir);
+    const { document } = parseHTML(compiled.html);
+
+    expect(document.querySelector("#sibling")?.getAttribute("src")).toBe(
+      "compositions/sibling.png",
+    );
+    expect(document.querySelector("#root")?.getAttribute("src")).toBe("root.png");
+  });
+
   // Shared fixture builder for the assertSubCompositionsUsable / EmptyCompositionError
   // pre-flight tests below. `subCompFiles` is a map of compositions/-relative
   // filename to raw file content (empty string / malformed text / valid HTML).

--- a/packages/producer/src/services/htmlCompiler.ts
+++ b/packages/producer/src/services/htmlCompiler.ts
@@ -11,7 +11,7 @@
  */
 
 import { createReadStream, existsSync, mkdirSync, readFileSync } from "fs";
-import { join, dirname, resolve, basename } from "path";
+import { join, dirname, resolve, basename, relative } from "path";
 import { parseHTML } from "linkedom";
 import {
   compileTimingAttrs,
@@ -25,6 +25,9 @@ import {
   readMediaStart,
   redactTelemetryString,
   resolveNaturalMediaTimelineDurationFromValues,
+  rewriteAssetPaths,
+  rewriteCssAssetUrls,
+  rewriteInlineStyleAssetUrls,
   type ResolvedDuration,
   type UnresolvedElement,
 } from "@hyperframes/core";
@@ -1846,6 +1849,38 @@ function rewriteUnresolvableGsapToCdn(html: string, projectDir: string): string 
 }
 
 /**
+ * Preserve a nested entry document's browser URL base when compilation moves
+ * it to compiled/index.html. Use the same sibling-first/project-root-fallback
+ * rule as mounted sub-compositions so both supported entry modes agree.
+ */
+function rebaseDirectEntryAssetPaths(html: string, projectDir: string, htmlPath: string): string {
+  if (!isPathInside(htmlPath, projectDir)) return html;
+  const entryPath = relative(projectDir, htmlPath).replace(/\\/g, "/");
+  if (!entryPath.includes("/")) return html;
+
+  const { document } = parseHTML(html);
+  const assetExists = (path: string) => existsSync(resolve(projectDir, path));
+  rewriteAssetPaths(
+    document.querySelectorAll("[src], [href]"),
+    entryPath,
+    (el: Element, attr: string) => el.getAttribute(attr),
+    (el: Element, attr: string, value: string) => el.setAttribute(attr, value),
+    assetExists,
+  );
+  rewriteInlineStyleAssetUrls(
+    document.querySelectorAll("[style]"),
+    entryPath,
+    (el: Element) => el.getAttribute("style"),
+    (el: Element, value: string) => el.setAttribute("style", value),
+    assetExists,
+  );
+  for (const style of document.querySelectorAll("style")) {
+    style.textContent = rewriteCssAssetUrls(style.textContent || "", entryPath, assetExists);
+  }
+  return document.toString();
+}
+
+/**
  * Compile an HTML composition project into a single self-contained HTML string
  * with all media metadata resolved.
  */
@@ -1856,7 +1891,12 @@ export async function compileForRender(
   downloadDir: string,
   options: CompileForRenderOptions = {},
 ): Promise<CompiledComposition> {
-  const rawHtml = rewriteUnresolvableGsapToCdn(readFileSync(htmlPath, "utf-8"), projectDir);
+  const entryHtml = rebaseDirectEntryAssetPaths(
+    readFileSync(htmlPath, "utf-8"),
+    projectDir,
+    htmlPath,
+  );
+  const rawHtml = rewriteUnresolvableGsapToCdn(entryHtml, projectDir);
 
   // Pre-flight: every data-composition-src reference must resolve to a
   // usable file before we spend any time compiling, launching a browser, or


### PR DESCRIPTION
## What

Direct `--composition compositions/scene.html` entries now keep the same sibling-asset resolution as mounted sub-compositions. A sibling `image.png` is emitted as `compositions/image.png`, while an existing project-root asset remains root-relative.

## Why

The compiler relocates every entry document to `compiled/index.html`. Direct nested entries previously kept plain relative URLs unchanged, so the render server requested `/image.png` and returned 404 even when `compositions/image.png` existed.

## How

Nested entry documents inside the project are rebased before compilation with the established mounted-subcomposition path resolver. The pass covers `src`/`href`, inline styles, and stylesheet `url(...)` values. Generated standalone wrappers outside the project are skipped, which prevents double rebasing of the existing mounted flow.

## Test plan

- [x] Regression test covers a direct nested entry with both a sibling image and a project-root image.
- [x] Full producer HTML compiler suite passes (132/132).
- [x] Shared path-rewriter suite passes (11/11).
- [x] Producer typecheck, oxlint, and oxfmt checks pass.
- [ ] Documentation updated (not applicable).
