### PR TITLE
fix(cli): retain compiler diagnostics in check reports

### DIFF
--- a/packages/cli/src/commands/check.test.ts
+++ b/packages/cli/src/commands/check.test.ts
@@ -905,6 +905,7 @@ function emptySection<T extends CheckFinding>(findings: T[] = []) {
 
 function reportWithFindings(overrides: Partial<CheckReport> = {}): CheckReport {
   return {
+    compile: { status: "completed", diagnostics: [] },
     ok: true,
     strict: false,
     lint: { ...emptySection(), filesScanned: 0 },
@@ -1631,4 +1632,23 @@ describe("dense motion-overlap re-sampling", () => {
     expect(driver.collectOverlap).toHaveBeenCalled();
     expect(report.layout.findings.some((f) => f.code === "content_overlap")).toBe(true);
   });
+});
+
+it("keeps compiler warnings informational under the existing strict exit policy", async () => {
+  const { deps } = dependencies(fakeDriver());
+  const runBrowser = deps.runBrowserCheck;
+  deps.runBrowserCheck = async (project, options, motion, compile) => {
+    compile.status = "completed";
+    compile.diagnostics.push({
+      code: "color_grading_lut_not_inlined",
+      severity: "warning",
+      source: "gone.cube",
+      message: "Could not inline LUT",
+    });
+    return runBrowser(project, options, motion, compile);
+  };
+  const report = await runCheckPipeline(PROJECT, { ...DEFAULT_CHECK_OPTIONS, strict: true }, deps);
+  expect(report.compile.diagnostics).toHaveLength(1);
+  expect(report.ok).toBe(true);
+  expect(checkExitCode(report)).toBe(0);
 });

--- a/packages/cli/src/utils/bundleWithLocalizedFonts.ts
+++ b/packages/cli/src/utils/bundleWithLocalizedFonts.ts
@@ -1,3 +1,4 @@
+import type { BundleOptions } from "@hyperframes/core/compiler";
 import { normalizeErrorMessage } from "./errorMessage.js";
 import { c } from "../ui/colors.js";
 
@@ -20,9 +21,10 @@ export async function bundleWithLocalizedFonts(
   // Injectable for tests. Production callers omit it and get the producer
   // font-localization pass (see localizeWithProducer).
   localizeFonts: (html: string) => Promise<string> = localizeWithProducer,
+  options?: Pick<BundleOptions, "onDiagnostic">,
 ): Promise<string> {
   const { bundleToSingleHtml } = await import("@hyperframes/core/compiler");
-  const html = await bundleToSingleHtml(projectDir);
+  const html = await bundleToSingleHtml(projectDir, options);
   return localizeFonts(html);
 }
 

--- a/packages/cli/src/utils/checkBrowser.test.ts
+++ b/packages/cli/src/utils/checkBrowser.test.ts
@@ -138,7 +138,9 @@ it("carries raw browser geometry through the page driver and pipeline", async ()
     runAuditGrid,
   );
 
-  expect(mocks.bundleWithLocalizedFonts).toHaveBeenCalledWith(PROJECT.dir);
+  expect(mocks.bundleWithLocalizedFonts).toHaveBeenCalledWith(PROJECT.dir, undefined, {
+    onDiagnostic: expect.any(Function),
+  });
   expect(result.layoutIssues).toEqual([
     expect.objectContaining({
       code: "frame_out_of_frame",

--- a/packages/cli/src/utils/checkBrowser.ts
+++ b/packages/cli/src/utils/checkBrowser.ts
@@ -34,6 +34,7 @@ import type {
   CheckAuditDriver,
   CheckBbox,
   CheckBrowserResult,
+  CheckCompileResult,
   CheckFinding,
   CheckFindingCropRequest,
   CheckGeometryCandidate,
@@ -148,9 +149,20 @@ export async function runBrowserCheck(
   options: CheckOptions,
   motion: MotionSpecResolution,
   runGrid: RunAuditGrid,
+  compile?: CheckCompileResult,
 ): Promise<CheckBrowserResult> {
   const { bundleWithLocalizedFonts } = await import("./bundleWithLocalizedFonts.js");
-  const html = await bundleWithLocalizedFonts(project.dir);
+  if (compile) compile.status = "running";
+  let html: string;
+  try {
+    html = await bundleWithLocalizedFonts(project.dir, undefined, {
+      onDiagnostic: (diagnostic) => compile?.diagnostics.push(diagnostic),
+    });
+    if (compile) compile.status = "completed";
+  } catch (error) {
+    if (compile) compile.status = "failed";
+    throw error;
+  }
   await preResolveHostileMediaProxies(project.dir, html, options.autoProxy);
   const server = await serveStaticProjectHtml(
     project.dir,

--- a/packages/cli/src/utils/checkCompile.test.ts
+++ b/packages/cli/src/utils/checkCompile.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { bundleWithLocalizedFonts } from "./bundleWithLocalizedFonts.js";
+import { runCheckPipeline, DEFAULT_CHECK_OPTIONS, checkExitCode } from "./checkPipeline.js";
+import { runBrowserCheck } from "./checkBrowser.js";
+import { createCheckCommand } from "../commands/check.js";
+import { consumeCommandResult } from "./commandResult.js";
+import type { CheckDependencies } from "./checkTypes.js";
+vi.mock("../capture/captureCompositionFrame.js", async (original) => ({
+  ...(await original<typeof import("../capture/captureCompositionFrame.js")>()),
+  openSettledCompositionPage: vi.fn(async () => {
+    throw new Error("Chrome unavailable");
+  }),
+}));
+vi.mock("./staticProjectServer.js", () => ({
+  serveStaticProjectHtml: vi.fn(async () => ({ url: "http://localhost:1", close: vi.fn() })),
+}));
+vi.mock("./producer.js", () => ({
+  loadProducer: vi.fn(async () => ({ injectDeterministicFontFaces: async (html: string) => html })),
+}));
+const dirs: string[] = [];
+afterEach(() => {
+  dirs.splice(0).forEach((dir) => rmSync(dir, { recursive: true, force: true }));
+  vi.restoreAllMocks();
+  consumeCommandResult();
+});
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), "check-compile-"));
+  dirs.push(dir);
+  writeFileSync(
+    join(dir, "index.html"),
+    `<!DOCTYPE html><html><head></head><body><div data-composition-id="main" data-width="640" data-height="360" data-duration="2" data-color-grading='{"lut":"gone.cube"}'><div data-composition-id="child" data-composition-src="gone.html" data-start="0" data-duration="2"></div></div></body></html>`,
+  );
+  return { dir, name: "compile fixture", indexPath: join(dir, "index.html") };
+}
+function dependencies(): CheckDependencies {
+  return {
+    lintProject: vi.fn(async () => ({
+      results: [],
+      totalErrors: 0,
+      totalWarnings: 0,
+      totalInfos: 0,
+    })),
+    resolveMotionSpec: vi.fn(() => ({ kind: "none" as const })),
+    runBrowserCheck: (project, options, motion, compile) =>
+      runBrowserCheck(project, options, motion, vi.fn(), compile),
+    writeSnapshot: vi.fn(),
+    captureFindingCrops: vi.fn(),
+  };
+}
+it("forwards real missing LUT and sub-composition warnings through the font bundler", async () => {
+  const diagnostics: unknown[] = [];
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  await bundleWithLocalizedFonts(fixture().dir, async (html) => html, {
+    onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+  });
+  expect(diagnostics).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        code: "static_guard_invalid",
+        source: "index.html",
+        severity: "warning",
+      }),
+      expect.objectContaining({
+        code: "color_grading_lut_not_inlined",
+        source: "gone.cube",
+        severity: "warning",
+      }),
+      expect.objectContaining({
+        code: "sub_composition_skipped",
+        source: "gone.html",
+        severity: "warning",
+      }),
+    ]),
+  );
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining('Could not inline color grading LUT "gone.cube"'),
+  );
+});
+it("keeps completed compile warnings in CLI JSON when Chrome later fails", async () => {
+  const project = fixture();
+  const deps = dependencies();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  const command = createCheckCommand({
+    withMeta: (value) => value,
+    resolveProject: () => project,
+    runPipeline: (p, options) => runCheckPipeline(p, { ...options, autoProxy: false }, deps),
+  });
+  await command.run!({ rawArgs: ["--json"], args: {}, cmd: command } as never);
+  const report = JSON.parse(
+    log.mock.calls.find(([line]) => typeof line === "string" && line.startsWith("{"))![0],
+  );
+  expect(report.compile.status).toBe("completed");
+  expect(report.compile.diagnostics).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ code: "color_grading_lut_not_inlined" }),
+      expect.objectContaining({ code: "sub_composition_skipped" }),
+    ]),
+  );
+  expect(report.runtime.findings).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ message: expect.stringContaining("Chrome unavailable") }),
+    ]),
+  );
+});
+it.each(["lint_errors", "motion_spec_invalid", "lint_failure"] as const)(
+  "truthfully skips compile for %s",
+  async (reason) => {
+    const deps = dependencies();
+    const browser = vi.fn(deps.runBrowserCheck);
+    deps.runBrowserCheck = browser;
+    if (reason === "lint_errors")
+      deps.lintProject = vi.fn(async () => ({
+        results: [],
+        totalErrors: 1,
+        totalWarnings: 0,
+        totalInfos: 0,
+      }));
+    if (reason === "lint_failure")
+      deps.lintProject = vi.fn(async () => {
+        throw new Error("lint crashed");
+      });
+    if (reason === "motion_spec_invalid")
+      deps.resolveMotionSpec = () => ({
+        kind: "invalid",
+        path: "index.motion.json",
+        message: "invalid motion",
+      });
+    const report = await runCheckPipeline(fixture(), DEFAULT_CHECK_OPTIONS, deps);
+    expect(report.compile).toEqual({ status: "not_run", reason, diagnostics: [] });
+    expect(browser).not.toHaveBeenCalled();
+  },
+);
+
+it("marks a real bundling failure failed rather than completed", async () => {
+  const project = fixture();
+  rmSync(join(project.dir, "index.html"));
+  const report = await runCheckPipeline(
+    project,
+    { ...DEFAULT_CHECK_OPTIONS, autoProxy: false },
+    dependencies(),
+  );
+  expect(report.compile).toEqual({ status: "failed", diagnostics: [] });
+  expect(report.runtime.findings[0]?.message).toContain("index.html not found");
+  expect(checkExitCode(report)).not.toBe(0);
+});

--- a/packages/cli/src/utils/checkPipeline.ts
+++ b/packages/cli/src/utils/checkPipeline.ts
@@ -36,6 +36,7 @@ import type {
   CheckAuditDriver,
   CheckBbox,
   CheckBrowserResult,
+  CheckCompileResult,
   CheckContrastFinding,
   CheckDependencies,
   CheckFinding,
@@ -1109,6 +1110,7 @@ export async function runCheckPipeline(
   options: CheckOptions,
   dependencies: CheckDependencies = DEFAULT_DEPENDENCIES,
 ): Promise<CheckReport> {
+  const compile: CheckCompileResult = { status: "not_run", diagnostics: [] };
   let lintResult: ProjectLintResult;
   const lintStartedAt = Date.now();
   try {
@@ -1127,7 +1129,10 @@ export async function runCheckPipeline(
 
   const lint = buildLintSection(lintResult);
   if (shouldBlockRender(true, false, lintResult.totalErrors, lintResult.totalWarnings)) {
-    return buildReport(options, lint, emptyBrowserResult(), { kind: "none" }, [], []);
+    return buildReport(options, lint, emptyBrowserResult(), { kind: "none" }, [], [], {
+      ...compile,
+      reason: "lint_errors",
+    });
   }
 
   const motion = dependencies.resolveMotionSpec(project.dir);
@@ -1138,12 +1143,15 @@ export async function runCheckPipeline(
       motion.message,
       relative(project.dir, motion.path) || "index.motion.json",
     );
-    return buildReport(options, lint, emptyBrowserResult(), motion, [finding], []);
+    return buildReport(options, lint, emptyBrowserResult(), motion, [finding], [], {
+      ...compile,
+      reason: "motion_spec_invalid",
+    });
   }
 
   let browser: CheckBrowserResult;
   try {
-    browser = await dependencies.runBrowserCheck(project, options, motion);
+    browser = await dependencies.runBrowserCheck(project, options, motion, compile);
   } catch (error) {
     browser = emptyBrowserResult();
     browser.runtimeFindings.push(runtimeFailure(error));
@@ -1152,7 +1160,7 @@ export async function runCheckPipeline(
   const snapshotFiles = options.snapshots
     ? await writeContrastSnapshots(dependencies, project.dir, browser)
     : [];
-  const report = buildReport(options, lint, browser, motion, [], snapshotFiles);
+  const report = buildReport(options, lint, browser, motion, [], snapshotFiles, compile);
   return options.snapshots
     ? await withFindingCrops(dependencies, project, options, report)
     : report;
@@ -1332,6 +1340,7 @@ function buildReport(
   motion: MotionSpecResolution,
   extraMotionFindings: CheckFinding[],
   snapshotFiles: string[],
+  compile: CheckCompileResult,
 ): CheckReport {
   const layout = shapeLayoutSection(browser.layoutIssues, browser, options);
   const shapedMotion = shapeLayoutFindings(browser.motionIssues, options);
@@ -1352,6 +1361,7 @@ function buildReport(
     motionSection.errorCount +
     contrastSection.errorCount;
   const report: CheckReport = {
+    compile,
     ok: errorCount === 0 && (!options.strict || warningCount === 0),
     strict: options.strict,
     lint,
@@ -1507,7 +1517,11 @@ function failureReport(options: CheckOptions, finding: CheckFinding): CheckRepor
   const lint = { ...section([]), filesScanned: 0 };
   const browser = emptyBrowserResult();
   browser.runtimeFindings.push(finding);
-  return buildReport(options, lint, browser, { kind: "none" }, [], []);
+  return buildReport(options, lint, browser, { kind: "none" }, [], [], {
+    status: "not_run",
+    reason: "lint_failure",
+    diagnostics: [],
+  });
 }
 
 function isBbox(value: unknown): value is CheckBbox {
@@ -1537,11 +1551,12 @@ async function runBrowserCheck(
   project: ProjectDir,
   options: CheckOptions,
   motion: MotionSpecResolution,
+  compile: CheckCompileResult,
 ): Promise<CheckBrowserResult> {
   const module = await import("./checkBrowser.js");
   // runAuditGrid is handed over as a callback so checkBrowser never imports
   // this module back (no import cycle).
-  return module.runBrowserCheck(project, options, motion, runAuditGrid);
+  return module.runBrowserCheck(project, options, motion, runAuditGrid, compile);
 }
 
 async function writeSnapshot(

--- a/packages/cli/src/utils/checkTypes.ts
+++ b/packages/cli/src/utils/checkTypes.ts
@@ -1,3 +1,4 @@
+import type { BundleDiagnostic } from "@hyperframes/core/compiler";
 import type { ProjectLintResult } from "./lintProject.js";
 import type { LayoutIssue, LayoutOverflow, LayoutRect } from "./layoutAudit.js";
 import type { Canvas, MotionFrame } from "./motionAudit.js";
@@ -261,7 +262,15 @@ export interface CheckSection<T extends CheckFinding = CheckFinding> {
   findings: T[];
 }
 
+export interface CheckCompileResult {
+  status: "not_run" | "running" | "completed" | "failed";
+  reason?: "lint_errors" | "motion_spec_invalid" | "lint_failure";
+  diagnostics: BundleDiagnostic[];
+}
+
 export interface CheckReport {
+  /** Compiler warnings are informational here and preserve the existing exit policy. */
+  compile: CheckCompileResult;
   ok: boolean;
   strict: boolean;
   lint: CheckSection & { filesScanned: number };
@@ -292,6 +301,7 @@ export interface CheckDependencies {
     project: ProjectDir,
     options: CheckOptions,
     motion: MotionSpecResolution,
+    compile: CheckCompileResult,
   ): Promise<CheckBrowserResult>;
   writeSnapshot(
     projectDir: string,

--- a/packages/core/src/compiler/htmlBundler.ts
+++ b/packages/core/src/compiler/htmlBundler.ts
@@ -321,16 +321,29 @@ function isExternalSvgFragmentUse(el: Element, attr: string, urlValue: string): 
   return pathBeforeFragment.toLowerCase().endsWith(".svg");
 }
 
-function warnColorGradingLutNotInlined(lutSrc: string): void {
+function warnColorGradingLutNotInlined(
+  lutSrc: string,
+  onDiagnostic?: BundleOptions["onDiagnostic"],
+): void {
   const trimmed = lutSrc.trim();
   if (!isRelativeUrl(trimmed)) return;
-  console.warn(
-    `[HyperFrames] Could not inline color grading LUT "${trimmed}". The rendered bundle may not be self-contained.`,
+  emitBundleDiagnostic(
+    {
+      code: "color_grading_lut_not_inlined",
+      severity: "warning",
+      source: trimmed,
+      message: `[HyperFrames] Could not inline color grading LUT "${trimmed}". The rendered bundle may not be self-contained.`,
+    },
+    onDiagnostic,
   );
 }
 
 // fallow-ignore-next-line complexity
-function rewriteColorGradingLutWithInlinedAssets(value: string, projectDir: string): string {
+function rewriteColorGradingLutWithInlinedAssets(
+  value: string,
+  projectDir: string,
+  onDiagnostic?: BundleOptions["onDiagnostic"],
+): string {
   if (!value.trim().startsWith("{")) return value;
   let parsed: unknown;
   try {
@@ -344,7 +357,7 @@ function rewriteColorGradingLutWithInlinedAssets(value: string, projectDir: stri
   if (typeof lut === "string") {
     const inlined = maybeInlineRelativeAssetUrl(lut, projectDir);
     if (!inlined) {
-      warnColorGradingLutNotInlined(lut);
+      warnColorGradingLutNotInlined(lut, onDiagnostic);
       return value;
     }
     Reflect.set(parsed, "lut", inlined);
@@ -355,7 +368,7 @@ function rewriteColorGradingLutWithInlinedAssets(value: string, projectDir: stri
   if (typeof lutSrc !== "string") return value;
   const inlined = maybeInlineRelativeAssetUrl(lutSrc, projectDir);
   if (!inlined) {
-    warnColorGradingLutNotInlined(lutSrc);
+    warnColorGradingLutNotInlined(lutSrc, onDiagnostic);
     return value;
   }
   Reflect.set(lut, "src", inlined);
@@ -683,7 +696,24 @@ function stripJsCommentsParserSafe(source: string): string {
   }
 }
 
+export interface BundleDiagnostic {
+  code: "color_grading_lut_not_inlined" | "static_guard_invalid" | "sub_composition_skipped";
+  severity: "warning";
+  message: string;
+  source: string;
+}
+
+function emitBundleDiagnostic(
+  diagnostic: BundleDiagnostic,
+  onDiagnostic?: BundleOptions["onDiagnostic"],
+): void {
+  console.warn(diagnostic.message);
+  onDiagnostic?.(diagnostic);
+}
+
 export interface BundleOptions {
+  /** Observe compiler warnings in addition to the existing console output. */
+  onDiagnostic?: (diagnostic: BundleDiagnostic) => void;
   /** Project-relative HTML entry to bundle. Defaults to `index.html`. */
   entryFile?: string;
   /** Optional media duration prober (e.g., ffprobe). If omitted, media durations are not resolved. */
@@ -813,8 +843,14 @@ export async function bundleToSingleHtml(
 
   const staticGuard = await validateHyperframeHtmlContract(compiled);
   if (!staticGuard.isValid) {
-    console.warn(
-      `[StaticGuard] Invalid HyperFrame contract: ${staticGuard.missingKeys.join("; ")}`,
+    emitBundleDiagnostic(
+      {
+        code: "static_guard_invalid",
+        severity: "warning",
+        source: entryFile,
+        message: `[StaticGuard] Invalid HyperFrame contract: ${staticGuard.missingKeys.join("; ")}`,
+      },
+      options?.onDiagnostic,
     );
   }
 
@@ -921,8 +957,14 @@ export async function bundleToSingleHtml(
     buildScopeSelector: (compId: string) => cssAttributeSelector("data-composition-id", compId),
     scriptErrorLabel: "[HyperFrames] composition script error:",
     onMissingComposition: (srcPath: string, reason?: string) => {
-      console.warn(
-        `[Bundler] Skipping sub-composition "${srcPath}": ${reason ?? "the file could not be found"}.`,
+      emitBundleDiagnostic(
+        {
+          code: "sub_composition_skipped",
+          severity: "warning",
+          source: srcPath,
+          message: `[Bundler] Skipping sub-composition "${srcPath}": ${reason ?? "the file could not be found"}.`,
+        },
+        options?.onDiagnostic,
       );
     },
   });
@@ -1136,7 +1178,7 @@ export async function bundleToSingleHtml(
       if (value) {
         el.setAttribute(
           HF_COLOR_GRADING_ATTR,
-          rewriteColorGradingLutWithInlinedAssets(value, projectDir),
+          rewriteColorGradingLutWithInlinedAssets(value, projectDir, options?.onDiagnostic),
         );
       }
     }

--- a/packages/core/src/compiler/index.ts
+++ b/packages/core/src/compiler/index.ts
@@ -33,6 +33,7 @@ export {
   type BundledHostCompositionIdentity,
   bundleToSingleHtml,
   type BundleOptions,
+  type BundleDiagnostic,
   prepareFlattenedInnerRoot,
   FLATTENED_INNER_ROOT_STRIP_ATTRS,
   emitRootCompositionVariableStyles,


### PR DESCRIPTION
## What

Structured check reports retain compiler warnings even when Chrome fails after compilation. Skipped compilation records why it did not run.

## Why

Missing LUT and sub-composition warnings were printed before browser listeners existed, so automation reading check JSON could miss them.

Related: #3104

## How

Add an optional bundler diagnostic callback and a report-owned compile phase record. Existing console messages and exit-code policy remain unchanged; these warnings are informational.

## Test plan

- [x] Five regressions failed before implementation, covering real bundler warnings, later browser failure and truthful skipped phases.
- [x] 82 CLI tests plus 58 core bundler tests pass, independently rerun.
- [x] Real bundler/font-helper/browser-check/pipeline/CLI JSON chain exercised with deliberate Chrome startup failure.
- [x] Typechecks, lint/format/Fallow and commit hooks pass; no production service calls.

## Post-Deploy Monitoring & Validation

On the next check with a missing relative LUT or sub-composition, confirm compile diagnostics appear in JSON. Browser failures must retain completed compile diagnostics. Revert report plumbing if warnings vanish or exit behavior changes.
