### PR TITLE
fix(studio-server): simplify normalized group ID trimming

### DIFF
--- a/packages/studio-server/src/helpers/sourceMutation.ts
+++ b/packages/studio-server/src/helpers/sourceMutation.ts
@@ -478,7 +478,8 @@ function uniqueGroupDomId(document: Document, groupId: string): string {
       .trim()
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "") || "group";
+      // Normalization above leaves at most one hyphen at either edge.
+      .replace(/^-|-$/g, "") || "group";
   let id = base;
   let n = 2;
   while (document.getElementById(id)) {

--- a/packages/studio-server/src/helpers/sourceMutationSplitAndGroup.test.ts
+++ b/packages/studio-server/src/helpers/sourceMutationSplitAndGroup.test.ts
@@ -197,6 +197,32 @@ describe("wrapElementsInHtml / unwrapElementsFromHtml", () => {
     return element;
   }
 
+  it.each([
+    ["Group 1", "group-1"],
+    [" --HELLO___World!! ", "hello-world"],
+    ["a---b---c", "a-b-c"],
+    ["--123--", "123"],
+    ["", "group"],
+    [" --- ", "group"],
+    ["你好", "group"],
+    ["-".repeat(100_000) + "Title" + "-".repeat(100_000), "title"],
+  ])("preserves normalized group IDs and collision suffixes (case %#)", (name, id) => {
+    const source = FIXTURE.replace(
+      "</body>",
+      `<div id="${id}"></div><div id="${id}-2"></div></body>`,
+    );
+    const result = wrapElementsInHtml(source, TARGETS, name, BBOX, REBASES);
+    expect(result.matched).toBe(true);
+    const { document } = parseHTML(result.html);
+    const group = document.getElementById(`${id}-3`);
+    expect(group?.getAttribute("data-hf-group")).toBe(name);
+    expect(Array.from(group?.children ?? []).map((child) => child.id)).toEqual([
+      "title",
+      "logo",
+      "badge",
+    ]);
+  });
+
   it("wraps members in a data-hf-group div, preserving order and rebasing left/top", () => {
     const { html, matched, groupId } = wrapElementsInHtml(
       FIXTURE,


### PR DESCRIPTION
Addresses CodeQL alert [#714](https://github.com/heygen-com/hyperframes/security/code-scanning/714) in group DOM ID generation. The preceding normalization already collapses every non-alphanumeric run into one hyphen, so the final leading/trailing hyphen repetitions are redundant. I did not find reachable quadratic behavior through the current normalization chain.

Trim one hyphen at each edge and document that invariant. Generated IDs, group labels, member order and collision suffixing remain unchanged; no rule suppression or alert dismissal is added.

Validation: all 101 source-mutation tests pass, including eight new grouping cases covering punctuation, Unicode, empty/default names, 200k-character hyphen runs and occupied base/base-2 IDs. A deterministic 100k-name comparison matched old/new normalized IDs. Parser/core builds, Studio-server typecheck, lint and format pass.
