### PR TITLE
fix(studio-server): bridge the node web stream type for the Windows build

### DIFF
--- a/packages/studio-server/src/routes/preview.ts
+++ b/packages/studio-server/src/routes/preview.ts
@@ -592,7 +592,11 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
     const bodyFor = (start: number, end: number): BodyInit =>
       textBuffer
         ? new Uint8Array(textBuffer.subarray(start, end + 1))
-        : (Readable.toWeb(createReadStream(servedPath, { start, end })) as ReadableStream);
+        : // Node's web stream type and the DOM one do not overlap for tsc on
+          // every platform's lib set; the double cast is the documented bridge.
+          (Readable.toWeb(
+            createReadStream(servedPath, { start, end }),
+          ) as unknown as ReadableStream);
 
     // Support byte-range requests so browsers can seek audio/video elements.
     const rangeHeader = c.req.header("Range");


### PR DESCRIPTION
## Problem

After #3745 the Windows jobs fail to build with:

```
studio-server/src/routes/preview.ts(595,12): error TS2352: Conversion of type 'import("node:stream/web").ReadableStream<any>' to type 'ReadableStream<any>' may be a mistake because neither type sufficiently overlaps with the other.
```

The macOS and Linux lib sets let the direct cast through; the Windows one does not.

## Fix

Cast through `unknown`, the bridge the error message recommends. No runtime change.

## Verification

- `tsc --noEmit`, `tsup` build for studio-server, and the core build all pass locally.
- `preview.test.ts`: 49 passed. oxlint and oxfmt clean.