### PR TITLE
fix(shader-transitions): preserve gravitational lens start frame

### DIFF
--- a/packages/shader-transitions/src/shaders/registry.ts
+++ b/packages/shader-transitions/src/shaders/registry.ts
@@ -87,6 +87,7 @@ const shaders: Record<string, ShaderDef> = {
   },
 
   "gravitational-lens": {
+    // Begin with the untouched source; full horizon darkening starts at progress 0.3.
     frag:
       H +
       "void main(){vec4 B=texture2D(u_to,v_uv);" +
@@ -98,7 +99,8 @@ const shaders: Record<string, ShaderDef> = {
       "float shift=pull*.02/(dist+.2);" +
       "float r=texture2D(u_from,clamp(v_uv-uv*(warpStr+shift),0.,1.)).r;" +
       "float b=texture2D(u_from,clamp(v_uv-uv*(warpStr-shift),0.,1.)).b;" +
-      "vec3 lensed=vec3(r,A.g,b)*horizon;" +
+      "float horizonStrength=smoothstep(0.,.3,u_progress);" +
+      "vec3 lensed=vec3(r,A.g,b)*mix(1.,horizon,horizonStrength);" +
       "gl_FragColor=vec4(mix(lensed,B.rgb,smoothstep(.3,.9,u_progress)),1.);}",
   },
 


### PR DESCRIPTION
The active gravitational-lens shader darkens the source scene at progress zero, producing a black-hole flash before the transition begins. Ramp in horizon darkening through progress 0.3; preserve the existing effect from that point onward.

Builds on #1579 by @calcarazgre646. The current shader renderer still calls this registered shader; the CSS fallback does not replace its WebGL path.

Validation: rendered the production shader and `renderShader` implementation in Chrome WebGL on ANGLE Metal / Apple M4 Max. Main's start differs from the source by up to 183 RGB levels; this change exactly matches both endpoint textures. Progress 0.3, 0.5, 0.75, 0.9 and 1 are byte-identical to main, and reverse/repeated samples match. Visually checked start, early and middle frames. All 12 shader-package tests and required hooks pass.
