### PR TITLE
fix(studio-server): publish waveform caches atomically

### DIFF
--- a/.github/workflows/windows-render.yml
+++ b/.github/workflows/windows-render.yml
@@ -474,6 +474,11 @@ jobs:
         # package scripts cannot oversubscribe the hosted Windows runner.
         run: bun run ${{ matrix.packages }} test -- --maxWorkers=2
 
+      - name: Verify waveform cache writes on Windows
+        if: matrix.lane == 'studio-engine-cli'
+        shell: pwsh
+        run: bun run --cwd packages/studio-server test -- src/helpers/waveform.test.ts src/helpers/waveform.file-race.test.ts --maxWorkers=2
+
       - name: Run runtime contract test
         if: matrix.runtime_contract
         shell: pwsh

--- a/packages/studio-server/src/helpers/waveform.file-race.test.ts
+++ b/packages/studio-server/src/helpers/waveform.file-race.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Hono } from "hono";
+import { buildWaveformCacheKey, generateWaveformCache } from "./waveform.js";
+import { registerWaveformRoutes } from "../routes/waveform.js";
+import type { StudioApiAdapter } from "../types.js";
+
+const hooks = vi.hoisted(() => {
+  const state: {
+    decode?: () => void;
+    writing?: () => void;
+    failDecode: boolean;
+    failWrite: boolean;
+    failRename: boolean;
+  } = { failDecode: false, failWrite: false, failRename: false };
+  return state;
+});
+vi.mock("node:child_process", async () => {
+  const { EventEmitter } = await import("node:events");
+  return {
+    spawn: vi.fn(() => {
+      const proc = Object.assign(new EventEmitter(), { stdout: new EventEmitter() });
+      queueMicrotask(() => {
+        hooks.decode?.();
+        if (!hooks.failDecode)
+          proc.stdout.emit("data", Buffer.from(new Float32Array([0.5]).buffer));
+        proc.emit("close", hooks.failDecode ? 1 : 0);
+      });
+      return proc;
+    }),
+  };
+});
+vi.mock("@hyperframes/parsers/ff-binaries", () => ({ findFfBinary: () => "ffmpeg" }));
+vi.mock("node:fs", async (importOriginal) => {
+  const fs = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...fs,
+    writeFileSync: (...args: Parameters<typeof fs.writeFileSync>) => {
+      hooks.writing?.();
+      if (hooks.failWrite) {
+        fs.writeFileSync(args[0], "partial");
+        throw new Error("cache write failed");
+      }
+      return fs.writeFileSync(...args);
+    },
+    renameSync: (...args: Parameters<typeof fs.renameSync>) => {
+      if (hooks.failRename) throw new Error("cache rename failed");
+      return fs.renameSync(...args);
+    },
+  };
+});
+const fs = await vi.importActual<typeof import("node:fs")>("node:fs");
+let projectDir: string;
+let cacheDir: string;
+let cachePath: string;
+let app: Hono;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.assign(hooks, {
+    decode: undefined,
+    writing: undefined,
+    failDecode: false,
+    failWrite: false,
+    failRename: false,
+  });
+  projectDir = fs.mkdtempSync(join(tmpdir(), "hf-waveform-test-"));
+  fs.writeFileSync(join(projectDir, "audio.wav"), "audio");
+  cacheDir = join(projectDir, ".waveform-cache");
+  cachePath = join(
+    cacheDir,
+    buildWaveformCacheKey("audio.wav", fs.statSync(join(projectDir, "audio.wav"))),
+  );
+  const adapter: StudioApiAdapter = {
+    listProjects: () => [],
+    resolveProject: (id) => (id === "demo" ? { id, dir: projectDir } : null),
+    bundle: async () => null,
+    lint: () => ({ findings: [] }),
+    runtimeUrl: "/runtime.js",
+    rendersDir: () => projectDir,
+    startRender: () => ({ id: "unused", status: "rendering", progress: 0, outputPath: "unused" }),
+  };
+  app = new Hono();
+  registerWaveformRoutes(app, adapter);
+});
+afterEach(() => fs.rmSync(projectDir, { recursive: true, force: true }));
+
+function readPeaks() {
+  return JSON.parse(fs.readFileSync(cachePath, "utf8"));
+}
+function seedCache(content: string) {
+  fs.mkdirSync(cacheDir, { recursive: true });
+  fs.writeFileSync(cachePath, content);
+}
+function request() {
+  return app.request("http://localhost/projects/demo/waveform/audio.wav");
+}
+
+for (const caller of ["helper", "route"]) {
+  describe(caller, () => {
+    async function generate() {
+      if (caller === "helper") return generateWaveformCache(projectDir, "audio.wav");
+      const response = await request();
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ peaks: readPeaks() });
+    }
+
+    it.each([true, false])(
+      "does not write through a swapped cache symlink (target exists: %s)",
+      async (exists) => {
+        const target = join(projectDir, "outside.json");
+        if (exists) fs.writeFileSync(target, "untouched");
+        hooks.decode = () => {
+          fs.mkdirSync(cacheDir, { recursive: true });
+          fs.symlinkSync(target, cachePath, "file");
+        };
+        await generate();
+        if (exists) expect(fs.readFileSync(target, "utf8")).toBe("untouched");
+        else expect(fs.existsSync(target)).toBe(false);
+        expect(fs.lstatSync(cachePath).isSymbolicLink()).toBe(false);
+        expect(readPeaks()).toHaveLength(4000);
+        expect(fs.readdirSync(cacheDir)).toEqual([
+          buildWaveformCacheKey("audio.wav", fs.statSync(join(projectDir, "audio.wav"))),
+        ]);
+      },
+    );
+
+    it("reuses an existing cache without decoding", async () => {
+      seedCache("[0.25,1]");
+      await generate();
+      expect(spawn).not.toHaveBeenCalled();
+      expect(readPeaks()).toEqual([0.25, 1]);
+    });
+
+    it("publishes complete JSON and removes staging directories", async () => {
+      hooks.writing = () => expect(fs.existsSync(cachePath)).toBe(false);
+      await generate();
+      expect(readPeaks()).toHaveLength(4000);
+      expect(fs.readdirSync(cacheDir)).toHaveLength(1);
+    });
+
+    it.each(["write", "rename"])(
+      "cleans up a failed %s and preserves the previous cache",
+      async (failure) => {
+        hooks.decode = () => seedCache("[0.25]");
+        hooks.failWrite = failure === "write";
+        hooks.failRename = failure === "rename";
+        if (caller === "helper") {
+          await expect(generateWaveformCache(projectDir, "audio.wav")).rejects.toThrow(
+            `cache ${failure} failed`,
+          );
+        } else {
+          const response = await request();
+          expect(response.status).toBe(200);
+          const body = await response.json();
+          expect(body.peaks).toHaveLength(4000);
+        }
+        expect(readPeaks()).toEqual([0.25]);
+        expect(fs.readdirSync(cacheDir)).toHaveLength(1);
+      },
+    );
+
+    it("handles a cache-directory creation failure with the existing error contract", async () => {
+      fs.writeFileSync(cacheDir, "blocked");
+      if (caller === "helper")
+        await expect(generateWaveformCache(projectDir, "audio.wav")).rejects.toThrow();
+      else expect((await request()).status).toBe(200);
+      expect(fs.readFileSync(cacheDir, "utf8")).toBe("blocked");
+    });
+  });
+}
+
+it("regenerates a corrupt cache and reuses the replacement", async () => {
+  seedCache("not JSON");
+  hooks.writing = () => expect(fs.readFileSync(cachePath, "utf8")).toBe("not JSON");
+  expect((await request()).status).toBe(200);
+  expect(readPeaks()).toHaveLength(4000);
+  expect((await request()).status).toBe(200);
+  expect(spawn).toHaveBeenCalledTimes(1);
+});
+it("concurrent misses leave one complete cache and no staging files", async () => {
+  await Promise.all([generateWaveformCache(projectDir, "audio.wav"), request(), request()]);
+  expect(readPeaks()).toHaveLength(4000);
+  expect(fs.readdirSync(cacheDir)).toHaveLength(1);
+});
+it("keeps helper skipping, route 404s and decode failures unchanged", async () => {
+  expect((await app.request("http://localhost/projects/missing/waveform/audio.wav")).status).toBe(
+    404,
+  );
+  hooks.failDecode = true;
+  await expect(generateWaveformCache(projectDir, "audio.wav")).rejects.toThrow(
+    "ffmpeg exited with code 1",
+  );
+  const failed = await request();
+  expect(failed.status).toBe(500);
+  expect(await failed.json()).toEqual({ error: "failed to decode audio" });
+  fs.unlinkSync(join(projectDir, "audio.wav"));
+  await expect(generateWaveformCache(projectDir, "audio.wav")).resolves.toBeUndefined();
+  expect((await request()).status).toBe(404);
+  expect(fs.existsSync(cacheDir)).toBe(false);
+});

--- a/packages/studio-server/src/helpers/waveform.file-race.test.ts
+++ b/packages/studio-server/src/helpers/waveform.file-race.test.ts
@@ -15,7 +15,8 @@ const hooks = vi.hoisted(() => {
     failDecode: boolean;
     failWrite: boolean;
     failRename: boolean;
-  } = { failDecode: false, failWrite: false, failRename: false };
+    failCleanup: boolean;
+  } = { failDecode: false, failWrite: false, failRename: false, failCleanup: false };
   return state;
 });
 vi.mock("node:child_process", async () => {
@@ -46,6 +47,10 @@ vi.mock("node:fs", async (importOriginal) => {
       }
       return fs.writeFileSync(...args);
     },
+    rmSync: (...args: Parameters<typeof fs.rmSync>) => {
+      if (hooks.failCleanup) throw new Error("cache cleanup failed");
+      return fs.rmSync(...args);
+    },
     renameSync: (...args: Parameters<typeof fs.renameSync>) => {
       if (hooks.failRename) throw new Error("cache rename failed");
       return fs.renameSync(...args);
@@ -66,6 +71,7 @@ beforeEach(() => {
     failDecode: false,
     failWrite: false,
     failRename: false,
+    failCleanup: false,
   });
   projectDir = fs.mkdtempSync(join(tmpdir(), "hf-waveform-test-"));
   fs.writeFileSync(join(projectDir, "audio.wav"), "audio");
@@ -127,6 +133,52 @@ for (const caller of ["helper", "route"]) {
         ]);
       },
     );
+
+    it.each([true, false])(
+      "rejects a cache-directory symlink (target exists: %s)",
+      async (exists) => {
+        const outside = fs.mkdtempSync(join(tmpdir(), "hf-waveform-outside-"));
+        const target = join(outside, "cache");
+        const outsideCache = join(
+          target,
+          buildWaveformCacheKey("audio.wav", fs.statSync(join(projectDir, "audio.wav"))),
+        );
+        if (exists) {
+          fs.mkdirSync(target);
+          fs.writeFileSync(outsideCache, "untouched");
+        }
+        fs.symlinkSync(target, cacheDir, process.platform === "win32" ? "junction" : "dir");
+        try {
+          if (caller === "helper")
+            await expect(generateWaveformCache(projectDir, "audio.wav")).rejects.toThrow();
+          else {
+            const response = await request();
+            expect(response.status).toBe(200);
+            expect((await response.json()).peaks).toHaveLength(4000);
+          }
+          if (exists) {
+            expect(fs.readFileSync(outsideCache, "utf8")).toBe("untouched");
+            expect(fs.readdirSync(target)).toHaveLength(1);
+          } else expect(fs.existsSync(target)).toBe(false);
+        } finally {
+          fs.rmSync(outside, { recursive: true, force: true });
+        }
+      },
+    );
+
+    it("rejects a cache-directory symlink planted during decoding", async () => {
+      const outside = fs.mkdtempSync(join(tmpdir(), "hf-waveform-outside-"));
+      hooks.decode = () =>
+        fs.symlinkSync(outside, cacheDir, process.platform === "win32" ? "junction" : "dir");
+      try {
+        if (caller === "helper")
+          await expect(generateWaveformCache(projectDir, "audio.wav")).rejects.toThrow();
+        else expect((await request()).status).toBe(200);
+        expect(fs.readdirSync(outside)).toEqual([]);
+      } finally {
+        fs.rmSync(outside, { recursive: true, force: true });
+      }
+    });
 
     it("reuses an existing cache without decoding", async () => {
       seedCache("[0.25,1]");
@@ -201,4 +253,18 @@ it("keeps helper skipping, route 404s and decode failures unchanged", async () =
   await expect(generateWaveformCache(projectDir, "audio.wav")).resolves.toBeUndefined();
   expect((await request()).status).toBe(404);
   expect(fs.existsSync(cacheDir)).toBe(false);
+});
+
+it("cleanup failure does not turn a successful publication into a helper error", async () => {
+  hooks.failCleanup = true;
+  await expect(generateWaveformCache(projectDir, "audio.wav")).resolves.toBeUndefined();
+  expect(readPeaks()).toHaveLength(4000);
+});
+it("cleanup failure does not mask the original write error", async () => {
+  hooks.failWrite = true;
+  hooks.failCleanup = true;
+  await expect(generateWaveformCache(projectDir, "audio.wav")).rejects.toThrow(
+    "cache write failed",
+  );
+  expect(fs.existsSync(cachePath)).toBe(false);
 });

--- a/packages/studio-server/src/helpers/waveform.ts
+++ b/packages/studio-server/src/helpers/waveform.ts
@@ -1,6 +1,14 @@
 import { spawn } from "node:child_process";
-import { existsSync, writeFileSync, mkdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import {
+  existsSync,
+  writeFileSync,
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
 import { findFfBinary } from "@hyperframes/parsers/ff-binaries";
 
 const SAMPLE_RATE = 4000;
@@ -100,6 +108,19 @@ export async function generateWaveformCache(projectDir: string, assetPath: strin
   if (existsSync(cachePath)) return;
 
   const peaks = await decodeAudioPeaks(audioPath);
+  writeWaveformCache(cachePath, peaks);
+}
+
+/** Publish complete peaks without following a replaced cache-file symlink. */
+export function writeWaveformCache(cachePath: string, peaks: number[]): void {
+  const cacheDir = dirname(cachePath);
   mkdirSync(cacheDir, { recursive: true });
-  writeFileSync(cachePath, JSON.stringify(peaks));
+  const stagingDir = mkdtempSync(join(cacheDir, ".waveform-"));
+  try {
+    const stagingPath = join(stagingDir, "peaks.json");
+    writeFileSync(stagingPath, JSON.stringify(peaks), { flag: "wx" });
+    renameSync(stagingPath, cachePath);
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true });
+  }
 }

--- a/packages/studio-server/src/helpers/waveform.ts
+++ b/packages/studio-server/src/helpers/waveform.ts
@@ -3,6 +3,7 @@ import {
   existsSync,
   writeFileSync,
   mkdirSync,
+  lstatSync,
   mkdtempSync,
   renameSync,
   rmSync,
@@ -105,22 +106,37 @@ export async function generateWaveformCache(projectDir: string, assetPath: strin
   const stats = statSync(audioPath);
   const cacheDir = join(projectDir, ".waveform-cache");
   const cachePath = join(cacheDir, buildWaveformCacheKey(assetPath, stats));
-  if (existsSync(cachePath)) return;
+  if (isWaveformCacheDirectory(cacheDir) && existsSync(cachePath)) return;
 
   const peaks = await decodeAudioPeaks(audioPath);
   writeWaveformCache(cachePath, peaks);
 }
 
+export function isWaveformCacheDirectory(cacheDir: string): boolean {
+  return lstatSync(cacheDir, { throwIfNoEntry: false })?.isDirectory() ?? false;
+}
+
 /** Publish complete peaks without following a replaced cache-file symlink. */
 export function writeWaveformCache(cachePath: string, peaks: number[]): void {
   const cacheDir = dirname(cachePath);
-  mkdirSync(cacheDir, { recursive: true });
+  try {
+    mkdirSync(cacheDir, { mode: 0o700 });
+  } catch (error) {
+    if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
+  }
+  if (!isWaveformCacheDirectory(cacheDir)) {
+    throw new Error("Waveform cache must be a directory, not a symlink");
+  }
   const stagingDir = mkdtempSync(join(cacheDir, ".waveform-"));
   try {
     const stagingPath = join(stagingDir, "peaks.json");
     writeFileSync(stagingPath, JSON.stringify(peaks), { flag: "wx" });
     renameSync(stagingPath, cachePath);
   } finally {
-    rmSync(stagingDir, { recursive: true, force: true });
+    try {
+      rmSync(stagingDir, { recursive: true, force: true });
+    } catch {
+      // Cleanup must not mask a write error or fail an already published cache.
+    }
   }
 }

--- a/packages/studio-server/src/routes/waveform.ts
+++ b/packages/studio-server/src/routes/waveform.ts
@@ -6,6 +6,7 @@ import {
   decodeAudioPeaks,
   buildWaveformCacheKey,
   writeWaveformCache,
+  isWaveformCacheDirectory,
 } from "../helpers/waveform.js";
 
 export function registerWaveformRoutes(api: Hono, adapter: StudioApiAdapter): void {
@@ -25,13 +26,13 @@ export function registerWaveformRoutes(api: Hono, adapter: StudioApiAdapter): vo
     // asset in place invalidates its peaks instead of drawing the old ones.
     const cachePath = join(cacheDir, buildWaveformCacheKey(assetPath, stats));
 
-    if (existsSync(cachePath)) {
-      try {
+    try {
+      if (isWaveformCacheDirectory(cacheDir) && existsSync(cachePath)) {
         const peaks = JSON.parse(readFileSync(cachePath, "utf-8")) as number[];
         return c.json({ peaks });
-      } catch {
-        // corrupt cache — regenerate
       }
+    } catch {
+      // corrupt or inaccessible cache — regenerate
     }
 
     let peaks: number[];

--- a/packages/studio-server/src/routes/waveform.ts
+++ b/packages/studio-server/src/routes/waveform.ts
@@ -1,8 +1,12 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { Hono } from "hono";
 import type { StudioApiAdapter } from "../types.js";
-import { decodeAudioPeaks, buildWaveformCacheKey } from "../helpers/waveform.js";
+import {
+  decodeAudioPeaks,
+  buildWaveformCacheKey,
+  writeWaveformCache,
+} from "../helpers/waveform.js";
 
 export function registerWaveformRoutes(api: Hono, adapter: StudioApiAdapter): void {
   api.get("/projects/:id/waveform/*", async (c) => {
@@ -38,8 +42,7 @@ export function registerWaveformRoutes(api: Hono, adapter: StudioApiAdapter): vo
     }
 
     try {
-      mkdirSync(cacheDir, { recursive: true });
-      writeFileSync(cachePath, JSON.stringify(peaks));
+      writeWaveformCache(cachePath, peaks);
     } catch {
       // cache write failure is non-fatal
     }


### PR DESCRIPTION
Waveform cache generation could follow a symlink planted at the cache filename while audio decoding was running, overwriting or creating the symlink target. Both the prewarming helper and the HTTP route now write complete JSON into a private directory beside the cache, then rename it into place. This addresses CodeQL alerts #690 and #691 and prevents readers from seeing partially written peaks.

Cache-directory symlinks are rejected before cache reuse and staging, including links planted during decoding. Directory creation is nonrecursive so dangling parent links are not traversed. The route still returns decoded peaks if caching fails; the helper propagates write errors. Cleanup is best-effort and does not hide the original error or turn a successful publication into failure. Cache keys, normal existing-cache reuse, corrupt-cache regeneration, decoding and response bodies are unchanged.

The existing Windows lane additionally runs the focused waveform tests without changing its existing test selection. All 531 Studio server tests, Studio server typecheck/build, dependency builds, lint/format and signed commit hooks pass locally. The 25 new cases cover leaf and directory symlinks, existing/dangling targets, concurrent misses, corrupt-cache replacement, partial-write/rename/cleanup failures, and caller error contracts. Four leaf witnesses fail on main; four additional directory witnesses and two cleanup cases fail on the initial PR head. Windows and CodeQL must pass before merge.
