### PR TITLE
docs(core): fix published frame adapter reference links

### DIFF
--- a/packages/core/docs/core.md
+++ b/packages/core/docs/core.md
@@ -4,7 +4,7 @@ Reference for generating and editing HyperFrames HTML compositions. This is your
 
 **New to HyperFrames?** Start with the [quickstart template](./quickstart-template.html) — a copy-paste composition with inline comments explaining every required piece. See [common mistakes](./common-mistakes.md) for pitfalls that break compositions.
 
-For Frame adapters and deterministic frame rendering direction, see [`../../FRAME.md`](../../FRAME.md) and [`../adapters/README.md`](../adapters/README.md).
+For frame adapters and deterministic frame rendering direction, see the [frame adapters](https://hyperframes.heygen.com/concepts/frame-adapters) and [determinism](https://hyperframes.heygen.com/concepts/determinism) concept docs.
 
 Producer-canonical parity note:
 


### PR DESCRIPTION
The core schema reference links to two documents that no longer exist. Point readers to the current frame adapter and determinism concept pages using public URLs, which also work from the published core package.

Successor to #1942 by @tianma-if; original authorship preserved. The proposed repository-relative replacements would escape the installed package.

Validation: both public pages resolve; package contents and adjacent local links checked; whitespace and all applicable commit hooks pass. The repository formatter skips this file.
