### PR TITLE
feat(audio): add deterministic music ducking helper

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -122,6 +122,7 @@
         "@types/jsdom": "^28.0.0",
         "@types/node": "^25.0.10",
         "@vitest/coverage-v8": "^3.2.4",
+        "gsap": "^3.15.0",
         "jsdom": "^29.0.0",
         "tsx": "^4.21.0",
         "typescript": "^5.0.0",

--- a/docs/packages/core.mdx
+++ b/docs/packages/core.mdx
@@ -134,6 +134,37 @@ if (!result.isValid) {
 For the full composition lint result, use [`@hyperframes/lint`](/packages/lint)
 or run `npx hyperframes lint`.
 
+## Lower music under speech
+
+`duck()` adds music volume ramps around voice clips on your paused GSAP timeline:
+
+```ts
+import { duck } from "@hyperframes/core";
+
+const timeline = gsap.timeline({ paused: true });
+const music = document.querySelector<HTMLAudioElement>("#music");
+const voice = document.querySelector<HTMLAudioElement>("#voice");
+if (music && voice) {
+  duck(music, voice, { timeline, amount: "-12dB", fade: 0.3 });
+}
+window.__timelines["my-composition"] = timeline;
+```
+
+Pass media elements with resolved composition timing (`data-start` and
+`data-duration` or `data-end`). When duration comes from loaded media metadata,
+source trimming and playback rate are respected. Register the timeline under
+your composition ID so preview and export can probe its volume changes.
+
+`amount` accepts a linear multiplier or a dB string; `fade` is seconds on each
+side of speech. Both default to the values shown above. With `fade: 0`, timeline
+changes use steps; the returned linear envelope represents each step across one
+microsecond. Preview and export still use their existing sampling resolution.
+
+Plain timing objects (`{ start, duration, volume }`) return composition-time
+keyframes for offline use. They do not change playback. Ducking owns the music
+volume during its generated windows; avoid overlapping hand-authored volume
+tweens on the same track.
+
 ## Build a frame adapter
 
 Frame adapters make an animation runtime seekable by frame. Core includes the

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -687,6 +687,7 @@
     "@types/jsdom": "^28.0.0",
     "@types/node": "^25.0.10",
     "@vitest/coverage-v8": "^3.2.4",
+    "gsap": "^3.15.0",
     "jsdom": "^29.0.0",
     "tsx": "^4.21.0",
     "typescript": "^5.0.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -293,6 +293,14 @@ export { formatRenderOutputTimestamp } from "./utils/renderOutputTimestamp.js";
 // Runtime helpers (composition-side)
 export { getVariables } from "./runtime/getVariables.js";
 export {
+  duck,
+  type DuckAmount,
+  type DuckOptions,
+  type DuckTimelineLike,
+  type DuckTrack,
+  type DuckTrackTiming,
+} from "./runtime/audioDucking.js";
+export {
   parseStartExpression,
   parseNumeric,
   type ReferenceExpression,

--- a/packages/core/src/runtime/audioDucking.test.ts
+++ b/packages/core/src/runtime/audioDucking.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from "vitest";
+import { gsap } from "gsap";
+import { probeAndCacheElementVolume, probeElementVolumeKeyframes } from "./mediaVolumeEnvelope.js";
+import { refreshRuntimeMediaCache, syncRuntimeMedia } from "./media.js";
+import {
+  duck,
+  type DuckTimelineLike,
+  type DuckTrack,
+  type DuckTrackTiming,
+} from "./audioDucking.js";
+import { interpolateVolumeGain, normaliseEnvelope } from "./mediaVolumeEnvelope.js";
+
+interface TimelineOp {
+  kind: "set" | "to";
+  target: DuckTrack;
+  at: number | undefined;
+  volume: number;
+  duration?: number;
+  ease?: "none";
+  overwrite?: false;
+}
+
+function recordingTimeline(ops: TimelineOp[]): DuckTimelineLike {
+  return {
+    set(target, vars, at) {
+      ops.push({ kind: "set", target, at, volume: vars.volume });
+    },
+    to(target, vars, at) {
+      ops.push({
+        kind: "to",
+        target,
+        at,
+        volume: vars.volume,
+        duration: vars.duration,
+        ease: vars.ease,
+        overwrite: vars.overwrite,
+      });
+    },
+  };
+}
+
+function audioTrack(start: number, duration: number, volume = 1): DuckTrackTiming {
+  return { start, duration, volume };
+}
+
+function requireOp(ops: TimelineOp[], index: number): TimelineOp {
+  const op = ops[index];
+  expect(op).toBeDefined();
+  if (!op) throw new Error(`Missing timeline op ${index}`);
+  return op;
+}
+
+describe("duck", () => {
+  it("generates volume ramps around voice overlaps", () => {
+    const keyframes = duck(audioTrack(0, 8, 0.8), audioTrack(2, 2), {
+      amount: "-12dB",
+      fade: 0.5,
+    });
+
+    expect(keyframes.map((kf) => kf.time)).toEqual([1.5, 2, 4, 4.5]);
+    expect(keyframes[0]?.volume).toBe(0.8);
+    expect(keyframes[1]?.volume).toBeCloseTo(0.20095, 5);
+    expect(keyframes[2]?.volume).toBeCloseTo(0.20095, 5);
+    expect(keyframes[3]?.volume).toBe(0.8);
+  });
+
+  it("writes generated ramps to a timeline", () => {
+    const music = audioTrack(0, 8, 0.8);
+    const voice = audioTrack(2, 2);
+    const ops: TimelineOp[] = [];
+
+    duck(music, voice, {
+      timeline: recordingTimeline(ops),
+      amount: "-12dB",
+      fade: 0.5,
+    });
+
+    expect(ops).toHaveLength(4);
+    expect(requireOp(ops, 0)).toMatchObject({ kind: "set", target: music, at: 1.5, volume: 0.8 });
+    expect(requireOp(ops, 1)).toMatchObject({
+      kind: "to",
+      target: music,
+      at: 1.5,
+      duration: 0.5,
+      ease: "none",
+      overwrite: false,
+    });
+    expect(requireOp(ops, 1).volume).toBeCloseTo(0.20095, 5);
+    expect(requireOp(ops, 2)).toMatchObject({ kind: "to", target: music, at: 2, duration: 2 });
+    expect(requireOp(ops, 3)).toMatchObject({
+      kind: "to",
+      target: music,
+      at: 4,
+      duration: 0.5,
+      volume: 0.8,
+    });
+  });
+
+  it("merges voice gaps shorter than two fades", () => {
+    const keyframes = duck(audioTrack(0, 5), [audioTrack(1, 1), audioTrack(2.3, 0.7)], {
+      amount: 0.25,
+      fade: 0.25,
+    });
+
+    expect(keyframes).toEqual([
+      { time: 0.75, volume: 1 },
+      { time: 1, volume: 0.25 },
+      { time: 3, volume: 0.25 },
+      { time: 3.25, volume: 1 },
+    ]);
+  });
+
+  it("uses resolved timeline duration for voice clips", () => {
+    const keyframes = duck(audioTrack(0, 8), audioTrack(1, 6), {
+      amount: 0.5,
+      fade: 0.5,
+    });
+
+    expect(keyframes).toEqual([
+      { time: 0.5, volume: 1 },
+      { time: 1, volume: 0.5 },
+      { time: 7, volume: 0.5 },
+      { time: 7.5, volume: 1 },
+    ]);
+  });
+
+  it("produces keyframes compatible with the shared volume envelope", () => {
+    const keyframes = duck(audioTrack(0, 4), audioTrack(1, 1), {
+      amount: "-12dB",
+      fade: 0.25,
+    });
+    const envelope = normaliseEnvelope(keyframes, 0, 1);
+
+    expect(interpolateVolumeGain(envelope, 0.5)).toBe(1);
+    expect(interpolateVolumeGain(envelope, 1.5)).toBeCloseTo(0.251189, 5);
+    expect(interpolateVolumeGain(envelope, 2.5)).toBe(1);
+  });
+
+  it("reads timed media elements without writing schema attributes", () => {
+    const music = document.createElement("audio");
+    music.id = "music";
+    music.dataset.start = "0";
+    music.dataset.duration = "4";
+    music.dataset.volume = "0.6";
+
+    const voice = document.createElement("audio");
+    voice.id = "voice";
+    voice.dataset.start = "1";
+    voice.dataset.duration = "1";
+
+    const keyframes = duck(music, [voice], { amount: 0.5, fade: 0.25 });
+
+    expect(keyframes).toEqual([
+      { time: 0.75, volume: 0.6 },
+      { time: 1, volume: 0.3 },
+      { time: 2, volume: 0.3 },
+      { time: 2.25, volume: 0.6 },
+    ]);
+    expect(music.hasAttribute("data-duck")).toBe(false);
+    expect(music.hasAttribute("data-duck-fade")).toBe(false);
+    expect(music.hasAttribute("data-role")).toBe(false);
+    expect(music.getAttributeNames().some((name) => name.startsWith("data-hf-duck"))).toBe(false);
+  });
+});
+
+describe("duck boundary and timing regressions", () => {
+  it("restores after a zero-fade voice and holds the surrounding music", () => {
+    const keyframes = duck(audioTrack(5, 10, 2), audioTrack(7, 1), { amount: 0.25, fade: 0 });
+    const envelope = normaliseEnvelope(keyframes, 5, 2);
+    for (const [time, volume] of [
+      [0, 2],
+      [1.9, 2],
+      [2, 0.5],
+      [2.9, 0.5],
+      [3, 2],
+      [9, 2],
+    ]) {
+      expect(interpolateVolumeGain(envelope, time!)).toBeCloseTo(volume!, 6);
+    }
+  });
+
+  it("resolves natural voice duration after source trimming and playback rate", () => {
+    const voice = document.createElement("audio");
+    voice.dataset.start = "7";
+    voice.dataset.mediaStart = "4";
+    voice.dataset.playbackRate = "2";
+    Object.defineProperty(voice, "duration", { value: 10 });
+    const keyframes = duck(audioTrack(5, 10), voice, { amount: 0.25, fade: 0.5 });
+    expect(keyframes.map((point) => point.time)).toEqual([6.5, 7, 10, 10.5]);
+    voice.dataset.duration = "20";
+    expect(duck(audioTrack(5, 30), voice, { fade: 0.5 }).at(-1)?.time).toBe(10.5);
+    voice.loop = true;
+    expect(duck(audioTrack(5, 30), voice, { fade: 0.5 }).at(-1)?.time).toBe(27.5);
+  });
+
+  it("honors duration before end and rejects partial numeric timings", () => {
+    const voice = document.createElement("audio");
+    voice.dataset.start = "2";
+    voice.dataset.duration = "1";
+    voice.dataset.end = "9";
+    expect(duck(audioTrack(0, 10), voice, { fade: 0.5 }).at(-1)?.time).toBe(3.5);
+    voice.dataset.duration = "1s";
+    delete voice.dataset.end;
+    expect(duck(audioTrack(0, 10), voice)).toEqual([]);
+  });
+
+  it("ignores silent, non-audio, invalid and nonoverlapping voice tracks", () => {
+    expect(
+      duck(audioTrack(0, 10), [
+        { start: 1, duration: 1, muted: true },
+        { start: 1, duration: 1, volume: 0 },
+        { start: 1, duration: 1, hasAudio: false },
+        { start: NaN, duration: 1 },
+        { start: 20, duration: 1 },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("duck GSAP preview/probe integration", () => {
+  it.each([0, 0.25])(
+    "uses clip-relative cached envelopes for fade=%s across reverse seeks",
+    (fade) => {
+      const music = document.createElement("audio");
+      music.dataset.start = "5";
+      music.dataset.duration = "8";
+      music.dataset.mediaStart = "4";
+      music.dataset.playbackRate = "2";
+      music.dataset.volume = "0.8";
+      music.volume = 0.8;
+      document.body.append(music);
+      vi.spyOn(music, "pause").mockImplementation(() => {});
+      const timeline = gsap.timeline({ paused: true });
+      try {
+        duck(music, audioTrack(7, 1), { timeline, amount: 0.25, fade });
+        // Preview probes into normalized cache; export consumes absolute probe samples.
+        const cache = new WeakMap<
+          HTMLMediaElement,
+          import("./mediaVolumeEnvelope.js").VolumeKeyframe[]
+        >();
+        probeAndCacheElementVolume(music, timeline, 13, cache);
+        const raw = probeElementVolumeKeyframes(
+          music,
+          (time) => {
+            timeline.totalTime(time, true);
+          },
+          13,
+          60,
+        );
+        expect(raw).not.toBeNull();
+        const exportEnvelope = normaliseEnvelope(raw!, 5, 0.8);
+        const clip = refreshRuntimeMediaCache().mediaClips.find(
+          (candidate) => candidate.el === music,
+        )!;
+        clip.volumeKeyframes = cache.get(music);
+        expect(clip.volumeKeyframes?.[0]?.time).toBe(0);
+        for (const time of [5.5, 7.5, 8.5, 6, 7.5, 12, 5.5]) {
+          syncRuntimeMedia({ clips: [clip], timeSeconds: time, playing: false, playbackRate: 1 });
+          const expected = time === 7.5 ? 0.2 : 0.8;
+          expect(music.volume).toBeCloseTo(expected, 5);
+          expect(music.volume).toBeCloseTo(interpolateVolumeGain(exportEnvelope, time - 5), 5);
+        }
+      } finally {
+        timeline.kill();
+        music.remove();
+        vi.restoreAllMocks();
+      }
+    },
+  );
+});

--- a/packages/core/src/runtime/audioDucking.ts
+++ b/packages/core/src/runtime/audioDucking.ts
@@ -1,0 +1,294 @@
+import { clampAudioGain } from "../audioGain.js";
+import { resolveAuthoredTimingWindow } from "./authoredTiming.js";
+import { resolveNaturalMediaTimelineDuration } from "./playbackRate.js";
+import type { VolumeKeyframe } from "./mediaVolumeEnvelope.js";
+
+export type DuckAmount = number | string;
+
+export interface DuckTimelineLike {
+  set: (target: DuckTrack, vars: { volume: number }, atSeconds?: number) => unknown;
+  to: (
+    target: DuckTrack,
+    vars: { volume: number; duration: number; ease: "none"; overwrite: false },
+    atSeconds?: number,
+  ) => unknown;
+}
+
+export interface DuckOptions {
+  /**
+   * Duck amount as a linear gain (0.25) or dB string/negative number ("-12dB", -12).
+   * Defaults to -12 dB.
+   */
+  amount?: DuckAmount;
+  /** Fade-in/fade-out ramp duration in seconds. Defaults to 0.3. */
+  fade?: number;
+  /** GSAP-compatible paused timeline that receives the generated volume ramps. */
+  timeline?: DuckTimelineLike;
+}
+
+export interface DuckTrackTiming {
+  start: number;
+  end?: number;
+  duration?: number;
+  volume?: number;
+  muted?: boolean;
+  hasAudio?: boolean;
+}
+
+export type DuckTrack = HTMLAudioElement | HTMLVideoElement | DuckTrackTiming;
+
+interface DuckInterval {
+  start: number;
+  end: number;
+}
+
+interface ResolvedDuckTrack extends DuckInterval {
+  volume: number;
+  muted: boolean;
+  hasAudio: boolean;
+}
+
+const DEFAULT_DUCK_AMOUNT = "-12dB";
+const DEFAULT_DUCK_FADE_SECONDS = 0.3;
+
+function finiteNumber(raw: string | number | null | undefined): number | null {
+  if (raw === null || raw === undefined || (typeof raw === "string" && raw.trim() === ""))
+    return null;
+  const parsed = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function signedAmountToGain(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return value < 0 ? Math.pow(10, value / 20) : value;
+}
+
+function stringAmountToGain(raw: string): number {
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) return 1;
+
+  if (trimmed.endsWith("db")) {
+    const db = Number(trimmed.slice(0, -2));
+    return Number.isFinite(db) ? Math.pow(10, db / 20) : 1;
+  }
+
+  return signedAmountToGain(Number(trimmed));
+}
+
+function amountToGain(amount: DuckAmount | undefined): number {
+  const raw = amount ?? DEFAULT_DUCK_AMOUNT;
+  if (typeof raw === "number") return signedAmountToGain(raw);
+  return stringAmountToGain(raw);
+}
+
+function elementEnd(el: HTMLAudioElement | HTMLVideoElement, start: number): number | null {
+  const authored = resolveAuthoredTimingWindow({
+    start,
+    duration: el.dataset.duration,
+    authoredDuration: el.getAttribute("data-hf-authored-duration"),
+    end: el.dataset.end,
+    authoredEnd: el.getAttribute("data-hf-authored-end"),
+  });
+  const natural = resolveNaturalMediaTimelineDuration(el, el.duration);
+  const authoredEnd = authored?.end ?? null;
+  if (natural === null || el.loop) return authoredEnd;
+  const sourceEnd = start + natural;
+  return authoredEnd === null ? sourceEnd : Math.min(authoredEnd, sourceEnd);
+}
+
+function isHtmlMediaTrack(track: DuckTrack): track is HTMLAudioElement | HTMLVideoElement {
+  return (
+    typeof HTMLAudioElement !== "undefined" &&
+    typeof HTMLVideoElement !== "undefined" &&
+    (track instanceof HTMLAudioElement || track instanceof HTMLVideoElement)
+  );
+}
+
+function hasUsableEnd(start: number, end: number | null): end is number {
+  return end !== null && end > start;
+}
+
+function resolveElementTrack(track: HTMLAudioElement | HTMLVideoElement): ResolvedDuckTrack | null {
+  const start = finiteNumber(track.dataset.start) ?? 0;
+  const end = elementEnd(track, start);
+  if (!hasUsableEnd(start, end)) return null;
+  const staticVolume = finiteNumber(track.dataset.volume);
+  return {
+    start,
+    end,
+    volume: clampAudioGain(staticVolume ?? track.volume),
+    muted: track.muted,
+    hasAudio: track instanceof HTMLAudioElement || track.dataset.hasAudio === "true",
+  };
+}
+
+function resolveTimingTrack(track: DuckTrackTiming): ResolvedDuckTrack | null {
+  const start = finiteNumber(track.start);
+  if (start === null) return null;
+  const end = resolveAuthoredTimingWindow(track)?.end ?? null;
+  if (!hasUsableEnd(start, end)) return null;
+  return {
+    start,
+    end,
+    volume: clampAudioGain(track.volume ?? 1),
+    muted: track.muted === true,
+    hasAudio: track.hasAudio !== false,
+  };
+}
+
+function resolveTrack(track: DuckTrack): ResolvedDuckTrack | null {
+  return isHtmlMediaTrack(track) ? resolveElementTrack(track) : resolveTimingTrack(track);
+}
+
+function isAudible(track: ResolvedDuckTrack): boolean {
+  return track.hasAudio && !track.muted && track.volume > 0;
+}
+
+function mergeIntervals(intervals: DuckInterval[], maxGap: number): DuckInterval[] {
+  const sorted = intervals
+    .filter((interval) => interval.end > interval.start)
+    .sort((a, b) => a.start - b.start);
+  const merged: DuckInterval[] = [];
+
+  for (const interval of sorted) {
+    const previous = merged.at(-1);
+    if (previous && interval.start <= previous.end + maxGap) {
+      previous.end = Math.max(previous.end, interval.end);
+    } else {
+      merged.push({ ...interval });
+    }
+  }
+
+  return merged;
+}
+
+function intersectIntervals(track: DuckInterval, intervals: DuckInterval[]): DuckInterval[] {
+  const overlaps: DuckInterval[] = [];
+  for (const interval of intervals) {
+    const start = Math.max(track.start, interval.start);
+    const end = Math.min(track.end, interval.end);
+    if (end > start) overlaps.push({ start, end });
+  }
+  return overlaps;
+}
+
+function roundedPoint(time: number, volume: number): VolumeKeyframe {
+  return {
+    time: Number(time.toFixed(6)),
+    volume: Number(clampAudioGain(volume).toFixed(6)),
+  };
+}
+
+function addPoint(keyframes: VolumeKeyframe[], time: number, volume: number): void {
+  const point = roundedPoint(time, volume);
+  const previous = keyframes.at(-1);
+  if (previous && previous.time === point.time) {
+    previous.volume = point.volume;
+  } else {
+    keyframes.push(point);
+  }
+}
+
+function appendDuckedWindow(
+  keyframes: VolumeKeyframe[],
+  music: ResolvedDuckTrack,
+  overlap: DuckInterval,
+  duckVolume: number,
+  fade: number,
+): void {
+  if (fade === 0) {
+    // The shared envelope is piecewise linear and deduplicates equal times.
+    // Keep distinct one-microsecond boundary points; timeline writes use sets.
+    if (overlap.start > music.start)
+      addPoint(keyframes, Math.max(music.start, overlap.start - 0.000001), music.volume);
+    addPoint(keyframes, overlap.start, duckVolume);
+    if (overlap.end > overlap.start + 0.000001)
+      addPoint(keyframes, overlap.end - 0.000001, duckVolume);
+    addPoint(keyframes, overlap.end, music.volume);
+    return;
+  }
+  const duration = overlap.end - overlap.start;
+  const rampDuration = Math.min(fade, duration / 2);
+  const rampStart = Math.max(music.start, overlap.start - rampDuration);
+  const rampEnd = Math.min(music.end, overlap.end + rampDuration);
+
+  if (rampStart < overlap.start) addPoint(keyframes, rampStart, music.volume);
+  addPoint(keyframes, overlap.start, duckVolume);
+  addPoint(keyframes, overlap.end, duckVolume);
+  if (rampEnd > overlap.end) addPoint(keyframes, rampEnd, music.volume);
+}
+
+function buildDuckKeyframes(
+  music: ResolvedDuckTrack,
+  voiceIntervals: DuckInterval[],
+  options: DuckOptions,
+): VolumeKeyframe[] {
+  if (!isAudible(music)) return [];
+
+  const fade = Math.max(0, finiteNumber(options.fade) ?? DEFAULT_DUCK_FADE_SECONDS);
+  const duckVolume = clampAudioGain(music.volume * amountToGain(options.amount));
+  if (duckVolume >= music.volume - 0.000001) return [];
+
+  const overlaps = mergeIntervals(intersectIntervals(music, voiceIntervals), fade * 2);
+  const keyframes: VolumeKeyframe[] = [];
+  for (const overlap of overlaps) appendDuckedWindow(keyframes, music, overlap, duckVolume, fade);
+  return keyframes;
+}
+
+function resolveVoiceIntervals(voiceTracks: DuckTrack | DuckTrack[]): DuckInterval[] {
+  const tracks = Array.isArray(voiceTracks) ? voiceTracks : [voiceTracks];
+  return mergeIntervals(
+    tracks
+      .map((track) => resolveTrack(track))
+      .filter((track): track is ResolvedDuckTrack => track !== null && isAudible(track))
+      .map((track) => ({ start: track.start, end: track.end })),
+    0,
+  );
+}
+
+function writeKeyframes(
+  target: DuckTrack,
+  timeline: DuckTimelineLike | undefined,
+  keyframes: VolumeKeyframe[],
+): void {
+  const [first, ...rest] = keyframes;
+  if (!timeline || !first) return;
+
+  timeline.set(target, { volume: first.volume }, first.time);
+  let previous = first;
+
+  for (const current of rest) {
+    const duration = current.time - previous.time;
+    if (duration <= 0.0000011) {
+      timeline.set(target, { volume: current.volume }, current.time);
+    } else {
+      timeline.to(
+        target,
+        { volume: current.volume, duration, ease: "none", overwrite: false },
+        previous.time,
+      );
+    }
+    previous = current;
+  }
+}
+
+/**
+ * Programmatically author deterministic music ducking.
+ *
+ * The helper computes overlap windows from already-authored media timings and
+ * writes linear volume ramps onto the supplied GSAP-compatible timeline. The
+ * producer's existing volume-automation probe then turns those timeline writes
+ * into the same render-time volume keyframes used by hand-authored fades.
+ */
+export function duck(
+  musicTrack: DuckTrack,
+  voiceTracks: DuckTrack | DuckTrack[],
+  options: DuckOptions = {},
+): VolumeKeyframe[] {
+  const music = resolveTrack(musicTrack);
+  if (!music) return [];
+
+  const keyframes = buildDuckKeyframes(music, resolveVoiceIntervals(voiceTracks), options);
+  writeKeyframes(musicTrack, options.timeline, keyframes);
+  return keyframes;
+}

--- a/packages/engine/src/services/audioVolumeEnvelope.test.ts
+++ b/packages/engine/src/services/audioVolumeEnvelope.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { duck } from "@hyperframes/core";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -68,6 +69,20 @@ describe("applyVolumeEnvelopeToWav", () => {
     expect(sampleAt(path, 0)).toBe(0); // gain 0
     expect(sampleAt(path, frames / 2)).toBeCloseTo(5000, -2); // gain ~0.5
     expect(sampleAt(path, frames - 1)).toBeGreaterThan(9900); // gain ~1
+  });
+
+  it.each([0, 0.25])("bakes ducking and restores boosted music with fade=%s", (fade) => {
+    const path = join(tmp(), "duck.wav");
+    writeConstantWav(path, SAMPLE_RATE * 4, 1000);
+    const keyframes = duck(
+      { start: 5, duration: 4, volume: 2 },
+      { start: 6, duration: 1 },
+      { amount: 0.25, fade },
+    );
+    expect(applyVolumeEnvelopeToWav(path, keyframes, 5, 2)).toBe(true);
+    expect(sampleAt(path, SAMPLE_RATE / 2)).toBe(2000);
+    expect(sampleAt(path, SAMPLE_RATE * 1.5)).toBe(500);
+    expect(sampleAt(path, SAMPLE_RATE * 2.5)).toBe(2000);
   });
 
   it("offsets keyframes by the track start (composition time -> track-relative)", () => {


### PR DESCRIPTION
Add `duck(music, voices, { timeline, amount, fade })` to lower music during speech using the existing preview/export volume envelopes. Rebuilds #1747 by @mvanhorn for current timing and gain behavior: zero-fade music restores, trimmed/rate-adjusted voices end correctly, and gains above unity survive.

The helper uses resolved composition timing and leaves the current clip-relative preview cache intact. The docs describe timeline registration and the one-microsecond linear representation of zero-fade steps.

Validation: 131 core tests and 11 PCM envelope tests pass, including real GSAP reverse-seek/probe coverage. Four regressions fail with the original helper. Core build, pre-commit typecheck/lint/format, Mintlify validation and broken-link checks pass. No full video export performed.
