### PR TITLE
fix(runtime): wait for a finite dotlottie duration

### DIFF
--- a/packages/core/src/runtime/adapters/lottie.test.ts
+++ b/packages/core/src/runtime/adapters/lottie.test.ts
@@ -109,6 +109,30 @@ describe("lottie adapter", () => {
       expect(player.setCurrentRawFrameValue).toHaveBeenCalledWith(59);
     });
 
+    it.each([0, -1, NaN, Infinity, undefined])(
+      "does not seek a dotlottie v1 player with duration %s",
+      (duration) => {
+        const player = { pause: vi.fn(), seek: vi.fn(), duration };
+        lottieWindow.__hfLottie = [player];
+        const adapter = createLottieAdapter();
+        adapter.seek({ time: 0 });
+        adapter.seek({ time: 1 });
+        expect(player.seek).not.toHaveBeenCalled();
+      },
+    );
+
+    it("seeks a dotlottie v1 player once its duration becomes available", () => {
+      const player = { pause: vi.fn(), seek: vi.fn(), duration: 0 };
+      lottieWindow.__hfLottie = [player];
+      const adapter = createLottieAdapter();
+      adapter.seek({ time: 0 });
+      player.duration = 2;
+      adapter.seek({ time: 1 });
+      adapter.seek({ time: -1 });
+      adapter.seek({ time: 3 });
+      expect(player.seek.mock.calls).toEqual([[50], [0], [100]]);
+    });
+
     it("does nothing with no instances", () => {
       const adapter = createLottieAdapter();
       expect(() => adapter.seek({ time: 1 })).not.toThrow();

--- a/packages/core/src/runtime/adapters/lottie.ts
+++ b/packages/core/src/runtime/adapters/lottie.ts
@@ -103,9 +103,11 @@ export function createLottieAdapter(): RuntimeDeterministicAdapter {
               }
             } else if (typeof anim.seek === "function") {
               // dotlottie-web v1: seek(percentage 0-100)
-              const duration = anim.duration ?? 1;
-              const percentage = Math.min(100, (time / duration) * 100);
-              anim.seek(percentage);
+              const duration = anim.duration ?? 0;
+              if (Number.isFinite(duration) && duration > 0) {
+                const percentage = Math.min(100, (time / duration) * 100);
+                anim.seek(percentage);
+              }
             }
           }
         } catch (err) {


### PR DESCRIPTION
A dotlottie v1 player reporting zero duration could receive `seek(NaN)` at time zero and blank its first frame. Wait for a positive finite duration before seeking, then preserve the existing percentage clamping.

Builds on #1577 by @calcarazgre646, refreshed against current main with invalid-duration and delayed-load coverage.

Validation: regression tests failed before the fix; all 171 adapter tests pass, runtime typecheck passes, and all pre-commit checks pass.
