### PR TITLE
docs(studio): align stack note with package dependency contract

### DIFF
--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -30,7 +30,7 @@ bun run typecheck  # Type-check
 
 ## Tech stack
 
-- React 18/19, Zustand (state management)
+- React 19, Zustand 4/5 (state management; development uses Zustand 5)
 - CodeMirror 6 (editor)
 - Tailwind CSS (styling)
 - Vite (bundler)


### PR DESCRIPTION
The Studio README still lists React 18/19. Match the package contract: React 19, Zustand 4/5 for consumers, and Zustand 5 for development.

Successor to #1948 by @tianma-if; original authorship preserved.

Validation: checked React/ReactDOM peers, React types, Zustand peers and development dependency; formatting and all applicable commit hooks pass. Documentation only.
