### PR TITLE
feat: offline asset ledger and vendor preflight CLI

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -825,13 +825,15 @@
             "pages": [
               "reference/html-schema",
               "reference/color-grading",
-              "reference/audio-effects"
+              "reference/audio-effects",
+              "reference/cli-ledger"
             ]
           },
           {
             "group": "Rendering paths",
             "pages": [
               "guides/rendering",
+              "guides/offline-deterministic-renders",
               "deploy/overview",
               "deploy/cloud",
               "guides/deploy"

--- a/docs/guides/offline-deterministic-renders.mdx
+++ b/docs/guides/offline-deterministic-renders.mdx
@@ -1,0 +1,100 @@
+---
+title: "Offline & deterministic renders"
+sidebarTitle: "Offline renders"
+description: "Make a composition render byte-identically with the network unplugged: inventory assets, vendor remotes, and gate CI on zero network references."
+---
+
+A HyperFrames render is a function of the composition and its assets — nothing
+else. Two things quietly break that:
+
+- **Remote assets.** A CDN `<script>`, a hotlinked image, or a Google Fonts
+  stylesheet means render output depends on a third-party server being up,
+  fast, and serving the same bytes as yesterday.
+- **Runtime nondeterminism.** `Date.now()`, unseeded `Math.random()`, and
+  render-time `fetch()` calls produce different frames on different runs.
+
+The composition contract already bans the second category. This guide is about
+the first: getting to — and staying at — **zero network references**.
+
+## The workflow
+
+<Steps>
+  <Step title="Inventory: hyperframes ledger">
+    ```bash
+    npx hyperframes ledger --json
+    ```
+
+    The ledger scans every HTML file and classifies each declared asset as
+    `remote`, `local`, `data`, or `missing` — scripts, stylesheets, fonts,
+    images, audio, video, iframes, and text tracks, including URLs inside
+    `<style>` blocks and inline styles. It is purely static (no browser, no
+    network), so it is safe anywhere, CI included.
+  </Step>
+  <Step title="Localize: hyperframes vendor">
+    ```bash
+    npx hyperframes vendor
+    ```
+
+    Every remote `http(s)` asset is downloaded into `assets/vendor/`, every
+    reference is rewritten to a relative path, and `vendor-manifest.json`
+    records the source URL, size, and SHA-256 of each download. Your
+    composition now carries its own dependencies.
+  </Step>
+  <Step title="Enforce: --strict-offline">
+    ```bash
+    npx hyperframes ledger --strict-offline
+    ```
+
+    Exits non-zero while any remote reference remains. Put it in CI right
+    before `hyperframes render` so a stray CDN reference fails the pipeline
+    instead of the render.
+  </Step>
+</Steps>
+
+## Example
+
+A fresh composition that pulls GSAP from jsDelivr:
+
+```bash
+$ npx hyperframes ledger
+◆  Asset ledger for my-video
+   1 HTML file scanned, 6 asset references
+
+   4 local   1 remote   1 data   0 missing
+
+   remote  script     https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js
+           index.html (src)
+
+   Run hyperframes vendor to download remote assets and rewrite references…
+
+$ npx hyperframes vendor
+↓  https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js → assets/vendor/gsap.min-8c6a2d81f0.js
+
+◆  Vendored 1 asset(s) into assets/vendor, rewrote 1 reference(s).
+   0 remote references remain — project renders offline.
+
+$ npx hyperframes ledger --strict-offline && npx hyperframes render
+```
+
+The `<script>` tag now reads
+`src="assets/vendor/gsap.min-8c6a2d81f0.js"` — same GSAP, no network.
+
+## What vendoring will not fix
+
+- **Remote iframes.** A live embedded page can never be deterministic.
+  `vendor` leaves iframes alone and `--strict-offline` keeps failing until you
+  replace the embed with captured media (`hyperframes capture`).
+- **Fonts hidden behind remote CSS.** A Google Fonts stylesheet is vendored as
+  the CSS file it is, but the font binaries it references are not crawled.
+  Self-host fonts with `@font-face` for text-critical typography.
+- **Runtime-constructed URLs.** The ledger reads declared markup, not script
+  behavior. `hyperframes check` (headless Chrome) remains the runtime gate.
+
+## Lint nudge
+
+`hyperframes lint` flags remote `<script src>` tags with an info-level
+`remote_script_not_vendored` finding. CDN scripts are fine while iterating;
+vendor before you care about reproducibility.
+
+See the [ledger & vendor CLI reference](/reference/cli-ledger) for flags,
+JSON schemas, and exit codes.

--- a/docs/reference/cli-ledger.mdx
+++ b/docs/reference/cli-ledger.mdx
@@ -1,0 +1,127 @@
+---
+title: "Asset ledger & vendor CLI"
+sidebarTitle: "Ledger & vendor"
+description: "Inventory every declared asset, download remote references locally, and gate renders on being fully offline."
+---
+
+Deterministic renders must not depend on the network at capture time. These two
+commands make that property inspectable and enforceable:
+
+- `hyperframes ledger` builds a static, agent-readable **asset graph** of every
+  declared reference — scripts, stylesheets, fonts, images, audio, video,
+  iframes, text tracks — and classifies each as `remote`, `local`, `data`, or
+  `missing`. No browser, no network.
+- `hyperframes vendor` **downloads** the remote references, rewrites the HTML
+  to relative paths, and records provenance, so the project renders offline.
+
+For the workflow view (why and when), see
+[Offline & deterministic renders](/guides/offline-deterministic-renders).
+
+## `hyperframes ledger [dir]`
+
+```bash
+npx hyperframes ledger                    # human-readable summary
+npx hyperframes ledger ./my-video --json  # machine-readable asset graph
+npx hyperframes ledger --strict-offline   # exit 1 if any remote ref remains
+```
+
+The scan is purely static: every `.html` file under the project directory
+(excluding `node_modules`, dot-directories, `dist`, `coverage`) is parsed for
+declared URLs in tag attributes (`src`, `href`, `srcset`, `poster`), inline
+`style=""` attributes, and `<style>` blocks (`url(…)`, `@import`,
+`@font-face src`). URLs constructed at runtime inside scripts are out of
+scope, as are assets nested inside remote stylesheets.
+
+Classification:
+
+| Status    | Meaning                                                                  |
+| --------- | ------------------------------------------------------------------------ |
+| `remote`  | `http(s)://`, protocol-relative `//…`, or any non-inline URL scheme      |
+| `local`   | Resolves to a file on disk (relative to the declaring file or the root)  |
+| `data`    | Inline `data:` URI — self-contained, render-safe                         |
+| `missing` | Looks like a local path but no file exists                               |
+
+Commented-out markup, `blob:`/`javascript:`/`about:` values, and unresolved
+templating placeholders (`{{ token }}`, `__UPPER__`) are skipped.
+
+### JSON shape
+
+```json
+{
+  "ok": true,
+  "strictOffline": false,
+  "files": ["index.html", "scenes/intro.html"],
+  "counts": { "total": 14, "remote": 2, "local": 11, "data": 1, "missing": 0 },
+  "remoteUrls": ["https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"],
+  "assets": [
+    {
+      "kind": "script",
+      "url": "https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js",
+      "rawUrl": "https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js",
+      "status": "remote",
+      "file": "index.html",
+      "via": "src"
+    }
+  ]
+}
+```
+
+`via` records where the reference was declared: `src`, `href`, `srcset`,
+`poster`, `css-url`, `css-import`, or `style-attr`. Local assets carry a
+`localPath` with the resolved project-relative file.
+
+### Exit codes
+
+| Condition                                     | Exit code |
+| --------------------------------------------- | --------- |
+| Default                                       | `0`       |
+| `--strict-offline` and ≥1 remote reference    | `1`       |
+| Invalid project directory                     | `1`       |
+
+## `hyperframes vendor [dir]`
+
+```bash
+npx hyperframes vendor                          # download into assets/vendor/
+npx hyperframes vendor --out assets/third-party # custom output directory
+npx hyperframes vendor --dry-run                # list, download nothing
+npx hyperframes vendor --strict-offline         # exit 1 if remotes remain after
+```
+
+For every unique remote URL in the ledger, `vendor`:
+
+1. Downloads it (only `http:`/`https:` are ever fetched; protocol-relative URLs
+   are fetched over `https:`). Each file is saved as
+   `<basename>-<sha256-prefix><ext>` so re-runs are stable and names never
+   collide.
+2. Rewrites every reference in every HTML file to a path **relative to the
+   declaring file** (`assets/vendor/gsap.min-1a2b3c4d5e.js` from `index.html`,
+   `../assets/vendor/…` from `scenes/intro.html`). The rewrite is text-level,
+   so your formatting is preserved and URLs mentioned in inline scripts are
+   localized too.
+3. Writes `vendor-manifest.json` into the output directory recording `url`,
+   `file`, `bytes`, `sha256`, and `contentType` per asset — the provenance
+   record for review and licensing checks.
+
+Remote **iframes** are never vendored: a live page cannot be made
+deterministic by downloading it. They stay remote and still fail
+`--strict-offline`, which is the point — replace them with captured media.
+
+Google Fonts stylesheets are downloaded as declared, but font binaries nested
+inside a remote CSS response are not crawled. Prefer self-hosted `@font-face`
+files (see [media guide](/guides/media)) for text-critical fonts.
+
+### Exit codes
+
+| Condition                                        | Exit code |
+| ------------------------------------------------ | --------- |
+| All downloads succeeded, no strict violation     | `0`       |
+| Any download failed                              | `1`       |
+| `--strict-offline` and remote references remain  | `1`       |
+
+## Lint integration
+
+`hyperframes lint` reports an info-level `remote_script_not_vendored` finding
+for every remote `<script src>`, pointing at `hyperframes vendor`. CDN scripts
+remain the documented quick-start path — the enforcing gate is
+`hyperframes ledger --strict-offline`, typically in CI just before
+`hyperframes render`.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -132,6 +132,8 @@ const commandLoaders = {
   publish: () => import("./commands/publish.js").then((m) => m.default),
   render: () => import("./commands/render.js").then((m) => m.default),
   lint: () => import("./commands/lint.js").then((m) => m.default),
+  ledger: () => import("./commands/ledger.js").then((m) => m.default),
+  vendor: () => import("./commands/vendor.js").then((m) => m.default),
   check: () => import("./commands/check.js").then((m) => m.default),
   beats: () => import("./commands/beats.js").then((m) => m.default),
   "normalize-audio": () => import("./commands/normalize-audio.js").then((m) => m.default),

--- a/packages/cli/src/commands/_offlineAssetsTestKit.ts
+++ b/packages/cli/src/commands/_offlineAssetsTestKit.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared fixtures/helpers for the ledger + vendor command tests. Underscore
+ * prefix (like _examples.ts) keeps it out of vitest's *.test.ts glob.
+ */
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { vi } from "vitest";
+import type { CommandDef } from "citty";
+
+export const GSAP_URL = "https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js";
+
+/** Invoke a citty command's run() with a context whose `args` we control. */
+export function makeRunner(
+  command: CommandDef,
+): (args: Record<string, unknown>) => Promise<unknown> {
+  return (args) =>
+    (command.run as (ctx: { args: Record<string, unknown> }) => Promise<unknown>)({ args });
+}
+
+/** Last console.log payload parsed as JSON (the --json output). */
+export function lastJsonOutput(): Record<string, unknown> {
+  const calls = vi.mocked(console.log).mock.calls;
+  const last = calls[calls.length - 1]?.[0];
+  return JSON.parse(String(last));
+}
+
+/**
+ * A minimal project: one jsDelivr CDN script (remote) + one local image.
+ * Returns the temp project dir; callers rmSync it in afterEach.
+ */
+export function makeFixtureProject(prefix: string, extraBody = ""): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(dir, "assets", "img"), { recursive: true });
+  writeFileSync(join(dir, "assets", "img", "logo.png"), "png");
+  writeFileSync(
+    join(dir, "index.html"),
+    `<!DOCTYPE html>
+<html><head>
+  <script src="${GSAP_URL}"></script>
+</head><body>
+  <img src="assets/img/logo.png">
+${extraBody}
+</body></html>`,
+  );
+  return dir;
+}
+
+/** Silence console and reset spies for one test. */
+export function spyOnConsole(): void {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+}

--- a/packages/cli/src/commands/ledger.test.ts
+++ b/packages/cli/src/commands/ledger.test.ts
@@ -1,0 +1,78 @@
+import { rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { consumeCommandResult } from "../utils/commandResult.js";
+import {
+  lastJsonOutput,
+  makeFixtureProject,
+  makeRunner,
+  spyOnConsole,
+} from "./_offlineAssetsTestKit.js";
+
+// withMeta just annotates the object; identity keeps the assertions simple.
+vi.mock("../utils/updateCheck.js", () => ({ withMeta: (o: unknown) => o }));
+// resolveProject reports invalid-dir failures to telemetry; keep tests silent.
+vi.mock("../telemetry/events.js", () => ({ trackCommandFailure: () => {} }));
+
+import ledgerCommand from "./ledger.js";
+
+const run = makeRunner(ledgerCommand);
+
+describe("ledger command", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    consumeCommandResult();
+    spyOnConsole();
+    dir = makeFixtureProject("hf-ledger-cmd-", `  <img src="assets/img/missing.png">`);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    consumeCommandResult();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("--json reports the classified asset graph and exits 0", async () => {
+    await run({ dir, json: true, "strict-offline": false });
+    expect(consumeCommandResult().exitCode).toBe(0);
+
+    const output = lastJsonOutput();
+    expect(output.ok).toBe(true);
+    expect(output.files).toEqual(["index.html"]);
+    expect(output.counts).toMatchObject({ total: 3, remote: 1, local: 1, missing: 1, data: 0 });
+    expect(output.remoteUrls).toEqual([
+      "https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js",
+    ]);
+  });
+
+  it("--strict-offline exits 1 while a remote reference remains", async () => {
+    await run({ dir, json: true, "strict-offline": true });
+    expect(consumeCommandResult().exitCode).toBe(1);
+    expect(lastJsonOutput().ok).toBe(false);
+  });
+
+  it("--strict-offline exits 0 once the project is fully local", async () => {
+    writeFileSync(join(dir, "index.html"), `<img src="assets/img/logo.png">`);
+    await run({ dir, json: true, "strict-offline": true });
+    expect(consumeCommandResult().exitCode).toBe(0);
+    expect(lastJsonOutput().ok).toBe(true);
+  });
+
+  it("human-readable output prints counts and the vendor hint", async () => {
+    await run({ dir, json: false, "strict-offline": false });
+    expect(consumeCommandResult().exitCode).toBe(0);
+    const printed = vi
+      .mocked(console.log)
+      .mock.calls.map((call) => call.join(" "))
+      .join("\n");
+    expect(printed).toContain("Asset ledger");
+    expect(printed).toContain("hyperframes vendor");
+  });
+
+  it("errors surface as JSON with exit 1", async () => {
+    await run({ dir: join(dir, "does-not-exist"), json: true, "strict-offline": false });
+    expect(consumeCommandResult().exitCode).toBe(1);
+    expect(lastJsonOutput().ok).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/ledger.ts
+++ b/packages/cli/src/commands/ledger.ts
@@ -1,0 +1,128 @@
+import { defineCommand } from "citty";
+import type { Example } from "./_examples.js";
+import type { AssetLedger } from "@hyperframes/core/asset-ledger";
+import { setCommandExitCode } from "../utils/commandResult.js";
+import { c } from "../ui/colors.js";
+import { resolveProject } from "../utils/project.js";
+import { withMeta } from "../utils/updateCheck.js";
+
+export const examples: Example[] = [
+  ["Inventory every declared asset", "hyperframes ledger"],
+  ["Machine-readable asset graph", "hyperframes ledger ./my-video --json"],
+  ["Fail CI when any remote reference remains", "hyperframes ledger --strict-offline"],
+];
+
+const STATUS_LABEL: Record<string, (s: string) => string> = {
+  remote: (s) => c.warn(s),
+  missing: (s) => c.error(s),
+  local: (s) => c.success(s),
+  data: (s) => c.dim(s),
+};
+
+function printHumanLedger(ledger: AssetLedger, projectName: string): void {
+  console.log(`${c.accent("◆")}  Asset ledger for ${c.accent(projectName)}`);
+  console.log(
+    `   ${ledger.files.length} HTML file${ledger.files.length === 1 ? "" : "s"} scanned, ` +
+      `${ledger.counts.total} asset reference${ledger.counts.total === 1 ? "" : "s"}`,
+  );
+  console.log();
+  console.log(
+    `   ${c.success(String(ledger.counts.local))} local   ` +
+      `${c.warn(String(ledger.counts.remote))} remote   ` +
+      `${c.dim(String(ledger.counts.data))} data   ` +
+      `${c.error(String(ledger.counts.missing))} missing`,
+  );
+
+  const actionable = ledger.assets.filter(
+    (asset) => asset.status === "remote" || asset.status === "missing",
+  );
+  if (actionable.length > 0) {
+    console.log();
+    for (const asset of actionable) {
+      const paint = STATUS_LABEL[asset.status] ?? ((s: string) => s);
+      console.log(`   ${paint(asset.status.padEnd(7))} ${asset.kind.padEnd(10)} ${asset.url}`);
+      console.log(`   ${" ".repeat(7)} ${c.dim(`${asset.file} (${asset.via})`)}`);
+    }
+  }
+
+  if (ledger.counts.remote > 0) {
+    console.log();
+    console.log(
+      `   ${c.dim("Run")} hyperframes vendor ${c.dim("to download remote assets and rewrite references for offline, deterministic renders.")}`,
+    );
+  }
+}
+
+function printStrictViolation(remoteCount: number): void {
+  console.log();
+  console.log(
+    c.error(
+      `✖  --strict-offline: ${remoteCount} remote reference${remoteCount === 1 ? "" : "s"} remain.`,
+    ),
+  );
+}
+
+export default defineCommand({
+  meta: {
+    name: "ledger",
+    description: "Inventory every declared asset and classify it remote | local | data | missing",
+  },
+  args: {
+    dir: {
+      type: "positional",
+      description: "Project directory",
+      required: false,
+    },
+    json: {
+      type: "boolean",
+      description: "Output the asset ledger as JSON",
+      default: false,
+    },
+    "strict-offline": {
+      type: "boolean",
+      description: "Exit non-zero when any remote asset reference remains",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const strictOffline = Boolean(args["strict-offline"]);
+    try {
+      const project = resolveProject(args.dir, { requireIndex: false });
+      const { buildProjectAssetLedger } = await import("@hyperframes/core/asset-ledger");
+      const ledger = buildProjectAssetLedger(project.dir);
+      const strictViolation = strictOffline && ledger.counts.remote > 0;
+
+      if (args.json) {
+        console.log(
+          JSON.stringify(
+            withMeta({
+              ok: !strictViolation,
+              strictOffline,
+              files: ledger.files,
+              counts: ledger.counts,
+              remoteUrls: ledger.remoteUrls,
+              assets: ledger.assets,
+            }),
+            null,
+            2,
+          ),
+        );
+        setCommandExitCode(strictViolation ? 1 : 0);
+        return;
+      }
+
+      printHumanLedger(ledger, project.name);
+      if (strictViolation) printStrictViolation(ledger.counts.remote);
+      setCommandExitCode(strictViolation ? 1 : 0);
+      return;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (args.json) {
+        console.log(JSON.stringify(withMeta({ ok: false, error: message }), null, 2));
+      } else {
+        console.error(message);
+      }
+      setCommandExitCode(1);
+    }
+  },
+});

--- a/packages/cli/src/commands/vendor.test.ts
+++ b/packages/cli/src/commands/vendor.test.ts
@@ -1,0 +1,162 @@
+import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { consumeCommandResult } from "../utils/commandResult.js";
+import {
+  GSAP_URL,
+  lastJsonOutput,
+  makeFixtureProject,
+  makeRunner,
+  spyOnConsole,
+} from "./_offlineAssetsTestKit.js";
+
+// withMeta just annotates the object; identity keeps the assertions simple.
+vi.mock("../utils/updateCheck.js", () => ({ withMeta: (o: unknown) => o }));
+// resolveProject reports invalid-dir failures to telemetry; keep tests silent.
+vi.mock("../telemetry/events.js", () => ({ trackCommandFailure: () => {} }));
+
+import vendorCommand, { rewriteHtmlReferences, toFetchableUrl, vendorFileName } from "./vendor.js";
+
+const run = makeRunner(vendorCommand);
+
+function fetchResponse(body: string, contentType: string): Response {
+  return new Response(body, { status: 200, headers: { "content-type": contentType } });
+}
+
+describe("toFetchableUrl", () => {
+  it("allows http(s) and upgrades protocol-relative URLs to https", () => {
+    expect(toFetchableUrl(GSAP_URL)).toBe(GSAP_URL);
+    expect(toFetchableUrl("http://example.com/a.js")).toBe("http://example.com/a.js");
+    expect(toFetchableUrl("//cdn.example.com/a.js")).toBe("https://cdn.example.com/a.js");
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    expect(toFetchableUrl("ftp://example.com/a.png")).toBeNull();
+    expect(toFetchableUrl("file:///etc/passwd")).toBeNull();
+    expect(toFetchableUrl("not a url")).toBeNull();
+  });
+});
+
+describe("vendorFileName", () => {
+  it("keeps the basename, appends a stable hash, and preserves the extension", () => {
+    const name = vendorFileName(GSAP_URL);
+    expect(name).toMatch(/^gsap\.min-[0-9a-f]{10}\.js$/);
+    expect(vendorFileName(GSAP_URL)).toBe(name);
+  });
+
+  it("derives the extension from content-type when the URL has none", () => {
+    expect(vendorFileName("https://fonts.example.com/inter", "font/woff2")).toMatch(/\.woff2$/);
+  });
+});
+
+describe("rewriteHtmlReferences", () => {
+  it("rewrites to a path relative to the referencing file", () => {
+    const html = `<script src="${GSAP_URL}"></script>`;
+    const fromRoot = rewriteHtmlReferences(html, "index.html", [
+      { rawUrl: GSAP_URL, vendorPath: "assets/vendor/gsap.min-abc.js" },
+    ]);
+    expect(fromRoot.rewritten).toBe(1);
+    expect(fromRoot.html).toContain('src="assets/vendor/gsap.min-abc.js"');
+
+    const fromScene = rewriteHtmlReferences(html, "scenes/intro.html", [
+      { rawUrl: GSAP_URL, vendorPath: "assets/vendor/gsap.min-abc.js" },
+    ]);
+    expect(fromScene.html).toContain('src="../assets/vendor/gsap.min-abc.js"');
+  });
+
+  it("replaces longer URLs first so prefixes cannot clobber", () => {
+    const html = `<script src="https://x.com/a.js"></script><script src="https://x.com/a.js.map"></script>`;
+    const { html: out } = rewriteHtmlReferences(html, "index.html", [
+      { rawUrl: "https://x.com/a.js", vendorPath: "v/a.js" },
+      { rawUrl: "https://x.com/a.js.map", vendorPath: "v/a.js.map" },
+    ]);
+    expect(out).toContain('src="v/a.js"');
+    expect(out).toContain('src="v/a.js.map"');
+  });
+});
+
+describe("vendor command", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    consumeCommandResult();
+    spyOnConsole();
+    dir = makeFixtureProject("hf-vendor-cmd-");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    consumeCommandResult();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("downloads remotes, rewrites HTML, and writes the manifest", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => fetchResponse("/* gsap */", "text/javascript")),
+    );
+
+    await run({ dir, out: "assets/vendor", json: true, "strict-offline": true });
+    expect(consumeCommandResult().exitCode).toBe(0);
+
+    const output = lastJsonOutput();
+    expect(output.ok).toBe(true);
+    expect(output.remainingRemoteUrls).toEqual([]);
+    expect(output.rewrittenReferences).toBe(1);
+
+    const html = readFileSync(join(dir, "index.html"), "utf-8");
+    expect(html).not.toContain("https://");
+    expect(html).toMatch(/src="assets\/vendor\/gsap\.min-[0-9a-f]{10}\.js"/);
+
+    const vendorFiles = readdirSync(join(dir, "assets", "vendor"));
+    expect(vendorFiles).toContain("vendor-manifest.json");
+    expect(vendorFiles.some((f) => f.startsWith("gsap.min-"))).toBe(true);
+
+    const manifest = JSON.parse(
+      readFileSync(join(dir, "assets", "vendor", "vendor-manifest.json"), "utf-8"),
+    );
+    expect(manifest.assets).toHaveLength(1);
+    expect(manifest.assets[0]).toMatchObject({ url: GSAP_URL, bytes: 10 });
+    expect(manifest.assets[0].sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("--dry-run lists candidate downloads without touching the project", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await run({ dir, out: "assets/vendor", json: true, "dry-run": true });
+    expect(consumeCommandResult().exitCode).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(lastJsonOutput().wouldDownload).toEqual([GSAP_URL]);
+    expect(existsSync(join(dir, "assets", "vendor"))).toBe(false);
+    expect(readFileSync(join(dir, "index.html"), "utf-8")).toContain(GSAP_URL);
+  });
+
+  it("reports failed downloads and exits 1 without rewriting their references", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 404 })),
+    );
+
+    await run({ dir, out: "assets/vendor", json: true });
+    expect(consumeCommandResult().exitCode).toBe(1);
+
+    const output = lastJsonOutput();
+    expect(output.ok).toBe(false);
+    expect(output.failed).toEqual([{ url: GSAP_URL, error: "HTTP 404" }]);
+    expect(readFileSync(join(dir, "index.html"), "utf-8")).toContain(GSAP_URL);
+  });
+
+  it("--strict-offline exits 1 when a non-vendorable remote (iframe) remains", async () => {
+    writeFileSync(join(dir, "index.html"), `<iframe src="https://example.com/embed"></iframe>`);
+    vi.stubGlobal("fetch", vi.fn());
+
+    await run({ dir, out: "assets/vendor", json: true, "strict-offline": true });
+    expect(consumeCommandResult().exitCode).toBe(1);
+
+    const output = lastJsonOutput();
+    expect(output.ok).toBe(false);
+    expect(output.remainingRemoteUrls).toEqual(["https://example.com/embed"]);
+  });
+});

--- a/packages/cli/src/commands/vendor.test.ts
+++ b/packages/cli/src/commands/vendor.test.ts
@@ -15,7 +15,12 @@ vi.mock("../utils/updateCheck.js", () => ({ withMeta: (o: unknown) => o }));
 // resolveProject reports invalid-dir failures to telemetry; keep tests silent.
 vi.mock("../telemetry/events.js", () => ({ trackCommandFailure: () => {} }));
 
-import vendorCommand, { rewriteHtmlReferences, toFetchableUrl, vendorFileName } from "./vendor.js";
+import vendorCommand, {
+  resolveVendorTarget,
+  rewriteHtmlReferences,
+  toFetchableUrl,
+  vendorFileName,
+} from "./vendor.js";
 
 const run = makeRunner(vendorCommand);
 
@@ -46,6 +51,23 @@ describe("vendorFileName", () => {
 
   it("derives the extension from content-type when the URL has none", () => {
     expect(vendorFileName("https://fonts.example.com/inter", "font/woff2")).toMatch(/\.woff2$/);
+  });
+});
+
+describe("resolveVendorTarget", () => {
+  it("resolves plain filenames under the vendor directory", () => {
+    const outDir = join("/tmp", "proj", "assets", "vendor");
+    expect(resolveVendorTarget(outDir, "gsap.min-abc.js")).toBe(join(outDir, "gsap.min-abc.js"));
+  });
+
+  it("refuses filenames that would escape the vendor directory", () => {
+    const outDir = join("/tmp", "proj", "assets", "vendor");
+    expect(() => resolveVendorTarget(outDir, "../../../etc/passwd")).toThrow(
+      /outside the vendor directory/,
+    );
+    expect(() => resolveVendorTarget(outDir, "/etc/passwd")).toThrow(
+      /outside the vendor directory/,
+    );
   });
 });
 
@@ -146,6 +168,33 @@ describe("vendor command", () => {
     expect(output.ok).toBe(false);
     expect(output.failed).toEqual([{ url: GSAP_URL, error: "HTTP 404" }]);
     expect(readFileSync(join(dir, "index.html"), "utf-8")).toContain(GSAP_URL);
+  });
+
+  it("rejects downloads over the size cap without rewriting their references", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => fetchResponse("0123456789", "text/javascript")),
+    );
+
+    await run({ dir, out: "assets/vendor", json: true, "max-bytes": "4" });
+    expect(consumeCommandResult().exitCode).toBe(1);
+
+    const output = lastJsonOutput();
+    expect(output.ok).toBe(false);
+    expect(output.failed).toEqual([
+      { url: GSAP_URL, error: expect.stringMatching(/exceeds size cap/) },
+    ]);
+    expect(readFileSync(join(dir, "index.html"), "utf-8")).toContain(GSAP_URL);
+  });
+
+  it("refuses an --out directory outside the project", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await run({ dir, out: "../outside-vendor", json: true });
+    expect(consumeCommandResult().exitCode).toBe(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(lastJsonOutput().error).toMatch(/inside the project directory/);
   });
 
   it("--strict-offline exits 1 when a non-vendorable remote (iframe) remains", async () => {

--- a/packages/cli/src/commands/vendor.ts
+++ b/packages/cli/src/commands/vendor.ts
@@ -1,0 +1,373 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, posix, resolve } from "node:path";
+import { defineCommand } from "citty";
+import type { Example } from "./_examples.js";
+import type { LedgerAssetKind } from "@hyperframes/core/asset-ledger";
+import { setCommandExitCode } from "../utils/commandResult.js";
+import { c } from "../ui/colors.js";
+import { resolveProject } from "../utils/project.js";
+import { withMeta } from "../utils/updateCheck.js";
+
+export const examples: Example[] = [
+  ["Download remote assets and rewrite references", "hyperframes vendor"],
+  ["Vendor into a custom directory", "hyperframes vendor ./my-video --out assets/third-party"],
+  ["Preview what would be downloaded", "hyperframes vendor --dry-run"],
+  ["Fail unless the project ends up fully offline", "hyperframes vendor --strict-offline"],
+];
+
+/** Only these URL schemes are ever fetched. Everything else stays remote. */
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+/**
+ * Kinds worth downloading. A remote iframe is a live page, not a static
+ * asset — vendoring cannot make it deterministic, so it is left in place
+ * (and still fails --strict-offline, which is the point).
+ */
+const VENDORABLE_KINDS = new Set<LedgerAssetKind>([
+  "script",
+  "stylesheet",
+  "font",
+  "image",
+  "audio",
+  "video",
+  "track",
+]);
+
+const CONTENT_TYPE_EXT: Record<string, string> = {
+  "text/javascript": ".js",
+  "application/javascript": ".js",
+  "text/css": ".css",
+  "font/woff2": ".woff2",
+  "font/woff": ".woff",
+  "font/ttf": ".ttf",
+  "font/otf": ".otf",
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/webp": ".webp",
+  "image/avif": ".avif",
+  "image/gif": ".gif",
+  "image/svg+xml": ".svg",
+  "audio/mpeg": ".mp3",
+  "audio/wav": ".wav",
+  "audio/ogg": ".ogg",
+  "video/mp4": ".mp4",
+  "video/webm": ".webm",
+  "text/vtt": ".vtt",
+  "application/json": ".json",
+};
+
+interface VendoredEntry {
+  url: string;
+  /** Project-root-relative path of the downloaded file (posix separators). */
+  file: string;
+  bytes: number;
+  sha256: string;
+  contentType?: string;
+}
+
+interface FailedDownload {
+  url: string;
+  error: string;
+}
+
+/** Normalize a declared remote URL to something fetchable, or null. */
+export function toFetchableUrl(url: string): string | null {
+  // Protocol-relative URLs default to https — the only sane offline-prep choice.
+  const absolute = url.startsWith("//") ? `https:${url}` : url;
+  try {
+    const parsed = new URL(absolute);
+    return ALLOWED_PROTOCOLS.has(parsed.protocol) ? parsed.href : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Stable, collision-free local filename for one remote URL. */
+export function vendorFileName(url: string, contentType?: string): string {
+  const hash = createHash("sha256").update(url).digest("hex").slice(0, 10);
+  let base = "asset";
+  let ext = "";
+  try {
+    const pathname = new URL(url).pathname;
+    const last = pathname.split("/").filter(Boolean).pop() ?? "";
+    const dot = last.lastIndexOf(".");
+    if (dot > 0) {
+      base = last.slice(0, dot);
+      ext = last.slice(dot);
+    } else if (last) {
+      base = last;
+    }
+  } catch {
+    /* keep defaults */
+  }
+  if (!ext && contentType) {
+    const normalized = contentType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+    ext = CONTENT_TYPE_EXT[normalized] ?? "";
+  }
+  const safeBase = base.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^[.-]+/, "") || "asset";
+  const safeExt = /^\.[a-zA-Z0-9]{1,8}$/.test(ext) ? ext.toLowerCase() : "";
+  return `${safeBase}-${hash}${safeExt}`;
+}
+
+async function downloadAsset(
+  url: string,
+  timeoutMs: number,
+): Promise<{ body: Buffer; contentType?: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { signal: controller.signal, redirect: "follow" });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const body = Buffer.from(await response.arrayBuffer());
+    const contentType = response.headers.get("content-type") ?? undefined;
+    return { body, ...(contentType !== undefined ? { contentType } : {}) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Rewrite every occurrence of each vendored URL (its raw as-written form) in
+ * one HTML file to a path relative to that file. Text-level on purpose: it
+ * preserves the author's formatting and also rewrites URLs mentioned inside
+ * inline scripts/styles, which is exactly what an offline render needs.
+ */
+export function rewriteHtmlReferences(
+  html: string,
+  file: string,
+  replacements: Array<{ rawUrl: string; vendorPath: string }>,
+): { html: string; rewritten: number } {
+  const fileDir = posix.dirname(file);
+  let out = html;
+  let rewritten = 0;
+  // Longest first so one URL that is a prefix of another can't clobber it.
+  const ordered = [...replacements].sort((a, b) => b.rawUrl.length - a.rawUrl.length);
+  for (const { rawUrl, vendorPath } of ordered) {
+    const relative = posix.relative(fileDir === "." ? "" : fileDir, vendorPath) || vendorPath;
+    if (!out.includes(rawUrl)) continue;
+    rewritten += out.split(rawUrl).length - 1;
+    out = out.split(rawUrl).join(relative);
+  }
+  return { html: out, rewritten };
+}
+
+function isVendoredEntry(value: unknown): value is VendoredEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const entry = value as Record<string, unknown>; // narrowed via the checks below
+  return (
+    typeof entry.url === "string" &&
+    typeof entry.file === "string" &&
+    typeof entry.bytes === "number" &&
+    typeof entry.sha256 === "string"
+  );
+}
+
+/** Entries from a previous manifest on disk, or empty when absent/malformed. */
+function readPreviousManifestEntries(manifestPath: string): VendoredEntry[] {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    if (typeof parsed !== "object" || parsed === null) return [];
+    const assets = (parsed as Record<string, unknown>).assets; // narrowed below
+    if (!Array.isArray(assets)) return [];
+    return assets.filter(isVendoredEntry);
+  } catch {
+    return [];
+  }
+}
+
+export default defineCommand({
+  meta: {
+    name: "vendor",
+    description: "Download remote assets locally and rewrite references for offline renders",
+  },
+  args: {
+    dir: {
+      type: "positional",
+      description: "Project directory",
+      required: false,
+    },
+    out: {
+      type: "string",
+      alias: "o",
+      description: "Directory (project-relative) to download assets into",
+      default: "assets/vendor",
+    },
+    json: {
+      type: "boolean",
+      description: "Output the vendoring report as JSON",
+      default: false,
+    },
+    "dry-run": {
+      type: "boolean",
+      description: "List what would be downloaded without writing anything",
+      default: false,
+    },
+    "strict-offline": {
+      type: "boolean",
+      description: "Exit non-zero when any remote reference remains after vendoring",
+      default: false,
+    },
+    timeout: {
+      type: "string",
+      description: "Per-download timeout in ms (default: 30000)",
+      default: "30000",
+    },
+  },
+  // fallow-ignore-next-line complexity
+  async run({ args }) {
+    const strictOffline = Boolean(args["strict-offline"]);
+    const dryRun = Boolean(args["dry-run"]);
+    const timeoutMs = Number.parseInt(String(args.timeout), 10) || 30000;
+    try {
+      const project = resolveProject(args.dir, { requireIndex: false });
+      const { buildProjectAssetLedger } = await import("@hyperframes/core/asset-ledger");
+      const ledger = buildProjectAssetLedger(project.dir);
+
+      const outRel = String(args.out ?? "assets/vendor").replace(/\\/g, "/");
+      const outDir = resolve(project.dir, outRel);
+
+      // Unique fetchable URLs, keyed by DECODED url; remember raw forms per file.
+      const candidates = new Map<string, string>();
+      for (const asset of ledger.assets) {
+        if (asset.status !== "remote" || !VENDORABLE_KINDS.has(asset.kind)) continue;
+        if (!candidates.has(asset.url)) {
+          const fetchable = toFetchableUrl(asset.url);
+          if (fetchable) candidates.set(asset.url, fetchable);
+        }
+      }
+
+      if (dryRun) {
+        const urls = [...candidates.keys()].sort();
+        if (args.json) {
+          console.log(
+            JSON.stringify(withMeta({ ok: true, dryRun: true, wouldDownload: urls }), null, 2),
+          );
+        } else {
+          console.log(`${c.accent("◆")}  Would download ${urls.length} remote asset(s):`);
+          for (const url of urls) console.log(`   ${url}`);
+        }
+        setCommandExitCode(0);
+        return;
+      }
+
+      const vendored: VendoredEntry[] = [];
+      const failed: FailedDownload[] = [];
+      const vendorPathByUrl = new Map<string, string>();
+
+      if (candidates.size > 0) mkdirSync(outDir, { recursive: true });
+      for (const [declaredUrl, fetchUrl] of candidates) {
+        try {
+          const { body, contentType } = await downloadAsset(fetchUrl, timeoutMs);
+          const fileName = vendorFileName(fetchUrl, contentType);
+          const vendorPath = posix.join(outRel, fileName);
+          writeFileSync(join(outDir, fileName), body);
+          vendorPathByUrl.set(declaredUrl, vendorPath);
+          vendored.push({
+            url: declaredUrl,
+            file: vendorPath,
+            bytes: body.length,
+            sha256: createHash("sha256").update(body).digest("hex"),
+            ...(contentType !== undefined ? { contentType } : {}),
+          });
+          if (!args.json) console.log(`${c.success("↓")}  ${declaredUrl} → ${vendorPath}`);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          failed.push({ url: declaredUrl, error: message });
+          if (!args.json) console.error(`${c.error("✖")}  ${declaredUrl} — ${message}`);
+        }
+      }
+
+      // Rewrite each HTML file's references to the vendored copies.
+      let totalRewritten = 0;
+      for (const file of ledger.files) {
+        const replacements: Array<{ rawUrl: string; vendorPath: string }> = [];
+        const seenRaw = new Set<string>();
+        for (const asset of ledger.assets) {
+          if (asset.file !== file || asset.status !== "remote") continue;
+          const vendorPath = vendorPathByUrl.get(asset.url);
+          if (!vendorPath || seenRaw.has(asset.rawUrl)) continue;
+          seenRaw.add(asset.rawUrl);
+          replacements.push({ rawUrl: asset.rawUrl, vendorPath });
+        }
+        if (replacements.length === 0) continue;
+        const absolute = join(project.dir, file);
+        const html = readFileSync(absolute, "utf-8");
+        const { html: next, rewritten } = rewriteHtmlReferences(html, file, replacements);
+        if (rewritten > 0) {
+          writeFileSync(absolute, next);
+          totalRewritten += rewritten;
+        }
+      }
+
+      // Persist a provenance manifest next to the downloads (merged over any
+      // previous run, keyed by URL, sorted for stable diffs).
+      if (vendored.length > 0) {
+        const manifestPath = join(outDir, "vendor-manifest.json");
+        const byUrl = new Map<string, VendoredEntry>();
+        for (const entry of readPreviousManifestEntries(manifestPath)) byUrl.set(entry.url, entry);
+        for (const entry of vendored) byUrl.set(entry.url, entry);
+        const manifest = {
+          version: 1,
+          assets: [...byUrl.values()].sort((a, b) => a.url.localeCompare(b.url)),
+        };
+        writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+      }
+
+      const after = buildProjectAssetLedger(project.dir);
+      const remaining = after.remoteUrls;
+      const strictViolation = strictOffline && remaining.length > 0;
+      const ok = failed.length === 0 && !strictViolation;
+
+      if (args.json) {
+        console.log(
+          JSON.stringify(
+            withMeta({
+              ok,
+              strictOffline,
+              out: outRel,
+              downloaded: vendored,
+              failed,
+              rewrittenReferences: totalRewritten,
+              remainingRemoteUrls: remaining,
+              counts: after.counts,
+            }),
+            null,
+            2,
+          ),
+        );
+        setCommandExitCode(ok ? 0 : 1);
+        return;
+      }
+
+      console.log();
+      console.log(
+        `${c.accent("◆")}  Vendored ${vendored.length} asset(s) into ${outRel}, ` +
+          `rewrote ${totalRewritten} reference(s).`,
+      );
+      if (failed.length > 0) {
+        console.log(c.error(`   ${failed.length} download(s) failed.`));
+      }
+      if (remaining.length > 0) {
+        console.log(c.warn(`   ${remaining.length} remote reference(s) remain:`));
+        for (const url of remaining) console.log(`   ${c.warn("•")} ${url}`);
+      } else {
+        console.log(c.success("   0 remote references remain — project renders offline."));
+      }
+      if (strictViolation) {
+        console.log();
+        console.log(c.error("✖  --strict-offline: remote references remain."));
+      }
+      setCommandExitCode(ok ? 0 : 1);
+      return;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (args.json) {
+        console.log(JSON.stringify(withMeta({ ok: false, error: message }), null, 2));
+      } else {
+        console.error(message);
+      }
+      setCommandExitCode(1);
+    }
+  },
+});

--- a/packages/cli/src/commands/vendor.ts
+++ b/packages/cli/src/commands/vendor.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join, posix, resolve } from "node:path";
+import { join, posix, resolve, sep } from "node:path";
 import { defineCommand } from "citty";
 import type { Example } from "./_examples.js";
 import type { LedgerAssetKind } from "@hyperframes/core/asset-ledger";
@@ -18,6 +18,9 @@ export const examples: Example[] = [
 
 /** Only these URL schemes are ever fetched. Everything else stays remote. */
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+/** Per-download size cap unless --max-bytes overrides it. */
+const DEFAULT_MAX_BYTES = 100 * 1024 * 1024;
 
 /**
  * Kinds worth downloading. A remote iframe is a live page, not a static
@@ -110,16 +113,36 @@ export function vendorFileName(url: string, contentType?: string): string {
   return `${safeBase}-${hash}${safeExt}`;
 }
 
+/**
+ * Resolve a vendor file target and refuse anything that would escape the
+ * vendor directory (defense in depth — `vendorFileName` already sanitizes).
+ */
+export function resolveVendorTarget(outDir: string, fileName: string): string {
+  const target = resolve(outDir, fileName);
+  if (target !== outDir && !target.startsWith(outDir + sep)) {
+    throw new Error(`refusing to write outside the vendor directory: ${fileName}`);
+  }
+  return target;
+}
+
 async function downloadAsset(
   url: string,
   timeoutMs: number,
+  maxBytes: number,
 ): Promise<{ body: Buffer; contentType?: string }> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const response = await fetch(url, { signal: controller.signal, redirect: "follow" });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const declared = Number(response.headers.get("content-length") ?? Number.NaN);
+    if (Number.isFinite(declared) && declared > maxBytes) {
+      throw new Error(`asset exceeds size cap (${declared} > ${maxBytes} bytes)`);
+    }
     const body = Buffer.from(await response.arrayBuffer());
+    if (body.length > maxBytes) {
+      throw new Error(`asset exceeds size cap (${body.length} > ${maxBytes} bytes)`);
+    }
     const contentType = response.headers.get("content-type") ?? undefined;
     return { body, ...(contentType !== undefined ? { contentType } : {}) };
   } finally {
@@ -213,19 +236,29 @@ export default defineCommand({
       description: "Per-download timeout in ms (default: 30000)",
       default: "30000",
     },
+    "max-bytes": {
+      type: "string",
+      description: "Per-download size cap in bytes (default: 104857600 = 100 MB)",
+      default: String(DEFAULT_MAX_BYTES),
+    },
   },
   // fallow-ignore-next-line complexity
   async run({ args }) {
     const strictOffline = Boolean(args["strict-offline"]);
     const dryRun = Boolean(args["dry-run"]);
     const timeoutMs = Number.parseInt(String(args.timeout), 10) || 30000;
+    const maxBytes = Number.parseInt(String(args["max-bytes"]), 10) || DEFAULT_MAX_BYTES;
     try {
       const project = resolveProject(args.dir, { requireIndex: false });
       const { buildProjectAssetLedger } = await import("@hyperframes/core/asset-ledger");
       const ledger = buildProjectAssetLedger(project.dir);
 
       const outRel = String(args.out ?? "assets/vendor").replace(/\\/g, "/");
-      const outDir = resolve(project.dir, outRel);
+      const projectRoot = resolve(project.dir);
+      const outDir = resolve(projectRoot, outRel);
+      if (outDir !== projectRoot && !outDir.startsWith(projectRoot + sep)) {
+        throw new Error(`--out must stay inside the project directory (got "${outRel}")`);
+      }
 
       // Unique fetchable URLs, keyed by DECODED url; remember raw forms per file.
       const candidates = new Map<string, string>();
@@ -258,10 +291,17 @@ export default defineCommand({
       if (candidates.size > 0) mkdirSync(outDir, { recursive: true });
       for (const [declaredUrl, fetchUrl] of candidates) {
         try {
-          const { body, contentType } = await downloadAsset(fetchUrl, timeoutMs);
+          const { body, contentType } = await downloadAsset(fetchUrl, timeoutMs, maxBytes);
           const fileName = vendorFileName(fetchUrl, contentType);
           const vendorPath = posix.join(outRel, fileName);
-          writeFileSync(join(outDir, fileName), body);
+          // Network→file is this command's entire purpose (download remote
+          // assets so renders run offline), so a CodeQL network-to-file-write
+          // finding here is expected. Guards: http(s)-only scheme allowlist +
+          // URL validation (toFetchableUrl), sanitized hash-suffixed filenames
+          // (vendorFileName), a traversal check pinning every write under the
+          // vendor directory (resolveVendorTarget, with outDir itself pinned
+          // under the project root), and a per-download size cap.
+          writeFileSync(resolveVendorTarget(outDir, fileName), body);
           vendorPathByUrl.set(declaredUrl, vendorPath);
           vendored.push({
             url: declaredUrl,

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -33,6 +33,8 @@ const GROUPS: Group[] = [
     title: "Project",
     commands: [
       ["lint", "Validate a composition for common mistakes"],
+      ["ledger", "Inventory declared assets and classify them remote | local | data | missing"],
+      ["vendor", "Download remote assets locally and rewrite references for offline renders"],
       ["check", "Run lint, runtime validation, and layout inspection as one gate"],
       [
         "validate",

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -14,6 +14,13 @@ export default defineConfig({
         find: /^@hyperframes\/core$/,
         replacement: resolve(__dirname, "../core/src/index.ts"),
       },
+      // The ledger/vendor command tests import this node-only subpath; its
+      // "node" export condition points at an unbuilt dist in the test job,
+      // so resolve it to source like the bare entry above.
+      {
+        find: /^@hyperframes\/core\/asset-ledger$/,
+        replacement: resolve(__dirname, "../core/src/assets/ledger.ts"),
+      },
       // Same reason the tsup build aliases this specifier to source: the CLI
       // bundles the producer rather than depending on it at runtime, so its
       // dist is not built for the test job. Without the alias, vite's import

--- a/packages/core/package-subpaths.json
+++ b/packages/core/package-subpaths.json
@@ -32,6 +32,12 @@
       "types": "./dist/beats/index.d.ts",
       "environments": ["browser", "bun", "node"]
     },
+    "./asset-ledger": {
+      "source": "./src/assets/ledger.ts",
+      "runtime": "./dist/assets/ledger.js",
+      "types": "./dist/assets/ledger.d.ts",
+      "environments": ["bun", "node"]
+    },
     "./html-attr-safety": {
       "source": "./src/utils/htmlAttrSafety.ts",
       "runtime": "./dist/utils/htmlAttrSafety.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,12 @@
       "import": "./src/beats/index.ts",
       "types": "./src/beats/index.ts"
     },
+    "./asset-ledger": {
+      "bun": "./src/assets/ledger.ts",
+      "node": "./dist/assets/ledger.js",
+      "import": "./src/assets/ledger.ts",
+      "types": "./src/assets/ledger.ts"
+    },
     "./html-attr-safety": {
       "bun": "./src/utils/htmlAttrSafety.ts",
       "node": "./dist/utils/htmlAttrSafety.js",
@@ -411,6 +417,10 @@
       "./beats": {
         "import": "./dist/beats/index.js",
         "types": "./dist/beats/index.d.ts"
+      },
+      "./asset-ledger": {
+        "import": "./dist/assets/ledger.js",
+        "types": "./dist/assets/ledger.d.ts"
       },
       "./html-attr-safety": {
         "import": "./dist/utils/htmlAttrSafety.js",

--- a/packages/core/src/assets/ledger.test.ts
+++ b/packages/core/src/assets/ledger.test.ts
@@ -1,0 +1,224 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildAssetLedger,
+  buildProjectAssetLedger,
+  classifyAssetUrl,
+  collectProjectHtmlFiles,
+  extractAssetRefs,
+} from "./ledger";
+
+// A representative composition: one CDN script (jsDelivr), local media, a
+// data URI, a missing reference, and CSS-declared assets.
+const FIXTURE_HTML = `<!DOCTYPE html>
+<html>
+<head>
+  <link rel="stylesheet" href="styles/theme.css">
+  <link rel="preload" as="font" href="assets/fonts/Inter.woff2" crossorigin>
+  <style>
+    @import url("https://cdn.example.com/base.css");
+    @font-face {
+      font-family: "Brand";
+      src: url("assets/fonts/brand.woff2") format("woff2");
+    }
+    .hero { background-image: url('assets/img/bg.png'); }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js"></script>
+  <script>
+    // Markup inside a script string must NOT register as a tag:
+    const tpl = "<img src='https://evil.example.com/x.png'>";
+  </script>
+</head>
+<body>
+  <div class="clip" style="background: url(assets/img/inline.png)">
+    <img src="assets/img/logo.png" srcset="assets/img/logo.png 1x, assets/img/logo@2x.png 2x">
+    <video src="assets/video/intro.mp4" poster="assets/img/poster.jpg"></video>
+    <audio src="assets/audio/bgm.mp3"></audio>
+    <picture>
+      <source srcset="assets/img/hero.avif" type="image/avif">
+      <img src="assets/img/hero.png">
+    </picture>
+    <iframe src="https://example.com/embed"></iframe>
+    <img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=">
+    <img src="assets/img/definitely-missing.png">
+  </div>
+  <!-- <script src="https://commented-out.example.com/never.js"></script> -->
+</body>
+</html>`;
+
+describe("classifyAssetUrl", () => {
+  it("classifies remote, data, and local candidates", () => {
+    expect(classifyAssetUrl("https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js")).toBe("remote");
+    expect(classifyAssetUrl("http://example.com/a.js")).toBe("remote");
+    expect(classifyAssetUrl("//cdn.example.com/a.js")).toBe("remote");
+    expect(classifyAssetUrl("data:image/png;base64,AAAA")).toBe("data");
+    expect(classifyAssetUrl("assets/img/logo.png")).toBe("local-candidate");
+    expect(classifyAssetUrl("/assets/img/logo.png")).toBe("local-candidate");
+  });
+
+  it("skips fragments, runtime schemes, and templating placeholders", () => {
+    expect(classifyAssetUrl("")).toBe("skip");
+    expect(classifyAssetUrl("#anchor")).toBe("skip");
+    expect(classifyAssetUrl("blob:https://x/y")).toBe("skip");
+    expect(classifyAssetUrl("javascript:void(0)")).toBe("skip");
+    expect(classifyAssetUrl("about:blank")).toBe("skip");
+    expect(classifyAssetUrl("{{ heroImage }}")).toBe("skip");
+    expect(classifyAssetUrl("__POSTER__")).toBe("skip");
+  });
+
+  it("marks unknown schemes as remote so --strict-offline surfaces them", () => {
+    expect(classifyAssetUrl("ftp://host/file.png")).toBe("remote");
+  });
+});
+
+describe("extractAssetRefs", () => {
+  const refs = extractAssetRefs(FIXTURE_HTML);
+  const find = (url: string) => refs.find((r) => r.url === url);
+
+  it("finds remote script tags but not scripts inside string literals or comments", () => {
+    const script = find("https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js");
+    expect(script).toMatchObject({ kind: "script", via: "src" });
+    expect(find("https://evil.example.com/x.png")).toBeUndefined();
+    expect(find("https://commented-out.example.com/never.js")).toBeUndefined();
+  });
+
+  it("classifies link tags by rel/as", () => {
+    expect(find("styles/theme.css")).toMatchObject({ kind: "stylesheet", via: "href" });
+    expect(find("assets/fonts/Inter.woff2")).toMatchObject({ kind: "font", via: "href" });
+  });
+
+  it("extracts CSS @import, @font-face urls, and background urls", () => {
+    expect(find("https://cdn.example.com/base.css")).toMatchObject({
+      kind: "stylesheet",
+      via: "css-import",
+    });
+    expect(find("assets/fonts/brand.woff2")).toMatchObject({ kind: "font", via: "css-url" });
+    expect(find("assets/img/bg.png")).toMatchObject({ kind: "image", via: "css-url" });
+    expect(find("assets/img/inline.png")).toMatchObject({ kind: "image", via: "style-attr" });
+  });
+
+  it("extracts media elements including srcset, poster, and picture sources", () => {
+    expect(find("assets/video/intro.mp4")).toMatchObject({ kind: "video", via: "src" });
+    expect(find("assets/img/poster.jpg")).toMatchObject({ kind: "image", via: "poster" });
+    expect(find("assets/audio/bgm.mp3")).toMatchObject({ kind: "audio", via: "src" });
+    expect(find("assets/img/logo@2x.png")).toMatchObject({ kind: "image", via: "srcset" });
+    expect(find("assets/img/hero.avif")).toMatchObject({ kind: "image", via: "srcset" });
+    expect(find("https://example.com/embed")).toMatchObject({ kind: "iframe", via: "src" });
+  });
+
+  it("maps <source src> inside <video> and <audio> to the parent kind", () => {
+    const html = `<video><source src="a.mp4"></video><audio><source src="b.mp3"></audio>`;
+    const sourceRefs = extractAssetRefs(html);
+    expect(sourceRefs).toEqual([
+      expect.objectContaining({ kind: "video", url: "a.mp4" }),
+      expect.objectContaining({ kind: "audio", url: "b.mp3" }),
+    ]);
+  });
+
+  it("decodes HTML entities in URLs but keeps the raw text for rewriting", () => {
+    const html = `<script src="https://cdn.example.com/a.js?v=1&amp;x=2"></script>`;
+    const [ref] = extractAssetRefs(html);
+    expect(ref?.url).toBe("https://cdn.example.com/a.js?v=1&x=2");
+    expect(ref?.rawUrl).toBe("https://cdn.example.com/a.js?v=1&amp;x=2");
+  });
+});
+
+describe("buildAssetLedger", () => {
+  it("classifies statuses via the resolver and counts them", () => {
+    const localFiles = new Set([
+      "styles/theme.css",
+      "assets/fonts/Inter.woff2",
+      "assets/fonts/brand.woff2",
+      "assets/img/bg.png",
+      "assets/img/inline.png",
+      "assets/img/logo.png",
+      "assets/img/logo@2x.png",
+      "assets/img/poster.jpg",
+      "assets/img/hero.avif",
+      "assets/img/hero.png",
+      "assets/video/intro.mp4",
+      "assets/audio/bgm.mp3",
+    ]);
+    const ledger = buildAssetLedger([{ file: "index.html", html: FIXTURE_HTML }], {
+      resolveLocalAsset: (_fromFile, url) => (localFiles.has(url) ? url : null),
+    });
+
+    expect(ledger.files).toEqual(["index.html"]);
+    // jsDelivr script + @import stylesheet + iframe embed
+    expect([...ledger.remoteUrls].sort()).toEqual([
+      "https://cdn.example.com/base.css",
+      "https://cdn.jsdelivr.net/npm/gsap@3.12.5/dist/gsap.min.js",
+      "https://example.com/embed",
+    ]);
+    expect(ledger.counts.remote).toBe(3);
+    expect(ledger.counts.data).toBe(1);
+    expect(ledger.counts.missing).toBe(1);
+    // Counts are per-reference: logo.png appears in both src and srcset.
+    expect(ledger.counts.local).toBe(localFiles.size + 1);
+    expect(ledger.counts.total).toBe(
+      ledger.counts.remote + ledger.counts.local + ledger.counts.data + ledger.counts.missing,
+    );
+
+    const missing = ledger.assets.filter((a) => a.status === "missing");
+    expect(missing).toEqual([
+      expect.objectContaining({ url: "assets/img/definitely-missing.png", kind: "image" }),
+    ]);
+  });
+
+  it("dedupes remote URLs across files but keeps every reference", () => {
+    const html = `<script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>`;
+    const ledger = buildAssetLedger([
+      { file: "index.html", html },
+      { file: "scenes/intro.html", html },
+    ]);
+    expect(ledger.remoteUrls).toHaveLength(1);
+    expect(ledger.assets).toHaveLength(2);
+    expect(ledger.counts.remote).toBe(2);
+  });
+
+  it("reports local candidates as missing when no resolver is provided", () => {
+    const ledger = buildAssetLedger([{ file: "index.html", html: `<img src="a.png">` }]);
+    expect(ledger.counts.missing).toBe(1);
+  });
+});
+
+describe("buildProjectAssetLedger", () => {
+  let dir: string;
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("scans HTML files on disk and resolves local assets file-relative", () => {
+    dir = mkdtempSync(join(tmpdir(), "hf-ledger-"));
+    mkdirSync(join(dir, "assets", "img"), { recursive: true });
+    mkdirSync(join(dir, "scenes"));
+    mkdirSync(join(dir, "node_modules", "pkg"), { recursive: true });
+    writeFileSync(join(dir, "assets", "img", "logo.png"), "png");
+    writeFileSync(
+      join(dir, "index.html"),
+      `<script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+       <img src="assets/img/logo.png">`,
+    );
+    writeFileSync(
+      join(dir, "scenes", "intro.html"),
+      `<img src="../assets/img/logo.png"><img src="missing.png">`,
+    );
+    // Must be ignored by the walk:
+    writeFileSync(join(dir, "node_modules", "pkg", "ignored.html"), `<img src="x.png">`);
+
+    expect(collectProjectHtmlFiles(dir)).toEqual(["index.html", "scenes/intro.html"]);
+
+    const ledger = buildProjectAssetLedger(dir);
+    expect(ledger.counts.remote).toBe(1);
+    expect(ledger.counts.local).toBe(2);
+    expect(ledger.counts.missing).toBe(1);
+
+    const fromScene = ledger.assets.find(
+      (a) => a.file === "scenes/intro.html" && a.status === "local",
+    );
+    expect(fromScene?.localPath).toBe("assets/img/logo.png");
+  });
+});

--- a/packages/core/src/assets/ledger.test.ts
+++ b/packages/core/src/assets/ledger.test.ts
@@ -123,6 +123,37 @@ describe("extractAssetRefs", () => {
     expect(ref?.url).toBe("https://cdn.example.com/a.js?v=1&x=2");
     expect(ref?.rawUrl).toBe("https://cdn.example.com/a.js?v=1&amp;x=2");
   });
+
+  it("decodes each entity exactly once — no double-unescape", () => {
+    // `&amp;lt;` is the author writing a literal `&lt;`: one decode pass must
+    // yield `&lt;`, never a second pass down to `<`.
+    const html = `<img src="a.png?q=&amp;lt;&amp;amp;x=&amp;#039;">`;
+    const [ref] = extractAssetRefs(html);
+    expect(ref?.url).toBe("a.png?q=&lt;&amp;x=&#039;");
+  });
+
+  it("leaves unknown entities untouched", () => {
+    const html = `<img src="a.png?c=&copy;&x=1">`;
+    const [ref] = extractAssetRefs(html);
+    expect(ref?.url).toBe("a.png?c=&copy;&x=1");
+  });
+
+  it("ignores urls inside CSS comments, including pathological comment runs", () => {
+    const html = `<style>
+      /* .old { background: url("assets/img/commented.png"); } */
+      .live { background: url("assets/img/live.png"); }
+    </style>`;
+    const refs = extractAssetRefs(html);
+    expect(refs.map((r) => r.url)).toEqual(["assets/img/live.png"]);
+
+    // Long unterminated-star runs must not hang the scanner (linear, not
+    // backtracking): finish quickly and still find the live url after.
+    const hostile = `<style>/*${"*".repeat(50_000)}*/ .a { background: url(x.png); }</style>`;
+    const started = Date.now();
+    const hostileRefs = extractAssetRefs(hostile);
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(hostileRefs.map((r) => r.url)).toEqual(["x.png"]);
+  });
 });
 
 describe("buildAssetLedger", () => {

--- a/packages/core/src/assets/ledger.ts
+++ b/packages/core/src/assets/ledger.ts
@@ -123,15 +123,24 @@ export function classifyAssetUrl(url: string): "remote" | "data" | "local-candid
 
 // ── HTML scanning ───────────────────────────────────────────────────────────
 
-/** Minimal entity decode for attribute values (URLs use a small entity set). */
+const HTML_ENTITY_MAP: Record<string, string> = {
+  amp: "&",
+  quot: '"',
+  apos: "'",
+  lt: "<",
+  gt: ">",
+};
+
+/**
+ * Minimal entity decode for attribute values (URLs use a small entity set).
+ * Single pass so each entity decodes exactly once — a decoded `&` can never
+ * recombine with following text into a second entity (`&amp;lt;` → `&lt;`,
+ * never `<`).
+ */
 function decodeHtmlEntities(value: string): string {
-  return value
-    .replace(/&amp;/gi, "&")
-    .replace(/&quot;/gi, '"')
-    .replace(/&#0*39;/g, "'")
-    .replace(/&apos;/gi, "'")
-    .replace(/&lt;/gi, "<")
-    .replace(/&gt;/gi, ">");
+  return value.replace(/&(?:(amp|quot|apos|lt|gt)|#0*39);/gi, (match, name: string | undefined) =>
+    name === undefined ? "'" : (HTML_ENTITY_MAP[name.toLowerCase()] ?? match),
+  );
 }
 
 /** Length-preserving `<!-- … -->` blanking so commented-out tags never count. */
@@ -306,8 +315,24 @@ const CSS_IMPORT_RE =
   /@import\s+(?:url\(\s*(?:"([^"]+)"|'([^']+)'|([^"')\s]+))\s*\)|"([^"]+)"|'([^']+)')/gi;
 const FONT_FACE_BLOCK_RE = /@font-face\s*\{[^}]*\}/gi;
 
+/**
+ * Length-preserving blanking of CSS block comments via a linear O(n) scan
+ * (CSS comments do not nest) — same shape as `maskHtmlComments`, no regex
+ * backtracking on adversarial input.
+ */
 function stripCssComments(css: string): string {
-  return css.replace(/\/\*[\s\S]*?\*\//g, (m) => " ".repeat(m.length));
+  const chunks: string[] = [];
+  let cursor = 0;
+  while (true) {
+    const start = css.indexOf("/*", cursor);
+    if (start === -1) break;
+    const end = css.indexOf("*/", start + 2);
+    if (end === -1) break;
+    const afterComment = end + 2;
+    chunks.push(css.slice(cursor, start), " ".repeat(afterComment - start));
+    cursor = afterComment;
+  }
+  return chunks.length === 0 ? css : chunks.join("") + css.slice(cursor);
 }
 
 function collectCssUrls(

--- a/packages/core/src/assets/ledger.ts
+++ b/packages/core/src/assets/ledger.ts
@@ -1,0 +1,493 @@
+/**
+ * Offline asset ledger — a static, agent-readable inventory of every asset a
+ * composition references: scripts, stylesheets, fonts, images, audio, video,
+ * iframes, and text tracks, each classified as `remote`, `local`, `data`, or
+ * `missing`.
+ *
+ * The ledger is what `hyperframes ledger` prints and what `hyperframes vendor`
+ * uses to find remote URLs worth localizing. It is built by scanning HTML
+ * text — no browser, no network — so it can run in CI preflight and unit
+ * tests. Only DECLARED URLs are inventoried (tag attributes, inline styles,
+ * `<style>` blocks); URLs constructed at runtime inside scripts are out of
+ * scope, as are assets nested inside remote stylesheets (e.g. font binaries
+ * referenced by a Google Fonts CSS response).
+ *
+ * Node-only (uses `node:fs` for project scanning) — import via the
+ * `@hyperframes/core/asset-ledger` subpath so the main entry stays
+ * browser-safe.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import {
+  isUnresolvedAssetPlaceholder,
+  maskNonScannableRanges,
+  resolveExistingLocalAsset,
+} from "@hyperframes/parsers/asset-resolution";
+
+export type LedgerAssetKind =
+  | "script"
+  | "stylesheet"
+  | "font"
+  | "image"
+  | "audio"
+  | "video"
+  | "iframe"
+  | "track";
+
+export type LedgerAssetStatus = "remote" | "local" | "data" | "missing";
+
+/** Where in the markup a reference was declared. */
+export type LedgerAssetVia =
+  | "src"
+  | "href"
+  | "srcset"
+  | "poster"
+  | "css-url"
+  | "css-import"
+  | "style-attr";
+
+export interface LedgerAssetRef {
+  kind: LedgerAssetKind;
+  /** Decoded URL (HTML entities like `&amp;` resolved) — what a fetch would use. */
+  url: string;
+  /** The URL exactly as written in the source, for text-level rewriting. */
+  rawUrl: string;
+  status: LedgerAssetStatus;
+  /** Project-root-relative path of the HTML file holding the reference. */
+  file: string;
+  via: LedgerAssetVia;
+  /** Project-root-relative path of the resolved file when status is `local`. */
+  localPath?: string;
+}
+
+export interface AssetLedger {
+  /** Project-root-relative HTML files that were scanned, in scan order. */
+  files: string[];
+  assets: LedgerAssetRef[];
+  counts: { total: number } & Record<LedgerAssetStatus, number>;
+  /** Deduped decoded remote URLs, in first-seen order. */
+  remoteUrls: string[];
+}
+
+export interface LedgerFileInput {
+  /** Project-root-relative path (used verbatim in findings). */
+  file: string;
+  html: string;
+}
+
+export interface BuildLedgerOptions {
+  /**
+   * Resolve a local URL candidate to a project-root-relative path, or null
+   * when the file does not exist. `fromFile` is the referencing HTML file
+   * (root-relative). When omitted, every local candidate reports `missing` —
+   * fine for pure-string unit tests, wrong for real projects.
+   */
+  resolveLocalAsset?: (fromFile: string, url: string) => string | null;
+}
+
+interface ExtractedRef {
+  kind: LedgerAssetKind;
+  url: string;
+  rawUrl: string;
+  via: LedgerAssetVia;
+}
+
+// ── URL classification ──────────────────────────────────────────────────────
+
+const REMOTE_URL_RE = /^(https?:)?\/\//i;
+// Runtime-only or non-asset schemes: nothing on disk to resolve, nothing a
+// vendor step could download deterministically.
+const NON_ASSET_SCHEME_RE = /^(blob:|about:|javascript:|mailto:|tel:)/i;
+const HAS_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+
+/**
+ * Classify one declared URL. `local-candidate` means "looks like a path on
+ * disk — resolve it to decide local vs missing"; `skip` means the value is not
+ * an inventoriable asset (empty, fragment, runtime-only scheme, or an
+ * unresolved templating placeholder a build step substitutes later).
+ */
+export function classifyAssetUrl(url: string): "remote" | "data" | "local-candidate" | "skip" {
+  const trimmed = url.trim();
+  if (!trimmed || trimmed.startsWith("#")) return "skip";
+  if (isUnresolvedAssetPlaceholder(trimmed)) return "skip";
+  if (/^data:/i.test(trimmed)) return "data";
+  if (REMOTE_URL_RE.test(trimmed)) return "remote";
+  if (NON_ASSET_SCHEME_RE.test(trimmed)) return "skip";
+  // Any other scheme (ftp:, ws:, file:, …) is still a non-relative reference
+  // that breaks a self-contained project — count it as remote so
+  // --strict-offline surfaces it, even though vendoring only downloads http(s).
+  if (HAS_SCHEME_RE.test(trimmed)) return "remote";
+  return "local-candidate";
+}
+
+// ── HTML scanning ───────────────────────────────────────────────────────────
+
+/** Minimal entity decode for attribute values (URLs use a small entity set). */
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0*39;/g, "'")
+    .replace(/&apos;/gi, "'")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">");
+}
+
+/** Length-preserving `<!-- … -->` blanking so commented-out tags never count. */
+function maskHtmlComments(html: string): string {
+  const chunks: string[] = [];
+  let cursor = 0;
+  while (true) {
+    const start = html.indexOf("<!--", cursor);
+    if (start === -1) break;
+    const end = html.indexOf("-->", start + 4);
+    if (end === -1) break;
+    const afterComment = end + 3;
+    chunks.push(html.slice(cursor, start), " ".repeat(afterComment - start));
+    cursor = afterComment;
+  }
+  return chunks.length === 0 ? html : chunks.join("") + html.slice(cursor);
+}
+
+/** Read one attribute value from a single already-delimited tag's source. */
+function readTagAttr(tagSource: string, attr: string): string | null {
+  const re = new RegExp(`\\b${attr}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s"'>]+))`, "i");
+  const match = re.exec(tagSource);
+  if (!match) return null;
+  return match[2] ?? match[3] ?? match[4] ?? null;
+}
+
+/** Split a `srcset` value into its URL parts (descriptors dropped). */
+function parseSrcset(value: string): string[] {
+  const urls: string[] = [];
+  for (const entry of value.split(",")) {
+    const url = entry.trim().split(/\s+/, 1)[0];
+    if (url) urls.push(url);
+  }
+  return urls;
+}
+
+const LINK_PRELOAD_AS_KIND: Record<string, LedgerAssetKind> = {
+  font: "font",
+  style: "stylesheet",
+  script: "script",
+  image: "image",
+  audio: "audio",
+  video: "video",
+  track: "track",
+};
+
+function linkKind(tagSource: string): LedgerAssetKind | null {
+  const rel = (readTagAttr(tagSource, "rel") ?? "").toLowerCase();
+  const relParts = rel.split(/\s+/);
+  if (relParts.includes("stylesheet")) return "stylesheet";
+  if (relParts.includes("modulepreload")) return "script";
+  if (relParts.includes("preload") || relParts.includes("prefetch")) {
+    const as = (readTagAttr(tagSource, "as") ?? "").toLowerCase();
+    return LINK_PRELOAD_AS_KIND[as] ?? null;
+  }
+  if (relParts.some((part) => part === "icon" || part === "apple-touch-icon")) return "image";
+  return null;
+}
+
+function pushRef(
+  refs: ExtractedRef[],
+  kind: LedgerAssetKind,
+  rawUrl: string | null,
+  via: LedgerAssetVia,
+): void {
+  if (!rawUrl) return;
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return;
+  refs.push({ kind, url: decodeHtmlEntities(trimmed), rawUrl: trimmed, via });
+}
+
+/** Media elements whose nested `<source>` children inherit their kind. */
+const SOURCE_PARENT_KIND: Record<string, LedgerAssetKind> = {
+  video: "video",
+  audio: "audio",
+  picture: "image",
+};
+
+// fallow-ignore-next-line complexity
+function collectTagRefs(html: string, refs: ExtractedRef[]): void {
+  // Script/style BODIES are blanked (length-preserving) so markup inside a
+  // string literal or template can't register as a real tag; the open tags of
+  // scripts are re-scanned separately below because the mask removes them too.
+  const scannable = maskNonScannableRanges(html);
+
+  // Nearest enclosing <video>/<audio>/<picture>, so a nested <source> knows
+  // which kind it feeds. Void/media tags are never nested inside each other
+  // in valid markup, so a one-deep stack is enough.
+  const parentStack: string[] = [];
+
+  let cursor = 0;
+  while (cursor < scannable.length) {
+    const open = scannable.indexOf("<", cursor);
+    if (open === -1) break;
+    const close = scannable.indexOf(">", open + 1);
+    if (close === -1) break;
+    cursor = close + 1;
+
+    const tagSource = scannable.slice(open, cursor);
+    const nameMatch = /^<\/?\s*([a-zA-Z][\w-]*)/.exec(tagSource);
+    if (!nameMatch) continue;
+    const name = (nameMatch[1] ?? "").toLowerCase();
+    const isClosing = tagSource.startsWith("</");
+
+    if (name in SOURCE_PARENT_KIND) {
+      if (isClosing) {
+        if (parentStack[parentStack.length - 1] === name) parentStack.pop();
+        continue;
+      }
+      parentStack.push(name);
+    }
+    if (isClosing) continue;
+
+    switch (name) {
+      case "link": {
+        const kind = linkKind(tagSource);
+        if (kind) pushRef(refs, kind, readTagAttr(tagSource, "href"), "href");
+        break;
+      }
+      case "img": {
+        pushRef(refs, "image", readTagAttr(tagSource, "src"), "src");
+        const srcset = readTagAttr(tagSource, "srcset");
+        if (srcset) for (const url of parseSrcset(srcset)) pushRef(refs, "image", url, "srcset");
+        break;
+      }
+      case "source": {
+        const parent = parentStack[parentStack.length - 1] ?? "";
+        const srcset = readTagAttr(tagSource, "srcset");
+        if (srcset) {
+          for (const url of parseSrcset(srcset)) pushRef(refs, "image", url, "srcset");
+        }
+        const parentKind = SOURCE_PARENT_KIND[parent] ?? "video";
+        pushRef(refs, parentKind, readTagAttr(tagSource, "src"), "src");
+        break;
+      }
+      case "video": {
+        pushRef(refs, "video", readTagAttr(tagSource, "src"), "src");
+        pushRef(refs, "image", readTagAttr(tagSource, "poster"), "poster");
+        break;
+      }
+      case "audio":
+        pushRef(refs, "audio", readTagAttr(tagSource, "src"), "src");
+        break;
+      case "iframe":
+        pushRef(refs, "iframe", readTagAttr(tagSource, "src"), "src");
+        break;
+      case "track":
+        pushRef(refs, "track", readTagAttr(tagSource, "src"), "src");
+        break;
+      default:
+        break;
+    }
+
+    const styleAttr = readTagAttr(tagSource, "style");
+    if (styleAttr) collectCssRefs(decodeHtmlEntities(styleAttr), refs, "style-attr");
+  }
+}
+
+/** `<script src>` open tags — masked out of the generic scan, so re-found here. */
+function collectScriptRefs(html: string, refs: ExtractedRef[]): void {
+  const scriptOpenRe = /<script\b[^>]*>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = scriptOpenRe.exec(html)) !== null) {
+    pushRef(refs, "script", readTagAttr(match[0], "src"), "src");
+  }
+}
+
+// ── CSS scanning ────────────────────────────────────────────────────────────
+
+const CSS_URL_RE = /url\(\s*(?:"([^"]+)"|'([^']+)'|([^"')\s]+))\s*\)/gi;
+const CSS_IMPORT_RE =
+  /@import\s+(?:url\(\s*(?:"([^"]+)"|'([^']+)'|([^"')\s]+))\s*\)|"([^"]+)"|'([^']+)')/gi;
+const FONT_FACE_BLOCK_RE = /@font-face\s*\{[^}]*\}/gi;
+
+function stripCssComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, (m) => " ".repeat(m.length));
+}
+
+function collectCssUrls(
+  css: string,
+  refs: ExtractedRef[],
+  kind: LedgerAssetKind,
+  via: LedgerAssetVia,
+): void {
+  let match: RegExpExecArray | null;
+  CSS_URL_RE.lastIndex = 0;
+  while ((match = CSS_URL_RE.exec(css)) !== null) {
+    pushRef(refs, kind, match[1] ?? match[2] ?? match[3] ?? null, via);
+  }
+}
+
+function collectCssRefs(css: string, refs: ExtractedRef[], via: LedgerAssetVia): void {
+  let source = stripCssComments(css);
+
+  let importMatch: RegExpExecArray | null;
+  CSS_IMPORT_RE.lastIndex = 0;
+  while ((importMatch = CSS_IMPORT_RE.exec(source)) !== null) {
+    const url =
+      importMatch[1] ?? importMatch[2] ?? importMatch[3] ?? importMatch[4] ?? importMatch[5];
+    pushRef(refs, "stylesheet", url ?? null, "css-import");
+  }
+  // Blank @import statements so their url() doesn't double-count as an image.
+  source = source.replace(CSS_IMPORT_RE, (m) => " ".repeat(m.length));
+
+  // @font-face src urls are fonts; everything else (backgrounds, masks,
+  // cursors) counts as image — the closest declared-asset category.
+  let fontMatch: RegExpExecArray | null;
+  FONT_FACE_BLOCK_RE.lastIndex = 0;
+  while ((fontMatch = FONT_FACE_BLOCK_RE.exec(source)) !== null) {
+    collectCssUrls(fontMatch[0], refs, "font", via);
+  }
+  source = source.replace(FONT_FACE_BLOCK_RE, (m) => " ".repeat(m.length));
+
+  collectCssUrls(source, refs, "image", via);
+}
+
+function collectStyleBlockRefs(html: string, refs: ExtractedRef[]): void {
+  const styleBlockRe = /<style\b[^>]*>([\s\S]*?)<\/style\b[^>]*>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = styleBlockRe.exec(html)) !== null) {
+    collectCssRefs(match[1] ?? "", refs, "css-url");
+  }
+}
+
+// ── Ledger assembly ─────────────────────────────────────────────────────────
+
+/** Every declared asset reference in one HTML document, in source order. */
+export function extractAssetRefs(html: string): ExtractedRef[] {
+  const refs: ExtractedRef[] = [];
+  const withoutComments = maskHtmlComments(html);
+  collectTagRefs(withoutComments, refs);
+  collectScriptRefs(withoutComments, refs);
+  collectStyleBlockRefs(withoutComments, refs);
+  return refs;
+}
+
+/** Classify one extracted reference into a full ledger row, or null to skip. */
+function toLedgerAsset(
+  file: string,
+  ref: ExtractedRef,
+  options: BuildLedgerOptions,
+): LedgerAssetRef | null {
+  const classified = classifyAssetUrl(ref.url);
+  if (classified === "skip") return null;
+
+  let status: LedgerAssetStatus = classified === "local-candidate" ? "missing" : classified;
+  let localPath: string | undefined;
+  if (classified === "local-candidate") {
+    localPath = options.resolveLocalAsset?.(file, ref.url) ?? undefined;
+    if (localPath !== undefined) status = "local";
+  }
+  return {
+    kind: ref.kind,
+    url: ref.url,
+    rawUrl: ref.rawUrl,
+    status,
+    file,
+    via: ref.via,
+    ...(localPath !== undefined ? { localPath } : {}),
+  };
+}
+
+/** Build a ledger from in-memory HTML sources. Pure except for the resolver. */
+export function buildAssetLedger(
+  inputs: LedgerFileInput[],
+  options: BuildLedgerOptions = {},
+): AssetLedger {
+  const assets: LedgerAssetRef[] = [];
+  const remoteUrls: string[] = [];
+  const seenRemote = new Set<string>();
+  const counts = { total: 0, remote: 0, local: 0, data: 0, missing: 0 };
+
+  for (const input of inputs) {
+    for (const ref of extractAssetRefs(input.html)) {
+      const asset = toLedgerAsset(input.file, ref, options);
+      if (!asset) continue;
+      counts.total += 1;
+      counts[asset.status] += 1;
+      if (asset.status === "remote" && !seenRemote.has(asset.url)) {
+        seenRemote.add(asset.url);
+        remoteUrls.push(asset.url);
+      }
+      assets.push(asset);
+    }
+  }
+
+  return { files: inputs.map((i) => i.file), assets, counts, remoteUrls };
+}
+
+// ── Project scanning (node-only) ────────────────────────────────────────────
+
+const SKIPPED_DIRS = new Set(["node_modules", ".git", "dist", "coverage", ".cache"]);
+
+/** Recursively list project-root-relative `.html` files, sorted for stability. */
+export function collectProjectHtmlFiles(projectDir: string): string[] {
+  const root = resolve(projectDir);
+  const files: string[] = [];
+  const walk = (dir: string): void => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        if (!SKIPPED_DIRS.has(entry.name) && !entry.name.startsWith(".")) {
+          walk(join(dir, entry.name));
+        }
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".html")) {
+        // Posix separators keep ledger output identical across platforms.
+        files.push(relative(root, join(dir, entry.name)).replace(/\\/g, "/"));
+      }
+    }
+  };
+  walk(root);
+  return files.sort();
+}
+
+/**
+ * Resolve one URL declared in `fromFile` (root-relative) against the project:
+ * relative URLs resolve from the declaring file's directory, `/`-prefixed and
+ * bare root-relative URLs from the project root (both via the shared
+ * candidate logic in `@hyperframes/parsers/asset-resolution`).
+ */
+export function resolveDeclaredLocalAsset(
+  projectDir: string,
+  fromFile: string,
+  url: string,
+): string | null {
+  const fromDir = fromFile.includes("/") ? fromFile.slice(0, fromFile.lastIndexOf("/")) : "";
+  const relativeToFile = fromDir && !url.startsWith("/") ? `${fromDir}/${url}` : url;
+  const hit =
+    resolveExistingLocalAsset(projectDir, relativeToFile) ??
+    resolveExistingLocalAsset(projectDir, url);
+  return hit ? hit.rootRelativePath.replace(/\\/g, "/") : null;
+}
+
+/** Scan a project directory on disk and build its asset ledger. */
+export function buildProjectAssetLedger(
+  projectDir: string,
+  options: { files?: string[] } = {},
+): AssetLedger {
+  const root = resolve(projectDir);
+  const files = options.files ?? collectProjectHtmlFiles(root);
+  const inputs: LedgerFileInput[] = [];
+  for (const file of files) {
+    let html: string;
+    try {
+      html = readFileSync(join(root, file), "utf-8");
+    } catch {
+      continue;
+    }
+    inputs.push({ file, html });
+  }
+  return buildAssetLedger(inputs, {
+    resolveLocalAsset: (fromFile, url) => resolveDeclaredLocalAsset(root, fromFile, url),
+  });
+}

--- a/packages/lint/src/hyperframeLinter.ts
+++ b/packages/lint/src/hyperframeLinter.ts
@@ -17,6 +17,7 @@ import { adapterRules } from "./rules/adapters";
 import { textureRules } from "./rules/textures";
 import { fontRules } from "./rules/fonts";
 import { slideshowRules } from "./rules/slideshow";
+import { runtimeNetworkFetchRules } from "./rules/runtimeNetworkFetch";
 
 // Rules are grouped by source module so a timing can be attributed to
 // something a human can act on. Individual rules stay anonymous: an
@@ -43,6 +44,7 @@ const RULE_GROUPS: ReadonlyArray<{
   { group: "textures", rules: textureRules },
   { group: "fonts", rules: fontRules },
   { group: "slideshow", rules: slideshowRules },
+  { group: "network", rules: runtimeNetworkFetchRules },
 ];
 
 /**

--- a/packages/lint/src/rules/runtimeNetworkFetch.test.ts
+++ b/packages/lint/src/rules/runtimeNetworkFetch.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { lintHyperframeHtml } from "../hyperframeLinter";
+
+const findRemoteScriptFindings = async (html: string) => {
+  const result = await lintHyperframeHtml(html);
+  return result.findings.filter((f) => f.code === "remote_script_not_vendored");
+};
+
+describe("remote_script_not_vendored", () => {
+  it("flags a remote script src as info with a vendor fixHint", async () => {
+    const findings = await findRemoteScriptFindings(
+      `<div id="root" class="clip" data-duration="1">
+         <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+       </div>`,
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ severity: "info" });
+    expect(findings[0]?.fixHint).toContain("hyperframes vendor");
+  });
+
+  it("dedupes repeated URLs and ignores local or inline scripts", async () => {
+    const findings = await findRemoteScriptFindings(
+      `<div id="root" class="clip" data-duration="1">
+         <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+         <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+         <script src="assets/vendor/gsap.min.js"></script>
+         <script>console.log("inline");</script>
+       </div>`,
+    );
+    expect(findings).toHaveLength(1);
+  });
+
+  it("stays silent on fully local compositions", async () => {
+    const findings = await findRemoteScriptFindings(
+      `<div id="root" class="clip" data-duration="1">
+         <script src="./gsap.min.js"></script>
+       </div>`,
+    );
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/packages/lint/src/rules/runtimeNetworkFetch.ts
+++ b/packages/lint/src/rules/runtimeNetworkFetch.ts
@@ -1,0 +1,42 @@
+import type { LintContext, HyperframeLintFinding } from "../context";
+import type { LintRule } from "../types";
+import { readAttr, truncateSnippet } from "../utils";
+
+/**
+ * Deterministic renders must not depend on the network at capture time
+ * (see the "no render-time network fetches" convention). A remote
+ * `<script src>` is the highest-risk network reference: if the CDN is slow,
+ * offline, or serves a different build, the render silently changes or
+ * fails. Vendoring the file (`hyperframes vendor`) makes the composition
+ * self-contained.
+ *
+ * Info-severity on purpose: remote CDN scripts (GSAP, Lottie, Three.js)
+ * are the documented quick-start path and several other rules' fixHints
+ * suggest adding them. This rule only nudges toward the offline-hardening
+ * step; `hyperframes ledger --strict-offline` is the enforcing gate.
+ */
+const REMOTE_SRC_RE = /^(https?:)?\/\//i;
+
+const remoteScriptNotVendored: LintRule<LintContext> = (ctx) => {
+  const findings: HyperframeLintFinding[] = [];
+  const seen = new Set<string>();
+  for (const script of ctx.scripts) {
+    const tagSource = `<script ${script.attrs}>`;
+    const src = readAttr(tagSource, "src");
+    if (!src || !REMOTE_SRC_RE.test(src.trim()) || seen.has(src)) continue;
+    seen.add(src);
+    findings.push({
+      code: "remote_script_not_vendored",
+      severity: "info",
+      message: `Remote <script> depends on the network at render time: ${src.slice(0, 120)}`,
+      fixHint:
+        "Run `hyperframes vendor` to download it into assets/vendor/ and rewrite the reference, then verify with `hyperframes ledger --strict-offline`.",
+      snippet: truncateSnippet(tagSource),
+    });
+  }
+  return findings;
+};
+
+export const runtimeNetworkFetchRules: ReadonlyArray<LintRule<LintContext>> = [
+  remoteScriptNotVendored,
+];


### PR DESCRIPTION
## Summary

Agents and authors routinely pull CDN scripts and remote media into compositions, which silently breaks deterministic and offline renders. This PR adds an agent-readable asset graph and a one-command localization step:

- **`hyperframes ledger [dir] [--json] [--strict-offline]`** — static inventory of every declared asset reference (scripts, stylesheets, fonts, images, audio, video, iframes, text tracks) across all project HTML, each classified `remote | local | data | missing`. No browser, no network. Under `--strict-offline` it exits non-zero while any remote reference remains — the CI gate for deterministic renders.
- **`hyperframes vendor [dir] [--out assets/vendor] [--dry-run] [--strict-offline]`** — downloads each unique remote URL (scheme allowlist: `http`/`https` only; protocol-relative upgraded to `https`), saves it as `<basename>-<sha256-prefix><ext>`, rewrites every HTML reference to a path relative to the declaring file, and records provenance (`url`, `bytes`, `sha256`, `contentType`) in `vendor-manifest.json`. Remote iframes are deliberately never vendored — a live page cannot be made deterministic — so they still fail the strict gate.
- **Core module** `@hyperframes/core/asset-ledger` — the pure extraction/classification engine (linear tag scan + CSS `url()`/`@import`/`@font-face` scanning), reusing `@hyperframes/parsers/asset-resolution` for on-disk resolution. New subpath export synced via `package-subpaths.json`.
- **Lint rule** `remote_script_not_vendored` (info) — nudges toward `hyperframes vendor` when a remote `<script src>` is detected, without breaking the documented CDN quick-start path.
- **Docs** — `reference/cli-ledger` (flags, JSON schema, exit codes) and `guides/offline-deterministic-renders` (workflow guide), both wired into the Mintlify nav.

Scope note: this does **not** implement Google Fonts crawling (#3583) — only declared URLs are inventoried/vendored; font binaries nested inside remote CSS are documented as out of scope.

## Walkthrough video (rendered by HyperFrames itself)

The walkthrough is not a screen recording — it is a HyperFrames HTML composition, storyboarded first and rendered to MP4 by the CLI. Every terminal/JSON panel shows the real captured output of running the new commands on the demo project, and the demo is self-referential: the composition was authored with GSAP on jsDelivr, `hyperframes vendor` downloaded it to `assets/vendor/gsap.min-0274614511.js` and rewrote the `<script src>`, `hyperframes ledger --strict-offline` passed with zero remote references, and **the video was then rendered with the vendored file**.

▶ **Walkthrough MP4 (public):** https://raw.githubusercontent.com/mvanhorn/hyperframes/walkthrough-assets/offline-asset-ledger-walkthrough.mp4

(1920×1080, 30 s @ 30 fps, 2.2 MB — HyperFrames CLI render output)

Render command:

```bash
npx hyperframes render   # → renders/offline-ledger-demo_2026-09-08_01-32-43.mp4 (rendered in 32.9s)
```

Full demo pipeline (all real, exit codes verified):

```bash
npx hyperframes ledger --json            # counts: { total: 1, remote: 1, … } — flags the jsDelivr GSAP script
npx hyperframes vendor                   # ↓ …gsap.min.js → assets/vendor/gsap.min-0274614511.js (71.1 KB, sha256 c174bfce…)
npx hyperframes ledger --strict-offline  # 1 local · 0 remote — exit 0
npx hyperframes lint && npx hyperframes check   # 0 errors; 38/38 WCAG AA text checks pass
npx hyperframes render
```

## Test plan

- `packages/core/src/assets/ledger.test.ts` — 13 tests: URL classification (remote/data/local/skip, unknown schemes, templating placeholders), extraction (script tags, `link rel`/`as`, CSS `@import`/`@font-face`/backgrounds, `srcset`, `poster`, `<source>` parent-kind mapping, entity decoding, comment/script-string immunity), ledger assembly (counts, dedupe, resolver), and on-disk project scanning with file-relative resolution. Fixture HTML uses jsDelivr + local media; no browser required.
- `packages/cli/src/commands/ledger.test.ts` — 5 tests: `--json` output shape, `--strict-offline` exit codes (1 with remotes, 0 when fully local), human output, error paths.
- `packages/cli/src/commands/vendor.test.ts` — 10 tests: scheme allowlist, stable hashed filenames, content-type extension fallback, relative-path rewriting (incl. prefix-safe longest-first replacement), full command flow with mocked `fetch` (download + rewrite + manifest), `--dry-run` no-op guarantee, failed-download exit 1, `--strict-offline` failure on non-vendorable remotes.
- `packages/lint/src/rules/runtimeNetworkFetch.test.ts` — 3 tests: info finding with vendor fixHint, URL dedupe, silence on local/inline scripts.
- Full suites pass: `@hyperframes/cli` (vitest, exit 0), `@hyperframes/core` (exit 0), `@hyperframes/lint` (604 tests, exit 0). `bun run build`, root `bun run lint` (incl. `check:package-subpaths`), typecheck, oxlint/oxfmt, and the fallow audit all pass.
- End-to-end verification against the live jsDelivr CDN is shown in the walkthrough video above.

## AI disclosure

This PR was implemented by an AI agent (Claude Fable 5, running as a Cursor cloud agent), including the code, tests, docs, storyboard, and the HyperFrames composition used for the walkthrough video. A human (mvanhorn) directed scope and requirements.