### PR TITLE
docs(registry): clarify catalog preview staging and published URLs

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -46,7 +46,7 @@
       "files": 3
     },
     "hyperframes-registry": {
-      "hash": "d6dfcc8ceb7c8178",
+      "hash": "0142a8e09bbe7e2c",
       "files": 12
     },
     "media-use": {

--- a/skills/hyperframes-registry/references/contributing.md
+++ b/skills/hyperframes-registry/references/contributing.md
@@ -118,9 +118,9 @@ hyperframes snapshot --at "1.0,3.0,5.0,7.0"
 npx hyperframes publish
 ```
 
-**Catalog preview image** — The catalog card uses a PNG at `docs/images/catalog/{kind}/{name}.png` (where `{kind}` is `blocks` or `components`). Generate it from a snapshot, then:
+**Catalog preview image** — For the default PNG preview, save your snapshot at `docs/images/catalog/{kind}/{name}.png` in the repository checkout (`{kind}` is `blocks` or `components`). After upload, the catalog serves it from `https://static.heygen.ai/hyperframes-oss/docs/images/catalog/{kind}/{name}.png`. If `registry-item.json` declares `preview`, the card uses its `poster` URL; a `preview` without `poster` has no image fallback.
 
-- **HeyGen internal contributors:** run `scripts/upload-docs-images.sh` (requires AWS profile `engineering-767398024897`)
+- **HeyGen internal contributors:** run `scripts/upload-docs-images.sh` from the repository root (requires AWS profile `engineering-767398024897`)
 - **External contributors:** attach the preview MP4 to your PR description. A maintainer will generate and upload the catalog image before merging.
 
 ### Step 6: Ship


### PR DESCRIPTION
The registry contribution guide presents the local snapshot path as the published catalog image. Explain local PNG staging, the uploaded CDN URL, and the existing manifest poster override, including previews without a poster. Clarify that the upload script runs from the repository checkout.

Successor to #1949 by @tianma-if; original authorship preserved. Regenerated the official skill manifest because this guide is installed skill content.

Validation: traced preview generation, catalog-index generation and upload script; checked 171 explicit poster URLs and the poster-less preview against the current index; local links also resolve in a copied skill. Only the registry skill hash changes. Formatting, manifest check and applicable commit hooks pass.
