### PR TITLE
docs(registry): explain installer metadata

### DIFF
--- a/docs/contributing/catalog.mdx
+++ b/docs/contributing/catalog.mdx
@@ -86,6 +86,28 @@ Other useful optional fields include `author`, `authorUrl`, `relatedSkill`,
 current authority. The published JSON schema validates the shared manifest
 fields but does not yet describe the block-only `params` field.
 
+### Installer metadata
+
+Use `registryDependencies` to name registry items that must be installed first.
+The installer resolves dependencies transitively and rejects missing items or
+cycles. Reference exact item names and keep the dependency graph small.
+
+Set `minCliVersion` to the first CLI version that supports the item. All resolved
+items, including dependencies, must pass the compatibility check before any item
+files are installed. An incompatible CLI reports the required version and an
+upgrade command.
+
+Set `deprecated` to a short migration message when an item has a replacement.
+The installer warns and keeps the item available for existing projects.
+
+```json
+{
+  "minCliVersion": "0.6.96",
+  "registryDependencies": ["grain-overlay"],
+  "deprecated": "Use my-block-v2 instead."
+}
+```
+
 ## Build for reuse
 
 Every registry item must:

--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -153,6 +153,12 @@ you a clear error pointing at `init --example`.
 pull from and where files land. If it is missing but the directory has an
 `index.html`, a default one is written on first use.
 
+When an item declares `registryDependencies`, `add` installs its dependencies
+first, resolving them transitively. Before installing any item files, it checks
+`minCliVersion` on every resolved item and reports upgrade guidance for an
+incompatible CLI. A `deprecated` message produces a warning without blocking
+installation.
+
 ### `catalog`
 
 Browse the registry.


### PR DESCRIPTION
The catalog lists installer metadata fields but does not explain their behavior. Document transitive dependencies, minimum CLI versions, and deprecation warnings in the current catalog and CLI guides.

Refreshes #1410 by @kiyeonjeon21, preserving the original author. The current installer gates all resolved items before writing item files; it may create hyperframes.json earlier, so the wording makes that distinction.

Validation: traced current add/resolver/compatibility code; 25 existing registry tests pass; catalog JSON examples, Markdown fences, and git diff checks pass. The repository formatter does not support MDX. No runtime changes.
