### PR TITLE
feat(lint): flag video/img src pointing at an audio file

### DIFF
--- a/packages/lint/src/rules/media.test.ts
+++ b/packages/lint/src/rules/media.test.ts
@@ -853,6 +853,59 @@ describe("media_src_kind_mismatch", () => {
     expect(result.findings.find((f) => f.code === "media_src_kind_mismatch")).toBeUndefined();
   });
 
+  it("errors when <img> src is an audio file", async () => {
+    const html = `
+<html><body>
+  <div id="root" data-composition-id="c1" data-width="1920" data-height="1080">
+    <img id="logo" src="https://cdn.example.com/brand-assets/music/theme.mp3?sig=abc">
+  </div>
+  <script>window.__timelines = {};</script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "media_src_kind_mismatch");
+    expect(finding?.severity).toBe("error");
+    expect(finding?.elementId).toBe("logo");
+    expect(finding?.message).toContain("an audio file");
+  });
+
+  it("errors when <video> src is an audio file", async () => {
+    const html = `
+<html><body>
+  <div id="root" data-composition-id="c1" data-width="1920" data-height="1080">
+    <video id="bg" src="theme.wav" data-start="0" data-duration="5" muted></video>
+  </div>
+  <script>window.__timelines = {};</script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find((f) => f.code === "media_src_kind_mismatch");
+    expect(finding?.severity).toBe("error");
+    expect(finding?.elementId).toBe("bg");
+  });
+
+  it("does not flag <audio> pointing at a video container", async () => {
+    const html = `
+<html><body>
+  <div id="root" data-composition-id="c1" data-width="1920" data-height="1080">
+    <audio id="sfx" src="whoosh.mp4" data-start="0"></audio>
+  </div>
+  <script>window.__timelines = {};</script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    expect(result.findings.find((f) => f.code === "media_src_kind_mismatch")).toBeUndefined();
+  });
+
+  it("does not flag .ogg, which carries video as well as audio", async () => {
+    const html = `
+<html><body>
+  <div id="root" data-composition-id="c1" data-width="1920" data-height="1080">
+    <video id="v1" src="clip.ogg" data-start="0" data-duration="5" muted></video>
+  </div>
+  <script>window.__timelines = {};</script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    expect(result.findings.find((f) => f.code === "media_src_kind_mismatch")).toBeUndefined();
+  });
+
   it("does not flag extensionless or audio src", async () => {
     const html = `
 <html><body>

--- a/packages/lint/src/rules/media.test.ts
+++ b/packages/lint/src/rules/media.test.ts
@@ -894,11 +894,14 @@ describe("media_src_kind_mismatch", () => {
     expect(result.findings.find((f) => f.code === "media_src_kind_mismatch")).toBeUndefined();
   });
 
-  it("does not flag .ogg, which carries video as well as audio", async () => {
+  it("does not flag .ogg or .m4a, whose containers can carry video too", async () => {
     const html = `
 <html><body>
   <div id="root" data-composition-id="c1" data-width="1920" data-height="1080">
     <video id="v1" src="clip.ogg" data-start="0" data-duration="5" muted></video>
+    <video id="v2" src="clip.m4a" data-start="0" data-duration="5" muted></video>
+    <img id="i1" src="clip.ogg" data-start="0" data-duration="5" />
+    <img id="i2" src="clip.m4a" data-start="0" data-duration="5" />
   </div>
   <script>window.__timelines = {};</script>
 </body></html>`;

--- a/packages/lint/src/rules/media.ts
+++ b/packages/lint/src/rules/media.ts
@@ -67,7 +67,17 @@ const VIDEO_SRC_EXT = new Set([
   "mpeg",
 ]);
 
-function srcKind(src: string): "image" | "video" | null {
+const AUDIO_SRC_EXT = new Set(["mp3", "wav", "m4a", "aac", "flac", "opus", "aiff", "wma"]);
+
+type SrcKind = "image" | "video" | "audio";
+
+const SRC_KIND_NOUN: Record<SrcKind, string> = {
+  image: "an image",
+  video: "a video",
+  audio: "an audio file",
+};
+
+function srcKind(src: string): SrcKind | null {
   const stripped = src.trim();
   if (!stripped) return null;
   const lower = stripped.toLowerCase();
@@ -76,6 +86,7 @@ function srcKind(src: string): "image" | "video" | null {
     if (!mime) return null;
     if (mime.startsWith("image/")) return "image";
     if (mime.startsWith("video/")) return "video";
+    if (mime.startsWith("audio/")) return "audio";
     return null;
   }
   if (lower.startsWith("blob:")) return null;
@@ -95,6 +106,7 @@ function srcKind(src: string): "image" | "video" | null {
   const ext = base.slice(dot + 1).toLowerCase();
   if (IMAGE_SRC_EXT.has(ext)) return "image";
   if (VIDEO_SRC_EXT.has(ext)) return "video";
+  if (AUDIO_SRC_EXT.has(ext)) return "audio";
   return null;
 }
 
@@ -106,19 +118,18 @@ function findMediaSrcKindMismatchFindings(ctx: LintContext): HyperframeLintFindi
     if (!src) continue;
     const kind = srcKind(src);
     if (kind === null) continue;
-    if (tag.name === "video" && kind !== "image") continue;
-    if (tag.name === "img" && kind !== "video") continue;
-    const elementId = readAttr(tag.raw, "id") || undefined;
     const expected = tag.name === "video" ? "video" : "image";
+    if (kind === expected) continue;
+    const elementId = readAttr(tag.raw, "id") || undefined;
     findings.push({
       code: "media_src_kind_mismatch",
       severity: "error",
-      message: `<${tag.name}${elementId ? ` id="${elementId}"` : ""}> src is a ${kind}, not a ${expected}. The producer fail-closes when the tag and file kind disagree.`,
+      message: `<${tag.name}${elementId ? ` id="${elementId}"` : ""}> src is ${SRC_KIND_NOUN[kind]}, not ${SRC_KIND_NOUN[expected]}. The producer fail-closes when the tag and file kind disagree.`,
       elementId,
       fixHint:
         tag.name === "video"
-          ? "Use <img> for a still, or point <video> at a video URL (mp4/webm/mov/…)."
-          : "Use <video> for a video URL, or point <img> at a still (png/jpg/webp/…).",
+          ? "Use <img> for a still, <audio> for sound, or point <video> at a video URL (mp4/webm/mov/…)."
+          : "Use <video> for a video URL, <audio> for sound, or point <img> at a still (png/jpg/webp/…).",
       snippet: truncateSnippet(tag.raw),
     });
   }

--- a/packages/lint/src/rules/media.ts
+++ b/packages/lint/src/rules/media.ts
@@ -67,7 +67,7 @@ const VIDEO_SRC_EXT = new Set([
   "mpeg",
 ]);
 
-const AUDIO_SRC_EXT = new Set(["mp3", "wav", "m4a", "aac", "flac", "opus", "aiff", "wma"]);
+const AUDIO_SRC_EXT = new Set(["mp3", "wav", "aac", "flac", "opus", "aiff", "wma"]);
 
 type SrcKind = "image" | "video" | "audio";
 


### PR DESCRIPTION
## What

`media_src_kind_mismatch` now also fires when a `<video>` or `<img>` owns a `src` that is an audio file (`mp3`, `wav`, `aac`, `flac`, `opus`, `aiff`, `wma`, or a `data:audio/*` URI).

`<audio>` is still never flagged, including `<audio src="sfx.mp4">`.

## Why

#3609 added this rule for the image↔video directions and dropped audio from the type lattice entirely — `srcKind()` returned `image | video | null`, so an audio extension fell through as `null` and the rule bailed.

That was the right call for the `<audio>` **element**: `<audio src="clip.mp4">` is legitimate, and an extension cannot prove whether that mp4 carries an audio stream. But it was implemented by deleting the audio *kind* rather than by skipping the audio *element*, which also dropped a direction that is provable: an `<img>` or `<video>` pointing at an mp3 can never satisfy the producer.

Found while auditing the `ASSET_MEDIA_TYPE_MISMATCH` renders still failing in prod after #3609 — one is a real `<img src=".../brand-assets/music/….mp3?…">` in a customer composition.

### Containers that are excluded, and why

`.ogg` and `.m4a` are deliberately absent: both are containers that can carry video, so the extension proves nothing about the file and this rule is error severity.

### The cover-art case is not a false positive

An mp3 with embedded cover art does carry a video stream, so it is worth spelling out why this still cannot fire wrongly. Probed a real one:

```
format_name=mp3
codec_name=mp3   codec_type=audio
codec_name=mjpeg codec_type=video  (attached_pic)
```

In `probeMediaProfile`, `isStillImageVisual` keys off the container demuxer (`STILL_IMAGE_DEMUXERS`), and `mp3` is not one, so `isStillImage` is false; `hasMovingVideoStream` filters `attached_pic === 1`, so that is false too. `visualKind` lands on `"none"`, which satisfies neither `expected: image` nor `expected: video` — the producer fail-closes either way.

## Test plan

- [x] `bunx vitest run` in `packages/lint` — 552 pass, including four new cases: `<img>`+mp3, `<video>`+wav, `<audio src="*.mp4">` stays clean, `.ogg`/`.m4a` stay clean
- [x] `bun run typecheck` in `packages/lint`