### PR TITLE
fix(producer): scale high-quality encode timeout

### DIFF
--- a/packages/producer/src/services/render/stages/encodeStage.test.ts
+++ b/packages/producer/src/services/render/stages/encodeStage.test.ts
@@ -259,6 +259,65 @@ describe("runEncodeStage config plumbing", () => {
     });
   });
 
+  it("gives the reported long high-quality encode a 24x source-duration budget", async () => {
+    const { runEncodeStage } = await import("./encodeStage.js");
+    const input = makeInput();
+
+    await runEncodeStage(
+      makeInput({
+        job: {
+          ...input.job,
+          config: { ...input.job.config, quality: "high" },
+          duration: 331.273,
+        },
+        engineConfig: { ffmpegEncodeTimeout: 600_000 },
+      }),
+    );
+
+    expect(encodeFramesFromDirMock.mock.calls[0]?.[5]).toEqual({
+      ffmpegEncodeTimeout: 7_950_552,
+    });
+  });
+
+  it("keeps the 4x budget for a standard encode", async () => {
+    const { runEncodeStage } = await import("./encodeStage.js");
+    const input = makeInput();
+
+    await runEncodeStage(
+      makeInput({
+        job: {
+          ...input.job,
+          config: { ...input.job.config, quality: "standard" },
+          duration: 331.273,
+        },
+        engineConfig: { ffmpegEncodeTimeout: 600_000 },
+      }),
+    );
+
+    expect(encodeFramesFromDirMock.mock.calls[0]?.[5]).toEqual({
+      ffmpegEncodeTimeout: 1_325_092,
+    });
+  });
+
+  it("preserves a larger operator timeout for high-quality encoding", async () => {
+    const { runEncodeStage } = await import("./encodeStage.js");
+    const input = makeInput();
+    const operatorConfig = { ffmpegEncodeTimeout: 9_000_000 };
+
+    await runEncodeStage(
+      makeInput({
+        job: {
+          ...input.job,
+          config: { ...input.job.config, quality: "high" },
+          duration: 331.273,
+        },
+        engineConfig: operatorConfig,
+      }),
+    );
+
+    expect(encodeFramesFromDirMock.mock.calls[0]?.[5]).toBe(operatorConfig);
+  });
+
   it("prefers engine config supplied by the orchestrator", async () => {
     const { runEncodeStage } = await import("./encodeStage.js");
     const orchestratorEngineConfig = { ffmpegEncodeTimeout: 54_321 };

--- a/packages/producer/src/services/render/stages/encodeStage.ts
+++ b/packages/producer/src/services/render/stages/encodeStage.ts
@@ -289,9 +289,11 @@ export async function runEncodeStage(input: EncodeStageInput): Promise<EncodeSta
 
   // ffmpegEncodeTimeout is a total wall-clock cap, not an inactivity timeout.
   // A fixed ten-minute cap reliably kills long high-quality disk-frame encodes
-  // that are still making progress. Preserve larger operator overrides while
-  // guaranteeing four seconds of encode budget per second of source video.
-  const scaledEncodeTimeout = Math.ceil((job.duration ?? 0) * 4_000);
+  // that are still making progress. High-quality CPU presets are substantially
+  // slower, so reserve 24x source duration there while retaining the established
+  // 4x budget for draft/standard and preserving larger operator overrides.
+  const baseScaledEncodeTimeout = Math.ceil((job.duration ?? 0) * 4_000);
+  const scaledEncodeTimeout = baseScaledEncodeTimeout * (job.config.quality === "high" ? 6 : 1);
   const videoEngineCfg =
     scaledEncodeTimeout > engineCfg.ffmpegEncodeTimeout
       ? { ...engineCfg, ffmpegEncodeTimeout: scaledEncodeTimeout }


### PR DESCRIPTION
## What

Long high-quality disk-frame renders now receive a 24× source-duration FFmpeg budget instead of the draft/standard 4× budget. The reported 331.273-second render receives 7,950,552 ms rather than being killed at 1,325,092 ms.

## Why

High-quality CPU encoding can remain healthy and make progress beyond the quality-blind wall-clock estimate. Killing it after completed frame capture wastes the most expensive stage and removes the captured frames during normal cleanup.

Related: #2419

## How

The existing duration scaler remains the single timeout owner. High quality multiplies its established 4× budget by six; draft and standard stay unchanged. A larger `FFMPEG_ENCODE_TIMEOUT_MS` operator override still wins.

## Test plan

- [x] Exact 331.273-second high-quality regression receives 7,950,552 ms.
- [x] Standard-quality control remains at 1,325,092 ms.
- [x] Larger operator timeout remains unchanged.
- [x] Encode-stage suite passes (16/16).
- [x] Producer typecheck, oxlint, and oxfmt checks pass.
- [ ] Documentation updated (not applicable).
