### PR TITLE
fix(capture): retain opaque and glass button styles

### DIFF
--- a/packages/cli/src/capture/designStyleExtractor.buttons.test.ts
+++ b/packages/cli/src/capture/designStyleExtractor.buttons.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { runInNewContext } from "node:vm";
+import { Window } from "happy-dom";
+import type { Page } from "puppeteer-core";
+import { extractDesignStyles } from "./designStyleExtractor.js";
+
+async function extractButtons(body: string) {
+  const window = new Window();
+  window.document.body.innerHTML = body;
+  for (const element of window.document.querySelectorAll("button, a")) {
+    element.getBoundingClientRect = () => new window.DOMRect(0, 0, 100, 40);
+  }
+  const evaluate: Page["evaluate"] = async (script, ..._args) => {
+    if (typeof script !== "string") throw new Error("Expected a page expression");
+    return runInNewContext(script, {
+      window,
+      document: window.document,
+      getComputedStyle: window.getComputedStyle.bind(window),
+    });
+  };
+  try {
+    return (await extractDesignStyles({ evaluate })).buttons;
+  } finally {
+    await window.happyDOM.close();
+  }
+}
+
+describe("capture button styles", () => {
+  // Chrome serializes opaque modern rgb() to rgb(r, g, b), and zero alpha to rgba().
+  it.each([
+    ["rgb(0, 0, 0)", "#000000"],
+    ["rgb(255, 180, 0)", "#FFB400"],
+  ])("retains an opaque navigation CTA with %s", async (color, background) => {
+    const buttons = await extractButtons(
+      `<nav><a class="btn" style="background-color: ${color}">Start</a></nav>`,
+    );
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]).toMatchObject({ label: "Start", background });
+  });
+
+  it("excludes a transparent navigation link", async () => {
+    const buttons = await extractButtons(
+      '<nav><a class="btn" style="background-color: rgba(0, 0, 0, 0)">Docs</a></nav>',
+    );
+    expect(buttons).toEqual([]);
+  });
+
+  it("retains a gradient navigation CTA with a transparent background color", async () => {
+    const buttons = await extractButtons(
+      '<nav><a class="btn" style="background-color: rgba(0, 0, 0, 0); background-image: linear-gradient(red, blue)">Start</a></nav>',
+    );
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]).toMatchObject({ label: "Start", background: "transparent" });
+    expect(buttons[0]?.backgroundImage).toContain("linear-gradient");
+  });
+
+  it("keeps glass and plain variants distinct while deduplicating identical glass buttons", async () => {
+    const buttons = await extractButtons(`
+      <button style="background-color: rgba(255, 255, 255, 0.5)">Plain</button>
+      <button style="background-color: rgba(255, 255, 255, 0.5); backdrop-filter: blur(12px)">Glass</button>
+      <button style="background-color: rgba(255, 255, 255, 0.5); backdrop-filter: blur(12px)">Glass copy</button>
+    `);
+    expect(buttons.map(({ label, backdropFilter }) => ({ label, backdropFilter }))).toEqual([
+      { label: "Plain", backdropFilter: "" },
+      { label: "Glass", backdropFilter: "blur(12px)" },
+    ]);
+  });
+});

--- a/packages/cli/src/capture/designStyleExtractor.ts
+++ b/packages/cli/src/capture/designStyleExtractor.ts
@@ -127,7 +127,7 @@ const EXTRACT_DESIGN_STYLES_SCRIPT = `(() => {
   var isFilledEl = (el) => {
     var cs = getComputedStyle(el);
     var bg = cs.backgroundColor;
-    var solid = !!bg && bg !== "transparent" && !/rgba?\\([^)]*,\\s*0\\s*\\)/.test(bg);
+    var solid = !!bg && rgbToHex(bg) !== "transparent";
     // a gradient-filled CTA (e.g. Snowflake's blue pill = background: var(--ui-background-03)) has a
     // transparent background-COLOR but a gradient background-IMAGE — count it as filled too.
     return solid || (cs.backgroundImage || "").indexOf("gradient") >= 0;
@@ -144,7 +144,7 @@ const EXTRACT_DESIGN_STYLES_SCRIPT = `(() => {
   for (var bi = 0; bi < buttonEls.length; bi++) {
     var bs = getStyles(buttonEls[bi]);
     // Deduplicate by visual appearance (gradient fill kept distinct so a gradient CTA survives)
-    var bKey = bs.background + "|" + bs.backgroundImage + "|" + bs.borderRadius + "|" + bs.border;
+    var bKey = bs.background + "|" + bs.backgroundImage + "|" + bs.backdropFilter + "|" + bs.borderRadius + "|" + bs.border;
     if (!buttonMap[bKey]) {
       var btnText = (buttonEls[bi].textContent || "").trim().slice(0, 40);
       buttonMap[bKey] = {
@@ -492,6 +492,6 @@ const EXTRACT_DESIGN_STYLES_SCRIPT = `(() => {
   };
 })()`;
 
-export async function extractDesignStyles(page: Page): Promise<DesignStyles> {
+export async function extractDesignStyles(page: Pick<Page, "evaluate">): Promise<DesignStyles> {
   return page.evaluate(EXTRACT_DESIGN_STYLES_SCRIPT) as Promise<DesignStyles>;
 }


### PR DESCRIPTION
`hyperframes capture` drops opaque navigation CTAs whose RGB blue channel is zero, including black buttons, and merges frosted buttons with otherwise identical plain variants. Reuse the existing color parser's transparent result and include backdrop blur in the button style key. Transparent navigation links remain excluded, gradients remain included, and identical glass variants still deduplicate.

Refreshes #1880 with credit to @xuanruli in the signed commit. The active capture path writes these styles to `extracted/design-styles.json` before DOM mutation.

Validation: five DOM/VM regressions (three fail before the fix); real Chrome 152.0.7977.77 extraction before/after, including modern authored RGB/alpha syntax and computed-style serialization; 198 capture tests; full workspace build; CLI typecheck; formatting, lint and required commit hooks. CI tests use Happy DOM and do not require Chromium.
