### PR TITLE
fix(lint): flag autoAlpha on clip elements

### DIFF
--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -387,6 +387,53 @@ describe("GSAP rules", () => {
     expect(finding?.message).toContain("visibility");
   });
 
+  it("ERRORS when GSAP animates autoAlpha on a clip element", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="incoming" class="clip" data-start="1.01" data-duration="5" data-track-index="1">
+      <p>Incoming scene</p>
+    </div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#incoming", { autoAlpha: 0 }, { autoAlpha: 1, duration: 0.3 }, 1.01);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "gsap_animates_clip_element");
+
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("error");
+    expect(finding?.message).toContain("autoAlpha");
+    expect(finding?.fixHint).toContain("child");
+  });
+
+  it("does NOT flag autoAlpha on content inside a clip", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="incoming" class="clip" data-start="1.01" data-duration="5" data-track-index="1">
+      <p id="content">Incoming scene</p>
+    </div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#content", { autoAlpha: 0 }, { autoAlpha: 1, duration: 0.3 }, 1.01);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "gsap_animates_clip_element");
+
+    expect(finding).toBeUndefined();
+  });
+
   it("ERRORS when GSAP animates display on a clip element", async () => {
     const html = `
 <html><body>

--- a/packages/lint/src/rules/gsap.ts
+++ b/packages/lint/src/rules/gsap.ts
@@ -1226,24 +1226,25 @@ export const gsapRules: LintRule<LintContext>[] = [
         });
       }
 
-      // gsap_animates_clip_element — only error when GSAP animates visibility/display
+      // gsap_animates_clip_element — GSAP must not compete with the framework's
+      // clip visibility window. autoAlpha owns visibility as well as opacity.
       for (const win of gsapWindows) {
         const sel = win.targetSelector;
         const clipInfo = clipIds.get(sel) || clipClasses.get(sel);
         if (!clipInfo) continue;
         const conflictingProps = win.properties.filter(
-          (p) => p === "visibility" || p === "display",
+          (p) => p === "visibility" || p === "display" || p === "autoAlpha",
         );
         if (conflictingProps.length === 0) continue;
         const elDesc = `<${clipInfo.tag}${clipInfo.id ? ` id="${clipInfo.id}"` : ""} class="${clipInfo.classes}">`;
         findings.push({
           code: "gsap_animates_clip_element",
           severity: "error",
-          message: `GSAP animation sets ${conflictingProps.join(", ")} on a clip element. Selector "${sel}" resolves to element ${elDesc}. The framework manages clip visibility via ${conflictingProps.join("/")} — do not animate these properties on clip elements.`,
+          message: `GSAP animation sets ${conflictingProps.join(", ")} on a clip element. Selector "${sel}" resolves to element ${elDesc}. The framework manages clip visibility, and autoAlpha writes visibility as well as opacity — do not animate these properties on clip elements.`,
           selector: sel,
           elementId: clipInfo.id || undefined,
           fixHint:
-            "Remove the visibility/display tween, or move the content into a child <div> and target that instead.",
+            "Remove the visibility/display/autoAlpha tween, or move the content into a child <div> and target that instead.",
           snippet: truncateSnippet(win.raw),
         });
       }


### PR DESCRIPTION
## What

- Report `gsap_animates_clip_element` when GSAP animates `autoAlpha` on a framework-owned `.clip` element.
- Keep `autoAlpha` animations on descendants valid.

## Why

GSAP `autoAlpha` writes both opacity and visibility. On a scene root it can override the framework's clip visibility window and leave a blank boundary frame, even though the fractional scene windows themselves are gap-free.

## How

- Add `autoAlpha` to the existing clip visibility conflict check.
- Clarify the diagnostic and fix hint to explain the visibility conflict.
- Cover both the invalid clip-root target and valid child target.

## Test plan

- RED/GREEN focused `autoAlpha` regression tests.
- Full GSAP lint-rule suite: 167 passed.
- Lint package typecheck.
- Oxlint and formatting checks on changed files.
