### PR TITLE
fix(lint): dedupe CSS transform text in gsap_css_transform_conflict

### DIFF
--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -565,6 +565,31 @@ describe("GSAP rules", () => {
     expect(conflicts[0]?.message).toMatch(/x\/scale|scale\/x/);
   });
 
+  it("does not duplicate the CSS transform text when one declaration matches both translate and scale", async () => {
+    const html = `
+<html><body>
+  <div id="root" data-composition-id="c1" data-width="1920" data-height="1080">
+    <div id="scene-1" class="scene-1">hi</div>
+  </div>
+  <style>
+    .scene-1 { transform: scale(1.08) translate3d(1.5%, 0, 0); }
+  </style>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    tl.to(".scene-1", { duration: 1, x: 100, scale: 1.2 });
+    window.__timelines["c1"] = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const conflict = result.findings.find((f) => f.code === "gsap_css_transform_conflict");
+    expect(conflict).toBeDefined();
+    const doubled = "scale(1.08) translate3d(1.5%, 0, 0) scale(1.08) translate3d(1.5%, 0, 0)";
+    expect(conflict?.message).not.toContain(doubled);
+    expect(conflict?.fixHint).not.toContain(doubled);
+    expect(conflict?.message).toContain("transform: scale(1.08) translate3d(1.5%, 0, 0)");
+  });
+
   // --- Inline style transform detection tests ---
 
   it("warns when inline style transform: translateX conflicts with GSAP x", async () => {

--- a/packages/lint/src/rules/gsap.ts
+++ b/packages/lint/src/rules/gsap.ts
@@ -1351,7 +1351,7 @@ export const gsapRules: LintRule<LintContext>[] = [
           scaleProps.length > 0 ? matchCssTransform(sel, cssScaleSelectors) : undefined;
         if (!cssFromTranslate && !cssFromScale) continue;
         const existing = conflicts.get(sel) ?? {
-          cssTransform: [cssFromTranslate, cssFromScale].filter(Boolean).join(" "),
+          cssTransform: [...new Set([cssFromTranslate, cssFromScale].filter(Boolean))].join(" "),
           props: new Set<string>(),
           raw: call.raw,
         };


### PR DESCRIPTION
## Summary

Fixes #3263. In the `gsap_css_transform_conflict` rule, `cssTransform` is built by joining `cssFromTranslate` and `cssFromScale`. When a single CSS declaration matches both the translate and scale selector maps (e.g. `transform: scale(1.08) translate3d(1.5%, 0, 0)`), both variables resolve to the same full-transform string, and `.join(" ")` concatenates the identical string with itself — doubling the text in both the finding `message` and `fixHint`.

## Fix

Deduplicate before joining, as suggested in the issue:

```js
cssTransform: [...new Set([cssFromTranslate, cssFromScale].filter(Boolean))].join(" ")
```

## Test plan

- [x] Added a failing regression test reproducing the issue's exact repro (combined `scale()`/`translate3d()` declaration), confirmed it failed before the fix
- [x] Applied the one-line fix, confirmed the new test and the full `@hyperframes/lint` suite pass (607/607)
- [x] `oxlint` and `oxfmt --check` clean on changed files