### PR TITLE
fix(studio-server): cascade GSAP cleanup when deleting subtrees

### DIFF
--- a/packages/parsers/src/htmlParser.test.ts
+++ b/packages/parsers/src/htmlParser.test.ts
@@ -580,6 +580,19 @@ describe("removeElementFromHtml", () => {
     expect(updated).toContain('id="el2"');
   });
 
+  it("cascades DOM and stable ids for every descendant", () => {
+    const html = `<!doctype html><html><body>
+      <div id="parent"><div id="box" data-hf-id="hf-box"></div></div>
+      <script>const tl = gsap.timeline();
+        tl.to("#parent", { x: 10 }); tl.to("#box", { x: 20 });
+        tl.to('[data-hf-id="hf-box"]', { x: 30 });
+      </script></body></html>`;
+    const updated = removeElementFromHtml(html, "parent");
+    expect(updated).not.toContain("#parent");
+    expect(updated).not.toContain("#box");
+    expect(updated).not.toContain("hf-box");
+  });
+
   it("strips ALL gsap tweens for the removed element, not just the first", () => {
     // Two tweens on the same element → count-based ids renumber when the first is
     // removed, so a single up-front parse left the second tween orphaned.

--- a/packages/parsers/src/htmlParser.ts
+++ b/packages/parsers/src/htmlParser.ts
@@ -725,41 +725,47 @@ export function addElementToHtml(
   };
 }
 
-function selectorTargetsId(selector: string, id: string): boolean {
-  return (
-    selector === `#${id}` ||
-    selector === `[data-hf-id="${id}"]` ||
-    selector === `[data-hf-id='${id}']`
-  );
+function elementSelectors(element: Element): string[] {
+  const selectors: string[] = [];
+  const id = element.getAttribute("id");
+  const hfId = element.getAttribute("data-hf-id");
+  if (id) selectors.push(`#${id}`);
+  if (hfId) selectors.push(`[data-hf-id="${hfId}"]`, `[data-hf-id='${hfId}']`);
+  return selectors;
 }
 
-function stripGsapForId(script: string, elementId: string): string {
-  // Re-parse after every removal. Animation ids are count-based (positional), so
-  // removing one tween renumbers the survivors — ids captured from a single
-  // up-front parse go stale and silently no-op, orphaning later tweens on the
-  // now-deleted element. Always remove the FIRST still-matching animation in a
-  // freshly-parsed script until none remain.
-  let current = script;
-  for (;;) {
-    const parsed = parseGsapScriptAcornForWrite(current);
-    if (!parsed) return current;
-    const match = parsed.located.find((l) =>
-      selectorTargetsId(l.animation.targetSelector, elementId),
-    );
-    if (!match) return current;
-    const updated = removeAnimationFromScript(current, match.id);
-    // Guard against a non-removing match (would otherwise loop forever).
-    if (updated === current) return current;
-    current = updated;
-  }
-}
+/** Remove a source subtree and its unambiguous, directly targeted GSAP tweens. */
+export function removeElementWithGsapCascade(doc: Document, element: Element): void {
+  const removedSelectors = new Set(elementSelectors(element));
+  walkCompositionDescendants(element, (child) => {
+    for (const selector of elementSelectors(child)) removedSelectors.add(selector);
+  });
+  element.remove();
 
-function cascadeRemoveGsapById(doc: Document, elementId: string): void {
+  // Bare selectors can target repeated sub-composition instances. Keep a tween
+  // if any surviving element still uses its selector rather than erasing the
+  // surviving instance's animation along with the deleted subtree.
+  walkCompositionDescendants(doc, (survivor) => {
+    for (const selector of elementSelectors(survivor)) removedSelectors.delete(selector);
+  });
+  if (removedSelectors.size === 0) return;
+
   for (const script of findScriptElementsDeep(doc)) {
-    const text = script.textContent ?? "";
-    if (!text.includes("gsap") && !text.includes("ScrollTrigger")) continue;
-    const updated = stripGsapForId(text, elementId);
-    if (updated !== text) script.textContent = updated;
+    let current = script.textContent ?? "";
+    if (!current.includes("gsap") && !current.includes("ScrollTrigger")) continue;
+    // Writer ids are positional: reparse after each removal so later tweens
+    // cannot be skipped after an earlier deletion renumbers them.
+    for (;;) {
+      const parsed = parseGsapScriptAcornForWrite(current);
+      const match = parsed?.located.find((located) =>
+        removedSelectors.has(located.animation.targetSelector),
+      );
+      if (!match) break;
+      const updated = removeAnimationFromScript(current, match.id);
+      if (updated === current) break;
+      current = updated;
+    }
+    if (current !== script.textContent) script.textContent = current;
   }
 }
 
@@ -771,8 +777,8 @@ export function removeElementFromHtml(html: string, elementId: string): string {
       "removeElementFromHtml: input HTML is empty or could not be parsed",
     );
   }
-  doc.getElementById(elementId)?.remove();
-  cascadeRemoveGsapById(doc, elementId);
+  const element = doc.getElementById(elementId);
+  if (element) removeElementWithGsapCascade(doc, element);
   return "<!DOCTYPE html>\n" + doc.documentElement.outerHTML;
 }
 

--- a/packages/studio-server/src/helpers/sourceMutation.test.ts
+++ b/packages/studio-server/src/helpers/sourceMutation.test.ts
@@ -28,6 +28,55 @@ describe("removeElementFromHtml", () => {
     expect(updated).toContain(`data-composition-id="scene-b"`);
   });
 
+  it("removes tweens for both DOM ids and stable ids throughout the deleted subtree", () => {
+    const html = `<!doctype html><html><body>
+      <div id="parent"><div id="box" data-hf-id="hf-box"><span id="leaf"></span></div></div>
+      <div id="keep"></div>
+      <script>
+        const tl = gsap.timeline({ paused: true });
+        tl.to("#parent", { x: 10 });
+        tl.to("#box", { x: 20 });
+        tl.to('[data-hf-id="hf-box"]', { x: 30 });
+        tl.to("#leaf", { x: 40 });
+        tl.to("#box", { x: 50 });
+        tl.to("#keep", { x: 60 });
+      </script></body></html>`;
+    const updated = removeElementFromHtml(html, { id: "parent" });
+    expect(updated).not.toContain("#parent");
+    expect(updated).not.toContain("#box");
+    expect(updated).not.toContain("hf-box");
+    expect(updated).not.toContain("#leaf");
+    expect(updated).toContain('tl.to("#keep", { x: 60 })');
+  });
+
+  it("cascades a stable-id deletion into nested composition template scripts", () => {
+    const html = `<div id="box" data-hf-id="hf-box"></div>
+      <template data-composition-id="outer"><template data-composition-id="inner">
+        <script>const tl = gsap.timeline(); tl.to("#box", { x: 10 });</script>
+      </template></template>`;
+    const updated = removeElementFromHtml(html, { hfId: "hf-box" });
+    expect(updated).not.toContain("#box");
+    expect(updated).not.toContain('id="box"');
+  });
+
+  it("retains shared selectors used by a surviving composition instance", () => {
+    const html = `<div data-hf-id="remove"><span id="box" data-hf-id="hf-box"></span></div>
+      <template data-composition-id="keep"><div id="box" data-hf-id="hf-box"></div>
+        <script>const tl = gsap.timeline();
+          tl.to("#box", { x: 10 }); tl.to('[data-hf-id="hf-box"]', { x: 20 });
+        </script>
+      </template>`;
+    const updated = removeElementFromHtml(html, { hfId: "remove" });
+    expect(updated).not.toContain('data-hf-id="remove"');
+    expect(updated).toContain('tl.to("#box", { x: 10 })');
+    expect(updated).toContain(`tl.to('[data-hf-id="hf-box"]', { x: 20 })`);
+  });
+
+  it("does not strip scripts when the requested element is absent", () => {
+    const html = `<script>const tl = gsap.timeline(); tl.to("#missing", { x: 10 });</script>`;
+    expect(removeElementFromHtml(html, { id: "missing" })).toBe(html);
+  });
+
   it("supports fragment html by returning updated body markup", () => {
     const html = `<div id="photo"></div><div id="rest"></div>`;
 

--- a/packages/studio-server/src/helpers/sourceMutation.ts
+++ b/packages/studio-server/src/helpers/sourceMutation.ts
@@ -1,4 +1,5 @@
 import { parseHTML } from "linkedom";
+import { removeElementWithGsapCascade } from "@hyperframes/parsers";
 import postcss from "postcss";
 import selectorParser from "postcss-selector-parser";
 import { isAllowedHtmlAttribute, isSafeAttributeValue } from "@hyperframes/core/html-attr-safety";
@@ -132,7 +133,7 @@ export function removeElementFromHtml(source: string, target: SourceMutationTarg
   const element = findTargetElement(document, target);
   if (!element) return source;
 
-  element.remove();
+  removeElementWithGsapCascade(document, element);
   return wrappedFragment ? document.body.innerHTML || "" : document.toString();
 }
 

--- a/packages/studio/src/hooks/useElementLifecycleOps.ts
+++ b/packages/studio/src/hooks/useElementLifecycleOps.ts
@@ -180,12 +180,6 @@ export function useElementLifecycleOps({
         }
         const patchedContent =
           typeof removeData.content === "string" ? removeData.content : originalContent;
-        // ponytail: the server remove-element route (removeElementFromHtml) strips
-        // only the element node — it does NOT cascade-remove GSAP tweens targeting
-        // it, unlike the SDK path (removeElement → cascadeRemoveAnimations). This
-        // fallback runs only when the element isn't in the SDK doc (e.g. runtime-
-        // generated / unaddressable), where targeting tweens are unlikely. Upgrade
-        // path: cascade in removeElementFromHtml by selector/hf-id to fully match.
         await saveProjectFilesWithHistory({
           projectId: pid,
           label: "Delete element",


### PR DESCRIPTION
Deleting a parent through Studio's server fallback left its GSAP tweens and descendant tweens in the source. Share subtree cleanup with the HTML parser, matching each element's DOM id and stable id and visiting nested composition-template scripts. Reparse after each removal so multiple tweens are all removed.

If a selector still matches a surviving element, retain its animations to protect repeated composition instances. This intentionally handles direct id/stable-id selectors; broad or computed selectors remain unchanged. SDK undo/redo behavior is unchanged.

Builds on #1566 by @vanceingalls, updated for the parser/server package split.

Validation: 197 targeted parser/source-mutation/file-route tests passed (2 existing todo); parser and studio-server typechecks, oxlint/oxfmt, and commit hooks passed.
