### PR TITLE
chore: release v0.8.31

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -13,7 +13,7 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
   description="Released - 2026-09-07"
   tags={["Release", "Studio Server", "Lint", "Check"]}
 >
-Studio preview now streams only the bytes a browser asks for, so large videos and voice tracks play and scrub without periodic stalls. Lint and check gain a rule for media pointing at the wrong file type and stop flagging code a composition only displays.
+Studio preview now serves only the bytes a browser asks for instead of reading a whole media file per request, which drops server memory and latency on large sources. Lint and check gain a rule for media pointing at the wrong file type and stop flagging code a composition only displays.
 
 ## Features
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,35 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.31"
+  description="Released - 2026-09-07"
+  tags={["Release", "Studio Server", "Lint", "Check"]}
+>
+Studio preview now streams only the bytes a browser asks for, so large videos and voice tracks play and scrub without periodic stalls. Lint and check gain a rule for media pointing at the wrong file type and stop flagging code a composition only displays.
+
+## Features
+
+- **Lint:** Flag video/img src pointing at an audio file ([0d5d3f3eb](https://github.com/heygen-com/hyperframes/commit/0d5d3f3eb3aecd9fd64954d2767d3d64e97e58fc), [#3741](https://github.com/heygen-com/hyperframes/pull/3741)).
+
+## Fixes
+
+- **Studio Server:** Bridge the node web stream type for the Windows build ([8958342dd](https://github.com/heygen-com/hyperframes/commit/8958342dd143d1eb00c75ec2293027eb0d8ac602), [#3746](https://github.com/heygen-com/hyperframes/pull/3746)).
+- **Studio Server:** Stream preview media byte ranges instead of reading the whole file ([8825def61](https://github.com/heygen-com/hyperframes/commit/8825def610fed12985329e495993d47a3943df3e), [#3745](https://github.com/heygen-com/hyperframes/pull/3745)).
+- **Lint:** See the grouped gsap.set that stages a whole scene at once ([b0ac581d8](https://github.com/heygen-com/hyperframes/commit/b0ac581d8e26a154604f009bd9c264c4d878507e), [#3737](https://github.com/heygen-com/hyperframes/pull/3737)).
+- **Check:** Key content_overlap and text_occluded collapse by pair, and bill a clipped text box once ([c59fd162a](https://github.com/heygen-com/hyperframes/commit/c59fd162aabf9d829e06d3237b930ed5b7658b1a), [#2801](https://github.com/heygen-com/hyperframes/pull/2801)).
+- **Lint:** Stop three rules matching code a composition only displays ([051336c07](https://github.com/heygen-com/hyperframes/commit/051336c07b34dec08b5dddf6f54dfcc7f4f64755), [#2811](https://github.com/heygen-com/hyperframes/pull/2811)).
+- **Check:** Keep auditing when a motion spec is partly unusable ([39ad2721b](https://github.com/heygen-com/hyperframes/commit/39ad2721b3875c0568130d3dae55b1df5f486477), [#2805](https://github.com/heygen-com/hyperframes/pull/2805)).
+- **Producer:** Pin lint entry reads to checked descriptors ([f1d0c2e55](https://github.com/heygen-com/hyperframes/commit/f1d0c2e553ba6e684fb935f22a059a9617cf149c), [#3734](https://github.com/heygen-com/hyperframes/pull/3734)).
+- **Studio Server:** Publish waveform caches atomically ([e5b351411](https://github.com/heygen-com/hyperframes/commit/e5b3514118cbd5d2ce97750455078e6b5cbee703), [#3731](https://github.com/heygen-com/hyperframes/pull/3731)).
+
+## Catalog
+
+- **Catalog:** Bind asset reads to checked project files ([7a2a69173](https://github.com/heygen-com/hyperframes/commit/7a2a6917367e6dd7ce22f4c321c4a852dcf58dfd), [#3735](https://github.com/heygen-com/hyperframes/pull/3735)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.30...v0.8.31).
+</Update>
+
+<Update
   label="HyperFrames v0.8.30"
   description="Released - 2026-09-06"
   tags={["Release", "CLI", "Render", "Core"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.30",
+  "version": "0.8.31",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.31.md
+++ b/releases/v0.8.31.md
@@ -2,7 +2,7 @@
 
 Released on 2026-09-07.
 
-Studio preview now streams only the bytes a browser asks for, so large videos and voice tracks play and scrub without periodic stalls. Lint and check gain a rule for media pointing at the wrong file type and stop flagging code a composition only displays.
+Studio preview now serves only the bytes a browser asks for instead of reading a whole media file per request, which drops server memory and latency on large sources. Lint and check gain a rule for media pointing at the wrong file type and stop flagging code a composition only displays.
 
 ## Features
 

--- a/releases/v0.8.31.md
+++ b/releases/v0.8.31.md
@@ -1,0 +1,28 @@
+# HyperFrames v0.8.31
+
+Released on 2026-09-07.
+
+Studio preview now streams only the bytes a browser asks for, so large videos and voice tracks play and scrub without periodic stalls. Lint and check gain a rule for media pointing at the wrong file type and stop flagging code a composition only displays.
+
+## Features
+
+- **Lint:** Flag video/img src pointing at an audio file ([0d5d3f3eb](https://github.com/heygen-com/hyperframes/commit/0d5d3f3eb3aecd9fd64954d2767d3d64e97e58fc), [#3741](https://github.com/heygen-com/hyperframes/pull/3741)).
+
+## Fixes
+
+- **Studio Server:** Bridge the node web stream type for the Windows build ([8958342dd](https://github.com/heygen-com/hyperframes/commit/8958342dd143d1eb00c75ec2293027eb0d8ac602), [#3746](https://github.com/heygen-com/hyperframes/pull/3746)).
+- **Studio Server:** Stream preview media byte ranges instead of reading the whole file ([8825def61](https://github.com/heygen-com/hyperframes/commit/8825def610fed12985329e495993d47a3943df3e), [#3745](https://github.com/heygen-com/hyperframes/pull/3745)).
+- **Lint:** See the grouped gsap.set that stages a whole scene at once ([b0ac581d8](https://github.com/heygen-com/hyperframes/commit/b0ac581d8e26a154604f009bd9c264c4d878507e), [#3737](https://github.com/heygen-com/hyperframes/pull/3737)).
+- **Check:** Key content_overlap and text_occluded collapse by pair, and bill a clipped text box once ([c59fd162a](https://github.com/heygen-com/hyperframes/commit/c59fd162aabf9d829e06d3237b930ed5b7658b1a), [#2801](https://github.com/heygen-com/hyperframes/pull/2801)).
+- **Lint:** Stop three rules matching code a composition only displays ([051336c07](https://github.com/heygen-com/hyperframes/commit/051336c07b34dec08b5dddf6f54dfcc7f4f64755), [#2811](https://github.com/heygen-com/hyperframes/pull/2811)).
+- **Check:** Keep auditing when a motion spec is partly unusable ([39ad2721b](https://github.com/heygen-com/hyperframes/commit/39ad2721b3875c0568130d3dae55b1df5f486477), [#2805](https://github.com/heygen-com/hyperframes/pull/2805)).
+- **Producer:** Pin lint entry reads to checked descriptors ([f1d0c2e55](https://github.com/heygen-com/hyperframes/commit/f1d0c2e553ba6e684fb935f22a059a9617cf149c), [#3734](https://github.com/heygen-com/hyperframes/pull/3734)).
+- **Studio Server:** Publish waveform caches atomically ([e5b351411](https://github.com/heygen-com/hyperframes/commit/e5b3514118cbd5d2ce97750455078e6b5cbee703), [#3731](https://github.com/heygen-com/hyperframes/pull/3731)).
+
+## Catalog
+
+- **Catalog:** Bind asset reads to checked project files ([7a2a69173](https://github.com/heygen-com/hyperframes/commit/7a2a6917367e6dd7ce22f4c321c4a852dcf58dfd), [#3735](https://github.com/heygen-com/hyperframes/pull/3735)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.30...v0.8.31


### PR DESCRIPTION
Released on 2026-09-07.

Studio preview now streams only the bytes a browser asks for, so large videos and voice tracks play and scrub without periodic stalls. Lint and check gain a rule for media pointing at the wrong file type and stop flagging code a composition only displays.

## Features

- **Lint:** Flag video/img src pointing at an audio file ([0d5d3f3eb](https://github.com/heygen-com/hyperframes/commit/0d5d3f3eb3aecd9fd64954d2767d3d64e97e58fc), [#3741](https://github.com/heygen-com/hyperframes/pull/3741)).

## Fixes

- **Studio Server:** Bridge the node web stream type for the Windows build ([8958342dd](https://github.com/heygen-com/hyperframes/commit/8958342dd143d1eb00c75ec2293027eb0d8ac602), [#3746](https://github.com/heygen-com/hyperframes/pull/3746)).
- **Studio Server:** Stream preview media byte ranges instead of reading the whole file ([8825def61](https://github.com/heygen-com/hyperframes/commit/8825def610fed12985329e495993d47a3943df3e), [#3745](https://github.com/heygen-com/hyperframes/pull/3745)).
- **Lint:** See the grouped gsap.set that stages a whole scene at once ([b0ac581d8](https://github.com/heygen-com/hyperframes/commit/b0ac581d8e26a154604f009bd9c264c4d878507e), [#3737](https://github.com/heygen-com/hyperframes/pull/3737)).
- **Check:** Key content_overlap and text_occluded collapse by pair, and bill a clipped text box once ([c59fd162a](https://github.com/heygen-com/hyperframes/commit/c59fd162aabf9d829e06d3237b930ed5b7658b1a), [#2801](https://github.com/heygen-com/hyperframes/pull/2801)).
- **Lint:** Stop three rules matching code a composition only displays ([051336c07](https://github.com/heygen-com/hyperframes/commit/051336c07b34dec08b5dddf6f54dfcc7f4f64755), [#2811](https://github.com/heygen-com/hyperframes/pull/2811)).
- **Check:** Keep auditing when a motion spec is partly unusable ([39ad2721b](https://github.com/heygen-com/hyperframes/commit/39ad2721b3875c0568130d3dae55b1df5f486477), [#2805](https://github.com/heygen-com/hyperframes/pull/2805)).
- **Producer:** Pin lint entry reads to checked descriptors ([f1d0c2e55](https://github.com/heygen-com/hyperframes/commit/f1d0c2e553ba6e684fb935f22a059a9617cf149c), [#3734](https://github.com/heygen-com/hyperframes/pull/3734)).
- **Studio Server:** Publish waveform caches atomically ([e5b351411](https://github.com/heygen-com/hyperframes/commit/e5b3514118cbd5d2ce97750455078e6b5cbee703), [#3731](https://github.com/heygen-com/hyperframes/pull/3731)).

## Catalog

- **Catalog:** Bind asset reads to checked project files ([7a2a69173](https://github.com/heygen-com/hyperframes/commit/7a2a6917367e6dd7ce22f4c321c4a852dcf58dfd), [#3735](https://github.com/heygen-com/hyperframes/pull/3735)).

## Full changelog

https://github.com/heygen-com/hyperframes/compare/v0.8.30...v0.8.31