### PR TITLE
fix(lint): give randomness guidance for crypto values

### DIFF
--- a/packages/lint/src/rules/core.test.ts
+++ b/packages/lint/src/rules/core.test.ts
@@ -601,6 +601,25 @@ describe("core rules", () => {
   });
 
   describe("non_deterministic_code", () => {
+    it("gives randomness guidance for crypto and clock guidance for wall time", async () => {
+      const result = await lintHyperframeHtml(`<html><body>
+        <div data-composition-id="c1" data-width="1920" data-height="1080"></div>
+        <script>
+          crypto.getRandomValues(new Uint32Array(1));
+          Date.now();
+          window.__timelines = { c1: gsap.timeline({ paused: true }) };
+        </script>
+      </body></html>`);
+      const crypto = result.findings.find((finding) =>
+        finding.message.includes("crypto.getRandomValues"),
+      );
+      const clock = result.findings.find((finding) => finding.message.includes("Date.now"));
+      expect(crypto).toMatchObject({ code: "non_deterministic_code", severity: "error" });
+      expect(crypto?.fixHint).toContain("seeded PRNG");
+      expect(crypto?.fixHint).not.toContain("time-dependent");
+      expect(clock?.fixHint).toContain("wall-clock time");
+    });
+
     it("detects Math.random() in script content", async () => {
       const html = `
 <html><body>

--- a/packages/lint/src/rules/core.ts
+++ b/packages/lint/src/rules/core.ts
@@ -478,7 +478,7 @@ export const coreRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
       {
         pattern: /crypto\.getRandomValues\s*\(/,
         label: "crypto.getRandomValues()",
-        hint: "Remove time-dependent code. Use a seeded PRNG for deterministic renders.",
+        hint: "Use a seeded PRNG (e.g. a simple mulberry32) so renders are deterministic across frames.",
       },
       {
         pattern: /gsap\.utils\.random\s*\(/,


### PR DESCRIPTION
`hyperframes lint` still labels `crypto.getRandomValues()` as time-dependent code in the current extracted lint package. Give it the same seeded-PRNG guidance as `Math.random()` while retaining clock-specific guidance for `Date.now()`.

Builds on #1729 by @AGRO-CODEX. Validation: 59 core-rule tests pass; the new semantic guidance regression fails on unchanged main. Required lint, format and typecheck hooks pass.
