### PR TITLE
fix(lint): see the grouped gsap.set that stages a whole scene at once

### DIFF
--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -1768,6 +1768,170 @@ describe("GSAP rules", () => {
     expect(finding).toBeDefined();
   });
 
+  it("errors when a grouped gsap.set array hides a fromTo target with no destination opacity", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="header">Header</div>
+    <div id="card">Visible after entrance</div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const header = "#header";
+    const card = "#card";
+    gsap.set([header, card], { opacity: 0 });
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#card", { opacity: 1, x: -60 }, { x: 0, duration: 0.5 }, 1);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (f) => f.code === "gsap_cold_seek_hidden_fromto_missing_reveal",
+    );
+    expect(finding).toBeDefined();
+    expect(finding?.selector).toBe("#card");
+  });
+
+  it("errors when a single-element gsap.set array hides a from({opacity:0}) target", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="card">Never visible</div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const card = "#card";
+    gsap.set([card], { opacity: 0 });
+    const tl = gsap.timeline({ paused: true });
+    tl.from("#card", { opacity: 0, y: 30, duration: 0.5 }, 0.2);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "gsap_from_opacity_noop");
+    expect(finding).toBeDefined();
+    expect(finding?.selector).toBe("#card");
+  });
+
+  it("errors when a gsap.set array of quoted selectors hides a fromTo target", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="header">Header</div>
+    <div id="card">Visible after entrance</div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    gsap.set(["#header", "#card"], { opacity: 0 });
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#card", { opacity: 1, x: -60 }, { x: 0, duration: 0.5 }, 1);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (f) => f.code === "gsap_cold_seek_hidden_fromto_missing_reveal",
+    );
+    expect(finding).toBeDefined();
+    expect(finding?.selector).toBe("#card");
+  });
+
+  it("errors when a comma-separated gsap.set selector string hides a fromTo target", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="header">Header</div>
+    <div id="card">Visible after entrance</div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    gsap.set("#header, #card", { opacity: 0 });
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#card", { opacity: 1, x: -60 }, { x: 0, duration: 0.5 }, 1);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (f) => f.code === "gsap_cold_seek_hidden_fromto_missing_reveal",
+    );
+    expect(finding).toBeDefined();
+    expect(finding?.selector).toBe("#card");
+  });
+
+  it("does NOT error when a grouped gsap.set array sets a non-opacity property", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="header">Header</div>
+    <div id="card">Visible after entrance</div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const header = "#header";
+    const card = "#card";
+    gsap.set([header, card], { scaleX: 0, transformOrigin: "left center" });
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#card", { opacity: 1, x: -60 }, { x: 0, duration: 0.5 }, 1);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (f) => f.code === "gsap_cold_seek_hidden_fromto_missing_reveal",
+    );
+    expect(finding).toBeUndefined();
+  });
+
+  it("keeps a later gsap.set hide visible when an earlier one has non-literal vars", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="card">Visible after entrance</div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const staggerVars = { y: 20 };
+    gsap.set(document.querySelectorAll(".row"), staggerVars);
+    gsap.set("#card", { opacity: 0 });
+    const tl = gsap.timeline({ paused: true });
+    tl.fromTo("#card", { opacity: 1, x: -60 }, { x: 0, duration: 0.5 }, 1);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (f) => f.code === "gsap_cold_seek_hidden_fromto_missing_reveal",
+    );
+    expect(finding).toBeDefined();
+    expect(finding?.selector).toBe("#card");
+  });
+
+  it("does NOT error when a grouped gsap.set hide sits inside a callback body", async () => {
+    const html = `
+<html><body>
+  <div data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="card">Visible after entrance</div>
+  </div>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const card = "#card";
+    const tl = gsap.timeline({ paused: true });
+    tl.eventCallback("onComplete", function () {
+      gsap.set([card], { opacity: 0 });
+    });
+    tl.fromTo("#card", { opacity: 1, x: -60 }, { x: 0, duration: 0.5 }, 1);
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (f) => f.code === "gsap_cold_seek_hidden_fromto_missing_reveal",
+    );
+    expect(finding).toBeUndefined();
+  });
+
   it("does NOT error when gsap.to() uses opacity:0 (exit animation)", async () => {
     const html = `
 <html><body>
@@ -3068,6 +3232,30 @@ describe("SVG draw-on rules", () => {
       expect(
         result.findings.find((f) => f.code === "gsap_fullscreen_overlay_starts_visible"),
       ).toBeDefined();
+    });
+
+    it("does not flag a fromTo() at 0 whose from-vars are hidden, which also seats at t=0", async () => {
+      const result = await lintHyperframeHtml(
+        overlay(
+          "",
+          `tl.fromTo("#flash", { opacity: 0, scale: 1.04 }, { opacity: 1, scale: 1, duration: 1.15 }, 0);\n    tl.to("#flash", { opacity: 0, duration: 0.42 }, 4);`,
+        ),
+      );
+      expect(
+        result.findings.find((f) => f.code === "gsap_fullscreen_overlay_starts_visible"),
+      ).toBeUndefined();
+    });
+
+    it("does not flag an overlay hidden by an aliased standalone gsap.set", async () => {
+      const result = await lintHyperframeHtml(
+        overlay(
+          "",
+          `const flash = "#flash";\n    gsap.set(flash, { opacity: 0 });\n    tl.to("#flash", { opacity: 1, duration: 1 }, 2);\n    tl.to("#flash", { opacity: 0, duration: 1 }, 5);`,
+        ),
+      );
+      expect(
+        result.findings.find((f) => f.code === "gsap_fullscreen_overlay_starts_visible"),
+      ).toBeUndefined();
     });
   });
   describe("gsap_timeline_return_used_as_tween", () => {

--- a/packages/lint/src/rules/gsap.ts
+++ b/packages/lint/src/rules/gsap.ts
@@ -203,6 +203,19 @@ function isHiddenGsapState(values: Record<string, string | number>): boolean {
   );
 }
 
+function hiddenSetTargetSelectors(target: string, aliases: Map<string, string>): string[] {
+  const parts =
+    target.startsWith("[") && target.endsWith("]") ? target.slice(1, -1).split(",") : [target];
+  return parts
+    .flatMap((part) => {
+      const trimmed = part.trim();
+      const resolved = /^(["'`])([^"'`]+)\1$/.exec(trimmed)?.[2] ?? aliases.get(trimmed);
+      return resolved === undefined ? [] : resolved.split(",");
+    })
+    .map((selector) => selector.trim())
+    .filter((selector) => selector.length > 0);
+}
+
 function extractStandaloneHiddenSelectors(script: string): Set<string> {
   const selectors = new Set<string>();
   const source = stripJsComments(script);
@@ -213,17 +226,17 @@ function extractStandaloneHiddenSelectors(script: string): Set<string> {
   )) {
     aliases.set(match[1] ?? "", match[3] ?? "");
   }
-  const pattern = /gsap\.set\s*\(\s*([^,]+?)\s*,\s*\{([\s\S]*?)\}\s*\)/g;
+  const pattern =
+    /gsap\.set\s*\(\s*(\[[^[\]]*\]|"[^"]*"|'[^']*'|`[^`]*`|[^,()[\]]+?)\s*,\s*\{([\s\S]*?)\}\s*\)/g;
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(source)) !== null) {
     // Skip callback/handler bodies; keep IIFEs (they run at parse time).
     if (indexInsideNonIifeRange(match.index, source, functionRanges)) continue;
-    const target = (match[1] ?? "").trim();
-    const selector = /^(["'`])([^"'`]+)\1$/.exec(target)?.[2] ?? aliases.get(target);
-    if (!selector) continue;
+    const targets = hiddenSetTargetSelectors((match[1] ?? "").trim(), aliases);
+    if (targets.length === 0) continue;
     const body = match[2] ?? "";
     if (/(?:opacity|autoAlpha)\s*:\s*0(?:\.0+)?\s*(?:,|$)/.test(body)) {
-      selectors.add(selector);
+      for (const selector of targets) selectors.add(selector);
     }
   }
   return selectors;
@@ -1044,6 +1057,9 @@ export const gsapRules: LintRule<LintContext>[] = [
   // fallow-ignore-next-line complexity
   async ({ source, tags, scripts, styles, rootCompositionId }) => {
     const findings: HyperframeLintFinding[] = [];
+    const authoredHiddenSelectors = new Set(
+      scripts.flatMap((script) => [...extractStandaloneHiddenSelectors(script.content)]),
+    );
 
     // Build clip element selector map
     type ClipInfo = { tag: string; id: string; classes: string };
@@ -1170,9 +1186,12 @@ export const gsapRules: LintRule<LintContext>[] = [
           .sort((a, b) => a.position - b.position);
         const startsHiddenAtZero = visibilityWindows.some(
           (win) =>
-            win.position <= SCENE_BOUNDARY_EPSILON_SECONDS && isHiddenGsapState(win.propertyValues),
+            win.position <= SCENE_BOUNDARY_EPSILON_SECONDS &&
+            (isHiddenGsapState(win.propertyValues) ||
+              (win.fromPropertyValues !== undefined && isHiddenGsapState(win.fromPropertyValues))),
         );
         if (startsHiddenAtZero) continue;
+        if (selectors.some((selector) => authoredHiddenSelectors.has(selector))) continue;
         const firstVisible = visibilityWindows.find((win) => makesOverlayVisible(win));
         if (!firstVisible) continue;
         const selector =


### PR DESCRIPTION
## The hole

`extractStandaloneHiddenSelectors` builds the hidden-selector set that both `gsap_cold_seek_hidden_fromto_missing_reveal` and `gsap_from_opacity_noop` work from. It could not read an **array target** — the shortest and most natural way to stage a scene:

```js
gsap.set([header, divider, body, cta], { opacity: 0 });
```

Two independent gates blocked it:

- the target group was `([^,]+?)`, which cannot contain a comma, so a multi-element array never matched at all;
- a single-element array got past the regex and then failed the selector parse, which accepted only a quoted string literal or a known string alias.

So for every grouped hide the hidden set was empty, and the two error rules that ask "was this hidden element ever properly revealed?" had nothing to ask about. A comma-separated selector string (`gsap.set("#a, #b", …)`) was silently half-broken the same way.

## The change

`hiddenSetTargetSelectors` resolves each part of a group on its own; a part that resolves to nothing drops out instead of voiding the whole group. A resolved string is split on commas too, so both grouping forms are handled by one path.

The target pattern is now an explicit alternation — bracketed list, one quoted string, or a bare **paren-free** expression. Keeping it paren-free matters: a comma-permissive target would let `gsap.set(document.querySelectorAll(".row"), staggerVars)` (whose vars are a variable, so there is no `{` to stop at) run past its own closing paren and consume the *next* `gsap.set`, losing the only hide the rule needed. There is a test for exactly that.

## Two false positives the wider hidden set exposed

Both in `gsap_fullscreen_overlay_starts_visible`:

1. a `fromTo` at 0 seats its from-vars immediately, exactly as `from()` does — so hidden from-vars there mean the overlay *does* start hidden. The rule was reading only the destination.
2. an overlay hidden by a standalone `gsap.set` is what this rule's own `fixHint` prescribes, so it now consults the source-level hidden set.

## Verification

**Corpus A/B on 1,181 real compositions** (extracted from production zips, same runner both sides, findings sorted and diffed):

- **2 new findings, 0 removed, 0 changed.**
- Both new ones are true positives in one composition: `gsap.set(['#clip1','#clip2','#clip3','#cta'], { opacity: 0 })` followed by `fromTo('#clip2', { opacity: 1, x: 1080 }, { x: 0, … })`. `fromTo` renders immediately by default, so the visible from-state lands at t=0 and undoes the hide — `#clip2` and `#clip3` are on screen from the first frame, stacked over `#clip1`.

**Tests:** 8 new cases — the three grouped forms and the comma-string form firing, the `scaleX: 0` group and the callback-body group staying quiet, the paren-safety case, and the two overlay false positives. `557 passed`. `tsc --noEmit` 0 errors, `oxlint` 0, `oxfmt --check` clean.

## Scope

This closes the extractor hole. It does **not** close the neighbouring gap that an element with no reveal tween of its own is never examined at all, because these rules iterate tweens rather than hidden elements — that one is a bigger change and belongs on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)