### PR TITLE
docs(adopters): add Mini Course Generator

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -16,12 +16,13 @@ If you'd rather not be listed publicly, that's fine — drop a note in [our Disc
 
 ## Production
 
-| Organization                             | Contact                                          | How HyperFrames is used                                                                                                       |
-| ---------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| [HeyGen](https://www.heygen.com)         | [@jrusso1020](https://github.com/jrusso1020)     | Powers AI-generated video composition and rendering across HeyGen's video product surface.                                    |
-| [tldraw](https://tldraw.com)             | [@steveruizok](https://github.com/steveruizok)   | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions.                   |
-| [TanStack](https://tanstack.com)         | [@AlemTuzlak](https://github.com/AlemTuzlak)     | Exploring HyperFrames for short-form code demo videos and documentation.                                                      |
-| [OptinMonster](https://optinmonster.com) | Angie Meeker                                     | Exploring HyperFrames for marketing and product video content.                                                                |
-| [reap](https://reap.video)               | [@usamaabid](https://github.com/usamaabid)       | Powers agent-first AI video clipping, editing, and rendering across reap.video's creator and agent workflows.                 |
-| [Typeframe](https://typeframe.app)       | [@kiyeonjeon21](https://github.com/kiyeonjeon21) | Renders speech videos into shareable MP4 exports with word-timed typing captions and styled caption layouts.                  |
-| [THU-MAIC](https://github.com/THU-MAIC)  | [@wyuc](https://github.com/wyuc)                 | Powers OpenMAIC's one-click MP4 export for AI-generated interactive classrooms using self-contained HyperFrames compositions. |
+| Organization                                             | Contact                                          | How HyperFrames is used                                                                                                       |
+| -------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| [HeyGen](https://www.heygen.com)                         | [@jrusso1020](https://github.com/jrusso1020)     | Powers AI-generated video composition and rendering across HeyGen's video product surface.                                    |
+| [tldraw](https://tldraw.com)                             | [@steveruizok](https://github.com/steveruizok)   | Generates automated pull-request walkthrough videos with GSAP-animated code diffs, narration, and captions.                   |
+| [TanStack](https://tanstack.com)                         | [@AlemTuzlak](https://github.com/AlemTuzlak)     | Exploring HyperFrames for short-form code demo videos and documentation.                                                      |
+| [OptinMonster](https://optinmonster.com)                 | Angie Meeker                                     | Exploring HyperFrames for marketing and product video content.                                                                |
+| [reap](https://reap.video)                               | [@usamaabid](https://github.com/usamaabid)       | Powers agent-first AI video clipping, editing, and rendering across reap.video's creator and agent workflows.                 |
+| [Typeframe](https://typeframe.app)                       | [@kiyeonjeon21](https://github.com/kiyeonjeon21) | Renders speech videos into shareable MP4 exports with word-timed typing captions and styled caption layouts.                  |
+| [THU-MAIC](https://github.com/THU-MAIC)                  | [@wyuc](https://github.com/wyuc)                 | Powers OpenMAIC's one-click MP4 export for AI-generated interactive classrooms using self-contained HyperFrames compositions. |
+| [Mini Course Generator](https://minicoursegenerator.com) | [@eren-commits](https://github.com/eren-commits) | Uses HyperFrames for AI-composed videos in its course creation workflow.                                                      |

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -75,9 +75,9 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
     [@wyuc](https://github.com/wyuc)
   </Card>
   <Card title="Mini Course Generator" href="https://minicoursegenerator.com/">
-    <img src="https://www.google.com/s2/favicons?domain=minicoursegenerator.com&sz=128" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
+    <img alt="Mini Course Generator logo" src="https://www.google.com/s2/favicons?domain=minicoursegenerator.com&sz=128" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
 
-    Powers course generation with AI-composed videos via HyperFrames.
+    Uses HyperFrames for AI-composed videos in its course creation workflow.
 
     [@eren-commits](https://github.com/eren-commits)
   </Card>

--- a/docs/community/adopters.mdx
+++ b/docs/community/adopters.mdx
@@ -74,6 +74,13 @@ If you'd rather not be listed publicly, we'd still love to hear about your usage
 
     [@wyuc](https://github.com/wyuc)
   </Card>
+  <Card title="Mini Course Generator" href="https://minicoursegenerator.com/">
+    <img src="https://www.google.com/s2/favicons?domain=minicoursegenerator.com&sz=128" width="48" height="48" style={{borderRadius: "10px", marginBottom: "12px"}} />
+
+    Powers course generation with AI-composed videos via HyperFrames.
+
+    [@eren-commits](https://github.com/eren-commits)
+  </Card>
 </CardGroup>
 
 The HeyGen team's actual launch-video sources (the ones featured in product announcements) live at [hyperframes-launches](https://github.com/heygen-com/hyperframes-launches) — see [Examples](/examples) for the writeup.


### PR DESCRIPTION
Add Mini Course Generator to the repository and documentation adopter lists, describing its use of HyperFrames for AI-composed course videos.

Refreshes #1415 by @eren-commits against current main and preserves the contributor's author attribution. The product website is live at https://minicoursegenerator.com; the integration claim is the contributor's public first-party attestation in #1415, whose commit author uses the product domain. No additional marketing claims were added.

Validation: website and source PR checked; both entries and logo alt text checked; Markdown formatting, diff checks, and pre-commit checks pass. Docs only.
