### PR TITLE
fix(capture): sample computed shadows on ordinary boxes

### DIFF
--- a/packages/cli/src/capture/designStyleExtractor.shadows.test.ts
+++ b/packages/cli/src/capture/designStyleExtractor.shadows.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import type { Page } from "puppeteer-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { extractDesignStyles } from "./designStyleExtractor.js";
+
+// Use the complete browser expression; happy-dom supplies CSS, and these
+// fixtures supply the layout measurements that a browser normally computes.
+async function shadows() {
+  const evaluate: Page["evaluate"] = async (script, ..._args) => {
+    if (typeof script !== "string") throw new Error("Expected a browser expression");
+    return window.eval(script);
+  };
+  return (await extractDesignStyles({ evaluate })).shadows;
+}
+
+beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function (this: HTMLElement) {
+      const style = getComputedStyle(this);
+      return new DOMRect(0, 0, parseFloat(style.width) || 0, parseFloat(style.height) || 0);
+    },
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.head.innerHTML = "";
+  document.body.innerHTML = "";
+});
+
+describe("computed box shadow capture", () => {
+  it("counts ordinary and utility-class boxes without counting semantic samples twice", async () => {
+    document.head.innerHTML = `<style>
+      div { width: 200px; height: 100px; box-shadow: 0 4px 12px rgba(20, 30, 40, .2); }
+    </style>`;
+    document.body.innerHTML = '<div></div><div class="u9"></div><div class="card"></div>';
+    const value = getComputedStyle(document.body.children[0]!).boxShadow;
+
+    expect(await shadows()).toEqual([{ value, count: 3 }]);
+  });
+
+  it("preserves small and full-viewport semantic samples after a dense structural prefix", async () => {
+    document.body.innerHTML = `${'<div style="width: 1px; height: 1px"></div>'.repeat(900)}
+      <button style="width: 20px; height: 20px; box-shadow: 0 1px 2px red">+</button>
+      <span class="card" style="width: 20px; height: 20px; box-shadow: 0 1px 2px red">A</span>
+      <header style="width: ${innerWidth}px; height: ${innerHeight}px; box-shadow: 0 2px 4px blue"></header>
+      <div style="width: 200px; height: 100px; box-shadow: 0 8px 16px green"></div>`;
+    const button = document.querySelector("button")!;
+    const header = document.querySelector("header")!;
+
+    expect(await shadows()).toEqual([
+      { value: getComputedStyle(button).boxShadow, count: 2 },
+      { value: getComputedStyle(header).boxShadow, count: 1 },
+    ]);
+  });
+
+  it("excludes hidden, tiny and page-sized additions while keeping a visible card", async () => {
+    document.head.innerHTML = `<style>
+      div { width: 200px; height: 100px; box-shadow: 0 4px 8px purple; }
+    </style>`;
+    document.body.innerHTML = `
+      <div style="display: none"></div>
+      <div style="visibility: hidden"></div>
+      <div style="opacity: 0"></div>
+      <div style="width: 20px; height: 20px"></div>
+      <div style="width: ${innerWidth}px; height: ${innerHeight}px"></div>
+      <div id="visible"></div>`;
+    const value = getComputedStyle(document.getElementById("visible")!).boxShadow;
+
+    expect(await shadows()).toEqual([{ value, count: 1 }]);
+  });
+});

--- a/packages/cli/src/capture/designStyleExtractor.ts
+++ b/packages/cli/src/capture/designStyleExtractor.ts
@@ -373,15 +373,27 @@ const EXTRACT_DESIGN_STYLES_SCRIPT = `(() => {
 
   // ── 7. Box shadows ──
   var shadowCounts = {};
-  var shadowSamples = Array.from(document.querySelectorAll(
+  // Keep semantic samples even when they are small or appear late in a dense page.
+  var semanticShadowSamples = new Set(Array.from(document.querySelectorAll(
     "[class*='card'], [class*='Card'], button, [class*='btn'], " +
     "[class*='dropdown'], [class*='modal'], [class*='popover'], " +
     "nav, header, [class*='panel'], article"
-  )).slice(0, 100);
+  )).slice(0, 100));
+  // Plain/utility-class boxes also carry elevation. Bound the extra style reads
+  // and deduplicate elements that already matched a semantic selector.
+  var shadowSamples = new Set([
+    ...semanticShadowSamples,
+    ...Array.from(document.querySelectorAll("div, section, aside, li, a, figure, main")).slice(0, 800)
+  ]);
 
-  for (var shi = 0; shi < shadowSamples.length; shi++) {
-    if (!isVisible(shadowSamples[shi])) continue;
-    var shVal = getComputedStyle(shadowSamples[shi]).boxShadow;
+  for (var shEl of shadowSamples) {
+    if (!isVisible(shEl)) continue;
+    if (!semanticShadowSamples.has(shEl)) {
+      var shRect = shEl.getBoundingClientRect();
+      if (shRect.width * shRect.height < 1600) continue;
+      if (shRect.width > window.innerWidth * 0.95 && shRect.height > window.innerHeight * 0.9) continue;
+    }
+    var shVal = getComputedStyle(shEl).boxShadow;
     if (shVal && shVal !== "none") {
       shadowCounts[shVal] = (shadowCounts[shVal] || 0) + 1;
     }
@@ -492,6 +504,6 @@ const EXTRACT_DESIGN_STYLES_SCRIPT = `(() => {
   };
 })()`;
 
-export async function extractDesignStyles(page: Page): Promise<DesignStyles> {
+export async function extractDesignStyles(page: Pick<Page, "evaluate">): Promise<DesignStyles> {
   return page.evaluate(EXTRACT_DESIGN_STYLES_SCRIPT) as Promise<DesignStyles>;
 }


### PR DESCRIPTION
Capture misses box shadows on ordinary or utility-class containers because it samples only named cards, buttons, and similar selectors. Add a bounded computed-style sample of structural boxes while preserving existing semantic samples, including small buttons and late-page headers. Deduplicate overlapping samples; apply tiny/full-page exclusions only to newly sampled boxes.

Successor to #1883 by @xuanruli; original authorship preserved. The separate toolkit in #2005 was closed and re-homed, while this extractor remains part of the active capture command.

Validation: 196 capture tests pass, including three new regressions; CLI typecheck, formatting/lint, and commit hooks pass. Chrome 152 reproduces the missed shadows before the fix and verifies coverage, deduplication, hidden/tiny/full-page exclusions, and preservation of late semantic samples afterward. A 10,000-div fixture adds only 1,600 computed-style reads (800 new candidates). No Chrome dependency added to CI tests.
