### PR TITLE
fix(player): pause the hidden loader sheen

### DIFF
--- a/packages/player/src/styles.ts
+++ b/packages/player/src/styles.ts
@@ -124,6 +124,10 @@ export const PLAYER_STYLES = /* css */ `
     animation: hfp-shader-loader-sheen 1.9s linear infinite;
   }
 
+  .hfp-shader-loader:not(.hfp-visible):not(.hfp-hiding) .hfp-shader-loader-title-text {
+    animation-play-state: paused;
+  }
+
   .hfp-shader-loader-detail {
     width: 100%;
     height: 26px;


### PR DESCRIPTION
## What

The loader sheen pauses once the loader is hidden and resumes when shown.

## Why

The permanently mounted title kept its infinite animation running despite hidden visibility. This change stops that animation without altering loader state transitions.

Related: #2999

## How

Pause only when neither the visible nor fading-out class is present. Keep animation running through the existing fade and preserve motion-preference behavior.

## Test plan

- [x] Actual loader CSS/controller browser witness failed on hidden states before the fix.
- [x] All18 samples pass after the fix, including repeated show/hide, interrupted fade, reset, and both motion preferences; rerun on current main a93106aeb.
- [x] Lint/format/Fallow/typechecks and commit hooks pass.
- [ ] No CSS-string unit test added; browser animation-time checks are the behavioral evidence. No CPU savings claimed.

## Post-Deploy Monitoring & Validation

On the next player load, inspect animation time through show/fade/hidden states. It should advance while visible/fading and stop while hidden. Revert the selector if loader transitions regress.
