### PR TITLE
fix(producer): bound existing font-face recognition scans

### DIFF
--- a/packages/producer/src/services/deterministicFonts.test.ts
+++ b/packages/producer/src/services/deterministicFonts.test.ts
@@ -1,5 +1,49 @@
 import { describe, expect, it } from "bun:test";
-import { FONT_ALIASES, FONT_ALIAS_KEYS } from "./deterministicFonts.js";
+import {
+  FONT_ALIASES,
+  FONT_ALIAS_KEYS,
+  injectDeterministicFontFaces,
+} from "./deterministicFonts.js";
+
+describe("existing font-face recognition", () => {
+  it.each([
+    ['@font-face { font-family: "Existing Font"; src: url(font.woff2); }', false],
+    ["@FONT-FACE\n{ FONT-FAMILY : 'EXISTING FONT'; }", false],
+    ['@font-face { font-family:\u00a0"Existing Font"; }', false],
+    ['@font-face { font-family:; font-family: "Existing Font"; }', false],
+    [
+      '@font-face { font-family: "Other Font"; } @font-face { font-family: "Existing Font"; }',
+      false,
+    ],
+    ['@font-face { font-family: "Existing Font" }', true],
+    ['@font-face { font-family: "Existing Font";', true],
+    ['@font-face { font-family: "Other Font"; font-family: "Existing Font"; }', true],
+    ['@font-face { font-family:   ; font-family: "Existing Font"; }', true],
+  ])("preserves authored font and fallback decisions for %j", async (css, needsFallback) => {
+    const html = `<html><head><style>${css}</style></head><body><p style="font-family: 'Existing Font';">Hello</p></body></html>`;
+    let requests = 0;
+    const fetchImpl = Object.assign(
+      async () => {
+        requests += 1;
+        return new Response("", { status: 404 });
+      },
+      { preconnect: fetch.preconnect },
+    );
+    expect(
+      await injectDeterministicFontFaces(html, { fetchImpl, allowSystemFontCapture: false }),
+    ).toBe(html);
+    expect(requests > 0).toBe(needsFallback);
+  });
+
+  it.each([
+    "@font-face{{".repeat(100_000),
+    "@font-face{{font-family:" + " ".repeat(100_000),
+    "@font-face{{font-family::;" + "font-family::;".repeat(100_000),
+  ])("handles a long incomplete font-face suffix", async (css) => {
+    const html = `<html><head><style>${css}</style></head><body>Hello</body></html>`;
+    expect(await injectDeterministicFontFaces(html, { allowSystemFontCapture: false })).toBe(html);
+  });
+});
 
 describe("FONT_ALIASES cross-platform coverage", () => {
   it("maps macOS sans-serif system fonts to inter", () => {

--- a/packages/producer/src/services/deterministicFonts.ts
+++ b/packages/producer/src/services/deterministicFonts.ts
@@ -438,13 +438,26 @@ function fontDataUri(
 
 function extractExistingFontFaces(html: string): Set<string> {
   const families = new Set<string>();
-  const fontFaceRegex = /@font-face\s*\{[\s\S]*?font-family\s*:\s*([^;]+);[\s\S]*?\}/gi;
-  for (const match of html.matchAll(fontFaceRegex)) {
-    const raw = match[1] || "";
-    const normalized = normalizeFamilyName(raw);
-    if (normalized) {
-      families.add(normalized);
+  const opening = /@font-face\s*\{/gi;
+  const family = /font-family\s*:/gi;
+  while (opening.exec(html)) {
+    family.lastIndex = opening.lastIndex;
+    let declaration = family.exec(html);
+    // The original matcher requires at least one character before ';'.
+    while (declaration && html[family.lastIndex] === ";") {
+      declaration = family.exec(html);
     }
+    // If this opener has no complete family/semicolon/closer suffix, no later
+    // opener can have one. Never retry the same unmatched suffix.
+    if (!declaration) break;
+    const valueStart = family.lastIndex;
+    const semicolon = html.indexOf(";", valueStart);
+    if (semicolon < 0) break;
+    const end = html.indexOf("}", semicolon + 1);
+    if (end < 0) break;
+    const normalized = normalizeFamilyName(html.slice(valueStart, semicolon));
+    if (normalized) families.add(normalized);
+    opening.lastIndex = end + 1;
   }
   return families;
 }


### PR DESCRIPTION
## What

Fix CodeQL [#751](https://github.com/heygen-com/hyperframes/security/code-scanning/751): malformed font-face input can make existing-font detection spend quadratic time retrying overlapping matches before font fallback decisions.

## Why

All three scanner examples exceeded two seconds with 100,000 repeated prefixes, spaces or family declarations. Existing-font detection runs before every deterministic font injection, so this can stall compilation.

## How

Scan the font-face opener, family declaration, semicolon and closing brace in order. Skip immediately empty declarations as before; stop once a required suffix is absent, since no later opener could complete it. Successful scans advance past the closing brace. Normalize the captured family using the existing function.

Preserve existing recognition and fallback decisions, including first-family ordering, whitespace-only values and malformed-input matching. This remains the existing recognition heuristic; it does not introduce a CSS parser or change fetch/retry/system-font behavior. Two files changed; no workflow changes.

## Test plan

- [x] All 90 deterministic-font tests pass, including 12 new cases for authored fonts, fallback decisions and the three adversarial inputs.
- [x] All five font-embedding tests pass with Vitest after building workspace dependencies.
- [x] 200,000 generated inputs match the original ordered normalized family sets exactly.
- [x] The three isolated adversarial scans complete in under a millisecond locally; public injection tests also finish promptly.
- [x] Parser/core/lint/Studio-server builds, producer typecheck, formatting, lint and complexity/duplication audit pass.
- Independent Magi review and CI/CodeQL remain landing gates. Verify main-branch alert closure after merge.
