### PR TITLE
fix(keyframes): resolve helper-returned DOM targets

### DIFF
--- a/packages/cli/src/commands/keyframes.test.ts
+++ b/packages/cli/src/commands/keyframes.test.ts
@@ -192,6 +192,20 @@ describe("keyframes runtime surfacing", () => {
 
     expect(selectors).toEqual(expect.arrayContaining([".dot", ".chip"]));
   });
+
+  it("does not forward unresolved static targets as concrete shot selectors", () => {
+    const html = wrap(`
+      const tl = gsap.timeline({ paused: true });
+      tl.to(runtimeOnlyTarget(), { x: 240, duration: 1 });
+      tl.to("#drag", { x: 240, duration: 1 });
+    `);
+
+    const selectors = collectShotSelectors([
+      surfaceComposition(html, "helper.html", "helper.html"),
+    ]).map((item) => item.selector);
+
+    expect(selectors).toEqual(["#drag"]);
+  });
 });
 
 describe("keyframes template-wrapped sub-compositions", () => {

--- a/packages/cli/src/commands/keyframes.ts
+++ b/packages/cli/src/commands/keyframes.ts
@@ -659,7 +659,7 @@ function addTraceSelectors(selectors: Set<string>, cmp: SurfacedComposition): vo
 
 function addTweenSelectors(selectors: Set<string>, cmp: SurfacedComposition): void {
   for (const t of cmp.tweens) {
-    if (t.method !== "set") selectors.add(t.target);
+    if (t.method !== "set" && t.target !== "__unresolved__") selectors.add(t.target);
   }
 }
 
@@ -701,7 +701,7 @@ function onionShotGuardError(
   // The rendered onion (--ghost) screenshots the whole painted stage, so it does
   // not need an animated DOM element to sample — only the marker onion does.
   if (requests.length === 0 && !ghost)
-    return "--shot: no animated element to sample for the selection.";
+    return "--shot: no statically resolved animated element to sample for the selection. Use a direct DOM selector or --ghost for runtime-only targets.";
   return null;
 }
 

--- a/packages/parsers/src/gsapParser.test.ts
+++ b/packages/parsers/src/gsapParser.test.ts
@@ -1241,6 +1241,22 @@ describe("variable-target resolution (querySelector pattern)", () => {
     expect(result.animations.map((a) => a.targetSelector)).toEqual([".literal", ".kicker"]);
   });
 
+  it("resolves a DOM target returned by a lexical helper", () => {
+    const script = `
+      function scoped(id) {
+        return document.getElementById(id);
+      }
+      const tl = gsap.timeline({ paused: true });
+      const target = scoped("drag");
+      tl.to(target, { x: 240, duration: 1 }, 0);
+    `;
+
+    const result = parseGsapScript(script);
+
+    expect(result.animations[0]?.targetSelector).toBe("#drag");
+    expect(result.animations[0]?.hasUnresolvedSelector).toBeUndefined();
+  });
+
   it("parses every tween in a real-world IIFE composition with interleaved gsap.set", () => {
     const result = parseGsapScript(REAL_WORLD_SCRIPT);
     expect(result.animations.map((a) => a.targetSelector)).toEqual([

--- a/packages/parsers/src/gsapParser.ts
+++ b/packages/parsers/src/gsapParser.ts
@@ -216,6 +216,13 @@ function scopeChainOf(path: AstPath): AstNode[] {
 /** Per-scope element bindings: scopeNode → (variable name → selector). */
 type TargetBindings = Map<any, Map<string, string>>;
 
+interface TargetHelper {
+  params: string[];
+  returnNode: AstNode;
+}
+
+type TargetHelpers = Map<any, Map<string, TargetHelper>>;
+
 function addBinding(
   bindings: TargetBindings,
   scopeNode: AstNode,
@@ -230,26 +237,110 @@ function addBinding(
   if (!scoped.has(name)) scoped.set(name, selector);
 }
 
+function directHelperReturn(node: AstNode): AstNode | null {
+  if (node.type === "ArrowFunctionExpression" && node.body?.type !== "BlockStatement") {
+    return node.body;
+  }
+  if (!isFunctionNode(node) || node.body?.type !== "BlockStatement") return null;
+  const returns = (node.body.body ?? []).filter(
+    (statement: AstNode) => statement.type === "ReturnStatement" && statement.argument,
+  );
+  return returns.length === 1 ? returns[0].argument : null;
+}
+
+function collectTargetHelpers(ast: AstNode): TargetHelpers {
+  const helpers: TargetHelpers = new Map();
+  const add = (scopeNode: AstNode, name: string, fn: AstNode): void => {
+    const returnNode = directHelperReturn(fn);
+    const params = (fn.params ?? [])
+      .filter((param: AstNode) => param.type === "Identifier")
+      .map((param: AstNode) => param.name);
+    if (!returnNode || params.length !== (fn.params?.length ?? 0)) return;
+    let scoped = helpers.get(scopeNode);
+    if (!scoped) {
+      scoped = new Map();
+      helpers.set(scopeNode, scoped);
+    }
+    if (!scoped.has(name)) scoped.set(name, { params, returnNode });
+  };
+
+  recast.types.visit(ast, {
+    visitFunctionDeclaration(path: AstPath) {
+      const name = path.node.id?.name;
+      const scopeNode = enclosingScopeNode(path);
+      if (name && scopeNode) add(scopeNode, name, path.node);
+      this.traverse(path);
+    },
+    visitVariableDeclarator(path: AstPath) {
+      const name = path.node.id?.name;
+      const fn = path.node.init;
+      const scopeNode = enclosingScopeNode(path);
+      if (name && fn && isFunctionNode(fn) && scopeNode) add(scopeNode, name, fn);
+      this.traverse(path);
+    },
+  });
+  return helpers;
+}
+
+function lookupTargetHelper(
+  name: string,
+  path: AstPath,
+  helpers: TargetHelpers,
+): TargetHelper | null {
+  for (const scopeNode of scopeChainOf(path)) {
+    const helper = helpers.get(scopeNode)?.get(name);
+    if (helper) return helper;
+  }
+  return null;
+}
+
+function selectorFromTargetCall(
+  node: AstNode,
+  path: AstPath,
+  scope: ScopeBindings,
+  helpers: TargetHelpers,
+): string | null {
+  const direct = selectorFromQueryCall(node, scope);
+  if (direct) return direct;
+  if (node?.type !== "CallExpression" || node.callee?.type !== "Identifier") return null;
+  const helper = lookupTargetHelper(node.callee.name, path, helpers);
+  if (!helper || helper.params.length !== (node.arguments?.length ?? 0)) return null;
+
+  const helperScope = new Map(scope);
+  for (let i = 0; i < helper.params.length; i += 1) {
+    const param = helper.params[i];
+    if (!param) return null;
+    const value = resolveNode(node.arguments[i], scope);
+    if (value === undefined) return null;
+    helperScope.set(param, value);
+  }
+  return selectorFromQueryCall(helper.returnNode, helperScope);
+}
+
 /**
  * Build a lexically-scoped index of element variables → selector. Two passes:
  * (1) direct DOM-lookup assignments (`const x = root.querySelector(...)`), then
  * (2) iteration callback params (`coll.forEach(el => …)`), whose element type is
  * the collection's selector — resolved against the pass-1 bindings.
  */
-function collectTargetBindings(ast: AstNode, scope: ScopeBindings): TargetBindings {
+function collectTargetBindings(
+  ast: AstNode,
+  scope: ScopeBindings,
+  helpers: TargetHelpers,
+): TargetBindings {
   const bindings: TargetBindings = new Map();
 
   recast.types.visit(ast, {
     visitVariableDeclarator(path: AstPath) {
       const name = path.node.id?.name;
-      const selector = selectorFromQueryCall(path.node.init, scope);
+      const selector = selectorFromTargetCall(path.node.init, path, scope, helpers);
       const scopeNode = enclosingScopeNode(path);
       if (name && selector !== null && scopeNode) addBinding(bindings, scopeNode, name, selector);
       this.traverse(path);
     },
     visitAssignmentExpression(path: AstPath) {
       const left = path.node.left;
-      const selector = selectorFromQueryCall(path.node.right, scope);
+      const selector = selectorFromTargetCall(path.node.right, path, scope, helpers);
       const scopeNode = enclosingScopeNode(path);
       if (left?.type === "Identifier" && selector !== null && scopeNode) {
         addBinding(bindings, scopeNode, left.name, selector);
@@ -324,6 +415,7 @@ function resolveTargetSelector(
   path: AstPath,
   scope: ScopeBindings,
   bindings: TargetBindings,
+  helpers: TargetHelpers,
 ): string | null {
   if (!node) return null;
   if (node.type === "StringLiteral" || node.type === "Literal") {
@@ -333,11 +425,11 @@ function resolveTargetSelector(
     return lookupBinding(node.name, path, bindings);
   }
   if (node.type === "CallExpression") {
-    return selectorFromQueryCall(node, scope);
+    return selectorFromTargetCall(node, path, scope, helpers);
   }
   if (node.type === "ArrayExpression") {
     const parts = node.elements
-      .map((el: AstNode) => resolveTargetSelector(el, path, scope, bindings))
+      .map((el: AstNode) => resolveTargetSelector(el, path, scope, bindings, helpers))
       .filter((s: string | null): s is string => typeof s === "string" && s.length > 0);
     return parts.length > 0 ? parts.join(", ") : null;
   }
@@ -518,6 +610,7 @@ function findAllTweenCalls(
   ref: TimelineRef,
   scope: ScopeBindings,
   targetBindings: TargetBindings,
+  targetHelpers: TargetHelpers,
 ): TweenCallInfo[] {
   const results: TweenCallInfo[] = [];
   recast.types.visit(ast, {
@@ -554,7 +647,8 @@ function findAllTweenCalls(
           return;
         }
         const selectorValue =
-          resolveTargetSelector(args[0], path, scope, targetBindings) ?? "__unresolved__";
+          resolveTargetSelector(args[0], path, scope, targetBindings, targetHelpers) ??
+          "__unresolved__";
 
         if (method === "fromTo") {
           results.push({
@@ -1178,11 +1272,12 @@ interface ParsedGsapAst {
 function parseGsapAst(script: string): ParsedGsapAst {
   const ast = parseScript(script);
   const scope = collectScopeBindings(ast);
-  const targetBindings = collectTargetBindings(ast, scope);
+  const targetHelpers = collectTargetHelpers(ast);
+  const targetBindings = collectTargetBindings(ast, scope, targetHelpers);
   const detection = findTimelineVar(ast, scope);
   const ref: TimelineRef = detection.ref ?? { kind: "identifier", name: "tl" };
   const timelineVar = timelineRootSource(ref);
-  const calls = findAllTweenCalls(ast, ref, scope, targetBindings);
+  const calls = findAllTweenCalls(ast, ref, scope, targetBindings, targetHelpers);
   sortBySourcePosition(calls);
   const rawAnims = calls.map((call) => tweenCallToAnimation(call, scope));
   applyTimelineDefaults(rawAnims, detection.defaults);


### PR DESCRIPTION
## What

`hyperframes keyframes` now resolves simple lexical helpers that return DOM lookups, so `const target = scoped("drag")` surfaces as `#drag` instead of `__unresolved__`. Truly runtime-only targets are no longer forwarded as concrete onion-shot selectors.

## Why

GSAP received the real DOM node and rendered motion correctly, but static introspection understood only direct lookup calls. The shot path then treated its internal unresolved marker as a selector and falsely reported that nothing animated under the requested scope.

## How

The parser indexes lexically scoped function declarations and function-valued variables when they have one direct return. At a helper call it binds literal arguments to parameters and reuses the existing DOM-query selector resolver on the return expression. Opaque helpers retain `hasUnresolvedSelector`; the CLI filters that marker and reports a static-analysis limitation with direct-selector and `--ghost` guidance.

## Test plan

- [x] `scoped(id) { return document.getElementById(id) }` resolves `scoped("drag")` to `#drag`.
- [x] Unknown runtime targets remain unresolved but are excluded from shot requests.
- [x] Parser and keyframes suites pass (225/225).
- [x] Parser package typecheck passes.
- [x] Changed files pass oxlint and oxfmt.
- [ ] Full CLI workspace typecheck: unavailable in the reused checkout because unrelated AWS/GCP/producer dependencies and generated types are missing or mismatched; no reported error points to the changed keyframes file.
- [ ] Documentation updated (not applicable).
