### PR TITLE
fix(engine): fail closed on blocked SRI scripts

### DIFF
--- a/packages/engine/src/services/frameCapture.test.ts
+++ b/packages/engine/src/services/frameCapture.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  classifyConsoleScriptFailure,
   DrawElementVerificationError,
   formatHttpErrorDiagnostic,
   formatConsoleDiagnostic,
@@ -12,6 +13,27 @@ import {
   sanitizeDiagnosticUrl,
   shouldIgnoreRequestFailureDiagnostic,
 } from "./frameCapture.js";
+
+describe("classifyConsoleScriptFailure", () => {
+  it("promotes Chromium's blocked subresource-integrity diagnostic", () => {
+    expect(
+      classifyConsoleScriptFailure(
+        "error",
+        "Failed to find a valid digest in the 'integrity' attribute for resource 'http://127.0.0.1:4173/_ext/vendor/gsap.js' with computed SHA-384 integrity 'abc'. The resource has been blocked.",
+      ),
+    ).toBe("runtime-error:subresource-integrity");
+  });
+
+  it("ignores non-error and unrelated integrity messages", () => {
+    expect(
+      classifyConsoleScriptFailure(
+        "warning",
+        "Failed to find a valid digest in the 'integrity' attribute. The resource has been blocked.",
+      ),
+    ).toBeNull();
+    expect(classifyConsoleScriptFailure("error", "Integrity metadata is present.")).toBeNull();
+  });
+});
 
 describe("isFontResourceError", () => {
   it("matches Google Fonts CSS load failures via location.url", () => {

--- a/packages/engine/src/services/frameCapture.ts
+++ b/packages/engine/src/services/frameCapture.ts
@@ -2056,6 +2056,22 @@ function recordScriptLoadFailure(session: CaptureSession, url: string): void {
   }
 }
 
+export function classifyConsoleScriptFailure(type: string, text: string): string | null {
+  if (type !== "error") return null;
+  if (text.startsWith("[HyperFrames] composition script error:")) {
+    const detail = text.slice("[HyperFrames] composition script error:".length).trim();
+    const compId = detail.split(" ")[0] || "unknown";
+    return `runtime-error:${compId}`;
+  }
+  if (
+    /failed to find a valid digest in the ['"]integrity['"] attribute/i.test(text) &&
+    /resource has been blocked/i.test(text)
+  ) {
+    return "runtime-error:subresource-integrity";
+  }
+  return null;
+}
+
 // fallow-ignore-next-line unit-size
 export async function initializeSession(session: CaptureSession): Promise<void> {
   const { page, serverUrl } = session;
@@ -2074,11 +2090,8 @@ export async function initializeSession(session: CaptureSession): Promise<void> 
     // can never arrive — same fail-fast treatment as script load failures.
     // Without this, pollSubCompositionTimelines burns the full timeout and
     // the render silently succeeds with a degenerate 2-frame output (#3352).
-    if (type === "error" && text.startsWith("[HyperFrames] composition script error:")) {
-      const detail = text.slice("[HyperFrames] composition script error:".length).trim();
-      const compId = detail.split(" ")[0] || "unknown";
-      recordScriptLoadFailure(session, `runtime-error:${compId}`);
-    }
+    const scriptFailure = classifyConsoleScriptFailure(type, text);
+    if (scriptFailure) recordScriptLoadFailure(session, scriptFailure);
   });
 
   page.on("pageerror", (err) => {


### PR DESCRIPTION
## What

Best-effort renders now fail closed when Chromium blocks a load-bearing script because its Subresource Integrity digest is stale. The failure reaches the existing `sub_timeline_script_failure` policy instead of degrading to static scenes under a non-fatal readiness timeout.

## Why

Chromium returns HTTP 200 for the script and emits the SRI rejection only as a generic console error. The engine previously monitored request failures, HTTP failures, and HyperFrames-prefixed runtime errors, so this browser diagnostic was invisible even though the script never executed.

## How

One console script-failure classifier now recognizes both existing composition runtime errors and Chromium’s exact blocked-integrity diagnostic. The classifier records a redacted stable failure ID through the existing deduplicated script-failure path. Authored integrity values and localized script bytes remain untouched.

## Test plan

- [x] Exact Chromium stale-SRI console diagnostic is classified as a script failure.
- [x] Non-error and unrelated integrity messages remain ignored.
- [x] Existing sub-timeline poll returns the fail-fast script-failure outcome.
- [x] Frame-capture and sub-timeline suites pass (32/32).
- [x] Engine typecheck, oxlint, and oxfmt checks pass.
- [ ] Documentation updated (not applicable).
