### PR TITLE
fix(lint): recognize supported timeline registration forms

### DIFF
--- a/packages/lint/src/rules/composition.test.ts
+++ b/packages/lint/src/rules/composition.test.ts
@@ -912,16 +912,39 @@ describe("composition rules", () => {
       expect(result.findings.find((f) => f.code === "missing_data_no_timeline")).toBeUndefined();
     });
 
-    it("does not warn when a script registers window.__timelines[id]", async () => {
+    it.each([
+      'window.__timelines["c1"] = gsap.timeline({ paused: true });',
+      "window.__timelines.c1 = gsap.timeline({ paused: true });",
+      "window.__timelines = { c1: gsap.timeline({ paused: true }) };",
+      'window.__timelines = { "c1": gsap.timeline({ paused: true }) };',
+      'const spec = { id: "c1" }; window.__timelines[spec.id] = gsap.timeline({ paused: true });',
+      'window.__timelines["c1"] ??= gsap.timeline({ paused: true });',
+      'window.__timelines["c1"] ||= gsap.timeline({ paused: true });',
+      'const ids = ["c1"]; window.__timelines[ids[0]] = gsap.timeline({ paused: true });',
+    ])("does not warn when a script registers a timeline: %s", async (registration) => {
       const html = `<!DOCTYPE html><html><body>
   <div data-composition-id="c1" data-width="320" data-height="180" data-duration="5"></div>
   <script>
     window.__timelines = window.__timelines || {};
-    window.__timelines["c1"] = gsap.timeline({ paused: true });
+    ${registration}
   </script>
 </body></html>`;
       const result = await lintHyperframeHtml(html);
       expect(result.findings.find((f) => f.code === "missing_data_no_timeline")).toBeUndefined();
+    });
+
+    it.each([
+      "window.__timelines = {};",
+      '// window.__timelines["c1"] = gsap.timeline({ paused: true });',
+    ])("still warns when a script does not register a timeline: %s", async (script) => {
+      const html = `<!DOCTYPE html><html><body>
+  <div data-composition-id="c1" data-width="320" data-height="180" data-duration="5"></div>
+  <script>${script}</script>
+</body></html>`;
+      const result = await lintHyperframeHtml(html);
+      expect(result.findings.find((f) => f.code === "missing_data_no_timeline")).toMatchObject({
+        severity: "warning",
+      });
     });
 
     it("does not warn when there is no root composition-id", async () => {

--- a/packages/lint/src/rules/composition.ts
+++ b/packages/lint/src/rules/composition.ts
@@ -8,6 +8,8 @@ import {
   stripJsComments,
   stripJsCode,
   truncateSnippet,
+  TIMELINE_REGISTRY_ASSIGN_PATTERN,
+  TIMELINE_REGISTRY_OBJECT_LITERAL_PATTERN,
   WINDOW_TIMELINE_ASSIGN_PATTERN,
 } from "../utils";
 import { COMPOSITION_VARIABLE_TYPES, isSafeMediaUrl } from "@hyperframes/parsers/composition";
@@ -631,7 +633,15 @@ export const compositionRules: Array<(ctx: LintContext) => HyperframeLintFinding
     // Can't scan external script files for timeline registration; skip to avoid
     // false positives on compositions that register via a bundled JS file.
     if (/<script\b[^>]*\bsrc\s*=/i.test(rawSource)) return [];
-    const registersTimeline = scripts.some((s) => s.content.includes("window.__timelines["));
+    const registersTimeline = scripts.some((script) => {
+      const source = stripJsComments(script.content);
+      return (
+        // Computed keys and logical assignments may not match the shared patterns.
+        source.includes("window.__timelines[") ||
+        TIMELINE_REGISTRY_ASSIGN_PATTERN.test(source) ||
+        TIMELINE_REGISTRY_OBJECT_LITERAL_PATTERN.test(source)
+      );
+    });
     if (registersTimeline) return [];
     return [
       {


### PR DESCRIPTION
## What

Stop warning that a composition has no timeline when it registers one with `window.__timelines.c1 = tl` or `window.__timelines = { c1: tl }`. Commented registrations no longer suppress the warning.

## Why

Those forms are already recognized by the core lint rule. The contradictory warning suggests adding `data-no-timeline` to a working composition.

## How

Reuse the existing registration patterns after stripping comments. Keep the conservative bracket check for computed keys and logical assignments.

## Test plan

- [x] Unit tests added/updated: all 615 lint tests pass with `bun run --filter @hyperframes/lint test -- --reporter=dot --maxWorkers=4`.
- [x] Manual testing performed: 12 checks against the built Node and browser entry points, executed in Node.
- [ ] Documentation updated (not applicable).

Oxlint, oxfmt, the lint package typecheck, and both package builds pass. Earlier runs hit the existing `stripJsStringLiterals scaling` timing assertion; it also failed on unchanged `e5d89f7`. The final full run passed.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required; this changes static lint diagnostics only.
