### PR TITLE
fix(engine): isolate chunked encode temporary files

### DIFF
--- a/packages/engine/src/services/chunkEncoder.test.ts
+++ b/packages/engine/src/services/chunkEncoder.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "node:events";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, it, expect, vi } from "vitest";
 import { ENCODER_PRESETS, getEncoderPreset, buildEncoderArgs } from "./chunkEncoder.js";
 import { renderProvenanceArgs } from "../utils/renderProvenance.js";
@@ -229,6 +229,50 @@ describe("encodeFramesFromDir ffmpegEncodeTimeout", () => {
 });
 
 describe("encodeFramesChunkedConcat ffmpegEncodeTimeout", () => {
+  it("isolates concurrent encodes and preserves pre-existing chunk files", async () => {
+    const { spawn, calls } = createSpawnSpy();
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+    const { encodeFramesChunkedConcat } = await import("./chunkEncoder.js");
+    const { root, framesDir } = createFrameFixture();
+    const legacyDir = join(root, "chunk-encode");
+    mkdirSync(legacyDir);
+    const legacyList = join(legacyDir, "concat-list.txt");
+    writeFileSync(legacyList, "another render's concat list");
+
+    const results = ["first.mp4", "second.mp4"].map((name) =>
+      encodeFramesChunkedConcat(
+        framesDir,
+        "frame_%06d.png",
+        join(root, name),
+        tinyEncodeOptions,
+        30,
+      ),
+    );
+    expect(calls).toHaveLength(2);
+    const chunkPaths = calls.map((call) => call.args.at(-1));
+    for (const call of [...calls]) emitClose(call.proc, 0);
+    await flushManagedProcessResolution();
+    expect(calls).toHaveLength(4);
+    const lists = calls.slice(2).map((call) => call.args[call.args.indexOf("-i") + 1]);
+    for (const call of calls.slice(2)) emitClose(call.proc, 0);
+    const completed = await Promise.all(results);
+
+    expect(completed.every((result) => result.success && result.framesEncoded === 2)).toBe(true);
+    expect(new Set(chunkPaths).size).toBe(2);
+    expect(new Set(lists).size).toBe(2);
+    for (let index = 0; index < 2; index++) {
+      const chunkPath = chunkPaths[index];
+      const list = lists[index];
+      if (!chunkPath || !list) throw new Error("Expected chunk and concat paths");
+      expect(dirname(chunkPath)).not.toBe(legacyDir);
+      expect(dirname(list)).toBe(dirname(chunkPath));
+      expect(dirname(dirname(list))).toBe(root);
+      expect(readFileSync(list, "utf8")).toBe(`file '${chunkPath.replace(/'/g, "'\\''")}'`);
+    }
+    expect(readFileSync(legacyList, "utf8")).toBe("another render's concat list");
+  });
+
   it("passes config timeout to per-chunk encodes", async () => {
     vi.useFakeTimers();
     const { spawn, calls } = createSpawnSpy();

--- a/packages/engine/src/services/chunkEncoder.ts
+++ b/packages/engine/src/services/chunkEncoder.ts
@@ -6,7 +6,15 @@
  * Supports CPU (libx264) and GPU encoding.
  */
 
-import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from "fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "fs";
 import { join, dirname, extname } from "path";
 import { DEFAULT_CONFIG, type EngineConfig } from "../config.js";
 import {
@@ -556,8 +564,10 @@ export async function encodeFramesChunkedConcat(
   }
   const chunkSize = Math.max(30, Math.floor(chunkSizeFrames));
   const chunkCount = Math.ceil(files.length / chunkSize);
-  const chunkDir = join(dirname(outputPath), "chunk-encode");
-  if (!existsSync(chunkDir)) mkdirSync(chunkDir, { recursive: true });
+  mkdirSync(dirname(outputPath), { recursive: true });
+  // Keep intermediates under the caller-owned output directory for its existing
+  // cleanup/debug policy, but never reuse another invocation's chunk files.
+  const chunkDir = mkdtempSync(join(dirname(outputPath), "chunk-encode-"));
   const chunkPaths: string[] = [];
 
   for (let i = 0; i < chunkCount; i++) {


### PR DESCRIPTION
Chunked encodes sharing an output directory currently reuse `chunk-encode/chunk_0000.mp4` and `concat-list.txt`. Concurrent calls can overwrite each other's inputs, and a pre-existing directory can supply files or links at these predictable write locations. This addresses [code-scanning alert 857](https://github.com/heygen-com/hyperframes/security/code-scanning/857).

Allocate each invocation's intermediate directory atomically with `mkdtempSync` beside the output. Keep the existing output, codec/timeout/concat behavior and caller-owned cleanup: the producer removes its work directory normally and retains artifacts for debug/KEEP_TEMP inspection. No workflows or public options change.

Validation: the new concurrent-encode regression fails on main because both calls use the same chunk path, and passes after the fix. It also checks separate concat manifests and preservation of a pre-existing concat file. All 102 chunk-encoder and provenance tests pass, including real FFmpeg renders; core/parser builds, engine typecheck, and changed-file lint/format pass. GitHub CI and CodeQL remain landing gates.
