### PR TITLE
fix(skills): forward Kokoro TTS speed

### DIFF
--- a/skills/media-use/audio/scripts/lib/tts.mjs
+++ b/skills/media-use/audio/scripts/lib/tts.mjs
@@ -241,6 +241,22 @@ save(audio, sys.argv[3])
 // [{text,start,end}] array for HeyGen (native), or null for ElevenLabs/Kokoro
 // (caller must transcribeWav). Never throws; failures return { ok:false, error }
 // where `error` states WHY (so the caller can surface it, not a bare "TTS failed").
+export function buildKokoroTtsArgs({ textPath, voiceId, wavRel, lang = "en", speed = 1.0 }) {
+  const args = [
+    "hyperframes",
+    "tts",
+    textPath,
+    "--voice",
+    voiceId,
+    "--output",
+    wavRel,
+    "--speed",
+    String(speed),
+  ];
+  if (lang !== "en") args.push("--lang", lang);
+  return args;
+}
+
 export async function synthesizeOne({
   provider,
   text,
@@ -276,8 +292,13 @@ export async function synthesizeOne({
   }
   // kokoro — via the published CLI; --output is relative to the project dir.
   const wavRel = relTo(hyperframesDir, wavAbs);
-  const args = ["hyperframes", "tts", writeTmpText(text), "--voice", voiceId, "--output", wavRel];
-  if (lang !== "en") args.push("--lang", lang);
+  const args = buildKokoroTtsArgs({
+    textPath: writeTmpText(text),
+    voiceId,
+    wavRel,
+    lang,
+    speed,
+  });
   const r = await spawnP("npx", args, { cwd: hyperframesDir });
   return synthResult(r, wavAbs, "kokoro (npx hyperframes tts)");
 }

--- a/skills/media-use/audio/scripts/lib/tts.test.mjs
+++ b/skills/media-use/audio/scripts/lib/tts.test.mjs
@@ -4,12 +4,46 @@ import { mkdtempSync, writeFileSync, chmodSync, rmSync, existsSync } from "node:
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  buildKokoroTtsArgs,
   parseFfmpegDurationBanner,
   ffprobeDuration,
   synthesizeOne,
   synthesizeHeygen,
   synthResult,
 } from "./tts.mjs";
+
+test("forwards a non-default speed to the Kokoro CLI", () => {
+  assert.deepEqual(
+    buildKokoroTtsArgs({
+      textPath: "/tmp/narration.txt",
+      voiceId: "am_michael",
+      wavRel: "audio/narration.wav",
+      lang: "en",
+      speed: 1.16,
+    }),
+    [
+      "hyperframes",
+      "tts",
+      "/tmp/narration.txt",
+      "--voice",
+      "am_michael",
+      "--output",
+      "audio/narration.wav",
+      "--speed",
+      "1.16",
+    ],
+  );
+});
+
+test("makes the Kokoro default speed explicit", () => {
+  const args = buildKokoroTtsArgs({
+    textPath: "/tmp/narration.txt",
+    voiceId: "am_michael",
+    wavRel: "audio/narration.wav",
+  });
+
+  assert.deepEqual(args.slice(-2), ["--speed", "1"]);
+});
 
 test("parseFfmpegDurationBanner reads ffmpeg's stderr Duration line", () => {
   const stderr = [


### PR DESCRIPTION
## What

Kokoro synthesis now receives the resolved TTS speed at the final subprocess boundary. A requested `--speed 1.16` reaches `npx hyperframes tts` as `--speed 1.16` instead of silently using Kokoro’s 1.0 default.

## Why

The faceless adapter and shared audio request preserved speed correctly, but Kokoro argv construction dropped it. Synthesis still exited successfully, leaving narration audio and word timing at the wrong pace.

Related: #2335
Related: #2407

## How

One Kokoro argument builder owns voice, output, speed, and optional language ordering. `synthesizeOne` passes its already-resolved speed into that builder, and the default 1.0 value is emitted explicitly under a tested contract.

## Test plan

- [x] Exact non-default argv includes `--speed 1.16`.
- [x] Default argv explicitly includes `--speed 1`.
- [x] Full provider helper suite passes (13/13).
- [x] Node syntax, oxlint, and oxfmt checks pass.
- [ ] Live Kokoro model synthesis (not required; subprocess boundary is deterministic).
- [ ] Documentation updated (not applicable).
