### PR TITLE
fix(engine): resolve provenance version from the owning package

### DIFF
--- a/packages/engine/src/utils/renderProvenance.test.ts
+++ b/packages/engine/src/utils/renderProvenance.test.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getFfmpegBinary, getFfprobeBinary } from "./ffmpegBinaries.js";
 import {
@@ -9,6 +10,7 @@ import {
   PROVENANCE_RENDERER_TAG,
   PROVENANCE_VERSION,
   PROVENANCE_VERSION_TAG,
+  readPackageVersionFrom,
   readRenderProvenance,
   renderProvenanceArgs,
 } from "./renderProvenance.js";
@@ -263,5 +265,87 @@ describe.skipIf(!HAS_FFMPEG)("provenance survives a real encode", () => {
       renderer: PROVENANCE_RENDERER_NAME,
       version: PROVENANCE_VERSION,
     });
+  });
+});
+
+describe("engine version resolution", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hf-provenance-version-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** Lay out a package root and return a directory `depth` levels inside it. */
+  const layout = (pkg: Record<string, unknown>, depth: number): string => {
+    writeFileSync(join(dir, "package.json"), JSON.stringify(pkg));
+    let inner = join(dir, "dist");
+    for (let i = 1; i < depth; i++) inner = join(inner, `nested${i}`);
+    mkdirSync(inner, { recursive: true });
+    return inner;
+  };
+
+  // The regression. The CLI bundles the engine flat into `dist/cli.js`
+  // (tsup `noExternal`), one directory below the package root rather than the
+  // two that `src/utils/` and the published `dist/utils/` sit at. The previous
+  // hardcoded `../../package.json` overshot to `node_modules/package.json`,
+  // threw MODULE_NOT_FOUND, and stamped the fallback — so every render from
+  // every published CLI carried `hyperframes_version=0.0.0-dev`. Nothing in
+  // the suite exercised this depth, which is exactly why it shipped.
+  it("resolves the version from the bundled CLI layout (one level deep)", () => {
+    const bundled = layout({ name: "hyperframes", version: "1.2.3" }, 1);
+    expect(readPackageVersionFrom(bundled)).toBe("1.2.3");
+  });
+
+  it("resolves the version from the published engine layout (two levels deep)", () => {
+    const published = layout({ name: "@hyperframes/engine", version: "1.2.3" }, 2);
+    expect(readPackageVersionFrom(published)).toBe("1.2.3");
+  });
+
+  it("resolves from any depth, because the depth is what broke", () => {
+    for (const depth of [1, 2, 3, 5]) {
+      rmSync(dir, { recursive: true, force: true });
+      mkdirSync(dir, { recursive: true });
+      expect(readPackageVersionFrom(layout({ name: "hyperframes", version: "9.9.9" }, depth))).toBe(
+        "9.9.9",
+      );
+    }
+  });
+
+  // Reporting someone else's version number under a `hyperframes_version` key
+  // is worse than admitting we don't know.
+  it("refuses a non-HyperFrames package rather than stamping its version", () => {
+    const foreign = layout({ name: "someones-app", version: "9.9.9" }, 1);
+    expect(readPackageVersionFrom(foreign)).toBe("0.0.0-dev");
+  });
+
+  // `hyperframes-monorepo` is this repo's own private root: a prefix match
+  // would accept it and stamp a version it does not even have.
+  it("matches the package name exactly, not by prefix", () => {
+    const monorepo = layout({ name: "hyperframes-monorepo", private: true }, 1);
+    expect(readPackageVersionFrom(monorepo)).toBe("0.0.0-dev");
+  });
+
+  it("falls back instead of throwing when there is no package.json to find", () => {
+    const orphan = join(dir, "deep", "nowhere");
+    mkdirSync(orphan, { recursive: true });
+    expect(readPackageVersionFrom(orphan)).toBe("0.0.0-dev");
+  });
+
+  it("falls back when the owning package.json is unreadable", () => {
+    writeFileSync(join(dir, "package.json"), "{ not json");
+    expect(readPackageVersionFrom(dir)).toBe("0.0.0-dev");
+  });
+
+  // The end-to-end assertion the rest of the suite cannot make: every other
+  // version test compares PROVENANCE_VERSION against itself, so all of them
+  // pass just as happily when it is the fallback sentinel.
+  it("stamps the real engine version, not the fallback", () => {
+    const pkg = JSON.parse(
+      readFileSync(fileURLToPath(new URL("../../package.json", import.meta.url)), "utf-8"),
+    ) as { version: string };
+    expect(PROVENANCE_VERSION).toBe(pkg.version);
+    expect(PROVENANCE_VERSION).not.toBe("0.0.0-dev");
   });
 });

--- a/packages/engine/src/utils/renderProvenance.ts
+++ b/packages/engine/src/utils/renderProvenance.ts
@@ -1,4 +1,6 @@
-import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { readTagCI } from "./ffprobe.js";
 
 /**
@@ -31,16 +33,61 @@ export const PROVENANCE_RENDERER_NAME = "hyperframes";
 
 const UNKNOWN_VERSION = "0.0.0-dev";
 
+/** `hyperframes` (the CLI) and the `@hyperframes/*` packages ship one locked version. */
+function isHyperframesPackage(name: unknown): boolean {
+  return name === "hyperframes" || (typeof name === "string" && name.startsWith("@hyperframes/"));
+}
+
+/**
+ * Walk up to the package that owns this file and read its version.
+ *
+ * Deliberately not a fixed relative path. This module is consumed at three
+ * different directory depths — `src/utils/` from source, `dist/utils/` from
+ * the published engine, and `dist/cli.js` once the CLI bundles the engine flat
+ * (tsup `noExternal`) — so any hardcoded `../..` is correct for at most two of
+ * them. A depth-2 path silently resolved to `node_modules/package.json` in the
+ * CLI bundle and every published CLI render was stamped `0.0.0-dev`.
+ *
+ * The nearest `package.json` is the package that owns this code; a non-
+ * HyperFrames one means the engine was bundled into someone else's package,
+ * where reporting *their* version under a `hyperframes_version` key would be
+ * worse than admitting we don't know.
+ *
+ * Exported so the depth behaviour is testable at a synthetic layout; the
+ * unreachability of this logic from a test is why the bundled case shipped
+ * broken. A failed read must never break a render, so the caller swallows.
+ */
+export function readPackageVersionFrom(startDir: string): string {
+  let dir = startDir;
+  for (;;) {
+    const pkg = readPackageJson(join(dir, "package.json"));
+    if (pkg) {
+      return isHyperframesPackage(pkg.name) && typeof pkg.version === "string" && pkg.version
+        ? pkg.version
+        : UNKNOWN_VERSION;
+    }
+    // `dirname` is a fixpoint at the filesystem root on every platform, which
+    // terminates the walk without hardcoding what a root looks like.
+    const parent = dirname(dir);
+    if (parent === dir) return UNKNOWN_VERSION;
+    dir = parent;
+  }
+}
+
 function readEngineVersion(): string {
   try {
-    // The engine ships as raw TS and exports "./package.json", so this
-    // resolves without a build-time define. A failed read must never break a
-    // render, hence the fallback rather than a throw.
-    const version = (createRequire(import.meta.url)("../../package.json") as { version?: string })
-      .version;
-    return typeof version === "string" && version.length > 0 ? version : UNKNOWN_VERSION;
+    return readPackageVersionFrom(dirname(fileURLToPath(import.meta.url)));
   } catch {
     return UNKNOWN_VERSION;
+  }
+}
+
+/** Null when there is no readable package.json here, so the walk continues. */
+function readPackageJson(path: string): { name?: unknown; version?: unknown } | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as { name?: unknown; version?: unknown };
+  } catch {
+    return null;
   }
 }
 


### PR DESCRIPTION
## What

Every render from the published `hyperframes` CLI stamps
`hyperframes_version=0.0.0-dev` instead of the real version. The renderer tag
is unaffected — only the version is dead.

Confirmed in the field before touching anything: all three tagged HyperFrames
videos I could find in Slack uploads carry `0.0.0-dev`.

```
$ ffprobe -show_entries format_tags -of json -- ep2-v3.mp4
"hyperframes_renderer": "hyperframes",
"hyperframes_version": "0.0.0-dev"
```

## Why

`readEngineVersion` resolved `../../package.json` relative to
`import.meta.url`. That depth is correct for two of the three layouts this
module actually runs in, and wrong for the one that ships to users:

| layout | path | result |
|---|---|---|
| source `src/utils/` | depth 2 | ✅ resolves |
| published engine `dist/utils/` | depth 2 | ✅ resolves |
| **bundled CLI `dist/cli.js`** | **depth 1** | ❌ `MODULE_NOT_FOUND` → fallback |

The CLI bundles the engine flat via tsup `noExternal`, so `../..` overshoots
the package root and lands on `node_modules/package.json`. The `catch` exists
so a failed read can never break a render, and it did its job silently.

Reproduced against the real published artifact rather than inferred — `npm pack
hyperframes@0.8.29`, whose `dist/cli.js` carries the call at line 71657:

```
$ node package/dist/probe.mjs      # the shipped logic, run from the real tarball
shipped logic -> 0.0.0-dev  (threw: MODULE_NOT_FOUND)
```

## How

Walk up from `import.meta.url` to the nearest `package.json` instead of
assuming a depth. The nearest one is by definition the package that owns the
running code, so the lookup stops depending on how the file was bundled.

Only a HyperFrames package is accepted. If the engine is ever bundled into
someone else's package, stamping *their* version number under a
`hyperframes_version` key is worse than admitting we don't know — that case
returns the fallback. The name match is exact rather than a prefix, because
this repo's own private root is `hyperframes-monorepo` and a prefix match
would accept it.

Termination is a `dirname` fixpoint rather than a comparison against a parsed
root, so it holds on every platform. This runs at module load, so a walk that
failed to terminate would hang every render.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

**The existing suite could not have caught this.** Every version assertion in
it compares `PROVENANCE_VERSION` against itself, so all 14 pass just as happily
when it is the fallback sentinel. I verified that directly: reverting the
implementation to the shipped depth-2 logic leaves all 14 green and fails only
the new tests, with the exact field symptom.

```
× resolves the version from the bundled CLI layout (one level deep)
  → expected '0.0.0-dev' to be '1.2.3'
× resolves from any depth, because the depth is what broke
  → expected '0.0.0-dev' to be '9.9.9'
Tests  2 failed | 20 passed (22)
```

New coverage: the bundled depth-1 layout, the published depth-2 layout,
arbitrary depths, the foreign-package refusal, the exact-name match, both
fallback paths, and an end-to-end assertion that the stamped version is the
package's real version and not the sentinel.

Verified in all four layouts with the fix applied:

```
source src/utils/                    -> 0.8.29
built engine dist/utils/             -> 0.8.29
flat CLI bundle at dist/ (depth 1)   -> 0.8.29   <- was 0.0.0-dev
third-party bundle                   -> 0.0.0-dev  (correctly refused)
```

Local checks: engine suite 1681 passed / 3 skipped / 0 failed, `tsc --noEmit`
clean, oxlint 0 errors, oxfmt clean, `fallow audit --fail-on-issues` no issues.

Note for whoever picks this up: the tag has been dead since it shipped, so
files already in the wild keep `0.0.0-dev` — this only fixes renders from here
on. The renderer tag was always correct, so detection by renderer still works
on every previously rendered file.

— Rames Jusso
