### PR TITLE
fix(captions): preserve zero plate grain in generated postfx

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -2,7 +2,7 @@
   "source": "heygen-com/hyperframes",
   "skills": {
     "embedded-captions": {
-      "hash": "1f29e0f6c77da4f5",
+      "hash": "1677ab00946eb80c",
       "files": 142
     },
     "faceless-explainer": {

--- a/skills/embedded-captions/scripts/make-theme.cjs
+++ b/skills/embedded-captions/scripts/make-theme.cjs
@@ -8574,7 +8574,9 @@ if (!bodyInBg || fx.html || fx.js || setp.fgHtml) {
 }
 
 // _postfx.sh: plate reaction after the matte composite (subject+text move as one)
-const P = HEROLESS ? { grain: (dna.plate || {}).grain || 5 } : dna.plate || {};
+const P = HEROLESS ? { grain: dna.plate?.grain ?? 5 } : dna.plate || {};
+const grain = P.grain ?? 5;
+const noise = grain === 0 ? "" : `,noise=alls=${grain}:allf=t+u`;
 // punchOffset: themes whose impact is NOT the hero onset (e.g. flapboard's
 // lock-complete clack) shift the plate punch anchor; default keeps onset+2f
 const anchorT = (heroIn + (P.punchOffset ?? 0.045)).toFixed(3);
@@ -8606,8 +8608,7 @@ fs.writeFileSync(
 set -euo pipefail
 cd "$(dirname "$0")"
 ffmpeg -y -v error -i final.mp4 -filter_complex "
-  [0:v]${filter}${rgba},
-  noise=alls=${P.grain || 5}:allf=t+u[v]" \\
+  [0:v]${filter}${rgba}${noise}[v]" \\
   -map "[v]" -map 0:a -c:v libx264 -crf 14 -preset slow -profile:v high -c:a copy \\
   final_fx.mp4
 echo "[postfx] ${dna.name} → final_fx.mp4"

--- a/skills/embedded-captions/scripts/make-theme.test.mjs
+++ b/skills/embedded-captions/scripts/make-theme.test.mjs
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { cpSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import test from "node:test";
@@ -80,3 +88,44 @@ test("every embedded-caption theme compiles a sane heroless body timeline", asyn
     });
   }
 });
+
+for (const heroless of [false, true]) {
+  for (const grain of [0, 3, undefined]) {
+    test(`postfx preserves grain ${grain} with heroless=${heroless}`, (t) => {
+      const workspace = mkdtempSync(join(tmpdir(), "embedded-captions-grain-"));
+      t.after(() => rmSync(workspace, { recursive: true, force: true }));
+      const project = join(workspace, "project");
+      cpSync(fixturesDir, project, { recursive: true });
+      mkdirSync(join(workspace, "scripts"));
+      mkdirSync(join(workspace, "themes"));
+      const compiler = join(workspace, "scripts", "make-theme.cjs");
+      cpSync(makeTheme, compiler);
+      const dna = JSON.parse(readFileSync(join(skillDir, "themes", "anchor.json"), "utf8"));
+      dna.plate.grain = grain;
+      writeFileSync(join(workspace, "themes", "anchor.json"), JSON.stringify(dna));
+      writeFileSync(
+        join(project, "theme.json"),
+        JSON.stringify({
+          ...fixtureTheme,
+          dna: "anchor",
+          ...(heroless
+            ? {}
+            : {
+                hero: { match: "hero" },
+                lines: fixtureTheme.lines.map((line) => line.filter((word) => word !== "hero")),
+              }),
+        }),
+      );
+      const result = spawnSync(process.execPath, [compiler, project], {
+        encoding: "utf8",
+        timeout: 10_000,
+      });
+      assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+      const postfx = readFileSync(join(project, "_postfx.sh"), "utf8");
+      if (grain === 0) assert.doesNotMatch(postfx, /noise=/);
+      else assert.match(postfx, new RegExp(`noise=alls=${grain ?? 5}:allf=t\\+u`));
+      assert.doesNotMatch(postfx, /,\s*\[v\]/);
+      assert.match(postfx, heroless ? /\[0:v\]null/ : /zoompan=/);
+    });
+  }
+}


### PR DESCRIPTION
Themes specifying `plate.grain: 0` still received the default FFmpeg noise filter. Preserve zero for both regular and heroless themes and omit noise entirely, while keeping level 5 when grain is absent.

Builds on #3032 by @miguel-heygen, updated for the heroless compiler changes in #3632. Regenerates the skills manifest.

Validation: both zero-grain regressions fail before the fix; all 586 skill tests pass, including six postfx cases and all 25 heroless themes. Syntax, changed-file lint/format, manifest sync, and pre-commit checks pass.
