### PR TITLE
feat(producer): write public render provenance sidecar next to outputs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -832,6 +832,7 @@
             "group": "Rendering paths",
             "pages": [
               "guides/rendering",
+              "reference/render-provenance",
               "deploy/overview",
               "deploy/cloud",
               "guides/deploy"

--- a/docs/reference/render-provenance.mdx
+++ b/docs/reference/render-provenance.mdx
@@ -1,0 +1,117 @@
+---
+title: "Render provenance sidecar"
+sidebarTitle: "Render provenance"
+description: "The portable JSON receipt written next to every rendered output."
+---
+
+Every successful `hyperframes render` writes a small JSON receipt next to the
+output file: `out.mp4` gets `out.mp4.hf-render.json`. The sidecar records what
+produced the file — tool versions, input hashes, fonts, format, encoder, stage
+timings, and warning codes — so agents, CI pipelines, and support tooling can
+answer "what rendered this, from what, and how" without re-running anything.
+
+```bash
+npx hyperframes render --output out.mp4
+# → out.mp4
+# → out.mp4.hf-render.json
+```
+
+```json
+{
+  "$schema": "https://hyperframes.heygen.com/schema/hf-render-sidecar.json",
+  "schemaVersion": 1,
+  "kind": "hf-render-sidecar",
+  "createdAt": "2026-09-08T01:10:29.640Z",
+  "versions": {
+    "producer": "0.8.31",
+    "node": "v22.22.2",
+    "ffmpeg": "ffmpeg version 6.1.1-3ubuntu5"
+  },
+  "render": {
+    "jobId": "render-1757294992655-h2y0iqk3d",
+    "outcome": "completed",
+    "warningCodes": [],
+    "totalElapsedMs": 36980,
+    "stages": { "compileMs": 189, "captureFrameMs": 33212, "encodeMs": 941 },
+    "workers": 1,
+    "quality": "standard"
+  },
+  "input": {
+    "entryFile": "index.html",
+    "entrySha256": "9917f7d1…",
+    "compositionHash": "d59fa8f6a2f95627",
+    "fonts": ["Inter", "Space Grotesk"],
+    "variables": { "count": 2, "sha256": "0b26e313…" }
+  },
+  "output": {
+    "file": "out.mp4",
+    "format": "mp4",
+    "fps": { "num": 30, "den": 1 },
+    "width": 1920,
+    "height": 1080,
+    "durationSeconds": 4,
+    "totalFrames": 120,
+    "sizeBytes": 693352,
+    "sha256": "6cbb43c1…",
+    "hdr": false,
+    "encoder": { "codec": "h264", "preset": "medium", "pixelFormat": "yuv420p" }
+  },
+  "host": { "platform": "linux", "arch": "x64" }
+}
+```
+
+## Controlling the sidecar
+
+The sidecar is on by default for every render, including `--docker` and
+`--batch` renders (each batch row writes its own
+`<row output>.hf-render.json`).
+
+```bash
+npx hyperframes render --output out.mp4 --no-provenance        # disable
+npx hyperframes render --output out.mp4 --provenance receipts/out.json  # relocate
+```
+
+Two combinations are rejected up front: a custom `--provenance <path>` with
+`--batch` (one fixed path cannot serve N row outputs) and with `--docker`
+(an arbitrary host path is not visible from the render container). Disabling
+works everywhere.
+
+Programmatic callers set the same tri-state on the render request:
+`provenance` omitted (default path), `false` (disabled), or a custom path
+string.
+
+## What the fields mean
+
+| Field | Meaning |
+| --- | --- |
+| `versions` | `@hyperframes/producer` package version, Node.js version, and the first line of `ffmpeg -version`. |
+| `render.outcome` | `completed` or `completed_with_warnings` — sidecars only exist for renders whose artifact committed. |
+| `render.warningCodes` | Sorted capture-readiness warning codes (empty on a clean render). |
+| `render.stages` | Per-stage wall-clock timings in milliseconds (`compileMs`, `captureMs`, `encodeMs`, …). |
+| `input.entrySha256` | sha256 of the entry HTML source bytes. |
+| `input.compositionHash` | Content hash of the compiled composition — the same value render telemetry reports. |
+| `input.fonts` | `@font-face` family names baked into the compiled composition. |
+| `input.variables` | Count and sha256 of the render-time variable overrides — the hash proves *which* parametrization produced the output without disclosing values. `null` when no variables were passed. |
+| `output.sha256` / `output.sizeBytes` | Digest and size of the committed artifact. Omitted for `png-sequence` directory outputs. |
+| `output.encoder` | Codec, preset, and pixel format used by the encode stage. `null` for `png-sequence` and `gif`. |
+
+The full contract is published as a JSON Schema at
+[`hf-render-sidecar.json`](https://hyperframes.heygen.com/schema/hf-render-sidecar.json)
+(source: `packages/core/schemas/hf-render-sidecar.json`).
+
+## What the sidecar deliberately omits
+
+Variable **values** (they routinely carry user text and tokens — only a hash
+is recorded), environment variables, absolute host paths, usernames, and
+machine names. Once a receipt travels with a shared file, metadata leaks are
+hard to walk back.
+
+## Sidecar vs. embedded container tags
+
+HyperFrames also stamps MP4/MOV/WebM containers with two unsigned metadata
+tags (`hyperframes_renderer`, `hyperframes_version`). The two are
+complementary: the embedded tags survive file moves but hold only the
+renderer name and version; the sidecar carries the full receipt but is a
+separate file. Both are unauthenticated hints — any tool can write either —
+so use them for diagnostics and CI bookkeeping, never as an authenticity or
+attribution boundary.

--- a/packages/cli/src/commands/render.provenance.test.ts
+++ b/packages/cli/src/commands/render.provenance.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CliUsageError } from "../utils/commandResult.js";
+import { buildDockerRunArgs } from "../utils/dockerRunArgs.js";
+import { createRenderPlan, parseProvenanceArg } from "./render/plan.js";
+
+describe("parseProvenanceArg", () => {
+  it("defaults to on (undefined) when the flag is absent or bare", () => {
+    expect(parseProvenanceArg(undefined)).toBeUndefined();
+    expect(parseProvenanceArg(true)).toBeUndefined();
+    expect(parseProvenanceArg("  ")).toBeUndefined();
+  });
+
+  it("disables on --no-provenance and on disable-alias values", () => {
+    expect(parseProvenanceArg(false)).toBe(false);
+    expect(parseProvenanceArg("false")).toBe(false);
+    expect(parseProvenanceArg("OFF")).toBe(false);
+    expect(parseProvenanceArg("0")).toBe(false);
+    expect(parseProvenanceArg("none")).toBe(false);
+  });
+
+  it("resolves a custom sidecar path", () => {
+    expect(parseProvenanceArg("receipts/out.json")).toBe(resolve("receipts/out.json"));
+  });
+});
+
+/** Minimal renderable project fixture — one composition root, no clips. */
+function makeProvenanceProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "hf-render-provenance-"));
+  const root =
+    '<main data-composition-id="main" data-width="1920" data-height="1080" data-fps="30"></main>';
+  writeFileSync(join(dir, "index.html"), root);
+  return dir;
+}
+
+describe("createRenderPlan provenance", () => {
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = makeProvenanceProjectDir();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("leaves provenance on by default", () => {
+    const plan = createRenderPlan({ dir: projectDir, output: "out.mp4" });
+    expect(plan.provenance).toBeUndefined();
+  });
+
+  it("threads --no-provenance through the plan", () => {
+    const plan = createRenderPlan({ dir: projectDir, output: "out.mp4", provenance: false });
+    expect(plan.provenance).toBe(false);
+  });
+
+  it("threads a custom sidecar path through the plan", () => {
+    const plan = createRenderPlan({
+      dir: projectDir,
+      output: "out.mp4",
+      provenance: "receipts/out.json",
+    });
+    expect(plan.provenance).toBe(resolve("receipts/out.json"));
+  });
+
+  it("rejects a custom sidecar path with --batch (rows write their own sidecars)", () => {
+    expect(() =>
+      createRenderPlan({
+        dir: projectDir,
+        batch: "rows.json",
+        provenance: "receipts/out.json",
+      }),
+    ).toThrow(CliUsageError);
+  });
+
+  it("allows disabling provenance batch-wide", () => {
+    const plan = createRenderPlan({ dir: projectDir, batch: "rows.json", provenance: false });
+    expect(plan.provenance).toBe(false);
+  });
+
+  it("rejects a custom sidecar path with --docker (path is not container-visible)", () => {
+    expect(() =>
+      createRenderPlan({
+        dir: projectDir,
+        output: "out.mp4",
+        docker: true,
+        provenance: "receipts/out.json",
+      }),
+    ).toThrow(CliUsageError);
+  });
+
+  it("allows disabling provenance with --docker", () => {
+    const plan = createRenderPlan({
+      dir: projectDir,
+      output: "out.mp4",
+      docker: true,
+      provenance: "false",
+    });
+    expect(plan.provenance).toBe(false);
+  });
+});
+
+describe("buildDockerRunArgs provenance forwarding", () => {
+  const base = {
+    imageTag: "hyperframes-renderer:test",
+    projectDir: "/host/project",
+    outputDir: "/host/renders",
+    outputFilename: "out.mp4",
+    platform: "linux/amd64",
+    options: {
+      fps: { num: 30, den: 1 },
+      quality: "standard" as const,
+      format: "mp4" as const,
+      gpu: false,
+      browserGpu: false,
+      hdrMode: "auto" as const,
+      quiet: true,
+    },
+  };
+
+  it("forwards --no-provenance into the container CLI", () => {
+    const args = buildDockerRunArgs({
+      ...base,
+      options: { ...base.options, provenance: false as const },
+    });
+    expect(args).toContain("--no-provenance");
+  });
+
+  it("does not forward anything for the default-on setting", () => {
+    const args = buildDockerRunArgs(base);
+    expect(args).not.toContain("--no-provenance");
+    expect(args).not.toContain("--provenance");
+  });
+});

--- a/packages/cli/src/commands/render.ts
+++ b/packages/cli/src/commands/render.ts
@@ -338,6 +338,15 @@ export default defineCommand({
       // guard below leaves PRODUCER_EXPERIMENTAL_FAST_CAPTURE untouched and the
       // env fallback survives (matches the --low-memory-mode idiom).
     },
+    provenance: {
+      type: "string",
+      description:
+        "Render provenance sidecar path (default: <output>.hf-render.json). " +
+        "The sidecar is a portable JSON receipt written next to the output " +
+        "after a successful render: tool versions, input hashes, variables " +
+        "hash, fonts, format/fps/resolution, encoder, stage timings, and " +
+        "warning codes. Pass false (or use --no-provenance) to disable.",
+    },
     "frames-cache-dir": {
       type: "string",
       description:
@@ -426,6 +435,11 @@ export interface RenderOptions {
   protocolTimeout?: number;
   /** Player-ready timeout override (ms). */
   playerReadyTimeout?: number;
+  /**
+   * Provenance sidecar setting: `undefined` = default sidecar next to the
+   * output, `false` = disabled, string = custom sidecar path.
+   */
+  provenance?: string | false;
   /** Throw render failures to the caller instead of printing and exiting. */
   throwOnError?: boolean;
   /** Skip the interactive feedback prompt after a successful render. */
@@ -728,6 +742,7 @@ async function renderDocker(
       pageNavigationTimeoutMs: options.pageNavigationTimeoutMs,
       protocolTimeoutMs: options.protocolTimeout,
       playerReadyTimeoutMs: options.playerReadyTimeout,
+      provenance: options.provenance,
     },
   });
 
@@ -894,6 +909,7 @@ export async function renderLocal(
       entryFile: options.entryFile,
       outputResolution: options.outputResolution,
       outputResolutionAspectAgnostic: options.outputResolutionAspectAgnostic,
+      provenance: options.provenance,
       debug: options.debug,
       strictness: options.bestEffort === false ? "strict" : "best-effort",
     },

--- a/packages/cli/src/commands/render/execute.ts
+++ b/packages/cli/src/commands/render/execute.ts
@@ -56,6 +56,43 @@ function renderLintShouldAbort(
   );
 }
 
+/**
+ * The plan-derived render options shared by the single-render and batch
+ * paths. Call-site-specific lifecycle fields (quiet override, variables,
+ * exitAfterComplete, throwOnError, skipFeedback, breaker management) are
+ * spread over this base by each caller.
+ */
+function planRenderOptions(plan: RenderPlan, browserPath: string | undefined): RenderOptions {
+  return {
+    fps: plan.fps,
+    quality: plan.quality,
+    authoringSkill: plan.authoringSkill,
+    catalogUsage: plan.catalogUsage,
+    format: plan.format,
+    gifLoop: plan.gifLoop,
+    workers: plan.workers,
+    gpu: plan.useGpu,
+    browserGpuMode: plan.browserGpuMode,
+    hdrMode: plan.hdrMode,
+    crf: plan.crf,
+    vp9CpuUsed: plan.vp9CpuUsed,
+    videoBitrate: plan.videoBitrate,
+    videoFrameFormat: plan.videoFrameFormat,
+    quiet: plan.quiet,
+    browserPath,
+    debug: plan.debug,
+    bestEffort: plan.bestEffort,
+    entryFile: plan.entryFile,
+    outputResolution: plan.outputResolution,
+    outputResolutionAspectAgnostic: plan.outputResolutionAspectAgnostic,
+    outputResolutionRaw: plan.outputResolutionRaw,
+    pageNavigationTimeoutMs: plan.pageNavigationTimeoutMs,
+    protocolTimeout: plan.protocolTimeout,
+    playerReadyTimeout: plan.playerReadyTimeout,
+    provenance: plan.provenance,
+  };
+}
+
 /** Execute a validated plan. Output and process lifecycle stay outside parsing. */
 export async function executeRenderPlan(
   plan: RenderPlan,
@@ -98,32 +135,8 @@ export async function executeRenderPlan(
   }
 
   const options: RenderOptions = {
-    fps: plan.fps,
-    quality: plan.quality,
-    authoringSkill: plan.authoringSkill,
-    catalogUsage: plan.catalogUsage,
-    format: plan.format,
-    gifLoop: plan.gifLoop,
-    workers: plan.workers,
-    gpu: plan.useGpu,
-    browserGpuMode: plan.browserGpuMode,
-    hdrMode: plan.hdrMode,
-    crf: plan.crf,
-    vp9CpuUsed: plan.vp9CpuUsed,
-    videoBitrate: plan.videoBitrate,
-    videoFrameFormat: plan.videoFrameFormat,
-    quiet: plan.quiet,
-    browserPath,
-    debug: plan.debug,
-    bestEffort: plan.bestEffort,
+    ...planRenderOptions(plan, browserPath),
     variables,
-    entryFile: plan.entryFile,
-    outputResolution: plan.outputResolution,
-    outputResolutionAspectAgnostic: plan.outputResolutionAspectAgnostic,
-    outputResolutionRaw: plan.outputResolutionRaw,
-    pageNavigationTimeoutMs: plan.pageNavigationTimeoutMs,
-    protocolTimeout: plan.protocolTimeout,
-    playerReadyTimeout: plan.playerReadyTimeout,
     exitAfterComplete: true,
     manageDeParallelRouterBreaker: true,
   };
@@ -252,31 +265,8 @@ async function executeBatchRender(
 ): Promise<void> {
   const batchQuiet = plan.quiet || plan.batchJson;
   const renderOptionsBase: RenderOptions = {
-    fps: plan.fps,
-    quality: plan.quality,
-    authoringSkill: plan.authoringSkill,
-    catalogUsage: plan.catalogUsage,
-    format: plan.format,
-    gifLoop: plan.gifLoop,
-    workers: plan.workers,
-    gpu: plan.useGpu,
-    browserGpuMode: plan.browserGpuMode,
-    hdrMode: plan.hdrMode,
-    crf: plan.crf,
-    vp9CpuUsed: plan.vp9CpuUsed,
-    videoBitrate: plan.videoBitrate,
-    videoFrameFormat: plan.videoFrameFormat,
+    ...planRenderOptions(plan, browserPath),
     quiet: batchQuiet,
-    browserPath,
-    entryFile: plan.entryFile,
-    outputResolution: plan.outputResolution,
-    outputResolutionAspectAgnostic: plan.outputResolutionAspectAgnostic,
-    outputResolutionRaw: plan.outputResolutionRaw,
-    pageNavigationTimeoutMs: plan.pageNavigationTimeoutMs,
-    protocolTimeout: plan.protocolTimeout,
-    playerReadyTimeout: plan.playerReadyTimeout,
-    debug: plan.debug,
-    bestEffort: plan.bestEffort,
     exitAfterComplete: false,
     throwOnError: true,
     skipFeedback: true,

--- a/packages/cli/src/commands/render/plan.ts
+++ b/packages/cli/src/commands/render/plan.ts
@@ -90,6 +90,12 @@ export interface RenderCommandArgs {
   "low-memory-mode"?: boolean;
   "experimental-fast-capture"?: boolean;
   "frames-cache-dir"?: string;
+  /**
+   * String when `--provenance <value>` was passed; boolean when the parser
+   * negated it (`--no-provenance` → false) or it was passed bare
+   * (`--provenance` → true).
+   */
+  provenance?: string | boolean;
 }
 
 export interface RenderPlan {
@@ -137,6 +143,11 @@ export interface RenderPlan {
   variablesArg?: string;
   variablesFileArg?: string;
   strictVariables: boolean;
+  /**
+   * Provenance sidecar setting: `undefined` = default sidecar next to the
+   * output, `false` = disabled, string = resolved custom sidecar path.
+   */
+  provenance?: string | false;
   environment: Readonly<Record<string, string>>;
 }
 
@@ -172,6 +183,29 @@ function positiveInteger(raw: string, title: string, message: string, min = 1): 
     failUsage();
   }
   return parsed;
+}
+
+/**
+ * Aliases that disable the provenance sidecar when passed as the flag VALUE
+ * (`--provenance false`). `--no-provenance` arrives as boolean `false` from
+ * the arg parser's standard negation and is handled separately.
+ */
+const PROVENANCE_DISABLE_ALIASES = new Set(["false", "off", "0", "none"]);
+
+/**
+ * Normalize the raw `--provenance` flag into the plan's tri-state setting:
+ * `undefined` = default on (sidecar next to the output), `false` = disabled,
+ * string = resolved custom sidecar path. A bare `--provenance` (boolean
+ * `true`) and an empty value both mean "default on" — the flag exists to
+ * relocate or disable the sidecar, not to enable an already-on default.
+ */
+export function parseProvenanceArg(raw: string | boolean | undefined): string | false | undefined {
+  if (raw === undefined || raw === true) return undefined;
+  if (raw === false) return false;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  if (PROVENANCE_DISABLE_ALIASES.has(trimmed.toLowerCase())) return false;
+  return resolve(trimmed);
 }
 
 /** Parse and validate command input into an immutable execution plan. */
@@ -409,6 +443,29 @@ export function createRenderPlan(args: RenderCommandArgs, now = new Date()): Ren
     failUsage();
   }
 
+  const provenance = parseProvenanceArg(args.provenance);
+  if (typeof provenance === "string" && batchPath) {
+    // One fixed sidecar path cannot serve N row outputs; rows always write
+    // `<row output>.hf-render.json`. Disabling still applies batch-wide.
+    errorBox(
+      "Invalid provenance",
+      "--provenance with a custom path cannot be combined with --batch. " +
+        "Each batch row writes its own <output>.hf-render.json; use --no-provenance to disable.",
+    );
+    failUsage();
+  }
+  if (typeof provenance === "string" && useDocker) {
+    // The containerized CLI writes the sidecar inside the mounted output
+    // directory; an arbitrary host path is not visible from the container.
+    errorBox(
+      "Invalid provenance",
+      "--provenance with a custom path is not supported with --docker. " +
+        "The sidecar is written next to the output inside the mounted output directory; " +
+        "use the default location or --no-provenance.",
+    );
+    failUsage();
+  }
+
   const quiet = args.quiet ?? false;
   const batchJson = args.json ?? false;
   return Object.freeze({
@@ -455,6 +512,7 @@ export function createRenderPlan(args: RenderCommandArgs, now = new Date()): Ren
     variablesArg: args.variables,
     variablesFileArg: args["variables-file"],
     strictVariables: args["strict-variables"] ?? false,
+    provenance,
     environment: Object.freeze(environment),
   });
 }

--- a/packages/cli/src/utils/dockerRunArgs.ts
+++ b/packages/cli/src/utils/dockerRunArgs.ts
@@ -70,6 +70,13 @@ export interface DockerRenderOptions {
   protocolTimeoutMs?: number;
   /** Player readiness timeout in milliseconds. */
   playerReadyTimeoutMs?: number;
+  /**
+   * Provenance sidecar setting. Only `false` is forwarded (as
+   * `--no-provenance`): the default sidecar already lands next to the output
+   * inside the mounted output directory, and custom host paths are rejected
+   * by the render plan before Docker is invoked.
+   */
+  provenance?: string | false;
 }
 
 /**
@@ -164,5 +171,6 @@ export function buildDockerRunArgs(input: DockerRunArgsInput): string[] {
     ...(options.playerReadyTimeoutMs != null
       ? ["--player-ready-timeout", String(options.playerReadyTimeoutMs)]
       : []),
+    ...(options.provenance === false ? ["--no-provenance"] : []),
   ];
 }

--- a/packages/core/schemas/hf-render-sidecar.json
+++ b/packages/core/schemas/hf-render-sidecar.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hyperframes.heygen.com/schema/hf-render-sidecar.json",
+  "title": "HyperFrames Render Provenance Sidecar",
+  "description": "Portable render receipt written next to a committed render artifact as <output>.hf-render.json. An unauthenticated hint for agents, CI, and support tooling — never an authenticity or attribution boundary.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "kind",
+    "createdAt",
+    "versions",
+    "render",
+    "input",
+    "output",
+    "host"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "schemaVersion": {
+      "const": 1,
+      "description": "Sidecar schema version. Bumped when the framing changes incompatibly."
+    },
+    "kind": {
+      "const": "hf-render-sidecar"
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp of sidecar creation (artifact commit time)."
+    },
+    "versions": {
+      "type": "object",
+      "required": ["producer", "node"],
+      "additionalProperties": false,
+      "properties": {
+        "producer": {
+          "type": "string",
+          "description": "@hyperframes/producer package version."
+        },
+        "node": {
+          "type": "string",
+          "description": "Node.js version the render ran on (process.version)."
+        },
+        "ffmpeg": {
+          "type": "string",
+          "description": "First line of `ffmpeg -version`. Absent when the probe failed."
+        }
+      }
+    },
+    "render": {
+      "type": "object",
+      "required": ["jobId", "outcome", "warningCodes", "totalElapsedMs", "stages", "quality"],
+      "additionalProperties": false,
+      "properties": {
+        "jobId": {
+          "type": "string",
+          "description": "Producer render job id."
+        },
+        "outcome": {
+          "type": "string",
+          "enum": ["completed", "completed_with_warnings"],
+          "description": "Sidecars are only written after a successful artifact commit."
+        },
+        "warningCodes": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Sorted, de-duplicated capture-readiness warning codes."
+        },
+        "totalElapsedMs": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Wall-clock render pipeline duration."
+        },
+        "stages": {
+          "type": "object",
+          "additionalProperties": { "type": "number" },
+          "description": "Per-stage wall-clock timings in milliseconds (compileMs, videoExtractMs, captureMs, encodeMs, assembleMs, …)."
+        },
+        "workers": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Parallel capture worker count actually used."
+        },
+        "quality": {
+          "type": "string",
+          "enum": ["draft", "standard", "high"]
+        }
+      }
+    },
+    "input": {
+      "type": "object",
+      "required": ["entryFile", "fonts", "variables"],
+      "additionalProperties": false,
+      "properties": {
+        "entryFile": {
+          "type": "string",
+          "description": "Project-relative entry HTML path."
+        },
+        "entrySha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "sha256 of the entry HTML source bytes. Absent when unreadable."
+        },
+        "compositionHash": {
+          "type": "string",
+          "description": "Content hash of the compiled composition (matches render telemetry)."
+        },
+        "fonts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Sorted @font-face family names baked into the compiled composition."
+        },
+        "variables": {
+          "description": "Render-time variable overrides, hashed (sha256 of canonical JSON) — never the raw values. Null when no variables were passed.",
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "required": ["count", "sha256"],
+              "additionalProperties": false,
+              "properties": {
+                "count": { "type": "integer", "minimum": 1 },
+                "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "output": {
+      "type": "object",
+      "required": ["file", "format", "fps", "hdr", "encoder"],
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string",
+          "description": "Output file (or png-sequence directory) basename. No host paths."
+        },
+        "format": {
+          "type": "string",
+          "enum": ["mp4", "webm", "mov", "gif", "png-sequence"]
+        },
+        "fps": {
+          "type": "object",
+          "required": ["num", "den"],
+          "additionalProperties": false,
+          "properties": {
+            "num": { "type": "integer", "minimum": 1 },
+            "den": { "type": "integer", "minimum": 1 }
+          },
+          "description": "Frame rate as an exact rational (NTSC 29.97 is 30000/1001)."
+        },
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 },
+        "durationSeconds": { "type": "number", "minimum": 0 },
+        "totalFrames": { "type": "integer", "minimum": 0 },
+        "sizeBytes": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "On-disk size of the committed artifact. File outputs only."
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "sha256 of the committed artifact bytes. File outputs only."
+        },
+        "hdr": {
+          "type": "boolean",
+          "description": "True when the artifact was encoded as HDR."
+        },
+        "encoder": {
+          "description": "Video encoder facts. Null for png-sequence and gif outputs.",
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "required": ["codec", "preset", "pixelFormat"],
+              "additionalProperties": false,
+              "properties": {
+                "codec": { "type": "string" },
+                "preset": { "type": "string" },
+                "pixelFormat": { "type": "string" }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "host": {
+      "type": "object",
+      "required": ["platform", "arch"],
+      "additionalProperties": false,
+      "properties": {
+        "platform": { "type": "string" },
+        "arch": { "type": "string" }
+      }
+    }
+  }
+}

--- a/packages/producer/src/index.ts
+++ b/packages/producer/src/index.ts
@@ -44,6 +44,16 @@ export {
   type RenderObservationEvent,
   type RenderObservationStatus,
 } from "./services/render/observability.js";
+// ── Render provenance sidecar ───────────────────────────────────────────────
+// Public receipt written next to committed render artifacts (default on).
+export {
+  RENDER_SIDECAR_SCHEMA_URL,
+  RENDER_SIDECAR_SCHEMA_VERSION,
+  RENDER_SIDECAR_SUFFIX,
+  resolveProvenanceSidecarPath,
+  type ProvenanceSetting,
+  type RenderProvenanceSidecar,
+} from "./services/render/provenanceSidecar.js";
 
 // ── HTML asset localization ─────────────────────────────────────────────────
 // Rewrite remote <img>/<video>/<audio>/@font-face to same-origin local paths

--- a/packages/producer/src/renderRequest.ts
+++ b/packages/producer/src/renderRequest.ts
@@ -49,6 +49,11 @@ export interface RenderRequestOptions {
   variables?: Record<string, unknown>;
   outputResolution?: CanvasResolution;
   outputResolutionAspectAgnostic?: boolean;
+  /**
+   * Provenance sidecar setting: omitted = default sidecar path, `false` =
+   * disabled, string = custom sidecar path. See `RenderConfig.provenance`.
+   */
+  provenance?: string | false;
   engineConfig: EngineConfig;
   distributed?: DistributedRenderOptions;
 }
@@ -174,6 +179,14 @@ function assertRequestOptionScalars(options: Record<string, unknown>): void {
   if (options.outputResolution !== undefined && !isCanvasResolution(options.outputResolution)) {
     throw new Error("Render request outputResolution is invalid");
   }
+  assertProvenanceOption(options.provenance);
+}
+
+/** Tri-state provenance setting: absent (default on), false, or a sidecar path. */
+function assertProvenanceOption(provenance: unknown): void {
+  if (provenance === undefined || provenance === false) return;
+  if (typeof provenance === "string" && provenance.trim() !== "") return;
+  throw new Error("Render request provenance must be false or a non-empty sidecar path string");
 }
 
 function assertRequestOptionObjects(options: Record<string, unknown>): void {

--- a/packages/producer/src/services/render/provenanceSidecar.test.ts
+++ b/packages/producer/src/services/render/provenanceSidecar.test.ts
@@ -1,0 +1,309 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ProducerLogger } from "../../logger.js";
+import {
+  RENDER_SIDECAR_SCHEMA_URL,
+  RENDER_SIDECAR_SCHEMA_VERSION,
+  RENDER_SIDECAR_SUFFIX,
+  buildRenderProvenanceSidecar,
+  collectFontFamilies,
+  emitRenderProvenanceSidecar,
+  hashVariables,
+  resolveProvenanceSidecarPath,
+  type BuildRenderProvenanceSidecarInput,
+} from "./provenanceSidecar.js";
+import { sha256Hex } from "./stages/planHash.js";
+
+function makeLogger(): ProducerLogger & { warnings: string[]; infos: string[] } {
+  const warnings: string[] = [];
+  const infos: string[] = [];
+  return {
+    warnings,
+    infos,
+    error() {},
+    warn(message) {
+      warnings.push(message);
+    },
+    info(message) {
+      infos.push(message);
+    },
+    debug() {},
+    isLevelEnabled: () => true,
+  };
+}
+
+describe("resolveProvenanceSidecarPath", () => {
+  it("defaults to <output>.hf-render.json beside the artifact", () => {
+    expect(resolveProvenanceSidecarPath("/renders/out.mp4", undefined)).toBe(
+      `${resolve("/renders/out.mp4")}${RENDER_SIDECAR_SUFFIX}`,
+    );
+  });
+
+  it("places a png-sequence sidecar NEXT TO the directory, not inside it", () => {
+    expect(resolveProvenanceSidecarPath("/renders/frames/", undefined)).toBe(
+      `${resolve("/renders/frames")}${RENDER_SIDECAR_SUFFIX}`,
+    );
+  });
+
+  it("returns null when disabled", () => {
+    expect(resolveProvenanceSidecarPath("/renders/out.mp4", false)).toBeNull();
+  });
+
+  it("resolves a custom sidecar path", () => {
+    expect(resolveProvenanceSidecarPath("/renders/out.mp4", "receipts/out.json")).toBe(
+      resolve("receipts/out.json"),
+    );
+  });
+});
+
+describe("collectFontFamilies", () => {
+  it("extracts sorted, de-duplicated @font-face families", () => {
+    const html = `<style>
+      @font-face { font-family: 'Space Grotesk'; src: url(a.woff2); }
+      @font-face { font-family: "Inter"; font-weight: 700; src: url(b.woff2); }
+      @font-face { font-family: Inter; font-weight: 400; src: url(c.woff2); }
+      body { font-family: Inter, sans-serif; }
+    </style>`;
+    expect(collectFontFamilies(html)).toEqual(["Inter", "Space Grotesk"]);
+  });
+
+  it("returns an empty list when the composition declares no @font-face", () => {
+    expect(collectFontFamilies("<style>body { font-family: system-ui; }</style>")).toEqual([]);
+  });
+});
+
+describe("hashVariables", () => {
+  it("returns null for absent or empty variables", () => {
+    expect(hashVariables(undefined)).toBeNull();
+    expect(hashVariables({})).toBeNull();
+  });
+
+  it("hashes canonically so property order does not change the receipt", () => {
+    const a = hashVariables({ title: "Q4", theme: "dark" });
+    const b = hashVariables({ theme: "dark", title: "Q4" });
+    expect(a).toEqual(b);
+    expect(a?.count).toBe(2);
+    expect(a?.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("changes when a value changes", () => {
+    expect(hashVariables({ title: "Q4" })?.sha256).not.toBe(hashVariables({ title: "Q5" })?.sha256);
+  });
+});
+
+function makeBuildInput(
+  overrides: Partial<BuildRenderProvenanceSidecarInput> = {},
+): BuildRenderProvenanceSidecarInput {
+  return {
+    jobId: "job-1",
+    outcome: "completed",
+    warningCodes: [],
+    totalElapsedMs: 1234,
+    stages: { compileMs: 10, captureMs: 100, encodeMs: 50 },
+    workers: 2,
+    quality: "standard",
+    producerVersion: "0.9.9-test",
+    ffmpegVersion: "ffmpeg version 6.1.1",
+    entryFile: "index.html",
+    entrySha256: sha256Hex("<html></html>"),
+    compositionHash: "abc123",
+    fonts: ["Inter"],
+    variables: { title: "secret launch name", apiKey: "sk-super-secret" },
+    outputPath: "/renders/out.mp4",
+    format: "mp4",
+    fps: { num: 30, den: 1 },
+    width: 1920,
+    height: 1080,
+    durationSeconds: 4,
+    totalFrames: 120,
+    outputSizeBytes: 4096,
+    outputSha256: sha256Hex("fake-mp4-bytes"),
+    hdr: false,
+    encoder: { codec: "h264", preset: "medium", pixelFormat: "yuv420p" },
+    createdAt: "2026-09-08T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("buildRenderProvenanceSidecar", () => {
+  it("builds the versioned receipt shape", () => {
+    const sidecar = buildRenderProvenanceSidecar(makeBuildInput());
+    expect(sidecar.$schema).toBe(RENDER_SIDECAR_SCHEMA_URL);
+    expect(sidecar.schemaVersion).toBe(RENDER_SIDECAR_SCHEMA_VERSION);
+    expect(sidecar.kind).toBe("hf-render-sidecar");
+    expect(sidecar.versions).toEqual({
+      producer: "0.9.9-test",
+      node: process.version,
+      ffmpeg: "ffmpeg version 6.1.1",
+    });
+    expect(sidecar.render.jobId).toBe("job-1");
+    expect(sidecar.output).toEqual({
+      file: "out.mp4",
+      format: "mp4",
+      fps: { num: 30, den: 1 },
+      width: 1920,
+      height: 1080,
+      durationSeconds: 4,
+      totalFrames: 120,
+      sizeBytes: 4096,
+      sha256: sha256Hex("fake-mp4-bytes"),
+      hdr: false,
+      encoder: { codec: "h264", preset: "medium", pixelFormat: "yuv420p" },
+    });
+    expect(sidecar.host).toEqual({ platform: process.platform, arch: process.arch });
+  });
+
+  it("hashes variables instead of embedding their values", () => {
+    const sidecar = buildRenderProvenanceSidecar(makeBuildInput());
+    const serialized = JSON.stringify(sidecar);
+    expect(serialized).not.toContain("sk-super-secret");
+    expect(serialized).not.toContain("secret launch name");
+    expect(sidecar.input.variables).toEqual({
+      count: 2,
+      sha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+    });
+  });
+
+  it("sorts and de-duplicates warning codes", () => {
+    const sidecar = buildRenderProvenanceSidecar(
+      makeBuildInput({
+        outcome: "completed_with_warnings",
+        warningCodes: ["video_not_ready", "audio_missing", "video_not_ready"],
+      }),
+    );
+    expect(sidecar.render.warningCodes).toEqual(["audio_missing", "video_not_ready"]);
+  });
+
+  it("omits absent optional facts rather than writing null placeholders", () => {
+    const sidecar = buildRenderProvenanceSidecar(
+      makeBuildInput({
+        ffmpegVersion: undefined,
+        entrySha256: undefined,
+        compositionHash: undefined,
+        variables: undefined,
+        outputSizeBytes: undefined,
+        outputSha256: undefined,
+        encoder: null,
+        format: "png-sequence",
+        outputPath: "/renders/frames",
+      }),
+    );
+    expect("ffmpeg" in sidecar.versions).toBe(false);
+    expect("entrySha256" in sidecar.input).toBe(false);
+    expect("sha256" in sidecar.output).toBe(false);
+    expect(sidecar.input.variables).toBeNull();
+    expect(sidecar.output.encoder).toBeNull();
+    expect(sidecar.output.file).toBe("frames");
+  });
+});
+
+describe("emitRenderProvenanceSidecar", () => {
+  // Each test provisions its own root through makeEmitInput; a single
+  // splice-and-remove afterEach keeps cleanup out of the fixture helper.
+  const tmpRoots: string[] = [];
+  let dir: string;
+
+  afterEach(() => {
+    for (const root of tmpRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
+
+  function makeEmitInput(overrides: Record<string, unknown> = {}) {
+    dir = mkdtempSync(join(tmpdir(), "hf-provenance-"));
+    tmpRoots.push(dir);
+    const projectDir = join(dir, "project");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(join(projectDir, "index.html"), "<html>entry</html>");
+    const outputPath = join(dir, "out.mp4");
+    writeFileSync(outputPath, "fake-mp4-bytes");
+    return {
+      outputPath,
+      provenance: undefined as string | false | undefined,
+      isFileArtifact: true,
+      projectDir,
+      entryFile: "index.html",
+      compiledHtml: "<style>@font-face { font-family: 'Inter'; }</style>",
+      jobId: "job-emit",
+      outcome: "completed" as const,
+      warningCodes: [],
+      totalElapsedMs: 99,
+      stages: { encodeMs: 5 },
+      workers: 1,
+      quality: "standard" as const,
+      compositionHash: "hash-1",
+      variables: { title: "Hello" },
+      format: "mp4",
+      fps: { num: 30, den: 1 },
+      width: 640,
+      height: 360,
+      durationSeconds: 1,
+      totalFrames: 30,
+      hdr: false,
+      encoder: { codec: "h264", preset: "medium", pixelFormat: "yuv420p" },
+      log: makeLogger(),
+      ...overrides,
+    };
+  }
+
+  it("writes the receipt beside the artifact by default", async () => {
+    const input = makeEmitInput();
+    const sidecarPath = await emitRenderProvenanceSidecar(input);
+    expect(sidecarPath).toBe(`${input.outputPath}${RENDER_SIDECAR_SUFFIX}`);
+    const sidecar = JSON.parse(readFileSync(sidecarPath as string, "utf-8"));
+    expect(sidecar.kind).toBe("hf-render-sidecar");
+    expect(sidecar.input.entrySha256).toBe(sha256Hex("<html>entry</html>"));
+    expect(sidecar.input.fonts).toEqual(["Inter"]);
+    expect(sidecar.input.variables.count).toBe(1);
+    expect(sidecar.output.sha256).toBe(sha256Hex("fake-mp4-bytes"));
+    expect(sidecar.output.sizeBytes).toBe("fake-mp4-bytes".length);
+    expect(sidecar.versions.producer).toEqual(expect.any(String));
+  });
+
+  it("returns null and writes nothing when disabled", async () => {
+    const input = makeEmitInput({ provenance: false });
+    expect(await emitRenderProvenanceSidecar(input)).toBeNull();
+    expect(existsSync(`${input.outputPath}${RENDER_SIDECAR_SUFFIX}`)).toBe(false);
+  });
+
+  it("honors a custom sidecar path", async () => {
+    const input = makeEmitInput();
+    const customPath = join(dir, "receipts", "out.json");
+    mkdirSync(join(dir, "receipts"), { recursive: true });
+    input.provenance = customPath;
+    expect(await emitRenderProvenanceSidecar(input)).toBe(customPath);
+    expect(existsSync(customPath)).toBe(true);
+  });
+
+  it("skips artifact size and sha256 for directory outputs", async () => {
+    const input = makeEmitInput({
+      isFileArtifact: false,
+      format: "png-sequence",
+      encoder: null,
+    });
+    const framesDir = join(dir, "frames");
+    mkdirSync(framesDir, { recursive: true });
+    input.outputPath = framesDir;
+    const sidecarPath = await emitRenderProvenanceSidecar(input);
+    const sidecar = JSON.parse(readFileSync(sidecarPath as string, "utf-8"));
+    expect("sha256" in sidecar.output).toBe(false);
+    expect("sizeBytes" in sidecar.output).toBe(false);
+    expect(sidecar.output.encoder).toBeNull();
+  });
+
+  it("logs a warning instead of failing when the sidecar cannot be written", async () => {
+    const log = makeLogger();
+    const input = makeEmitInput({ log });
+    input.provenance = join(dir, "missing-dir", "out.json");
+    expect(await emitRenderProvenanceSidecar(input)).toBeNull();
+    expect(log.warnings).toContain("Failed to write render provenance sidecar");
+  });
+
+  it("tolerates an unreadable entry file", async () => {
+    const input = makeEmitInput({ entryFile: "missing.html" });
+    const sidecarPath = await emitRenderProvenanceSidecar(input);
+    const sidecar = JSON.parse(readFileSync(sidecarPath as string, "utf-8"));
+    expect("entrySha256" in sidecar.input).toBe(false);
+    expect(sidecar.input.entryFile).toBe("missing.html");
+  });
+});

--- a/packages/producer/src/services/render/provenanceSidecar.test.ts
+++ b/packages/producer/src/services/render/provenanceSidecar.test.ts
@@ -260,6 +260,15 @@ describe("emitRenderProvenanceSidecar", () => {
     expect(sidecar.versions.producer).toEqual(expect.any(String));
   });
 
+  it("publishes atomically — no temp file remains beside the receipt", async () => {
+    const input = makeEmitInput();
+    const sidecarPath = await emitRenderProvenanceSidecar(input);
+    expect(existsSync(sidecarPath as string)).toBe(true);
+    expect(existsSync(`${sidecarPath}.tmp`)).toBe(false);
+    // The rename target must be complete, parseable JSON.
+    expect(JSON.parse(readFileSync(sidecarPath as string, "utf-8")).kind).toBe("hf-render-sidecar");
+  });
+
   it("returns null and writes nothing when disabled", async () => {
     const input = makeEmitInput({ provenance: false });
     expect(await emitRenderProvenanceSidecar(input)).toBeNull();

--- a/packages/producer/src/services/render/provenanceSidecar.ts
+++ b/packages/producer/src/services/render/provenanceSidecar.ts
@@ -1,0 +1,400 @@
+/**
+ * provenanceSidecar — build and write the public render-provenance sidecar
+ * (`<output>.hf-render.json`) next to a committed render artifact.
+ *
+ * The sidecar is a portable receipt for agents and CI: which tool versions
+ * produced the file, what input (entry hash, compiled-composition hash,
+ * variables hash, fonts) went in, what came out (format, fps, resolution,
+ * duration, encoder, output sha256), and how the render ran (stage timings,
+ * workers, warning codes). It complements the in-container metadata tags
+ * written by the engine's `renderProvenance` utility — those survive file
+ * moves but hold only renderer name + version; the sidecar carries the full
+ * receipt but travels as a separate file.
+ *
+ * Deliberately NOT included: raw variable values (hashed instead — callers
+ * pass API keys and user text through variables), environment variables,
+ * absolute host paths, usernames, or machine names. Once a receipt is
+ * shared, metadata leaks are hard to walk back.
+ *
+ * Like the engine's container tags, this is an unauthenticated hint, not an
+ * authenticity boundary: any tool can write or edit a JSON file. Good for
+ * diagnostics, reproducibility checks and CI bookkeeping; never a basis for
+ * trust decisions.
+ *
+ * JSON Schema: `packages/core/schemas/hf-render-sidecar.json` (published at
+ * the `$schema` URL below). Keep the interface, the schema, and
+ * `docs/reference/render-provenance.mdx` in sync.
+ */
+
+import { execFile as execFileCallback } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { stat, writeFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { getFfmpegBinary } from "@hyperframes/engine";
+import type { Fps } from "@hyperframes/core";
+import type { ProducerLogger } from "../../logger.js";
+import { readProducerVersion } from "../distributed/shared.js";
+import { canonicalJsonStringify, sha256Hex } from "./stages/planHash.js";
+
+const execFile = promisify(execFileCallback);
+
+/**
+ * Build-time producer version injected by bundlers (the CLI's tsup config
+ * defines it). `readProducerVersion` walks the filesystem for the producer's
+ * own package.json, which cannot succeed when this source is bundled into
+ * ANOTHER package's dist (the CLI inlines the producer via `noExternal`),
+ * so the define wins when present and the walker is the unbundled fallback.
+ */
+declare const __PRODUCER_VERSION__: string | undefined;
+
+function resolveProducerVersion(): string {
+  if (typeof __PRODUCER_VERSION__ === "string" && __PRODUCER_VERSION__.length > 0) {
+    return __PRODUCER_VERSION__;
+  }
+  return readProducerVersion();
+}
+
+export const RENDER_SIDECAR_SCHEMA_VERSION = 1 as const;
+export const RENDER_SIDECAR_SUFFIX = ".hf-render.json";
+export const RENDER_SIDECAR_SCHEMA_URL =
+  "https://hyperframes.heygen.com/schema/hf-render-sidecar.json";
+
+/**
+ * Caller-facing provenance setting, threaded from the CLI flag through
+ * `RenderConfig.provenance`:
+ *
+ * - `undefined` — default ON; sidecar at `<output>.hf-render.json`.
+ * - `false` — disabled (`--no-provenance`).
+ * - string — custom sidecar path (`--provenance <path>`).
+ */
+export type ProvenanceSetting = string | false | undefined;
+
+export interface RenderProvenanceSidecar {
+  $schema: string;
+  schemaVersion: typeof RENDER_SIDECAR_SCHEMA_VERSION;
+  kind: "hf-render-sidecar";
+  /** ISO-8601 timestamp of sidecar creation (artifact commit time). */
+  createdAt: string;
+  versions: {
+    /** `@hyperframes/producer` package version. */
+    producer: string;
+    /** Node.js version the render ran on (`process.version`). */
+    node: string;
+    /** First line of `ffmpeg -version`; absent when the probe failed. */
+    ffmpeg?: string;
+  };
+  render: {
+    jobId: string;
+    outcome: "completed" | "completed_with_warnings";
+    /** Sorted, de-duplicated capture-readiness warning codes. */
+    warningCodes: string[];
+    totalElapsedMs: number;
+    /** Per-stage wall-clock timings (compileMs, captureMs, encodeMs, …). */
+    stages: Record<string, number>;
+    /** Parallel capture worker count actually used. */
+    workers?: number;
+    quality: "draft" | "standard" | "high";
+  };
+  input: {
+    /** Project-relative entry HTML path. */
+    entryFile: string;
+    /** sha256 of the entry HTML source bytes; absent when unreadable. */
+    entrySha256?: string;
+    /** Content hash of the compiled composition (same value telemetry reports). */
+    compositionHash?: string;
+    /** Sorted `@font-face` family names baked into the compiled composition. */
+    fonts: string[];
+    /** Render-time variable overrides, hashed — never the raw values. */
+    variables: { count: number; sha256: string } | null;
+  };
+  output: {
+    /** Output file (or directory, for png-sequence) basename. No host paths. */
+    file: string;
+    format: string;
+    fps: { num: number; den: number };
+    width?: number;
+    height?: number;
+    durationSeconds?: number;
+    totalFrames?: number;
+    /** On-disk size of the committed artifact. File outputs only. */
+    sizeBytes?: number;
+    /** sha256 of the committed artifact bytes. File outputs only. */
+    sha256?: string;
+    /** True when the artifact was encoded as HDR. */
+    hdr: boolean;
+    /** Video encoder facts; null for png-sequence and gif outputs. */
+    encoder: { codec: string; preset: string; pixelFormat: string } | null;
+  };
+  host: { platform: string; arch: string };
+}
+
+/**
+ * Resolve where the sidecar should be written, or `null` when disabled.
+ * The default sits beside the artifact so the receipt travels with it.
+ */
+export function resolveProvenanceSidecarPath(
+  outputPath: string,
+  provenance: ProvenanceSetting,
+): string | null {
+  if (provenance === false) return null;
+  if (typeof provenance === "string" && provenance.trim() !== "") {
+    return resolve(provenance);
+  }
+  // `resolve` also strips a trailing separator from png-sequence directory
+  // outputs so the sidecar lands NEXT TO the directory, not inside it.
+  return `${resolve(outputPath)}${RENDER_SIDECAR_SUFFIX}`;
+}
+
+/**
+ * Extract the `@font-face` family names from the compiled composition HTML.
+ * The producer's deterministic-font injector writes these blocks with plain
+ * `font-family: '<name>'` declarations, so a bounded scan is reliable for
+ * framework-compiled output. Returns sorted, de-duplicated names.
+ */
+export function collectFontFamilies(compiledHtml: string): string[] {
+  const families = new Set<string>();
+  const fontFace = /@font-face\s*\{[^}]*?font-family\s*:\s*(['"]?)([^'";}]+)\1/g;
+  for (const match of compiledHtml.matchAll(fontFace)) {
+    const family = match[2]?.trim();
+    if (family) families.add(family);
+  }
+  return [...families].sort();
+}
+
+/**
+ * Hash render-time variables into `{ count, sha256 }` — the receipt proves
+ * WHICH parametrization produced the output without disclosing the values
+ * (variables routinely carry user text or tokens). Canonical JSON (sorted
+ * keys) keeps the hash stable across property order.
+ */
+export function hashVariables(
+  variables: Record<string, unknown> | undefined,
+): { count: number; sha256: string } | null {
+  if (!variables || Object.keys(variables).length === 0) return null;
+  // JSON round-trip drops `undefined`-valued keys and non-JSON values the
+  // same way the render request boundary does, so direct RenderConfig
+  // callers hash identically to CLI callers.
+  const normalized: unknown = JSON.parse(JSON.stringify(variables));
+  return {
+    count: Object.keys(variables).length,
+    sha256: sha256Hex(canonicalJsonStringify(normalized)),
+  };
+}
+
+/** Streaming sha256 of a file — output artifacts can be large. */
+async function sha256File(path: string): Promise<string> {
+  const hash = createHash("sha256");
+  const stream = createReadStream(path);
+  for await (const chunk of stream) hash.update(chunk as Buffer);
+  return hash.digest("hex");
+}
+
+/**
+ * Cached first line of `ffmpeg -version`, probed via the engine's binary
+ * resolution (honors `HYPERFRAMES_FFMPEG_PATH`). Returns `undefined` when
+ * the probe fails — a missing version line must never fail a render that
+ * already committed its artifact.
+ */
+let cachedFfmpegVersionLine: string | undefined | null = null;
+async function readFfmpegVersionLine(): Promise<string | undefined> {
+  if (cachedFfmpegVersionLine !== null) return cachedFfmpegVersionLine;
+  try {
+    const { stdout } = await execFile(getFfmpegBinary(), ["-version"], {
+      maxBuffer: 1024 * 1024,
+      windowsHide: true,
+    });
+    const firstLine = stdout.split(/\r?\n/)[0]?.trim();
+    cachedFfmpegVersionLine = firstLine && firstLine.length > 0 ? firstLine : undefined;
+  } catch {
+    cachedFfmpegVersionLine = undefined;
+  }
+  return cachedFfmpegVersionLine;
+}
+
+export interface BuildRenderProvenanceSidecarInput {
+  jobId: string;
+  outcome: "completed" | "completed_with_warnings";
+  warningCodes: readonly string[];
+  totalElapsedMs: number;
+  stages: Record<string, number>;
+  workers?: number;
+  quality: "draft" | "standard" | "high";
+  producerVersion: string;
+  ffmpegVersion?: string;
+  entryFile: string;
+  entrySha256?: string;
+  compositionHash?: string;
+  fonts: readonly string[];
+  variables?: Record<string, unknown>;
+  outputPath: string;
+  format: string;
+  fps: Fps;
+  width?: number;
+  height?: number;
+  durationSeconds?: number;
+  totalFrames?: number;
+  outputSizeBytes?: number;
+  outputSha256?: string;
+  hdr: boolean;
+  encoder: { codec: string; preset: string; pixelFormat: string } | null;
+  /** Injectable for deterministic tests; defaults to the current time. */
+  createdAt?: string;
+}
+
+export function buildRenderProvenanceSidecar(
+  input: BuildRenderProvenanceSidecarInput,
+): RenderProvenanceSidecar {
+  return {
+    $schema: RENDER_SIDECAR_SCHEMA_URL,
+    schemaVersion: RENDER_SIDECAR_SCHEMA_VERSION,
+    kind: "hf-render-sidecar",
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    versions: {
+      producer: input.producerVersion,
+      node: process.version,
+      ...(input.ffmpegVersion !== undefined && { ffmpeg: input.ffmpegVersion }),
+    },
+    render: {
+      jobId: input.jobId,
+      outcome: input.outcome,
+      warningCodes: [...new Set(input.warningCodes)].sort(),
+      totalElapsedMs: input.totalElapsedMs,
+      stages: { ...input.stages },
+      ...(input.workers !== undefined && { workers: input.workers }),
+      quality: input.quality,
+    },
+    input: {
+      entryFile: input.entryFile,
+      ...(input.entrySha256 !== undefined && { entrySha256: input.entrySha256 }),
+      ...(input.compositionHash !== undefined && { compositionHash: input.compositionHash }),
+      fonts: [...input.fonts],
+      variables: hashVariables(input.variables),
+    },
+    output: {
+      file: basename(resolve(input.outputPath)),
+      format: input.format,
+      fps: { num: input.fps.num, den: input.fps.den },
+      ...(input.width !== undefined && { width: input.width }),
+      ...(input.height !== undefined && { height: input.height }),
+      ...(input.durationSeconds !== undefined && { durationSeconds: input.durationSeconds }),
+      ...(input.totalFrames !== undefined && { totalFrames: input.totalFrames }),
+      ...(input.outputSizeBytes !== undefined && { sizeBytes: input.outputSizeBytes }),
+      ...(input.outputSha256 !== undefined && { sha256: input.outputSha256 }),
+      hdr: input.hdr,
+      encoder: input.encoder,
+    },
+    host: { platform: process.platform, arch: process.arch },
+  };
+}
+
+/**
+ * Serialize + write the sidecar. Pretty-printed with a trailing newline so
+ * the receipt is diff-friendly in CI artifacts and shell-readable via `jq`.
+ */
+async function writeRenderProvenanceSidecar(
+  sidecarPath: string,
+  sidecar: RenderProvenanceSidecar,
+): Promise<void> {
+  await writeFile(sidecarPath, `${JSON.stringify(sidecar, null, 2)}\n`, "utf-8");
+}
+
+/**
+ * Orchestrator-facing fields for {@link emitRenderProvenanceSidecar} —
+ * everything the pipeline already holds at artifact-commit time, minus the
+ * facts the emitter derives itself (fonts, hashes, versions, output size).
+ */
+export interface EmitRenderProvenanceSidecarInput {
+  outputPath: string;
+  provenance: ProvenanceSetting;
+  /** False for png-sequence — directory artifacts skip size + sha256. */
+  isFileArtifact: boolean;
+  projectDir: string;
+  /** Project-relative entry HTML path (`RenderConfig.entryFile` default). */
+  entryFile: string;
+  /** Compiled composition HTML — scanned for `@font-face` families. */
+  compiledHtml: string;
+  jobId: string;
+  outcome: "completed" | "completed_with_warnings";
+  warningCodes: readonly string[];
+  totalElapsedMs: number;
+  stages: Record<string, number>;
+  workers?: number;
+  quality: "draft" | "standard" | "high";
+  compositionHash?: string;
+  variables?: Record<string, unknown>;
+  format: string;
+  fps: Fps;
+  width?: number;
+  height?: number;
+  durationSeconds?: number;
+  totalFrames?: number;
+  hdr: boolean;
+  encoder: { codec: string; preset: string; pixelFormat: string } | null;
+  log: ProducerLogger;
+}
+
+async function sha256FileOrUndefined(path: string): Promise<string | undefined> {
+  try {
+    return await sha256File(path);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Build and write the provenance sidecar for a committed render artifact.
+ * Returns the sidecar path, or `null` when disabled or when writing failed —
+ * the sidecar is a receipt, so a failure here logs a warning and never
+ * un-completes a render whose artifact already committed.
+ */
+export async function emitRenderProvenanceSidecar(
+  input: EmitRenderProvenanceSidecarInput,
+): Promise<string | null> {
+  const sidecarPath = resolveProvenanceSidecarPath(input.outputPath, input.provenance);
+  if (sidecarPath === null) return null;
+  try {
+    const outputStat = input.isFileArtifact
+      ? await stat(input.outputPath).catch(() => undefined)
+      : undefined;
+    const sidecar = buildRenderProvenanceSidecar({
+      jobId: input.jobId,
+      outcome: input.outcome,
+      warningCodes: input.warningCodes,
+      totalElapsedMs: input.totalElapsedMs,
+      stages: input.stages,
+      workers: input.workers,
+      quality: input.quality,
+      producerVersion: resolveProducerVersion(),
+      ffmpegVersion: await readFfmpegVersionLine(),
+      entryFile: input.entryFile,
+      entrySha256: await sha256FileOrUndefined(join(input.projectDir, input.entryFile)),
+      compositionHash: input.compositionHash,
+      fonts: collectFontFamilies(input.compiledHtml),
+      variables: input.variables,
+      outputPath: input.outputPath,
+      format: input.format,
+      fps: input.fps,
+      width: input.width,
+      height: input.height,
+      durationSeconds: input.durationSeconds,
+      totalFrames: input.totalFrames,
+      outputSizeBytes: outputStat?.size,
+      outputSha256: input.isFileArtifact
+        ? await sha256FileOrUndefined(input.outputPath)
+        : undefined,
+      hdr: input.hdr,
+      encoder: input.encoder,
+    });
+    await writeRenderProvenanceSidecar(sidecarPath, sidecar);
+    input.log.info("Render provenance sidecar written", { sidecarPath });
+    return sidecarPath;
+  } catch (error) {
+    input.log.warn("Failed to write render provenance sidecar", {
+      sidecarPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}

--- a/packages/producer/src/services/render/provenanceSidecar.ts
+++ b/packages/producer/src/services/render/provenanceSidecar.ts
@@ -29,7 +29,7 @@
 import { execFile as execFileCallback } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";
-import { stat, writeFile } from "node:fs/promises";
+import { open, rename, rm, stat } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { getFfmpegBinary } from "@hyperframes/engine";
@@ -292,12 +292,31 @@ export function buildRenderProvenanceSidecar(
 /**
  * Serialize + write the sidecar. Pretty-printed with a trailing newline so
  * the receipt is diff-friendly in CI artifacts and shell-readable via `jq`.
+ *
+ * Written atomically: the JSON goes to a sibling `.tmp` file in the SAME
+ * directory as the destination (never a shared, world-writable os.tmpdir()),
+ * is flushed, then renamed over the final path — readers can only ever
+ * observe a complete receipt, and no cross-device or symlink-swap window
+ * exists between write and publish.
  */
 async function writeRenderProvenanceSidecar(
   sidecarPath: string,
   sidecar: RenderProvenanceSidecar,
 ): Promise<void> {
-  await writeFile(sidecarPath, `${JSON.stringify(sidecar, null, 2)}\n`, "utf-8");
+  const tmpPath = `${sidecarPath}.tmp`;
+  const handle = await open(tmpPath, "w", 0o644);
+  try {
+    await handle.writeFile(`${JSON.stringify(sidecar, null, 2)}\n`, "utf-8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await rename(tmpPath, sidecarPath);
+  } catch (error) {
+    await rm(tmpPath, { force: true }).catch(() => {});
+    throw error;
+  }
 }
 
 /**

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -115,6 +115,7 @@ import { publishRenderFailure } from "./render/renderEventPublisher.js";
 import { EncoderInterruptedError } from "./render/encoderInterruption.js";
 import { RenderExecutionContext } from "./render/renderExecutionContext.js";
 import { ArtifactTransaction } from "./render/artifactTransaction.js";
+import { emitRenderProvenanceSidecar, type ProvenanceSetting } from "./render/provenanceSidecar.js";
 import {
   createCapturePlan,
   replanAfterFailure,
@@ -360,6 +361,14 @@ export interface RenderConfig {
    * HDR constraints.
    */
   outputResolution?: CanvasResolution;
+  /**
+   * Render provenance sidecar setting. `undefined` (default) writes the
+   * public receipt to `<outputPath>.hf-render.json` after a successful
+   * artifact commit; `false` disables it; a string sets a custom sidecar
+   * path. Populated by the CLI from `--provenance <path|false>` /
+   * `--no-provenance`. See `services/render/provenanceSidecar.ts`.
+   */
+  provenance?: ProvenanceSetting;
   /**
    * True when `outputResolution` was normalized from an aspect-agnostic alias
    * (`1080p`, `hd`, `4k`, `uhd`) rather than a preset that names its own
@@ -4044,6 +4053,41 @@ async function executeRenderPipeline(input: {
 
     await artifactTransaction.commit();
     job.outputPath = outputPath;
+
+    // Public provenance receipt beside the committed artifact (default on,
+    // `provenance: false` / `--no-provenance` disables). Emitted only after a
+    // successful commit; a sidecar write failure logs a warning and never
+    // un-completes the render.
+    await emitRenderProvenanceSidecar({
+      outputPath,
+      provenance: job.config.provenance,
+      isFileArtifact: !isPngSequence,
+      projectDir,
+      entryFile: job.config.entryFile ?? "index.html",
+      compiledHtml: compiled.html,
+      jobId: job.id,
+      outcome: job.warnings.length > 0 ? "completed_with_warnings" : "completed",
+      warningCodes: job.warnings.map((warning) => warning.code),
+      totalElapsedMs: totalElapsed,
+      stages: perfStages,
+      workers: workerCount,
+      quality: job.config.quality,
+      compositionHash,
+      variables: job.config.variables,
+      format: outputFormat,
+      fps: job.config.fps,
+      width: outputWidth,
+      height: outputHeight,
+      durationSeconds: composition.duration,
+      totalFrames,
+      hdr: !isPngSequence && !isGif && Boolean(preset.hdr),
+      encoder:
+        isPngSequence || isGif
+          ? null
+          : { codec: preset.codec, preset: preset.preset, pixelFormat: preset.pixelFormat },
+      log,
+    });
+
     updateJobStatus(job, "complete", "Render complete", 100, onProgress);
     await eventPublisher.flush();
   } catch (error) {


### PR DESCRIPTION
## What

Every successful render now writes a portable JSON receipt next to the output artifact: `out.mp4` gets `out.mp4.hf-render.json`. The sidecar records tool versions (producer / node / ffmpeg), the entry HTML sha256, the compiled-composition hash, `@font-face` families, a variables hash (count + sha256 of canonical JSON — never the raw values), format / exact-rational fps / resolution / duration / total frames, encoder facts (codec, preset, pixel format), the committed artifact's sha256 + size, per-stage wall-clock timings, worker count, HDR flag, outcome, and capture-readiness warning codes.

- **Default ON.** `--no-provenance` (or `--provenance false`) disables; `--provenance <path>` relocates the sidecar.
- **Batch mode:** each row writes its own `<row output>.hf-render.json` (verified: distinct variables hashes per row). A fixed custom path with `--batch` is rejected up front.
- **Docker mode:** the disable flag is forwarded into the container; the default sidecar lands next to the output in the mounted output directory. A custom host path with `--docker` is rejected up front (not container-visible).
- **JSON Schema** published at `packages/core/schemas/hf-render-sidecar.json` (`$id` `https://hyperframes.heygen.com/schema/hf-render-sidecar.json`); every emitted sidecar in testing validates against it (ajv, draft 2020-12).
- **Docs:** `docs/reference/render-provenance.mdx`, registered under the "Rendering paths" nav group.

## Why

Agents and CI need a machine-readable receipt beside the MP4 answering "what rendered this, from what inputs, and how" without re-running anything — reproducibility checks, cache keys, and support triage all want it. Today the closest thing (`runtimeEnvSnapshot`, `perfSummary`) is internal-only, and the engine's embedded container tags carry only renderer name + version. The sidecar complements those tags: full receipt, separate file, deliberately excluding secrets (variable **values** are hashed, no env dump, no host paths/usernames).

## How

- `packages/producer/src/services/render/provenanceSidecar.ts` — sidecar builder + emitter. Wired into `renderOrchestrator.ts` immediately after `artifactTransaction.commit()` (the actual commit site; there is no `stages/commitArtifact.ts` in the codebase). A sidecar write failure logs a warning and never un-completes a render whose artifact already committed.
- Reuses existing producer facts at the commit site: the compiled HTML (fonts scan), the observability composition hash, the encoder preset, `perfStages`, `workerCount`, and job warnings. Producer version prefers the bundler-injected `__PRODUCER_VERSION__` define (the CLI inlines the producer via `noExternal`, where the package-walking reader can't resolve) with the filesystem walker as the unbundled fallback; ffmpeg version is probed once via the engine's binary resolution (honors `HYPERFRAMES_FFMPEG_PATH`) and cached.
- Threading: `--provenance` flag → render plan (`parseProvenanceArg`, tri-state) → `RenderOptions` → `createRenderRequest` (validated: `false` or non-empty string) → `RenderConfig.provenance` → orchestrator. `dockerRunArgs` forwards `--no-provenance`.
- `png-sequence` directory outputs skip artifact sha256/size; `encoder` is `null` for `png-sequence`/`gif`.

## Test plan

- [x] Unit tests added/updated — `provenanceSidecar.test.ts` (19 tests: path resolution incl. directory outputs, font extraction, canonical variables hashing, receipt shape, secrets-not-embedded, emit integration incl. write-failure and unreadable-entry tolerance) and `render.provenance.test.ts` (12 tests: flag parsing, plan threading, batch/docker conflicts, docker arg forwarding). Full CLI suite: 3021 passed. Producer unit lane: green except `audioPadTrim.integration.test.ts`, which fails identically on unmodified `main` in this environment (host-ffmpeg loudness variance — pre-existing, unrelated).
- [x] Manual testing performed — real end-to-end renders with the branch CLI: single render (sidecar written, `output.sha256` matches `sha256sum` of the MP4), `--no-provenance` (no sidecar), `--provenance <path>` (relocated), `--batch` with 2 rows (one sidecar per row, distinct variables hashes), sidecars validated against the JSON Schema with ajv. `bun run build`, `tsc --noEmit` (producer + cli), oxlint/oxfmt, and the full lefthook pre-commit suite (incl. the fallow gate) all pass.
- [x] Documentation updated (if applicable) — `docs/reference/render-provenance.mdx` + `docs/docs.json`.

## Walkthrough (HyperFrames-rendered)

![HyperFrames walkthrough](https://raw.githubusercontent.com/mvanhorn/hyperframes/walkthrough-assets/render-provenance-walkthrough.gif)

<video src="https://raw.githubusercontent.com/mvanhorn/hyperframes/walkthrough-assets/render-provenance-walkthrough.mp4" controls width="100%"></video>

**MP4:** https://raw.githubusercontent.com/mvanhorn/hyperframes/walkthrough-assets/render-provenance-walkthrough.mp4

The demo was storyboarded first (script, beat sheet, and seam vector ledger — [`render-provenance-ce-plan.md`](https://github.com/mvanhorn/hyperframes/blob/walkthrough-assets/render-provenance-ce-plan.md)), built as a HyperFrames composition ([source](https://github.com/mvanhorn/hyperframes/blob/walkthrough-assets/render-provenance-composition.html)) that passed `hyperframes lint` and `hyperframes check` (0 errors, WCAG AA contrast), and rendered with:

```bash
node packages/cli/bin/hyperframes.mjs render /tmp/provenance-walkthrough --output walkthrough.mp4 --fps 30
```

**Self-proof:** that render exercised this PR's feature on itself. Its own receipt, [`render-provenance-walkthrough.mp4.hf-render.json`](https://github.com/mvanhorn/hyperframes/blob/walkthrough-assets/render-provenance-walkthrough.mp4.hf-render.json), records

```
"sha256": "6af87ebf6a630a417e64db98c6d6e05f50f3fa99dcc5063e3757ae3d4e8b8de1"
```

which is exactly `sha256sum` of the published MP4 above (verified after download from the public URL).

## AI disclosure

This PR — feature code, tests, schema, docs, the walkthrough storyboard, composition, and render — was authored end-to-end by an AI agent (Claude Fable 5, running as a Cursor Cloud Agent), with all repository gates (build, typecheck, lint/format, lefthook, targeted test suites) executed and passing before submission.

