### PR TITLE
fix(core): avoid grade stats regex backtracking

### DIFF
--- a/packages/core/src/mediaGradeAnalyzer.ts
+++ b/packages/core/src/mediaGradeAnalyzer.ts
@@ -157,7 +157,8 @@ export function parseMediaTreatmentSignalStats(raw: string): GradeSignalFrame[] 
   const frames: GradeSignalFrame[] = [];
   let current: GradeSignalFrame | null = null;
   for (const line of raw.split(/\r?\n/)) {
-    const frame = line.match(/^frame:\d+.*pts_time:([+-]?(?:\d+(?:\.\d+)?|\.\d+))/);
+    // One digit is enough: .* consumes the rest without overlapping repetitions.
+    const frame = line.match(/^frame:\d.*pts_time:([+-]?(?:\d+(?:\.\d+)?|\.\d+))/);
     if (frame?.[1]) {
       if (current) frames.push(current);
       current = { ptsTime: Number(frame[1]) };

--- a/packages/core/src/mediaGradeAnalyzer.vendoredParity.test.ts
+++ b/packages/core/src/mediaGradeAnalyzer.vendoredParity.test.ts
@@ -98,3 +98,27 @@ describe("vendored media grade analyzer parity", () => {
     expect(await vendoredResult(signalStats)).toEqual(product);
   });
 });
+
+describe("signal-stats frame headers", () => {
+  it.each([
+    ["frame:123 pts:42 pts_time:-12.5", -12.5],
+    ["frame:000pts_time:+.25", 0.25],
+    ["frame:1 pts_time:1 pts_time:2.5", 2.5],
+    ["frame:1 pts_time:1 pts_time:invalid", 1],
+    ["frame:1 pts_time:12.", 12],
+    ["frame:1 pts_time:2e3", 2],
+    ["frame: pts_time:1", undefined],
+    ["frame:-1 pts_time:1", undefined],
+    ["prefix frame:1 pts_time:1", undefined],
+    ["frame:1\u2028pts_time:1", undefined],
+    ["frame:" + "0".repeat(100_000) + "!", undefined],
+    ["frame:" + "0".repeat(100_000) + " pts_time:-.5", -0.5],
+  ])("preserves header parsing (case %#)", async (header, ptsTime) => {
+    const raw = SIGNALSTATS.replace("frame:0 pts:0 pts_time:0", String(header));
+    const product = productResult(raw);
+    expect(product.frames).toHaveLength(2);
+    expect(product.frames[0]?.ptsTime).toBe(ptsTime);
+    expect(product.frames[1]?.ptsTime).toBe(1);
+    expect(await vendoredResult(raw)).toEqual(product);
+  });
+});

--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -50,7 +50,7 @@
       "files": 12
     },
     "media-use": {
-      "hash": "00a2d26e22fc1ab1",
+      "hash": "5b35f62a2c59f220",
       "files": 153
     },
     "motion-graphics": {

--- a/skills/media-use/scripts/lib/grade-analyzer.mjs
+++ b/skills/media-use/scripts/lib/grade-analyzer.mjs
@@ -76,7 +76,8 @@ export function parseMediaTreatmentSignalStats(raw) {
   const frames = [];
   let current = null;
   for (const line of String(raw).split(/\r?\n/)) {
-    const frame = line.match(/^frame:\d+.*pts_time:([+-]?(?:\d+(?:\.\d+)?|\.\d+))/);
+    // One digit is enough: .* consumes the rest without overlapping repetitions.
+    const frame = line.match(/^frame:\d.*pts_time:([+-]?(?:\d+(?:\.\d+)?|\.\d+))/);
     if (frame) {
       if (current) frames.push(current);
       current = { ptsTime: Number(frame[1]) };


### PR DESCRIPTION
Fixes CodeQL alert [#796](https://github.com/heygen-com/hyperframes/security/code-scanning/796): malformed FFmpeg signal-stat headers containing long digit runs cause quadratic regex backtracking.

Require one initial frame digit instead of a repeated digit group overlapping `.*`. The existing wildcard already consumes all remaining digits, preserving accepted headers and the last valid `pts_time` capture. Apply the same change to the standalone media-use skill copy. No process invocation or grading logic changes.

Validation: the original regex exceeded a two-second subprocess timeout on 100,000 digits. All 15 product/parity tests and 10 standalone skill tests (including real FFmpeg cases) pass. New coverage checks long malformed and valid headers, frame boundaries, signed/fractional timestamps, duplicate timestamps, numeric prefixes and invalid headers. Parser/core builds, core/runtime typechecks, lint, format and commit hooks pass.
