### PR TITLE
fix(check): retry system Chrome after managed launch crash

### DIFF
--- a/packages/cli/src/browser/manager.test.ts
+++ b/packages/cli/src/browser/manager.test.ts
@@ -229,6 +229,23 @@ describe("findBrowser — cache resolution", () => {
     );
   });
 
+  it("finds Chrome in the standard Windows Program Files location", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    const windowsChrome = join(
+      "C:\\Program Files",
+      "Google",
+      "Chrome",
+      "Application",
+      "chrome.exe",
+    );
+    installFsMocks({ existing: new Set([windowsChrome]) });
+    installPuppeteerBrowsersMock();
+
+    const { findSystemBrowser } = await import("./manager.js");
+
+    expect(findSystemBrowser()).toEqual({ executablePath: windowsChrome, source: "system" });
+  });
+
   it("does not resolve to a hyperframes-cache build from an older CHROME_VERSION pin", async () => {
     // A build downloaded by a prior hyperframes version (this pin has moved
     // 131 -> 151 -> 152 across releases) must not satisfy resolution, or an

--- a/packages/cli/src/browser/manager.ts
+++ b/packages/cli/src/browser/manager.ts
@@ -240,12 +240,32 @@ function purgeStaleInstall(installPath: string): void {
 const SYSTEM_CHROME_PATHS: ReadonlyArray<string> =
   process.platform === "darwin"
     ? ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"]
-    : [
-        "/usr/bin/google-chrome",
-        "/usr/bin/google-chrome-stable",
-        "/usr/bin/chromium",
-        "/usr/bin/chromium-browser",
-      ];
+    : process.platform === "win32"
+      ? [
+          join(
+            process.env["ProgramW6432"] ?? process.env["PROGRAMFILES"] ?? "C:\\Program Files",
+            "Google",
+            "Chrome",
+            "Application",
+            "chrome.exe",
+          ),
+          join(
+            process.env["PROGRAMFILES(X86)"] ?? "C:\\Program Files (x86)",
+            "Google",
+            "Chrome",
+            "Application",
+            "chrome.exe",
+          ),
+          ...(process.env["LOCALAPPDATA"]
+            ? [join(process.env["LOCALAPPDATA"], "Google", "Chrome", "Application", "chrome.exe")]
+            : []),
+        ]
+      : [
+          "/usr/bin/google-chrome",
+          "/usr/bin/google-chrome-stable",
+          "/usr/bin/chromium",
+          "/usr/bin/chromium-browser",
+        ];
 
 function whichBinary(name: string): string | undefined {
   try {
@@ -486,7 +506,7 @@ export function _resetSystemFallbackWarnForTests(): void {
   _warnedSystemFallback = false;
 }
 
-function findFromSystem(): BrowserResult | undefined {
+export function findSystemBrowser(): BrowserResult | undefined {
   for (const p of SYSTEM_CHROME_PATHS) {
     if (existsSync(p)) {
       return { executablePath: p, source: "system" };
@@ -531,7 +551,7 @@ export async function findBrowser(): Promise<BrowserResult | undefined> {
     }
   }
 
-  const fromSystem = findFromSystem();
+  const fromSystem = findSystemBrowser();
   if (fromSystem) {
     warnSystemFallbackOnce(fromSystem.executablePath);
   }
@@ -613,7 +633,7 @@ export async function ensureBrowser(options?: EnsureBrowserOptions): Promise<Bro
     }
 
     if (!options?.preferManagedChrome) {
-      const fromSystem = findFromSystem();
+      const fromSystem = findSystemBrowser();
       if (fromSystem) {
         warnSystemFallbackOnce(fromSystem.executablePath);
         return fromSystem;

--- a/packages/cli/src/capture/captureCompositionFrame.browserFallback.test.ts
+++ b/packages/cli/src/capture/captureCompositionFrame.browserFallback.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  ensureBrowser: vi.fn(),
+  findSystemBrowser: vi.fn(),
+  launch: vi.fn(),
+  buildChromeArgs: vi.fn(() => []),
+  resolveBrowserGpuMode: vi.fn(async () => "software" as const),
+}));
+
+vi.mock("../browser/manager.js", () => ({
+  ensureBrowser: mocks.ensureBrowser,
+  findSystemBrowser: mocks.findSystemBrowser,
+}));
+
+vi.mock("puppeteer-core", () => ({ default: { launch: mocks.launch } }));
+
+vi.mock("@hyperframes/engine", () => ({
+  buildChromeArgs: mocks.buildChromeArgs,
+  resolveBrowserGpuMode: mocks.resolveBrowserGpuMode,
+}));
+
+import { openSettledCompositionPage } from "./captureCompositionFrame.js";
+
+const HTML = '<div data-composition-id="main" data-width="1920" data-height="1080"></div>';
+const OPTIONS = {
+  renderReadyTimeoutMs: 1000,
+  renderReadyWarningSuffix: "test",
+  browserGpuMode: "software" as const,
+};
+const BUNDLED = "C:\\hyperframes\\chrome-headless-shell.exe";
+const SYSTEM = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe";
+
+function launchCrash(): Error {
+  return new Error("Failed to launch the browser process! Code: 3221225595");
+}
+
+function fakeBrowser() {
+  const page = {
+    evaluateOnNewDocument: vi.fn(async () => undefined),
+    setViewport: vi.fn(async () => undefined),
+    goto: vi.fn(async () => undefined),
+    waitForFunction: vi.fn(async () => undefined),
+    evaluate: vi.fn(async () => undefined),
+  };
+  return {
+    browser: {
+      newPage: vi.fn(async () => page),
+      close: vi.fn(async () => undefined),
+    },
+    page,
+  };
+}
+
+describe("openSettledCompositionPage Windows bundled-browser recovery", () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    mocks.ensureBrowser.mockResolvedValue({ executablePath: BUNDLED, source: "cache" });
+    mocks.findSystemBrowser.mockReturnValue({ executablePath: SYSTEM, source: "system" });
+    mocks.buildChromeArgs.mockReturnValue([]);
+    mocks.resolveBrowserGpuMode.mockResolvedValue("software");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+  });
+
+  it("retries the known managed-shell crash once with system Chrome", async () => {
+    const fallback = fakeBrowser();
+    mocks.launch.mockRejectedValueOnce(launchCrash()).mockResolvedValueOnce(fallback.browser);
+
+    const session = await openSettledCompositionPage(HTML, "http://127.0.0.1:3000", OPTIONS);
+
+    expect(mocks.launch).toHaveBeenCalledTimes(2);
+    expect(mocks.launch.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({ executablePath: BUNDLED }),
+    );
+    expect(mocks.launch.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({ executablePath: SYSTEM }),
+    );
+    expect(session.browser).toBe(fallback.browser);
+  });
+
+  it("adds STATUS_STACK_BUFFER_OVERRUN and browser-path guidance when no system Chrome exists", async () => {
+    mocks.findSystemBrowser.mockReturnValue(undefined);
+    mocks.launch.mockRejectedValueOnce(launchCrash());
+
+    await expect(
+      openSettledCompositionPage(HTML, "http://127.0.0.1:3000", OPTIONS),
+    ).rejects.toThrow(/STATUS_STACK_BUFFER_OVERRUN[\s\S]*HYPERFRAMES_BROWSER_PATH/);
+    expect(mocks.launch).toHaveBeenCalledOnce();
+  });
+
+  it("keeps unrelated launch errors unchanged", async () => {
+    const error = new Error("Failed to launch the browser process! Code: 1");
+    mocks.launch.mockRejectedValueOnce(error);
+
+    await expect(openSettledCompositionPage(HTML, "http://127.0.0.1:3000", OPTIONS)).rejects.toBe(
+      error,
+    );
+    expect(mocks.findSystemBrowser).not.toHaveBeenCalled();
+    expect(mocks.launch).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/capture/captureCompositionFrame.ts
+++ b/packages/cli/src/capture/captureCompositionFrame.ts
@@ -7,7 +7,9 @@ import {
   resolveLocalBrowserGpuMode,
   type BrowserGpuMode,
 } from "../browser/gpuPolicy.js";
+import { windowsChromeCrashRemediation } from "../browser/windowsCrash.js";
 import { resolveCompositionViewportFromHtml } from "../utils/compositionViewport.js";
+import { normalizeErrorMessage } from "../utils/errorMessage.js";
 import { resolveDiagnosticNavigationTimeoutMs } from "../utils/renderArgs.js";
 
 const SHADER_TRANSITIONS_TIMEOUT_MS = 90_000;
@@ -167,27 +169,53 @@ export async function openSettledCompositionPage(
   options: OpenSettledCompositionPageOptions,
 ): Promise<SettledCompositionPage> {
   const viewport = resolveCompositionViewportFromHtml(html);
-  const { ensureBrowser } = await import("../browser/manager.js");
+  const { ensureBrowser, findSystemBrowser } = await import("../browser/manager.js");
   const browser = await ensureBrowser();
   const puppeteer = await import("puppeteer-core");
   const { buildChromeArgs } = await import("@hyperframes/engine");
   const requestedGpuMode = options.browserGpuMode ?? resolveCliChromeGpuMode();
-  const resolvedGpuMode = await resolveCaptureBrowserGpuMode(
-    requestedGpuMode,
-    browser.executablePath,
-  );
-  assertWebGpuRequirement(html, requestedGpuMode, resolvedGpuMode);
-
-  let chromeBrowser: Browser | undefined;
-  try {
-    chromeBrowser = await puppeteer.default.launch({
+  const launch = async (executablePath: string): Promise<Browser> => {
+    const resolvedGpuMode = await resolveCaptureBrowserGpuMode(requestedGpuMode, executablePath);
+    assertWebGpuRequirement(html, requestedGpuMode, resolvedGpuMode);
+    return puppeteer.default.launch({
       headless: true,
-      executablePath: browser.executablePath,
+      executablePath,
       args: buildChromeArgs(
         { ...viewport, captureMode: "screenshot" },
         { browserGpuMode: resolvedGpuMode },
       ),
     });
+  };
+
+  let chromeBrowser: Browser | undefined;
+  try {
+    try {
+      chromeBrowser = await launch(browser.executablePath);
+    } catch (launchError) {
+      const message = normalizeErrorMessage(launchError);
+      const remediation = windowsChromeCrashRemediation(message);
+      if (!remediation) throw launchError;
+
+      const systemBrowser =
+        browser.source === "cache" || browser.source === "download"
+          ? findSystemBrowser()
+          : undefined;
+      if (!systemBrowser || systemBrowser.executablePath === browser.executablePath) {
+        throw new Error(`${message}\n\n${remediation}`, { cause: launchError });
+      }
+
+      console.warn(
+        `[hyperframes] Managed chrome-headless-shell crashed at launch; retrying once with system Chrome at ${systemBrowser.executablePath}.`,
+      );
+      try {
+        chromeBrowser = await launch(systemBrowser.executablePath);
+      } catch (fallbackError) {
+        throw new Error(
+          `System Chrome fallback also failed: ${normalizeErrorMessage(fallbackError)}\n\n${remediation}`,
+          { cause: fallbackError },
+        );
+      }
+    }
 
     const page = await chromeBrowser.newPage();
     await installPageFunctionGuard(page);


### PR DESCRIPTION
## What

`check` and the other shared screenshot diagnostics now recover when the managed Windows chrome-headless-shell exits with `STATUS_STACK_BUFFER_OVERRUN`. They retry once with an installed system Chrome, or return actionable `HYPERFRAMES_BROWSER_PATH` guidance when no fallback exists.

## Why

HyperFrames already recognizes exit code `3221225595` and explains the system-Chrome workaround for `render`, but the shared page-open path closed and rethrew the raw launch error. A valid composition therefore failed before navigation even though Chrome was available on the host.

## How

The screenshot page-open boundary reuses the existing Windows crash detector, retries only managed cache/download sources, and recomputes browser GPU policy for the fallback executable. System Chrome discovery now checks the standard machine-wide and per-user Windows install locations before `where`, so Chrome need not be on `PATH`. Explicit/system browser choices and unrelated launch failures retain their existing behavior.

## Test plan

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Documentation updated (not applicable)

- Five browser-manager, page-open, crash-detector, and check suites: 96 tests passed
- Changed-file oxlint, oxfmt, and diff checks passed

The Windows binary crash was injected on this Linux host rather than rerun on Windows. CLI-wide typecheck remains unavailable because optional AWS/GCP dependencies are absent and unrelated Studio/schema errors predate this change; it reported no changed-path error.
