### PR TITLE
fix(engine): flag single-keyframe videos as sparse instead of skipping them

### DIFF
--- a/packages/engine/src/utils/ffprobe.test.ts
+++ b/packages/engine/src/utils/ffprobe.test.ts
@@ -931,6 +931,91 @@ describe("ffprobe option separator", () => {
   });
 });
 
+describe("analyzeKeyframeIntervals — single-keyframe videos", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("child_process");
+  });
+
+  it("treats a single keyframe spanning a long duration as problematic, not as a skip", async () => {
+    const { spawn } = createSpawnSpy([
+      // keyframe timestamp probe: one keyframe at t=0
+      { kind: "exit", code: 0, stdout: "0.000000\n" },
+      // duration probe (extractMediaMetadata), used to size the effective interval
+      {
+        kind: "exit",
+        code: 0,
+        stdout: JSON.stringify({
+          streams: [
+            {
+              codec_type: "video",
+              codec_name: "h264",
+              width: 640,
+              height: 360,
+              r_frame_rate: "30/1",
+              avg_frame_rate: "30/1",
+            },
+          ],
+          format: { duration: "10.0" },
+        }),
+      },
+    ]);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { analyzeKeyframeIntervals } = await import("./ffprobe.js");
+    const result = await analyzeKeyframeIntervals("/tmp/single-gop.mp4");
+
+    expect(result.keyframeCount).toBe(1);
+    expect(result.maxIntervalSeconds).toBe(10);
+    expect(result.avgIntervalSeconds).toBe(10);
+    expect(result.isProblematic).toBe(true);
+  });
+
+  it("does not flag a single keyframe on a short (still-image-like) asset", async () => {
+    const { spawn } = createSpawnSpy([
+      { kind: "exit", code: 0, stdout: "0.000000\n" },
+      {
+        kind: "exit",
+        code: 0,
+        stdout: JSON.stringify({
+          streams: [
+            {
+              codec_type: "video",
+              codec_name: "h264",
+              width: 640,
+              height: 360,
+              r_frame_rate: "30/1",
+              avg_frame_rate: "30/1",
+            },
+          ],
+          format: { duration: "1.0" },
+        }),
+      },
+    ]);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { analyzeKeyframeIntervals } = await import("./ffprobe.js");
+    const result = await analyzeKeyframeIntervals("/tmp/short-single-gop.mp4");
+
+    expect(result.keyframeCount).toBe(1);
+    expect(result.isProblematic).toBe(false);
+  });
+
+  it("still reports zero keyframes as non-problematic", async () => {
+    const { spawn } = createSpawnSpy([{ kind: "exit", code: 0, stdout: "" }]);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { analyzeKeyframeIntervals } = await import("./ffprobe.js");
+    const result = await analyzeKeyframeIntervals("/tmp/no-keyframes.mp4");
+
+    expect(result.keyframeCount).toBe(0);
+    expect(result.isProblematic).toBe(false);
+  });
+});
+
 describe("parseFrameRate", () => {
   // Direct against the exported function. The previous table drove this
   // through extractMediaMetadata behind a spawn mock, which cost a

--- a/packages/engine/src/utils/ffprobe.ts
+++ b/packages/engine/src/utils/ffprobe.ts
@@ -1050,11 +1050,25 @@ async function analyzeKeyframeIntervalsUncached(filePath: string): Promise<Keyfr
     .map((line) => parseFloat(line.trim()))
     .filter((t) => Number.isFinite(t));
 
-  if (timestamps.length < 2) {
+  if (timestamps.length === 1) {
+    // A single keyframe means every seek past 0 lands inside one GOP
+    // spanning the whole file — the effective interval is the stream
+    // duration, not zero. Still images and single-frame assets stay
+    // unproblematic because their duration is at or below the threshold.
+    const { durationSeconds } = await extractMediaMetadata(filePath);
+    return {
+      avgIntervalSeconds: durationSeconds,
+      maxIntervalSeconds: durationSeconds,
+      keyframeCount: 1,
+      isProblematic: durationSeconds > 2,
+    };
+  }
+
+  if (timestamps.length === 0) {
     return {
       avgIntervalSeconds: 0,
       maxIntervalSeconds: 0,
-      keyframeCount: timestamps.length,
+      keyframeCount: 0,
       isProblematic: false,
     };
   }


### PR DESCRIPTION
## Summary

Fixes #3460. `analyzeKeyframeIntervals` returned `isProblematic: false` whenever a video had fewer than two keyframes, treating a single-GOP video the same as a still image. But a video with exactly one keyframe is the *worst* case for the failure mode the check exists to catch: every seek past 0 lands inside a single GOP spanning the whole file. A 10s single-GOP video went unreported while a video with a 5s max interval triggered the warning.

## Fix

When exactly one keyframe is found, the effective interval is now the stream duration (fetched via the already-available `extractMediaMetadata`), not zero — matching the fix suggested in the issue. Still images and single-frame assets keep their current (non-problematic) behavior, since their duration is at or below the 2s threshold. Zero-keyframe handling is unchanged.

## Test plan

- [x] Added regression tests to `packages/engine/src/utils/ffprobe.test.ts` covering: a long-duration single keyframe (now flagged problematic), a short single keyframe (still not flagged), and zero keyframes (unchanged, not flagged) — confirmed the long-duration case failed before the fix
- [x] Full `@hyperframes/engine` suite passes (1641/1641)
- [x] `oxlint` and `oxfmt --check` clean on changed files

Note: the issue also raises a "side note" about whether the warning targets `render`'s decode path at all, based on the reporter's own frame-accuracy measurements — that's a separate scoping question I've left alone; this PR only fixes the single-keyframe detection gap.