### PR TITLE
fix(engine): preserve mono narration loudness

### DIFF
--- a/packages/engine/src/services/audioFxRender.ts
+++ b/packages/engine/src/services/audioFxRender.ts
@@ -61,6 +61,11 @@ function readWavChunks(buf: Buffer): {
       head.channels = buf.readUInt16LE(body + 2);
       head.sampleRate = buf.readUInt32LE(body + 4);
       head.bits = buf.readUInt16LE(body + 14);
+      // FFmpeg writes mono pcm_f32le as WAVE_FORMAT_EXTENSIBLE. Its subformat
+      // tag carries the actual PCM kind in the first two GUID bytes.
+      if (head.format === 0xfffe && size >= 40) {
+        head.format = buf.readUInt16LE(body + 24);
+      }
     } else if (id === "data") {
       data = buf.subarray(body, Math.min(buf.length, body + size));
       // The payload is the rest of the file for anything the mixer writes, and

--- a/packages/engine/src/services/audioMixer.level.test.ts
+++ b/packages/engine/src/services/audioMixer.level.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { getFfmpegBinary } from "../utils/ffmpegBinaries.js";
+import { getFfmpegBinary, getFfprobeBinary } from "../utils/ffmpegBinaries.js";
 import { MIXED_AUDIO_FILENAME, processCompositionAudio } from "./audioMixer.js";
 
 const HAS_FFMPEG = spawnSync(getFfmpegBinary(), ["-version"], { encoding: "utf-8" }).status === 0;
@@ -20,6 +20,42 @@ function meanVolumeDb(path: string): number {
     throw new Error(`Could not measure mean volume: ${result.stderr}`);
   }
   return Number(match[1]);
+}
+
+function integratedLoudness(path: string): number {
+  const result = spawnSync(
+    getFfmpegBinary(),
+    ["-nostdin", "-hide_banner", "-nostats", "-i", path, "-af", "ebur128", "-f", "null", "-"],
+    { encoding: "utf-8" },
+  );
+  const match = [...result.stderr.matchAll(/^\s*I:\s*(-?[\d.]+) LUFS$/gm)].at(-1)?.[1];
+  if (result.status !== 0 || match === undefined) {
+    throw new Error(`Could not measure integrated loudness: ${result.stderr}`);
+  }
+  return Number(match);
+}
+
+function channelCount(path: string): number {
+  const result = spawnSync(
+    getFfprobeBinary(),
+    [
+      "-v",
+      "error",
+      "-select_streams",
+      "a:0",
+      "-show_entries",
+      "stream=channels",
+      "-of",
+      "csv=p=0",
+      path,
+    ],
+    { encoding: "utf-8" },
+  );
+  const channels = Number(result.stdout.trim());
+  if (result.status !== 0 || !Number.isFinite(channels)) {
+    throw new Error(`Could not probe channel count: ${result.stderr}`);
+  }
+  return channels;
 }
 
 /** Seconds until the first sample loud enough to be signal rather than codec noise. */
@@ -65,7 +101,7 @@ describe.skipIf(!HAS_FFMPEG)(
       for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
     });
 
-    it("preserves the level of a mono source in the stereo mix", async () => {
+    it("preserves the mean level of a mono source", async () => {
       const projectDir = mkdtempSync(join(tmpdir(), "hf-mono-level-"));
       const workDir = mkdtempSync(join(tmpdir(), "hf-mono-work-"));
       tempDirs.push(projectDir, workDir);
@@ -112,6 +148,124 @@ describe.skipIf(!HAS_FFMPEG)(
 
       expect(result.success).toBe(true);
       expect(meanVolumeDb(outputPath) - meanVolumeDb(sourcePath)).toBeGreaterThan(-0.3);
+    });
+
+    it("preserves mono-only integrated loudness and channel layout", async () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "hf-mono-loudness-"));
+      const workDir = mkdtempSync(join(tmpdir(), "hf-mono-loudness-work-"));
+      tempDirs.push(projectDir, workDir);
+      const sourcePath = join(projectDir, "narration.wav");
+      const outputPath = join(projectDir, MIXED_AUDIO_FILENAME);
+      const setup = spawnSync(
+        getFfmpegBinary(),
+        [
+          "-nostdin",
+          "-v",
+          "error",
+          "-f",
+          "lavfi",
+          "-i",
+          "sine=frequency=440:duration=1:sample_rate=48000",
+          "-ac",
+          "1",
+          "-c:a",
+          "pcm_s16le",
+          sourcePath,
+        ],
+        { encoding: "utf-8" },
+      );
+      expect(setup.status, setup.stderr).toBe(0);
+
+      const result = await processCompositionAudio(
+        [
+          {
+            id: "narration",
+            src: "narration.wav",
+            start: 0,
+            end: 1,
+            mediaStart: 0,
+            layer: 0,
+            volume: 1,
+            type: "audio",
+          },
+        ],
+        projectDir,
+        workDir,
+        outputPath,
+        1,
+      );
+
+      expect(result.success).toBe(true);
+      expect(channelCount(outputPath)).toBe(1);
+      expect(
+        Math.abs(integratedLoudness(outputPath) - integratedLoudness(sourcePath)),
+      ).toBeLessThan(0.5);
+    });
+
+    it("keeps unity mono amplitude when a native stereo track requires stereo output", async () => {
+      const projectDir = mkdtempSync(join(tmpdir(), "hf-mixed-layout-"));
+      const workDir = mkdtempSync(join(tmpdir(), "hf-mixed-layout-work-"));
+      tempDirs.push(projectDir, workDir);
+      const monoPath = join(projectDir, "voice.wav");
+      const stereoPath = join(projectDir, "silent-stereo.wav");
+      const outputPath = join(projectDir, MIXED_AUDIO_FILENAME);
+      for (const [source, filter, channels] of [
+        [monoPath, "sine=frequency=1000:duration=1:sample_rate=48000", "1"],
+        [stereoPath, "anullsrc=r=48000:cl=stereo", "2"],
+      ] as const) {
+        const setup = spawnSync(
+          getFfmpegBinary(),
+          [
+            "-nostdin",
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            filter,
+            "-t",
+            "1",
+            "-ac",
+            channels,
+            source,
+          ],
+          { encoding: "utf-8" },
+        );
+        expect(setup.status, setup.stderr).toBe(0);
+      }
+
+      const result = await processCompositionAudio(
+        [
+          {
+            id: "voice",
+            src: "voice.wav",
+            start: 0,
+            end: 1,
+            mediaStart: 0,
+            layer: 0,
+            volume: 1,
+            type: "audio",
+          },
+          {
+            id: "bed",
+            src: "silent-stereo.wav",
+            start: 0,
+            end: 1,
+            mediaStart: 0,
+            layer: 1,
+            volume: 1,
+            type: "audio",
+          },
+        ],
+        projectDir,
+        workDir,
+        outputPath,
+        1,
+      );
+
+      expect(result.success).toBe(true);
+      expect(channelCount(outputPath)).toBe(2);
+      expect(meanVolumeDb(outputPath) - meanVolumeDb(monoPath)).toBeGreaterThan(-0.3);
     });
 
     it("places a delayed track on its authored start, not one AAC frame later", async () => {

--- a/packages/engine/src/services/audioMixer.ts
+++ b/packages/engine/src/services/audioMixer.ts
@@ -129,8 +129,11 @@ function buildAtempoFilter(playbackRate: number): string | null {
   return stages.map((stage) => `atempo=${formatFilterNumber(stage)}`).join(",");
 }
 
-function preparedAudioOutputArgs(srcPath: string, playbackRate: number): Promise<string[]> {
-  return stereoOutputArgs(srcPath).then((channelArgs) => {
+function preparedAudioOutputArgs(
+  srcPath: string,
+  playbackRate: number,
+): Promise<{ args: string[]; channels: number }> {
+  return sourceChannelOutputArgs(srcPath).then(({ channelArgs, channels }) => {
     const filters: string[] = [];
     const outputArgs: string[] = [];
     if (channelArgs[0] === "-af" && channelArgs[1]) {
@@ -141,7 +144,7 @@ function preparedAudioOutputArgs(srcPath: string, playbackRate: number): Promise
     const atempo = buildAtempoFilter(playbackRate);
     if (atempo) filters.push(atempo);
     if (filters.length > 0) outputArgs.push("-af", filters.join(","));
-    return outputArgs;
+    return { args: outputArgs, channels };
   });
 }
 
@@ -178,19 +181,28 @@ const MAX_VOLUME_SEGMENTS = 32;
  */
 const VOLUME_SIMPLIFY_EPSILON = 0.005;
 
-// `-ac 2` uses FFmpeg's default mono-to-stereo rematrix, which attenuates a
-// mono source by 3 dB. Explicitly map front-center into both stereo channels;
-// native stereo sources have FL/FR and pass through unchanged.
+// Mono stays mono until the mixer knows whether any track requires stereo.
+// When stereo is required, the final mix applies this unity map so preview's
+// per-channel amplitude contract remains intact without inflating mono-only
+// programme loudness by 3 LU.
 const STEREO_CHANNEL_FILTER = "pan=stereo|FL=FL+FC|FR=FR+FC";
 
-async function stereoOutputArgs(srcPath: string): Promise<string[]> {
+async function sourceChannelOutputArgs(
+  srcPath: string,
+): Promise<{ channelArgs: string[]; channels: number }> {
   try {
     const { channels } = await extractAudioMetadata(srcPath);
-    if (channels === 1) return ["-af", STEREO_CHANNEL_FILTER];
+    if (channels === 1) return { channelArgs: [], channels: 1 };
   } catch {
     // Preserve the previous FFmpeg conversion path when metadata probing fails.
   }
-  return ["-ac", "2"];
+  return { channelArgs: ["-ac", "2"], channels: 2 };
+}
+
+function mixInputChannelFilter(tracks: readonly AudioTrack[], index: number): string {
+  const track = tracks[index];
+  if (!track || track.channels !== 1) return "";
+  return tracks.some((candidate) => candidate.channels > 1) ? `,${STEREO_CHANNEL_FILTER}` : "";
 }
 
 /**
@@ -308,6 +320,7 @@ interface ExtractResult {
   durationMs: number;
   error?: string;
   failure?: AudioProcessingFailure;
+  channels?: number;
 }
 
 function boundedDetail(message: string, maxLength = 2_000): string {
@@ -598,8 +611,8 @@ async function extractAudioFromVideo(
   if (options?.startTime !== undefined) args.push("-ss", String(options.startTime));
   if (options?.duration !== undefined) args.push("-t", String(options.duration * playbackRate));
   args.push("-i", videoPath);
-  const outputArgs = await preparedAudioOutputArgs(videoPath, playbackRate);
-  args.push("-vn", "-acodec", "pcm_s16le", "-ar", "48000", ...outputArgs);
+  const preparedOutput = await preparedAudioOutputArgs(videoPath, playbackRate);
+  args.push("-vn", "-acodec", "pcm_s16le", "-ar", "48000", ...preparedOutput.args);
   if (playbackRate !== 1 && options?.duration !== undefined) {
     args.push("-t", String(options.duration));
   }
@@ -633,7 +646,12 @@ async function extractAudioFromVideo(
       failure,
     };
   }
-  return { success: true, outputPath, durationMs: result.durationMs };
+  return {
+    success: true,
+    outputPath,
+    durationMs: result.durationMs,
+    channels: preparedOutput.channels,
+  };
 }
 
 async function prepareAudioTrack(
@@ -649,7 +667,7 @@ async function prepareAudioTrack(
   const outputDir = dirname(outputPath);
   if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
   const normalizedPlaybackRate = normalizePlaybackRate(playbackRate);
-  const outputArgs = await preparedAudioOutputArgs(srcPath, normalizedPlaybackRate);
+  const preparedOutput = await preparedAudioOutputArgs(srcPath, normalizedPlaybackRate);
 
   const args = [
     "-ss",
@@ -662,7 +680,7 @@ async function prepareAudioTrack(
     "pcm_s16le",
     "-ar",
     "48000",
-    ...outputArgs,
+    ...preparedOutput.args,
   ];
   if (normalizedPlaybackRate !== 1) args.push("-t", String(duration));
   args.push("-y", outputPath);
@@ -692,6 +710,7 @@ async function prepareAudioTrack(
     durationMs: result.durationMs,
     error: failure?.detail,
     failure,
+    channels: preparedOutput.channels,
   };
 }
 
@@ -781,6 +800,7 @@ async function mixAudioTracks(
       // can run over what follows but never past the end of the video.
       const trimDuration = track.end - track.start + (track.tailSeconds ?? 0);
       const volumeFilter = buildVolumeExpression(track, ignoreAutomation);
+      const channelFilter = mixInputChannelFilter(tracks, i);
       // `apad` then `atrim` is the portable pad-to-length shape: PR #2769 moved
       // off `apad=whole_dur=` because some FFmpeg builds reject that option
       // outright ("Error applying option 'whole_dur': Option not found").
@@ -793,7 +813,7 @@ async function mixAudioTracks(
       // 7.0.2, an 8.x nightly and 8.1.1; the un-reset form is wrong on the
       // middle two.
       filterParts.push(
-        `[${i}:a]atrim=0:${formatFilterNumber(trimDuration)},${volumeFilter},adelay=${delayMs}|${delayMs},apad,asetpts=N/SR/TB,atrim=0:${formatFilterNumber(totalDuration)}[a${i}]`,
+        `[${i}:a]atrim=0:${formatFilterNumber(trimDuration)},${volumeFilter}${channelFilter},adelay=${delayMs}|${delayMs},apad,asetpts=N/SR/TB,atrim=0:${formatFilterNumber(totalDuration)}[a${i}]`,
       );
     });
 
@@ -965,11 +985,12 @@ async function mixGroupMembers(
       const delayMs = Math.round(track.start * 1000);
       const trimDuration = track.end - track.start + (track.tailSeconds ?? 0);
       const volumeFilter = buildVolumeExpression(track, ignoreKeyframes);
+      const channelFilter = mixInputChannelFilter(memberTracks, i);
       // Same `asetpts=N/SR/TB` as the master mix above, for the same reason and
       // on the same builds: these are delayed branches padded to length and then
       // amix'd, so without the renumbering a delayed member lands at t=0 and a
       // group of four or more loses its last one.
-      return `[${i}:a]atrim=0:${formatFilterNumber(trimDuration)},${volumeFilter},adelay=${delayMs}|${delayMs},apad,asetpts=N/SR/TB,atrim=0:${formatFilterNumber(totalDuration)}[a${i}]`;
+      return `[${i}:a]atrim=0:${formatFilterNumber(trimDuration)},${volumeFilter}${channelFilter},adelay=${delayMs}|${delayMs},apad,asetpts=N/SR/TB,atrim=0:${formatFilterNumber(totalDuration)}[a${i}]`;
     });
   const mixInputs = memberTracks.map((_, i) => `[a${i}]`).join("");
 
@@ -1192,6 +1213,7 @@ export async function processCompositionAudio(
         }
 
         let audioSrcPath = srcPath;
+        let preparedChannels = 2;
         if (element.type === "video") {
           const extractedPath = join(workDir, `${element.id}-extracted.wav`);
           const extractResult = await extractAudioFromVideo(
@@ -1221,6 +1243,7 @@ export async function processCompositionAudio(
             return;
           }
           audioSrcPath = extractedPath;
+          preparedChannels = extractResult.channels ?? 2;
         } else {
           const trimmedPath = join(workDir, `${element.id}-trimmed.wav`);
           const prepResult = await prepareAudioTrack(
@@ -1248,6 +1271,7 @@ export async function processCompositionAudio(
             return;
           }
           audioSrcPath = trimmedPath;
+          preparedChannels = prepResult.channels ?? 2;
         }
 
         // Apply the track's FX chain to the dry, trimmed audio, before volume
@@ -1327,6 +1351,7 @@ export async function processCompositionAudio(
           end: element.end,
           mediaStart: element.mediaStart,
           duration: element.end - element.start,
+          channels: preparedChannels,
           // Gain is already in the samples when baked, so mix at unity.
           volume: bakedEnvelope ? 1.0 : (element.volume ?? 1.0),
           volumeKeyframes: bakedEnvelope ? undefined : (envelopeKeyframes ?? undefined),
@@ -1503,6 +1528,7 @@ export async function processCompositionAudio(
         end: totalDuration,
         mediaStart: 0,
         duration: totalDuration,
+        channels: memberTracks.some((track) => track.channels > 1) ? 2 : 1,
         volume: bakedEnvelope ? 1.0 : meta.volume,
         // Same fallback an ungrouped track gets: when the envelope could not be
         // baked into the samples, hand the keyframes to the outer mix's volume

--- a/packages/engine/src/services/audioMixer.types.ts
+++ b/packages/engine/src/services/audioMixer.types.ts
@@ -40,6 +40,8 @@ export interface AudioTrack {
   end: number;
   mediaStart: number;
   duration: number;
+  /** Prepared PCM channel count. Mono is preserved until the final mix. */
+  channels: number;
   volume: number;
   volumeKeyframes?: AudioVolumeKeyframe[];
   /**


### PR DESCRIPTION
## What

Mono-only renders now keep a mono delivery channel and preserve source integrated loudness. Mixed sessions still produce stereo when any native-stereo track requires it, with the existing unity mono amplitude preserved in that stereo mix.

## Why

The mixer previously duplicated every mono source into left and right at unity before it knew the final layout. That preserved per-channel amplitude but raised mono-only programme loudness by about 3 LU, turning a measured -21.8 LUFS narration into approximately -18.8 LUFS delivery.

Related: #2392

## How

Prepared tracks retain their channel count until the final mix. Mono is upmixed with the established unity pan only when another input requires stereo; otherwise the AAC sidecar remains mono. Mono float group buses are decoded through their WAVE_FORMAT_EXTENSIBLE subtype so group FX retain the same channel-preserving path.

## Test plan

- [x] Real FFmpeg test preserves mono-only channel count and integrated loudness within 0.5 LU.
- [x] Mixed mono/native-stereo control preserves stereo output and mono mean amplitude.
- [x] Main mixer suite passes (61/61).
- [x] Level and grouping suites pass (16/16), including group FX and over-unity float buses.
- [x] Engine typecheck, oxlint, and oxfmt checks pass.
- [ ] Documentation updated (not applicable).
