### PR TITLE
fix(lint): flag repeated fromTo state leaks

### DIFF
--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -2932,33 +2932,93 @@ describe("SVG draw-on rules", () => {
     expect(finding).toBeUndefined();
   });
 
-  it.each([
-    ["timeline", 'tl.set("#ring", { opacity: 0, scale: 1 }, 0);'],
-    ["standalone", 'gsap.set("#ring", { opacity: 0, scale: 1 });'],
-  ])(
-    "gsap_repeated_fromto_without_baseline: accepts an earlier %s set baseline",
-    async (_kind, baseline) => {
-      const html = `
+  it("gsap_repeated_fromto_without_baseline: accepts an earlier timeline set baseline", async () => {
+    const html = `
 <html><body>
   <div data-composition-id="main" data-width="1920" data-height="1080"><div id="ring"></div></div>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
   <script>
     window.__timelines = window.__timelines || {};
     const tl = gsap.timeline({ paused: true });
-    ${baseline}
+    tl.set("#ring", { opacity: 0, scale: 1 }, 0);
     tl.fromTo("#ring", { opacity: 0 }, { opacity: 1, duration: 0.5 }, 5);
     tl.fromTo("#ring", { opacity: 1 }, { opacity: 0, duration: 0.5 }, 10);
     window.__timelines.main = tl;
   </script>
 </body></html>`;
-      const result = await lintHyperframeHtml(html);
-      const finding = result.findings.find(
-        (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
-      );
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
+    );
 
-      expect(finding).toBeUndefined();
-    },
-  );
+    expect(finding).toBeUndefined();
+  });
+
+  it("gsap_repeated_fromto_without_baseline: rejects an earlier standalone set", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"><div id="ring"></div></div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    gsap.set("#ring", { opacity: 0, scale: 1 });
+    tl.fromTo("#ring", { opacity: 0, scale: 1 }, { opacity: 1, duration: 0.5 }, 5);
+    tl.fromTo("#ring", { opacity: 1, scale: 0.4 }, { opacity: 0, duration: 0.5 }, 10);
+    window.__timelines.main = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
+    );
+
+    expect(finding?.severity).toBe("warning");
+  });
+
+  it("gsap_repeated_fromto_without_baseline: rejects a later incomplete standalone set", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"><div id="ring"></div></div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#ring", { opacity: 0, scale: 1 }, { opacity: 1, duration: 0.5 }, 5);
+    tl.fromTo("#ring", { opacity: 1, scale: 0.4 }, { opacity: 0, duration: 0.5 }, 10);
+    gsap.set("#ring", { x: 0 });
+    window.__timelines.main = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
+    );
+
+    expect(finding?.severity).toBe("warning");
+  });
+
+  it("gsap_repeated_fromto_without_baseline: does not guess that a later standalone set is a timeline baseline", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"><div id="ring"></div></div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#ring", { opacity: 0, scale: 1 }, { opacity: 1, duration: 0.5 }, 5);
+    tl.fromTo("#ring", { opacity: 1, scale: 0.4 }, { opacity: 0, duration: 0.5 }, 10);
+    gsap.set("#ring", { opacity: 0, scale: 1 });
+    window.__timelines.main = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
+    );
+
+    expect(finding?.severity).toBe("warning");
+  });
 
   it("gsap_repeated_fromto_without_baseline: does not treat a deferred callback set as baseline", async () => {
     const html = `

--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -2886,6 +2886,173 @@ describe("SVG draw-on rules", () => {
     expect(finding).toBeUndefined();
   });
 
+  it("gsap_repeated_fromto_without_baseline: warns for repeated future fromTo state", async () => {
+    const html = `
+<html><body>
+  <style>#ring { opacity: 0; }</style>
+  <div data-composition-id="main" data-width="1920" data-height="1080">
+    <div id="ring"></div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#ring", { opacity: 0, scale: 1 }, { opacity: 1, duration: 0.5 }, 5);
+    tl.fromTo("#ring", { opacity: 1, scale: 0.4 }, { opacity: 0, duration: 0.5 }, 10);
+    window.__timelines.main = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
+    );
+
+    expect(finding?.severity).toBe("warning");
+    expect(finding?.selector).toBe("#ring");
+  });
+
+  it("gsap_repeated_fromto_without_baseline: accepts explicit immediateRender false", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"><div id="ring"></div></div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#ring", { opacity: 0 }, { opacity: 1, duration: 0.5, immediateRender: false }, 5);
+    tl.fromTo("#ring", { opacity: 1 }, { opacity: 0, duration: 0.5, immediateRender: false }, 10);
+    window.__timelines.main = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
+    );
+
+    expect(finding).toBeUndefined();
+  });
+
+  it.each([
+    ["timeline", 'tl.set("#ring", { opacity: 0, scale: 1 }, 0);'],
+    ["standalone", 'gsap.set("#ring", { opacity: 0, scale: 1 });'],
+  ])(
+    "gsap_repeated_fromto_without_baseline: accepts an earlier %s set baseline",
+    async (_kind, baseline) => {
+      const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"><div id="ring"></div></div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    ${baseline}
+    tl.fromTo("#ring", { opacity: 0 }, { opacity: 1, duration: 0.5 }, 5);
+    tl.fromTo("#ring", { opacity: 1 }, { opacity: 0, duration: 0.5 }, 10);
+    window.__timelines.main = tl;
+  </script>
+</body></html>`;
+      const result = await lintHyperframeHtml(html);
+      const finding = result.findings.find(
+        (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
+      );
+
+      expect(finding).toBeUndefined();
+    },
+  );
+
+  it("gsap_repeated_fromto_without_baseline: does not treat a deferred callback set as baseline", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080">
+    <div id="ring"></div><button id="reset"></button>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    document.getElementById("reset").addEventListener("click", () => {
+      gsap.set("#ring", { opacity: 0, scale: 1 });
+    });
+    tl.fromTo("#ring", { opacity: 0 }, { opacity: 1, duration: 0.5 }, 5);
+    tl.fromTo("#ring", { opacity: 1 }, { opacity: 0, duration: 0.5 }, 10);
+    window.__timelines.main = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
+    );
+
+    expect(finding?.severity).toBe("warning");
+  });
+
+  it("gsap_repeated_fromto_without_baseline: requires a timeline baseline to be authored first", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"><div id="ring"></div></div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#ring", { opacity: 0 }, { opacity: 1, duration: 0.5 }, 5);
+    tl.fromTo("#ring", { opacity: 1 }, { opacity: 0, duration: 0.5 }, 10);
+    tl.set("#ring", { opacity: 0 }, 0);
+    window.__timelines.main = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
+    );
+
+    expect(finding?.severity).toBe("warning");
+  });
+
+  it("gsap_repeated_fromto_without_baseline: accepts one future fromTo writer", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"><div id="ring"></div></div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#ring", { opacity: 0 }, { opacity: 1, duration: 0.5 }, 5);
+    window.__timelines.main = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+
+    expect(
+      result.findings.find(
+        (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("gsap_repeated_fromto_without_baseline: keeps different selectors independent", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080">
+    <div id="ring-a"></div><div id="ring-b"></div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#ring-a", { opacity: 0 }, { opacity: 1, duration: 0.5 }, 5);
+    tl.fromTo("#ring-b", { opacity: 1 }, { opacity: 0, duration: 0.5 }, 10);
+    window.__timelines.main = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+
+    expect(
+      result.findings.find(
+        (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
+      ),
+    ).toBeUndefined();
+  });
+
   // ── svg_measure_before_path_d ──────────────────────────────────────────────
 
   it("svg_measure_before_path_d: ERROR when no d assignment exists anywhere", async () => {

--- a/packages/lint/src/rules/gsap.ts
+++ b/packages/lint/src/rules/gsap.ts
@@ -55,7 +55,8 @@ type GsapWindow = {
   propertyValues: Record<string, string | number>;
   fromPropertyValues?: Record<string, string | number>;
   overwriteAuto: boolean;
-  immediateRender: boolean;
+  /** Explicit immediateRender option; undefined keeps the GSAP method default. */
+  immediateRender?: boolean;
   method: string;
   /** True for an off-timeline `gsap.set(...)` (applied once at load). */
   global?: boolean;
@@ -150,6 +151,7 @@ async function extractGsapWindows(script: string): Promise<GsapWindow[]> {
     const cycleCount = infiniteRepeat ? 1 : repeat > 0 ? repeat + 1 : 1;
     const effectiveDuration =
       animation.method === "set" ? 0 : (animation.duration ?? 0) * cycleCount;
+    const immediateRender = unwrapRaw(animation.extras?.immediateRender);
     windows.push({
       targetSelector: animation.targetSelector,
       targetIdentity: animation.targetIdentity,
@@ -162,7 +164,8 @@ async function extractGsapWindows(script: string): Promise<GsapWindow[]> {
       propertyValues: animation.properties,
       fromPropertyValues: animation.fromProperties,
       overwriteAuto: unwrapRaw(animation.extras?.overwrite) === "auto",
-      immediateRender: unwrapRaw(animation.extras?.immediateRender) === "true",
+      immediateRender:
+        immediateRender === "true" ? true : immediateRender === "false" ? false : undefined,
       method: animation.method,
       global: animation.global,
       raw: synthesizeWindowRaw(parsed.timelineVar, animation),
@@ -203,8 +206,10 @@ function isHiddenGsapState(values: Record<string, string | number>): boolean {
   );
 }
 
-function extractStandaloneHiddenSelectors(script: string): Set<string> {
-  const selectors = new Set<string>();
+type LoadTimeStandaloneGsapSet = { selector: string; propertiesSource: string };
+
+function extractLoadTimeStandaloneGsapSets(script: string): LoadTimeStandaloneGsapSet[] {
+  const sets: LoadTimeStandaloneGsapSet[] = [];
   const source = stripJsComments(script);
   const functionRanges = collectFunctionBodyRanges(source);
   const aliases = new Map<string, string>();
@@ -221,10 +226,16 @@ function extractStandaloneHiddenSelectors(script: string): Set<string> {
     const target = (match[1] ?? "").trim();
     const selector = /^(["'`])([^"'`]+)\1$/.exec(target)?.[2] ?? aliases.get(target);
     if (!selector) continue;
-    const body = match[2] ?? "";
-    if (/(?:opacity|autoAlpha)\s*:\s*0(?:\.0+)?\s*(?:,|$)/.test(body)) {
+    sets.push({ selector, propertiesSource: match[2] ?? "" });
+  }
+  return sets;
+}
+
+function extractStandaloneHiddenSelectors(script: string): Set<string> {
+  const selectors = new Set<string>();
+  for (const { selector, propertiesSource } of extractLoadTimeStandaloneGsapSets(script)) {
+    if (/(?:opacity|autoAlpha)\s*:\s*0(?:\.0+)?\s*(?:,|$)/.test(propertiesSource))
       selectors.add(selector);
-    }
   }
   return selectors;
 }
@@ -1106,6 +1117,58 @@ export const gsapRules: LintRule<LintContext>[] = [
             snippet: truncateSnippet(`${left.raw}\n${right.raw}`),
           });
         }
+      }
+
+      // gsap_repeated_fromto_without_baseline
+      const fromToWindowsBySelector = new Map<string, GsapWindow[]>();
+      for (const win of gsapWindows) {
+        if (win.method !== "fromTo" || win.immediateRender === false) continue;
+        if (win.targetSelector === UNRESOLVED_TARGET) continue;
+        const windows = fromToWindowsBySelector.get(win.targetSelector) ?? [];
+        windows.push(win);
+        fromToWindowsBySelector.set(win.targetSelector, windows);
+      }
+
+      const repeatedFromToGroups = [...fromToWindowsBySelector.values()].filter(
+        (windows) => windows.length >= 2,
+      );
+      const standaloneSetSelectors =
+        repeatedFromToGroups.length > 0
+          ? new Set(extractLoadTimeStandaloneGsapSets(script.content).map((set) => set.selector))
+          : new Set<string>();
+
+      for (const fromToWindows of repeatedFromToGroups) {
+        const firstFromTo = fromToWindows[0];
+        if (!firstFromTo) continue;
+        const selector = firstFromTo.targetSelector;
+        const firstFromToIndex = gsapWindows.indexOf(firstFromTo);
+        const firstFromToPosition = Math.min(...fromToWindows.map((win) => win.position));
+        const hasTimelineBaseline = gsapWindows
+          .slice(0, firstFromToIndex)
+          .some(
+            (candidate) =>
+              candidate.method === "set" &&
+              !candidate.global &&
+              candidate.targetSelector === selector &&
+              candidate.position <= firstFromToPosition,
+          );
+        if (hasTimelineBaseline || standaloneSetSelectors.has(selector)) continue;
+
+        findings.push({
+          code: "gsap_repeated_fromto_without_baseline",
+          severity: "warning",
+          message:
+            `${fromToWindows.length} tl.fromTo() calls target "${selector}" with no stable baseline. ` +
+            `The last-authored fromTo "from" values become the element's resting state for any seek before ` +
+            `the first tween actually runs, because GSAP applies fromTo from-values at authoring time ` +
+            `(immediateRender), not at tween position.`,
+          selector,
+          fixHint:
+            `Add \`immediateRender: false\` to the destination vars of each future fromTo, or set a safe ` +
+            `resting state with an earlier \`gsap.set("${selector}", { ... })\`. Pre-first-tween seeks must not ` +
+            `inherit whichever fromTo call happened to author last.`,
+          snippet: truncateSnippet(fromToWindows.map((win) => win.raw).join("\n")),
+        });
       }
 
       // gsap_exit_missing_hard_kill
@@ -2362,7 +2425,7 @@ export const gsapRules: LintRule<LintContext>[] = [
       const initialHolds = firstTweenIndex < 0 ? windows : windows.slice(0, firstTweenIndex);
       for (const win of initialHolds) {
         if (!isInstantHold(win) || win.position !== 0) continue;
-        if (win.global || win.immediateRender) continue;
+        if (win.global || win.immediateRender === true) continue;
         if (targetHasNoStableIdentity(win.targetSelector, win.targetIdentity)) continue;
         const targetTokens = [...targetedSelectorTokens(win.targetSelector)];
         const hiddenByToken =

--- a/packages/lint/src/rules/gsap.ts
+++ b/packages/lint/src/rules/gsap.ts
@@ -206,10 +206,8 @@ function isHiddenGsapState(values: Record<string, string | number>): boolean {
   );
 }
 
-type LoadTimeStandaloneGsapSet = { selector: string; propertiesSource: string };
-
-function extractLoadTimeStandaloneGsapSets(script: string): LoadTimeStandaloneGsapSet[] {
-  const sets: LoadTimeStandaloneGsapSet[] = [];
+function extractStandaloneHiddenSelectors(script: string): Set<string> {
+  const selectors = new Set<string>();
   const source = stripJsComments(script);
   const functionRanges = collectFunctionBodyRanges(source);
   const aliases = new Map<string, string>();
@@ -226,16 +224,10 @@ function extractLoadTimeStandaloneGsapSets(script: string): LoadTimeStandaloneGs
     const target = (match[1] ?? "").trim();
     const selector = /^(["'`])([^"'`]+)\1$/.exec(target)?.[2] ?? aliases.get(target);
     if (!selector) continue;
-    sets.push({ selector, propertiesSource: match[2] ?? "" });
-  }
-  return sets;
-}
-
-function extractStandaloneHiddenSelectors(script: string): Set<string> {
-  const selectors = new Set<string>();
-  for (const { selector, propertiesSource } of extractLoadTimeStandaloneGsapSets(script)) {
-    if (/(?:opacity|autoAlpha)\s*:\s*0(?:\.0+)?\s*(?:,|$)/.test(propertiesSource))
+    const body = match[2] ?? "";
+    if (/(?:opacity|autoAlpha)\s*:\s*0(?:\.0+)?\s*(?:,|$)/.test(body)) {
       selectors.add(selector);
+    }
   }
   return selectors;
 }
@@ -1132,11 +1124,6 @@ export const gsapRules: LintRule<LintContext>[] = [
       const repeatedFromToGroups = [...fromToWindowsBySelector.values()].filter(
         (windows) => windows.length >= 2,
       );
-      const standaloneSetSelectors =
-        repeatedFromToGroups.length > 0
-          ? new Set(extractLoadTimeStandaloneGsapSets(script.content).map((set) => set.selector))
-          : new Set<string>();
-
       for (const fromToWindows of repeatedFromToGroups) {
         const firstFromTo = fromToWindows[0];
         if (!firstFromTo) continue;
@@ -1152,7 +1139,7 @@ export const gsapRules: LintRule<LintContext>[] = [
               candidate.targetSelector === selector &&
               candidate.position <= firstFromToPosition,
           );
-        if (hasTimelineBaseline || standaloneSetSelectors.has(selector)) continue;
+        if (hasTimelineBaseline) continue;
 
         findings.push({
           code: "gsap_repeated_fromto_without_baseline",
@@ -1165,7 +1152,7 @@ export const gsapRules: LintRule<LintContext>[] = [
           selector,
           fixHint:
             `Add \`immediateRender: false\` to the destination vars of each future fromTo, or set a safe ` +
-            `resting state with an earlier \`gsap.set("${selector}", { ... })\`. Pre-first-tween seeks must not ` +
+            `resting state with an earlier \`tl.set("${selector}", { ... }, 0)\`. Pre-first-tween seeks must not ` +
             `inherit whichever fromTo call happened to author last.`,
           snippet: truncateSnippet(fromToWindows.map((win) => win.raw).join("\n")),
         });


### PR DESCRIPTION
## What

Lint now warns when repeated future `fromTo` calls can leak the last authored start state into earlier frames. Explicit `immediateRender: false` and an earlier timeline baseline remain clean.

## Why

GSAP applies default `fromTo` start values while the timeline is built, before the tween's scheduled position. When several calls target the same element, the last authored start state can become visible before the first tween, while existing lint reports no cause.

A standalone `gsap.set` is not accepted as proof of safety. An earlier global set can be overwritten by later `fromTo` construction, and a set for unrelated properties does not establish the affected state. The warning therefore clears only for explicit opt-out or an earlier `tl.set` baseline that participates in deterministic timeline seeking.

## How

- Preserve `immediateRender` as explicit true, explicit false, or the GSAP method default.
- Group default or explicitly immediate-rendered `fromTo` writers by stable selector.
- Require an earlier timeline set for that selector, or explicit `immediateRender: false` on the repeated writers.
- Keep render seeking and GSAP runtime behavior unchanged.

## Test plan

- [x] GSAP lint suite: 175 tests passed.
- [x] Regression cases cover omitted options, explicit false, earlier timeline baseline, earlier standalone set, unrelated standalone properties, later standalone set, deferred callback set, and late timeline baseline.
- [x] Lint package typecheck passed.
- [x] Changed-file oxlint, formatting, and diff checks passed.
- [ ] Manual testing performed (not applicable; lint-only behavior).
- [ ] Documentation updated (not applicable).
