### PR TITLE
fix(parsers): allow asset names beginning with two dots

### DIFF
--- a/packages/parsers/src/assetPaths.test.ts
+++ b/packages/parsers/src/assetPaths.test.ts
@@ -1,0 +1,38 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { isPathInside } from "./assetPaths.js";
+import { isWithinProjectRoot, resolveLocalAssetCandidates } from "./assetResolution.js";
+
+describe("asset path containment", () => {
+  const root = resolve("project");
+
+  it.each(["..intro.mp4", "..assets/clip.mp4", ".../clip.mp4"])(
+    "accepts an in-project path named %s",
+    (name) => {
+      const candidate = resolve(root, name);
+      expect(isPathInside(candidate, root)).toBe(true);
+      expect(isWithinProjectRoot(root, candidate)).toBe(true);
+      expect(resolveLocalAssetCandidates(root, name)).toEqual([candidate]);
+    },
+  );
+
+  it.each(["..", "../outside.mp4", "../project-sibling/clip.mp4"])(
+    "rejects a path outside the project: %s",
+    (name) => {
+      const candidate = resolve(root, name);
+      expect(isPathInside(candidate, root)).toBe(false);
+      expect(isWithinProjectRoot(root, candidate)).toBe(false);
+    },
+  );
+
+  it("keeps the existing project-root clamping for dot-prefixed asset names", () => {
+    expect(resolveLocalAssetCandidates(root, "../..assets/clip.mp4")).toEqual([
+      resolve(root, "..assets/clip.mp4"),
+    ]);
+  });
+
+  it("accepts the project root itself", () => {
+    expect(isPathInside(root, root)).toBe(true);
+    expect(isWithinProjectRoot(root, root)).toBe(true);
+  });
+});

--- a/packages/parsers/src/assetPaths.ts
+++ b/packages/parsers/src/assetPaths.ts
@@ -5,7 +5,7 @@
  * localizeExternalAssets (CLI publish).
  */
 
-import { isAbsolute, relative, resolve } from "node:path";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 
 /**
  * Regex matching CSS `url(...)` references — captures the quote style and the
@@ -41,5 +41,5 @@ export function isPathInside(childPath: string, parentPath: string): boolean {
   const absParent = resolve(parentPath);
   if (absChild === absParent) return true;
   const rel = relative(absParent, absChild);
-  return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+  return rel !== ".." && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
 }

--- a/packages/parsers/src/assetResolution.ts
+++ b/packages/parsers/src/assetResolution.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { isAbsolute, posix, relative, resolve } from "node:path";
+import { isAbsolute, posix, relative, resolve, sep } from "node:path";
 import { decodeUrlPathVariants } from "./composition.js";
 
 /**
@@ -118,7 +118,7 @@ export function cleanAssetUrl(url: string): string {
 export function isWithinProjectRoot(projectDir: string, candidate: string): boolean {
   const projectRoot = resolve(projectDir);
   const relativePath = relative(projectRoot, candidate);
-  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+  return relativePath !== ".." && !relativePath.startsWith(`..${sep}`) && !isAbsolute(relativePath);
 }
 
 function addCandidate(candidates: string[], candidate: string): void {
@@ -140,7 +140,7 @@ export function resolveLocalAssetCandidates(projectDir: string, url: string): st
 
     const normalized = posix.normalize(projectRelative.replace(/\\/g, "/"));
     const clamped = normalized.replace(/^(\.\.\/)+/, "");
-    if (clamped && !clamped.startsWith("..")) {
+    if (clamped && clamped !== ".." && !clamped.startsWith("../")) {
       addCandidate(candidates, resolve(projectRoot, clamped));
     }
   }


### PR DESCRIPTION
## What
Fix local asset resolution and containment checks for valid names beginning with two dots, such as `..intro.mp4` and `..assets/clip.mp4`.

## Why
The checks treated every relative path starting with `..` as traversal. As a result, local assets with these names were rejected even when they were inside the project. The candidate resolver returned no candidates, which can produce false missing-asset reports.

## How
Check for the complete parent-directory segment (`..` or `..` followed by the platform separator). Apply the same distinction to the existing POSIX-normalized root-clamping fallback. Actual parent and sibling paths remain outside the containment boundary.

## Test plan
- Added 8 regression cases covering dot-prefixed files/directories, parent/sibling rejection, root equality, and root-clamping behavior. Four cases failed before the fix.
- All 30 focused tests passed: `bun run --cwd packages/parsers test --configLoader runner src/assetPaths.test.ts src/assetResolution.test.ts src/rewriteSubCompPaths.test.ts`.
- Parser typecheck passed: `bun run --cwd packages/parsers typecheck`.
- oxlint, oxfmt, fallow audit, tracked-artifact, large-file, and commit-message checks passed.
- Full monorepo build passed: `bun run build`.
- The broader pre-commit typecheck commands passed after generating build artifacts: core, studio, and scripts TypeScript checks.
- Full parser suite after building: 935 passed, 2 failed, 4 skipped, 3 todo. Both failures are existing `ffBinaries.test.ts` Windows failures, reproduced against the original code (Windows exe preference and PATH fallback spy count).
