### PR TITLE
fix(cli): reject confirmed unsupported SDR encoders

### DIFF
--- a/packages/cli/src/browser/ffmpeg.test.ts
+++ b/packages/cli/src/browser/ffmpeg.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { findFFmpeg, findFFprobe } from "./ffmpeg.js";
+import { findFFmpeg, findFFprobe, H264EncoderUnavailableError } from "./ffmpeg.js";
 
 // Only child_process is mocked: the H264 encoder probe shells out, while the
 // wrapper tests below resolve via env overrides and need the real `existsSync`.
@@ -60,9 +60,27 @@ describe("resolveH264EncoderMode", () => {
  V....D h264_vaapi    H.264/AVC (VAAPI)
 `;
 
-    expect(() => resolveH264EncoderMode(encoders, false)).toThrow(
-      "neither libx264 nor VideoToolbox",
+    expect(() => resolveH264EncoderMode(encoders, false)).toThrow(H264EncoderUnavailableError);
+  });
+
+  it("prefers libx264 when both encoders are available", async () => {
+    const { resolveH264EncoderMode } = await import("./ffmpeg.js");
+    expect(
+      resolveH264EncoderMode(" V....D libx264 H.264\n V....D h264_videotoolbox H.264\n", false),
+    ).toBe("software");
+  });
+
+  it("distinguishes a successful unsupported probe from an unavailable probe", async () => {
+    const { detectH264EncoderMode } = await import("./ffmpeg.js");
+    mockExecFile.mockReturnValue(" V....D libvpx-vp9 VP9\n");
+    expect(() => detectH264EncoderMode("/custom/ffmpeg", false)).toThrow(
+      H264EncoderUnavailableError,
     );
+    const timeout = new Error("ETIMEDOUT");
+    mockExecFile.mockImplementationOnce(() => {
+      throw timeout;
+    });
+    expect(() => detectH264EncoderMode("/custom/ffmpeg", false)).toThrow(timeout);
   });
 
   it("inspects the configured FFmpeg binary", async () => {

--- a/packages/cli/src/browser/ffmpeg.ts
+++ b/packages/cli/src/browser/ffmpeg.ts
@@ -6,6 +6,13 @@ export { FFMPEG_PATH_ENV, FFPROBE_PATH_ENV } from "@hyperframes/parsers/ff-binar
 
 export type H264EncoderMode = "software" | "gpu";
 
+export class H264EncoderUnavailableError extends Error {
+  constructor() {
+    super("This FFmpeg build has neither libx264 nor VideoToolbox H.264 encoding.");
+    this.name = "H264EncoderUnavailableError";
+  }
+}
+
 /**
  * Select the H.264 encoder class supported by an FFmpeg build.
  *
@@ -20,7 +27,7 @@ export function resolveH264EncoderMode(
   if (gpuRequested) return "gpu";
   if (/\blibx264\b/.test(ffmpegEncodersOutput)) return "software";
   if (/\bh264_videotoolbox\b/.test(ffmpegEncodersOutput)) return "gpu";
-  throw new Error("This FFmpeg build has neither libx264 nor VideoToolbox H.264 encoding.");
+  throw new H264EncoderUnavailableError();
 }
 
 export function detectH264EncoderMode(ffmpegPath: string, gpuRequested: boolean): H264EncoderMode {

--- a/packages/cli/src/commands/render.test.ts
+++ b/packages/cli/src/commands/render.test.ts
@@ -78,6 +78,7 @@ const preflightState = vi.hoisted(() => ({
 const ffmpegEncoderState = vi.hoisted(() => ({
   mode: "software" as "software" | "gpu",
   error: null as Error | null,
+  encoders: null as string | null,
 }));
 const orphanCleanupState = vi.hoisted(() => ({
   calls: 0,
@@ -180,14 +181,20 @@ vi.mock("../telemetry/events.js", () => ({
   }),
 }));
 
-vi.mock("../browser/ffmpeg.js", () => ({
-  detectH264EncoderMode: vi.fn(() => {
-    if (ffmpegEncoderState.error) throw ffmpegEncoderState.error;
-    return ffmpegEncoderState.mode;
-  }),
-  findFFmpeg: vi.fn(() => "/usr/bin/ffmpeg"),
-  getFFmpegInstallHint: vi.fn(() => "brew install ffmpeg"),
-}));
+vi.mock("../browser/ffmpeg.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../browser/ffmpeg.js")>();
+  return {
+    ...actual,
+    detectH264EncoderMode: vi.fn(() => {
+      if (ffmpegEncoderState.error) throw ffmpegEncoderState.error;
+      if (ffmpegEncoderState.encoders !== null)
+        return actual.resolveH264EncoderMode(ffmpegEncoderState.encoders, false);
+      return ffmpegEncoderState.mode;
+    }),
+    findFFmpeg: vi.fn(() => "/usr/bin/ffmpeg"),
+    getFFmpegInstallHint: vi.fn(() => "brew install ffmpeg"),
+  };
+});
 
 vi.mock("../browser/preflight.js", () => ({
   runEnvironmentChecks: vi.fn(async () => preflightState.result),
@@ -294,6 +301,7 @@ describe("renderLocal browser GPU config", () => {
     trackingState.renderObservations = [];
     ffmpegEncoderState.mode = "software";
     ffmpegEncoderState.error = null;
+    ffmpegEncoderState.encoders = null;
     orphanCleanupState.calls = 0;
     orphanCleanupState.killed = 0;
     resetTrialState();
@@ -477,6 +485,63 @@ describe("renderLocal browser GPU config", () => {
 
     expect(producerState.createdJobs[0]?.useGpu).toBe(true);
   });
+
+  it("rejects confirmed unsupported SDR MP4 before loading the producer", async () => {
+    ffmpegEncoderState.encoders = " V....D h264_vaapi H.264/AVC (VAAPI)\n";
+    const { loadProducer } = await import("../utils/producer.js");
+    vi.mocked(loadProducer).mockClear();
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(
+      renderLocal("/tmp/project", "/tmp/out.mp4", {
+        fps: { num: 30, den: 1 },
+        quality: "high",
+        format: "mp4",
+        gpu: false,
+        browserGpuMode: "software",
+        hdrMode: "force-sdr",
+        quiet: true,
+      }),
+    ).rejects.toMatchObject({ name: "CliRuntimeError" });
+
+    expect(loadProducer).not.toHaveBeenCalled();
+    expect(producerState.createdJobs).toHaveLength(0);
+    expect(stderr.mock.calls.flat().join(" ")).toContain("libx264");
+  });
+
+  it.each(["webm", "mov", "png-sequence"] as const)(
+    "does not require H.264 for %s",
+    async (format) => {
+      ffmpegEncoderState.encoders = " V....D libvpx-vp9 VP9\n";
+      await renderLocal("/tmp/project", `/tmp/out.${format}`, {
+        fps: { num: 30, den: 1 },
+        quality: "high",
+        format,
+        gpu: false,
+        browserGpuMode: "software",
+        hdrMode: "force-sdr",
+        quiet: true,
+      });
+      expect(producerState.createdJobs).toHaveLength(1);
+    },
+  );
+
+  it.each(["auto", "force-hdr"] as const)(
+    "does not reject potential HEVC output in %s mode",
+    async (hdrMode) => {
+      ffmpegEncoderState.encoders = " V....D libx265 HEVC\n";
+      await renderLocal("/tmp/project", "/tmp/out.mp4", {
+        fps: { num: 30, den: 1 },
+        quality: "high",
+        format: "mp4",
+        gpu: false,
+        browserGpuMode: "software",
+        hdrMode,
+        quiet: true,
+      });
+      expect(producerState.createdJobs).toHaveLength(1);
+    },
+  );
 
   it("lets the encoder surface its own error when capability detection fails", async () => {
     ffmpegEncoderState.error = new Error("encoder probe timed out");

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -77,7 +77,11 @@ import { isDevMode } from "../utils/env.js";
 import { buildDockerRunArgs, resolveDockerPlatform } from "../utils/dockerRunArgs.js";
 import { normalizeErrorMessage } from "../utils/errorMessage.js";
 import { runEnvironmentChecks } from "../browser/preflight.js";
-import { detectH264EncoderMode } from "../browser/ffmpeg.js";
+import {
+  detectH264EncoderMode,
+  getFFmpegInstallHint,
+  H264EncoderUnavailableError,
+} from "../browser/ffmpeg.js";
 import { chromeLaunchRemediation } from "../browser/linuxDeps.js";
 import { macosOldChromeCrashRemediation } from "../browser/macosOldChromeCrash.js";
 import { windowsChromeCrashRemediation } from "../browser/windowsCrash.js";
@@ -838,6 +842,16 @@ export async function renderLocal(
     try {
       encoderMode = detectH264EncoderMode(preflight.ffmpegPath, false);
     } catch (error) {
+      // HDR MP4 uses HEVC; auto mode cannot resolve the codec until sources
+      // have been inspected. Only forced SDR is definitely H.264 here.
+      if (error instanceof H264EncoderUnavailableError && options.hdrMode === "force-sdr") {
+        errorBox(
+          "MP4 H.264 encoder unavailable",
+          error.message,
+          `Install an FFmpeg build with libx264 support (${getFFmpegInstallHint()}), or render WebM instead: hyperframes render --format webm --output output.webm`,
+        );
+        failCommand();
+      }
       // Capability probing is advisory. Let the real encode surface the
       // authoritative FFmpeg error instead of failing here with a bare stack.
       if (!options.quiet) {


### PR DESCRIPTION
## What

An explicitly SDR MP4 render now stops before loading the producer when FFmpeg confirms that the required H.264 encoder is unavailable.

## Why

The preflight catch treated a definitive unsupported-encoder result as an inconclusive probe and continued. That wasted rendering work before the same failure surfaced later.

Related: #2735

## How

Distinguish confirmed encoder absence with a typed error. Keep unknown/probe-timeout results advisory. Restrict early rejection to forced SDR: auto and HDR may select HEVC after inspecting source media, so this preflight cannot safely reject those paths.

## Test plan

- [x] Regression failed before the change: unsupported SDR render incorrectly completed.
- [x] 91 render/FFmpeg tests pass on current main, including unknown probe, auto/HDR, alternate format and VideoToolbox controls.
- [x] Independent review found no issues; lint, format, Fallow, typechecks and commit hooks pass.
- [ ] No live full encode performed; the regression verifies rejection before producer loading.

## Post-Deploy Monitoring & Validation

On the next unsupported forced-SDR render, expect an actionable encoder error before capture begins. Auto/HDR and inconclusive probes retain fallback behavior. Revert this classification if valid supported encoders are rejected.
