### PR TITLE
fix(shader): keep shader handles within their WebGL context

### DIFF
--- a/packages/shader-transitions/src/webgl.test.ts
+++ b/packages/shader-transitions/src/webgl.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { createProgram } from "./webgl.js";
+
+/** Model WebGL's rule that shader handles belong to the context that created them. */
+function createMockContext() {
+  const shaders = new Set<WebGLShader>();
+  const gl = {
+    VERTEX_SHADER: 0x8b31,
+    FRAGMENT_SHADER: 0x8b30,
+    COMPILE_STATUS: 0x8b81,
+    LINK_STATUS: 0x8b82,
+    createShader: vi.fn(() => {
+      const shader = {};
+      shaders.add(shader);
+      return shader;
+    }),
+    shaderSource: vi.fn(),
+    compileShader: vi.fn(),
+    getShaderParameter: vi.fn(() => true),
+    createProgram: vi.fn(() => ({})),
+    attachShader: vi.fn((_program: WebGLProgram, shader: WebGLShader) => {
+      if (!shaders.has(shader)) throw new Error("Shader belongs to another WebGL context");
+    }),
+    linkProgram: vi.fn(),
+    getProgramParameter: vi.fn(() => true),
+  };
+  return gl;
+}
+
+describe("createProgram", () => {
+  it("uses context-owned shaders across multiple contexts and repeated calls", () => {
+    const first = createMockContext();
+    const second = createMockContext();
+    const fragment = "precision mediump float;void main(){gl_FragColor=vec4(1.0);}";
+
+    for (const gl of [first, second, first, second]) {
+      // The test double implements only the WebGL methods used to create a program.
+      expect(() => createProgram(gl as unknown as WebGLRenderingContext, fragment)).not.toThrow();
+    }
+
+    expect(first.linkProgram).toHaveBeenCalledTimes(2);
+    expect(second.linkProgram).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/shader-transitions/src/webgl.ts
+++ b/packages/shader-transitions/src/webgl.ts
@@ -23,8 +23,6 @@ export function setupQuad(gl: WebGLRenderingContext): WebGLBuffer {
   return buf;
 }
 
-let cachedVertexShader: WebGLShader | null = null;
-
 function compileShader(gl: WebGLRenderingContext, src: string, type: number): WebGLShader {
   const s = gl.createShader(type);
   if (!s) throw new Error("[HyperShader] Failed to create shader");
@@ -53,10 +51,7 @@ function linkProgram(
 }
 
 export function createProgram(gl: WebGLRenderingContext, fragSrc: string): WebGLProgram {
-  if (!cachedVertexShader) {
-    cachedVertexShader = compileShader(gl, vertSrc, gl.VERTEX_SHADER);
-  }
-  return linkProgram(gl, cachedVertexShader, fragSrc);
+  return createProgramWithVertex(gl, vertSrc, fragSrc);
 }
 
 export function createProgramWithVertex(


### PR DESCRIPTION
## What

Shader transitions now initialize correctly when a second WebGL context is created.

## Why

A module-global vertex shader belonged to the first context. Reusing it in another context failed program linking. The old lifecycle rewrite is unnecessary for this specific defect.

Related: #3005

## How

Use the existing per-context program creation helper instead of caching a shader globally. Context-loss handling and lazy allocation are unchanged.

## Test plan

- [x] New ownership regression fails before the fix; all13 shader-package tests pass.
- [x] Actual-source Chrome probe: two distinct contexts link and render across alternating calls, with no WebGL errors; rerun on current main a93106aeb.
- [x] Independent review, package typecheck, lint/format/Fallow and commit hooks pass.
- [ ] Physical GPU matrix/full producer render: not run; browser proof uses SwiftShader.

## Post-Deploy Monitoring & Validation

On the next shader integration run, exercise two independently mounted contexts and watch for program-link failures. Expected: both render. Revert this narrow helper change if a new initialization regression appears.
