### PR TITLE
chore: release v0.8.28

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,75 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.28"
+  description="Released - 2026-09-05"
+  tags={["Release", "Capture", "Core", "Render"]}
+>
+Rendering is more reliable across audio, fonts, assets, and nested compositions, while capture now preserves real shadows and button materials.
+Snapshot comparisons and stricter media lint make regressions easier to spot before export.
+
+## Features
+
+- **CLI:** Snapshot --against pairs each frame with a reference video ([c5224ac7e3](https://github.com/heygen-com/hyperframes/commit/c5224ac7e3cbd06962d5dc013470b5c75e5422a2), [#3637](https://github.com/heygen-com/hyperframes/pull/3637)).
+- **Lint:** Error when a video or img src is the other media kind ([8fade97da9](https://github.com/heygen-com/hyperframes/commit/8fade97da9eb59ff8c62cbebc4cd09ea0fefdf9c), [#3609](https://github.com/heygen-com/hyperframes/pull/3609)).
+
+## Fixes
+
+- **Capture:** Sample computed shadows on ordinary boxes ([9ed50028c4](https://github.com/heygen-com/hyperframes/commit/9ed50028c4345b001165d9a5809725abdca02719), [#3686](https://github.com/heygen-com/hyperframes/pull/3686)).
+- **Capture:** Retain opaque and glass button styles ([a7cdd583e7](https://github.com/heygen-com/hyperframes/commit/a7cdd583e74e5bc7602aded9e45948fa58e2597d), [#3685](https://github.com/heygen-com/hyperframes/pull/3685)).
+- **Core:** Scope composition root pattern selectors per instance ([65cf87de38](https://github.com/heygen-com/hyperframes/commit/65cf87de38b2c6b132381a1d40ccb1309d5d4a50), [#3684](https://github.com/heygen-com/hyperframes/pull/3684)).
+- **Render:** Serve media assets with registered content types ([19dee4cede](https://github.com/heygen-com/hyperframes/commit/19dee4cede76c9ff2b3a03aa926217794d7692fa), [#3677](https://github.com/heygen-com/hyperframes/pull/3677)).
+- **CLI:** Forward GIF and frame-format options in batch renders ([36ec028d5f](https://github.com/heygen-com/hyperframes/commit/36ec028d5f95542cb9e50101406636a2ab0d4961), [#3666](https://github.com/heygen-com/hyperframes/pull/3666)).
+- **Producer:** Isolate font cache temporary writes ([66052255cf](https://github.com/heygen-com/hyperframes/commit/66052255cf6c92125e40ce0c91a732a341f827ac), [#3669](https://github.com/heygen-com/hyperframes/pull/3669)).
+- **Producer:** Constrain delivered AAC true peak ([cb44fe1c0b](https://github.com/heygen-com/hyperframes/commit/cb44fe1c0b7b306abd029d8edb815f7627ec53e4), [#3644](https://github.com/heygen-com/hyperframes/pull/3644)).
+- **Producer:** Preserve nested entry asset base ([32f9ed9880](https://github.com/heygen-com/hyperframes/commit/32f9ed988000ffc669799e4b29b979a8a0586232), [#3645](https://github.com/heygen-com/hyperframes/pull/3645)).
+- **Producer:** Guard disk capture capacity ([3314168e30](https://github.com/heygen-com/hyperframes/commit/3314168e30f14c8230220a883df930ce3242653b), [#3643](https://github.com/heygen-com/hyperframes/pull/3643)).
+- **Engine:** Fail closed on blocked SRI scripts ([c0303fc523](https://github.com/heygen-com/hyperframes/commit/c0303fc5237a95469ae1d8b57b2f2239e7556b0e), [#3664](https://github.com/heygen-com/hyperframes/pull/3664)).
+- **Producer:** Scale high-quality encode timeout ([50af764b7d](https://github.com/heygen-com/hyperframes/commit/50af764b7d5f2c6feefe387d031a2cebdc764e7a), [#3649](https://github.com/heygen-com/hyperframes/pull/3649)).
+- **Producer:** Follow variable audio duration ([2ca493094e](https://github.com/heygen-com/hyperframes/commit/2ca493094ecc558af3d833e00e130237d919ff5e), [#3647](https://github.com/heygen-com/hyperframes/pull/3647)).
+- **Producer:** Preserve render warning attribution ([78a28b8942](https://github.com/heygen-com/hyperframes/commit/78a28b8942f2003babbad04d49c8d9e42ae37b41), [#3642](https://github.com/heygen-com/hyperframes/pull/3642)).
+- **Engine:** Retry capture screenshot timeouts ([f334b0e735](https://github.com/heygen-com/hyperframes/commit/f334b0e73585fe7dd03a33d41beb4c8f1442fadf), [#3641](https://github.com/heygen-com/hyperframes/pull/3641)).
+- **Runtime:** Align nested activation to export frames ([c8ddbe0a4b](https://github.com/heygen-com/hyperframes/commit/c8ddbe0a4be54722956af3dc91cf7191dae4d1a4), [#3640](https://github.com/heygen-com/hyperframes/pull/3640)).
+- **Studio Server:** Block dangling symlink upload escapes ([723cd0d785](https://github.com/heygen-com/hyperframes/commit/723cd0d7853e2ef5cc4f1b2fba12521ed5d9d5bc), [#3661](https://github.com/heygen-com/hyperframes/pull/3661)).
+- **Shader Transitions:** Preserve gravitational lens start frame ([dd06b321cd](https://github.com/heygen-com/hyperframes/commit/dd06b321cda5630bb40c5799afc5c704a1f6a12c), [#3660](https://github.com/heygen-com/hyperframes/pull/3660)).
+- **Lint:** Give randomness guidance for crypto values ([0ad9c700ac](https://github.com/heygen-com/hyperframes/commit/0ad9c700ac0f235c496f08ed29b09b2c2fb5f73a), [#3659](https://github.com/heygen-com/hyperframes/pull/3659)).
+- **Studio Server:** Preserve binary file writes and versions ([d2741b3a28](https://github.com/heygen-com/hyperframes/commit/d2741b3a28a222f00580d145bc00575f8f696d66), [#3653](https://github.com/heygen-com/hyperframes/pull/3653)).
+- **Captions:** Preserve zero plate grain in generated postfx ([924b98a0dc](https://github.com/heygen-com/hyperframes/commit/924b98a0dc9f04ba4bbfe0452706057322417342), [#3656](https://github.com/heygen-com/hyperframes/pull/3656)).
+- **Studio Server:** Cascade GSAP cleanup when deleting subtrees ([3bc46a8ade](https://github.com/heygen-com/hyperframes/commit/3bc46a8ade37661e2c0680b3da16a9900c2af308), [#3655](https://github.com/heygen-com/hyperframes/pull/3655)).
+- **Fonts:** Retain non-Latin subsets for bundled weights ([ef63e02936](https://github.com/heygen-com/hyperframes/commit/ef63e02936b114f598444a9fabf2d501d244d8de), [#3652](https://github.com/heygen-com/hyperframes/pull/3652)).
+- **Runtime:** Wait for a finite dotlottie duration ([bec11b1293](https://github.com/heygen-com/hyperframes/commit/bec11b129372d02601b37985861df211c4ffc706), [#3651](https://github.com/heygen-com/hyperframes/pull/3651)).
+- **Embedded Captions:** Support heroless themes ([62d3304caf](https://github.com/heygen-com/hyperframes/commit/62d3304caf2cc36981c20152e46d49d42126736d), [#3632](https://github.com/heygen-com/hyperframes/pull/3632)).
+- **CLI:** Count font axes as motion in the sweep fingerprint ([19a512c05a](https://github.com/heygen-com/hyperframes/commit/19a512c05a5929a9860ef97ee47812c5e7108e57), [#3107](https://github.com/heygen-com/hyperframes/pull/3107)).
+- **CLI:** Upgrade project wrapper pins ([e147613542](https://github.com/heygen-com/hyperframes/commit/e1476135422e528c9958f2eefadf3e6821f35011), [#3042](https://github.com/heygen-com/hyperframes/pull/3042)).
+- **CLI:** Render SVG selector proof strips ([709d70c675](https://github.com/heygen-com/hyperframes/commit/709d70c6750c7af906e8df31b79cabbac5919b0c), [#3537](https://github.com/heygen-com/hyperframes/pull/3537)).
+- **Producer:** Scale frame coverage by playback rate ([353b9eb3da](https://github.com/heygen-com/hyperframes/commit/353b9eb3da5e6496f0eb91fdce0ee69d56945cc1), [#3542](https://github.com/heygen-com/hyperframes/pull/3542)).
+- **Studio:** Drop the resurrected WebMCP polyfill assertion ([ece09d830d](https://github.com/heygen-com/hyperframes/commit/ece09d830ded702728d1eb461c2efc95228e375d), [#3556](https://github.com/heygen-com/hyperframes/pull/3556)).
+- **CLI:** Split Kokoro text on token overflow ([faaafbb251](https://github.com/heygen-com/hyperframes/commit/faaafbb2513ed18ef900e08f935237ee4c002b6d), [#3041](https://github.com/heygen-com/hyperframes/pull/3041)).
+- **Captions:** Derive preview GSAP integrity ([0154b40b65](https://github.com/heygen-com/hyperframes/commit/0154b40b65929a53bfa729c8de441f5c5332b0ae), [#3631](https://github.com/heygen-com/hyperframes/pull/3631)).
+- **CLI:** Persist what the server answered for a captured page ([a3954aa1cb](https://github.com/heygen-com/hyperframes/commit/a3954aa1cbdaa21bfc751f13cbde5e87ae499ad5), [#3553](https://github.com/heygen-com/hyperframes/pull/3553)).
+- **CLI:** Install the published skill set, not every SKILL.md in the repo ([c8300c69a1](https://github.com/heygen-com/hyperframes/commit/c8300c69a1807d439dd951f94f325c806e020841), [#3636](https://github.com/heygen-com/hyperframes/pull/3636)).
+- **Render:** Allow resolution scaling for alpha output ([e0007b86e0](https://github.com/heygen-com/hyperframes/commit/e0007b86e0e6b65352bd658e1c4e21717ffe3d3f), [#3634](https://github.com/heygen-com/hyperframes/pull/3634)).
+- **Fonts:** Make Google Fonts subsetting CSS text-transform aware ([05b57f9204](https://github.com/heygen-com/hyperframes/commit/05b57f9204a963104f1f79ef88ffc24cd174fd68), [#3577](https://github.com/heygen-com/hyperframes/pull/3577)).
+
+## Docs & Examples
+
+- **Studio:** Align stack note with package dependency contract ([1f9f86c857](https://github.com/heygen-com/hyperframes/commit/1f9f86c8575a181452af760f815834d4edc40200), [#3675](https://github.com/heygen-com/hyperframes/pull/3675)).
+- **CLI:** Document current publish workflow ([44208ceada](https://github.com/heygen-com/hyperframes/commit/44208ceadac894149d69970a0ef86ee5caf2ecfe), [#3674](https://github.com/heygen-com/hyperframes/pull/3674)).
+- **Core:** Fix published frame adapter reference links ([893141413e](https://github.com/heygen-com/hyperframes/commit/893141413e27ac149d43fc5d4efc044a6b675b03), [#3667](https://github.com/heygen-com/hyperframes/pull/3667)).
+- **Skills:** Fix creative house style reference links ([a93106aebf](https://github.com/heygen-com/hyperframes/commit/a93106aebff66f1cf6b982699e30c44581b8c38c), [#3668](https://github.com/heygen-com/hyperframes/pull/3668)).
+- **Adopters:** Add PandaStudio ([7b772465e3](https://github.com/heygen-com/hyperframes/commit/7b772465e3aa18cd4ed060147a913a5c016a96fb), [#3663](https://github.com/heygen-com/hyperframes/pull/3663)).
+- **Adopters:** Add Mini Course Generator ([f7cac7287a](https://github.com/heygen-com/hyperframes/commit/f7cac7287adfd1026318353f4487936e854aeb55), [#3662](https://github.com/heygen-com/hyperframes/pull/3662)).
+
+## Catalog
+
+- **Registry:** Clarify catalog preview staging and published URLs ([7fcb5be6ea](https://github.com/heygen-com/hyperframes/commit/7fcb5be6ea9d9c0d7789d7ee0a909201dedc9a44), [#3676](https://github.com/heygen-com/hyperframes/pull/3676)).
+- **Registry:** Document installer metadata ([29efd5dfa8](https://github.com/heygen-com/hyperframes/commit/29efd5dfa8003054586b64adc3b3316c30ba56e4), [#3658](https://github.com/heygen-com/hyperframes/pull/3658)).
+- **CLI:** Forward a reported catalog gap to the feedback channel ([2dc4bbfa75](https://github.com/heygen-com/hyperframes/commit/2dc4bbfa7502db90c6fbd501d06b85a33fbdd561), [#3204](https://github.com/heygen-com/hyperframes/pull/3204)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.27...v0.8.28).
+</Update>
+
+<Update
   label="HyperFrames v0.8.27"
   description="Released - 2026-09-03"
   tags={["Release", "CLI"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.27",
+  "version": "0.8.28",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.28.md
+++ b/releases/v0.8.28.md
@@ -1,0 +1,68 @@
+# HyperFrames v0.8.28
+
+Released on 2026-09-05.
+
+Rendering is more reliable across audio, fonts, assets, and nested compositions, while capture now preserves real shadows and button materials.
+Snapshot comparisons and stricter media lint make regressions easier to spot before export.
+
+## Features
+
+- **CLI:** Snapshot --against pairs each frame with a reference video ([c5224ac7e3](https://github.com/heygen-com/hyperframes/commit/c5224ac7e3cbd06962d5dc013470b5c75e5422a2), [#3637](https://github.com/heygen-com/hyperframes/pull/3637)).
+- **Lint:** Error when a video or img src is the other media kind ([8fade97da9](https://github.com/heygen-com/hyperframes/commit/8fade97da9eb59ff8c62cbebc4cd09ea0fefdf9c), [#3609](https://github.com/heygen-com/hyperframes/pull/3609)).
+
+## Fixes
+
+- **Capture:** Sample computed shadows on ordinary boxes ([9ed50028c4](https://github.com/heygen-com/hyperframes/commit/9ed50028c4345b001165d9a5809725abdca02719), [#3686](https://github.com/heygen-com/hyperframes/pull/3686)).
+- **Capture:** Retain opaque and glass button styles ([a7cdd583e7](https://github.com/heygen-com/hyperframes/commit/a7cdd583e74e5bc7602aded9e45948fa58e2597d), [#3685](https://github.com/heygen-com/hyperframes/pull/3685)).
+- **Core:** Scope composition root pattern selectors per instance ([65cf87de38](https://github.com/heygen-com/hyperframes/commit/65cf87de38b2c6b132381a1d40ccb1309d5d4a50), [#3684](https://github.com/heygen-com/hyperframes/pull/3684)).
+- **Render:** Serve media assets with registered content types ([19dee4cede](https://github.com/heygen-com/hyperframes/commit/19dee4cede76c9ff2b3a03aa926217794d7692fa), [#3677](https://github.com/heygen-com/hyperframes/pull/3677)).
+- **CLI:** Forward GIF and frame-format options in batch renders ([36ec028d5f](https://github.com/heygen-com/hyperframes/commit/36ec028d5f95542cb9e50101406636a2ab0d4961), [#3666](https://github.com/heygen-com/hyperframes/pull/3666)).
+- **Producer:** Isolate font cache temporary writes ([66052255cf](https://github.com/heygen-com/hyperframes/commit/66052255cf6c92125e40ce0c91a732a341f827ac), [#3669](https://github.com/heygen-com/hyperframes/pull/3669)).
+- **Producer:** Constrain delivered AAC true peak ([cb44fe1c0b](https://github.com/heygen-com/hyperframes/commit/cb44fe1c0b7b306abd029d8edb815f7627ec53e4), [#3644](https://github.com/heygen-com/hyperframes/pull/3644)).
+- **Producer:** Preserve nested entry asset base ([32f9ed9880](https://github.com/heygen-com/hyperframes/commit/32f9ed988000ffc669799e4b29b979a8a0586232), [#3645](https://github.com/heygen-com/hyperframes/pull/3645)).
+- **Producer:** Guard disk capture capacity ([3314168e30](https://github.com/heygen-com/hyperframes/commit/3314168e30f14c8230220a883df930ce3242653b), [#3643](https://github.com/heygen-com/hyperframes/pull/3643)).
+- **Engine:** Fail closed on blocked SRI scripts ([c0303fc523](https://github.com/heygen-com/hyperframes/commit/c0303fc5237a95469ae1d8b57b2f2239e7556b0e), [#3664](https://github.com/heygen-com/hyperframes/pull/3664)).
+- **Producer:** Scale high-quality encode timeout ([50af764b7d](https://github.com/heygen-com/hyperframes/commit/50af764b7d5f2c6feefe387d031a2cebdc764e7a), [#3649](https://github.com/heygen-com/hyperframes/pull/3649)).
+- **Producer:** Follow variable audio duration ([2ca493094e](https://github.com/heygen-com/hyperframes/commit/2ca493094ecc558af3d833e00e130237d919ff5e), [#3647](https://github.com/heygen-com/hyperframes/pull/3647)).
+- **Producer:** Preserve render warning attribution ([78a28b8942](https://github.com/heygen-com/hyperframes/commit/78a28b8942f2003babbad04d49c8d9e42ae37b41), [#3642](https://github.com/heygen-com/hyperframes/pull/3642)).
+- **Engine:** Retry capture screenshot timeouts ([f334b0e735](https://github.com/heygen-com/hyperframes/commit/f334b0e73585fe7dd03a33d41beb4c8f1442fadf), [#3641](https://github.com/heygen-com/hyperframes/pull/3641)).
+- **Runtime:** Align nested activation to export frames ([c8ddbe0a4b](https://github.com/heygen-com/hyperframes/commit/c8ddbe0a4be54722956af3dc91cf7191dae4d1a4), [#3640](https://github.com/heygen-com/hyperframes/pull/3640)).
+- **Studio Server:** Block dangling symlink upload escapes ([723cd0d785](https://github.com/heygen-com/hyperframes/commit/723cd0d7853e2ef5cc4f1b2fba12521ed5d9d5bc), [#3661](https://github.com/heygen-com/hyperframes/pull/3661)).
+- **Shader Transitions:** Preserve gravitational lens start frame ([dd06b321cd](https://github.com/heygen-com/hyperframes/commit/dd06b321cda5630bb40c5799afc5c704a1f6a12c), [#3660](https://github.com/heygen-com/hyperframes/pull/3660)).
+- **Lint:** Give randomness guidance for crypto values ([0ad9c700ac](https://github.com/heygen-com/hyperframes/commit/0ad9c700ac0f235c496f08ed29b09b2c2fb5f73a), [#3659](https://github.com/heygen-com/hyperframes/pull/3659)).
+- **Studio Server:** Preserve binary file writes and versions ([d2741b3a28](https://github.com/heygen-com/hyperframes/commit/d2741b3a28a222f00580d145bc00575f8f696d66), [#3653](https://github.com/heygen-com/hyperframes/pull/3653)).
+- **Captions:** Preserve zero plate grain in generated postfx ([924b98a0dc](https://github.com/heygen-com/hyperframes/commit/924b98a0dc9f04ba4bbfe0452706057322417342), [#3656](https://github.com/heygen-com/hyperframes/pull/3656)).
+- **Studio Server:** Cascade GSAP cleanup when deleting subtrees ([3bc46a8ade](https://github.com/heygen-com/hyperframes/commit/3bc46a8ade37661e2c0680b3da16a9900c2af308), [#3655](https://github.com/heygen-com/hyperframes/pull/3655)).
+- **Fonts:** Retain non-Latin subsets for bundled weights ([ef63e02936](https://github.com/heygen-com/hyperframes/commit/ef63e02936b114f598444a9fabf2d501d244d8de), [#3652](https://github.com/heygen-com/hyperframes/pull/3652)).
+- **Runtime:** Wait for a finite dotlottie duration ([bec11b1293](https://github.com/heygen-com/hyperframes/commit/bec11b129372d02601b37985861df211c4ffc706), [#3651](https://github.com/heygen-com/hyperframes/pull/3651)).
+- **Embedded Captions:** Support heroless themes ([62d3304caf](https://github.com/heygen-com/hyperframes/commit/62d3304caf2cc36981c20152e46d49d42126736d), [#3632](https://github.com/heygen-com/hyperframes/pull/3632)).
+- **CLI:** Count font axes as motion in the sweep fingerprint ([19a512c05a](https://github.com/heygen-com/hyperframes/commit/19a512c05a5929a9860ef97ee47812c5e7108e57), [#3107](https://github.com/heygen-com/hyperframes/pull/3107)).
+- **CLI:** Upgrade project wrapper pins ([e147613542](https://github.com/heygen-com/hyperframes/commit/e1476135422e528c9958f2eefadf3e6821f35011), [#3042](https://github.com/heygen-com/hyperframes/pull/3042)).
+- **CLI:** Render SVG selector proof strips ([709d70c675](https://github.com/heygen-com/hyperframes/commit/709d70c6750c7af906e8df31b79cabbac5919b0c), [#3537](https://github.com/heygen-com/hyperframes/pull/3537)).
+- **Producer:** Scale frame coverage by playback rate ([353b9eb3da](https://github.com/heygen-com/hyperframes/commit/353b9eb3da5e6496f0eb91fdce0ee69d56945cc1), [#3542](https://github.com/heygen-com/hyperframes/pull/3542)).
+- **Studio:** Drop the resurrected WebMCP polyfill assertion ([ece09d830d](https://github.com/heygen-com/hyperframes/commit/ece09d830ded702728d1eb461c2efc95228e375d), [#3556](https://github.com/heygen-com/hyperframes/pull/3556)).
+- **CLI:** Split Kokoro text on token overflow ([faaafbb251](https://github.com/heygen-com/hyperframes/commit/faaafbb2513ed18ef900e08f935237ee4c002b6d), [#3041](https://github.com/heygen-com/hyperframes/pull/3041)).
+- **Captions:** Derive preview GSAP integrity ([0154b40b65](https://github.com/heygen-com/hyperframes/commit/0154b40b65929a53bfa729c8de441f5c5332b0ae), [#3631](https://github.com/heygen-com/hyperframes/pull/3631)).
+- **CLI:** Persist what the server answered for a captured page ([a3954aa1cb](https://github.com/heygen-com/hyperframes/commit/a3954aa1cbdaa21bfc751f13cbde5e87ae499ad5), [#3553](https://github.com/heygen-com/hyperframes/pull/3553)).
+- **CLI:** Install the published skill set, not every SKILL.md in the repo ([c8300c69a1](https://github.com/heygen-com/hyperframes/commit/c8300c69a1807d439dd951f94f325c806e020841), [#3636](https://github.com/heygen-com/hyperframes/pull/3636)).
+- **Render:** Allow resolution scaling for alpha output ([e0007b86e0](https://github.com/heygen-com/hyperframes/commit/e0007b86e0e6b65352bd658e1c4e21717ffe3d3f), [#3634](https://github.com/heygen-com/hyperframes/pull/3634)).
+- **Fonts:** Make Google Fonts subsetting CSS text-transform aware ([05b57f9204](https://github.com/heygen-com/hyperframes/commit/05b57f9204a963104f1f79ef88ffc24cd174fd68), [#3577](https://github.com/heygen-com/hyperframes/pull/3577)).
+
+## Docs & Examples
+
+- **Studio:** Align stack note with package dependency contract ([1f9f86c857](https://github.com/heygen-com/hyperframes/commit/1f9f86c8575a181452af760f815834d4edc40200), [#3675](https://github.com/heygen-com/hyperframes/pull/3675)).
+- **CLI:** Document current publish workflow ([44208ceada](https://github.com/heygen-com/hyperframes/commit/44208ceadac894149d69970a0ef86ee5caf2ecfe), [#3674](https://github.com/heygen-com/hyperframes/pull/3674)).
+- **Core:** Fix published frame adapter reference links ([893141413e](https://github.com/heygen-com/hyperframes/commit/893141413e27ac149d43fc5d4efc044a6b675b03), [#3667](https://github.com/heygen-com/hyperframes/pull/3667)).
+- **Skills:** Fix creative house style reference links ([a93106aebf](https://github.com/heygen-com/hyperframes/commit/a93106aebff66f1cf6b982699e30c44581b8c38c), [#3668](https://github.com/heygen-com/hyperframes/pull/3668)).
+- **Adopters:** Add PandaStudio ([7b772465e3](https://github.com/heygen-com/hyperframes/commit/7b772465e3aa18cd4ed060147a913a5c016a96fb), [#3663](https://github.com/heygen-com/hyperframes/pull/3663)).
+- **Adopters:** Add Mini Course Generator ([f7cac7287a](https://github.com/heygen-com/hyperframes/commit/f7cac7287adfd1026318353f4487936e854aeb55), [#3662](https://github.com/heygen-com/hyperframes/pull/3662)).
+
+## Catalog
+
+- **Registry:** Clarify catalog preview staging and published URLs ([7fcb5be6ea](https://github.com/heygen-com/hyperframes/commit/7fcb5be6ea9d9c0d7789d7ee0a909201dedc9a44), [#3676](https://github.com/heygen-com/hyperframes/pull/3676)).
+- **Registry:** Document installer metadata ([29efd5dfa8](https://github.com/heygen-com/hyperframes/commit/29efd5dfa8003054586b64adc3b3316c30ba56e4), [#3658](https://github.com/heygen-com/hyperframes/pull/3658)).
+- **CLI:** Forward a reported catalog gap to the feedback channel ([2dc4bbfa75](https://github.com/heygen-com/hyperframes/commit/2dc4bbfa7502db90c6fbd501d06b85a33fbdd561), [#3204](https://github.com/heygen-com/hyperframes/pull/3204)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.27...v0.8.28


### PR DESCRIPTION
## What

Prepare HyperFrames v0.8.28 with reviewed release notes and synchronized versions for all 13 published packages and 3 plugin manifests.

## Why

Ship the stable changes merged since v0.8.27, including more reliable rendering, sharper capture fidelity, snapshot comparisons, and stricter media lint.

## How

Generated the changelog from `v0.8.27...HEAD`, rewrote the user-facing summary, and ran the guarded `release:prepare` flow. The local tag is intentionally unpushed; the stable publish workflow will create `v0.8.28` at the reviewed PR merge SHA.

Code review: skipped (mechanical diff) — the branch contains only generated version bumps plus synchronized release-note artifacts, with no executable code changes.

## Test plan

- [x] `bun run test:scripts` — 230 tests passed
- [x] `bun run build`
- [x] `bun run typecheck:scripts`
- [x] `bun run lint`
- [x] `bunx oxfmt --check` on all 18 release files
- [x] Documentation updated

## Post-Deploy Monitoring & Validation

- Watch the merged release PR's **Publish to npm** workflow through completion.
- Verify `v0.8.28` points to the PR merge SHA and the GitHub Release uses `releases/v0.8.28.md`.
- Verify `npm view hyperframes version dist-tags --json` reports `0.8.28` on `latest`, then spot-check the scoped packages.
- Healthy: publish workflow succeeds, the tag/release share the merge SHA, and npm returns 0.8.28.
- Failure: any workflow failure, tag mismatch, or package-version mismatch. Do not push or rewrite the stable tag; rerun the original merged-PR workflow after fixing the cause.
- Validation window/owner: immediately after merge until GitHub and npm converge; Home owns the check with Miguel as release owner.
