### PR TITLE
fix(core): scope composition root pattern selectors per instance

### DIFF
--- a/packages/core/src/compiler/compositionScoping.test.ts
+++ b/packages/core/src/compiler/compositionScoping.test.ts
@@ -106,6 +106,31 @@ body { margin: 0; }
     expect(wrapped).not.toContain("requestAnimationFrame");
   });
 
+  it.each(["=", "^=", "*=", "$="])(
+    "scopes %s authored-root selectors to the duplicate instance and its box",
+    (operator) => {
+      const scope = '[data-composition-id="scene__hf2"]';
+      const scoped = scopeCssToComposition(
+        `[data-composition-id${operator}"scene"] { padding: 13px; }
+[data-composition-id${operator}"scene"] .item { border-width: 3px; }`,
+        "scene",
+        scope,
+      );
+
+      expect(scoped).toContain(
+        `${scope}:not(:has([data-hf-inner-root])), ${scope} > [data-hf-inner-root] { padding: 13px; }`,
+      );
+      expect(scoped).toContain(`${scope} .item { border-width: 3px; }`);
+      expect(scoped).not.toContain(`[data-composition-id${operator}"scene"]`);
+    },
+  );
+
+  it("preserves pattern selectors for a different nested composition", () => {
+    const scope = '[data-composition-id="scene__hf2"]';
+    const css = '[data-composition-id^="nested"] .item { color: red; }';
+    expect(scopeCssToComposition(css, "scene", scope)).toBe(`${scope} ${css}`);
+  });
+
   it("normalizes root timing attributes when scoping selectors", () => {
     const scoped = scopeCssToComposition(
       '[data-composition-id="scene"][data-start="0"] .title { opacity: 0; }',

--- a/packages/core/src/compiler/compositionScoping.ts
+++ b/packages/core/src/compiler/compositionScoping.ts
@@ -137,8 +137,9 @@ function scopeSelector(
     // caused the parent-body clobber, which is what this remap targets.
     return scopeRootSelectors ? compositionBoxSelector(scope) : selector;
   }
+  // Authored-root patterns must follow the renamed instance, not require a nested root.
   const compositionIdPattern = new RegExp(
-    `\\[\\s*data-composition-id\\s*=\\s*(["'])${escapeRegExp(compositionId)}\\1\\s*\\]`,
+    `\\[\\s*data-composition-id\\s*[\\^\\*\\$]?=\\s*(["'])${escapeRegExp(compositionId)}\\1\\s*\\]`,
     "g",
   );
   if (compositionIdPattern.test(trimmed)) {


### PR DESCRIPTION
Duplicate sub-compositions lose styles authored with `[data-composition-id^="scene"]`, `*=` or `$=`: the scoper prepends an instance selector instead of replacing the authored root. After mounting strips the inner root ID, these rules match nothing. Recognize those operators when their value is the authored root ID, preserving the existing composition-box remap and exact-match behavior.

Successor to Thomaswebstich’s #2262, with co-author credit. Different nested-composition IDs remain scoped descendants. The pre-existing exact-only timing-attribute normalization is unchanged.

Validation: headless Chrome measured root padding, descendant borders/colors and outside isolation for two instances through both `bundleToSingleHtml` and `loadInlineTemplateCompositions`. Before the fix, exact `=` passed and all six pattern cases failed; all eight cases pass afterward. All 199 scoper/compiler/loader tests, core/runtime typechecks, lint/format and commit hooks pass.
