### PR TITLE
feat(registry): add pendulum-swing component

### DIFF
--- a/docs/catalog/components/pendulum-swing.mdx
+++ b/docs/catalog/components/pendulum-swing.mdx
@@ -1,0 +1,189 @@
+---
+title: "Pendulum Swing"
+description: "Content hangs from a fixed pivot and swings into rest with gravity-damped oscillation, like a hanging sign settling on its hook."
+---
+
+import { InstallCommand } from "/snippets/install-command.jsx";
+
+<video className="w-full aspect-video rounded-xl object-cover bg-zinc-100 dark:bg-zinc-800" src="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/pendulum-swing.mp4" poster="https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/pendulum-swing.png" autoPlay muted loop playsInline />
+
+## Install
+
+<InstallCommand command="npx hyperframes add pendulum-swing" item="pendulum-swing" />
+
+That writes one file: `compositions/components/pendulum-swing.html`.
+
+## Paste it into your composition
+
+Open `compositions/components/pendulum-swing.html` and copy what is inside into your own composition.
+The file opens with a comment header that walks you through it.
+
+A component has no size or duration of its own. It takes both from the composition
+you paste it into.
+
+## Variables
+
+Every one of these has a default, so the piece works untouched. Set the ones you
+want to change on the element:
+
+| Variable | Default | Accepts | What it does |
+| --- | --- | --- | --- |
+| `pivot` | `top-center` | `top-center`, `top-left`, `top-right` | Where the content hangs from. The swing rotates about this point, so the top edge stays pinned. |
+| `amplitude` | `standard` | `gentle`, `standard`, `wide` | How far the first swing reaches before it settles. Every later swing scales with it, so the pendulum still comes to rest upright. |
+| `direction` | `right` | `right`, `left` | Which side the pendulum swings in from: right lifts the first swing clockwise, left mirrors it. |
+| `tone` | `ink` | `ink`, `paper`, `accent` | Content colour: ink for light frames, paper for dark ones, accent rides --brand. |
+
+Set them with `data-variable-values` on the element that mounts it. These are the
+defaults, so this behaves exactly like the preview above until you change one:
+
+```html wrap
+<div
+  data-composition-id="pendulum-swing"
+  data-composition-src="compositions/components/pendulum-swing.html"
+  data-variable-values='{"pivot":"top-center","amplitude":"standard","direction":"right","tone":"ink"}'
+></div>
+```
+
+## Source
+
+<Accordion title={`pendulum-swing.html`}>
+
+```html
+<!--
+  Pendulum Swing - motion primitive for HyperFrames.
+
+  Paste the markup, CSS and script into a composition. Drive the timeline
+  integration from a paused GSAP timeline so renders remain deterministic.
+
+  Variables. The script reads each one, falls back to the declared default on
+  anything missing or unrecognised, and writes the result as a custom property
+  the CSS below consumes. The timeline recipe stays untouched by them: it keeps
+  easing one unitless swing value from 1 down to 0, and these decide where the
+  content hangs from, how far the first swing reaches, which way it enters and
+  what colour it is.
+
+    - pivot (top-center | top-left | top-right, default top-center): where the
+      content hangs from. The swing rotates about this point, so the pinned top
+      edge never drifts.
+    - amplitude (gentle | standard | wide, default standard): how far the first
+      swing reaches, 18deg, 34deg or 52deg. Every later swing scales with it, so
+      whatever the reach the pendulum still comes to rest upright.
+    - direction (right | left, default right): which side the pendulum swings in
+      from. right lifts the first swing clockwise, left mirrors it.
+    - tone (ink | paper | accent, default ink): content colour. ink is
+      near-black for light frames, paper near-white for dark ones, accent rides
+      --brand.
+
+  On every default the result is identical to the original: a near-black sign
+  hanging from its top centre, entering from the right through a 34deg swing.
+
+  Motion note. The swing is one rotation about the pivot, animated through a
+  single unitless custom property (--hf-swing-angle). Rotation interpolates
+  sub-pixel and stays smooth under the seek-by-frame capture engine; nothing
+  here animates a layout or reflow property.
+-->
+
+<div
+  class="hf-catalog-pendulum-swing"
+  data-composition-variables='[
+    { "id": "pivot", "type": "enum", "role": "layout", "label": "Pivot", "description": "Where the content hangs from. The swing rotates about this point, so the top edge stays pinned.", "default": "top-center", "options": [{ "value": "top-center", "label": "Top center" }, { "value": "top-left", "label": "Top left" }, { "value": "top-right", "label": "Top right" }] },
+    { "id": "amplitude", "type": "enum", "role": "motion", "label": "Amplitude", "description": "How far the first swing reaches before it settles. Every later swing scales with it, so the pendulum still comes to rest upright.", "default": "standard", "options": [{ "value": "gentle", "label": "Gentle" }, { "value": "standard", "label": "Standard" }, { "value": "wide", "label": "Wide" }] },
+    { "id": "direction", "type": "enum", "role": "motion", "label": "Direction", "description": "Which side the pendulum swings in from: right lifts the first swing clockwise, left mirrors it.", "default": "right", "options": [{ "value": "right", "label": "Right" }, { "value": "left", "label": "Left" }] },
+    { "id": "tone", "type": "enum", "role": "style", "label": "Tone", "description": "Content colour: ink for light frames, paper for dark ones, accent rides --brand.", "default": "ink", "options": [{ "value": "ink", "label": "Ink" }, { "value": "paper", "label": "Paper" }, { "value": "accent", "label": "Accent" }] }
+  ]'
+>
+  <span class="hf-catalog-pendulum-swing__body">Hanging&nbsp;Sign</span>
+</div>
+
+<style>
+  .hf-catalog-pendulum-swing {
+    display: inline-block;
+    /* The pendulum is one rotation about the hanging pivot. The angle stays a
+       unitless factor so the timeline can ease it 1 -> 0 while amplitude and
+       direction, set once from the variables, decide the reach and the side. */
+    transform-origin: var(--hf-swing-origin, 50% 0%);
+    transform: rotate(
+      calc(
+        var(--hf-swing-angle, 0) * var(--hf-swing-dir, 1) *
+          var(--hf-swing-max, 34deg)
+      )
+    );
+  }
+  .hf-catalog-pendulum-swing__body {
+    display: inline-block;
+    padding: 22px 40px;
+    border-radius: 14px;
+    /* Tone sets a background/foreground pair so the sign stays legible whatever
+       the frame: the fill is the tone colour, the text its paired contrast. */
+    background: var(--hf-swing-bg, #18181b);
+    color: var(--hf-swing-fg, #fafafa);
+    font-family: Inter, system-ui, sans-serif;
+    font-weight: 800;
+    font-size: 54px;
+    letter-spacing: -0.02em;
+    white-space: nowrap;
+  }
+</style>
+
+<script>
+  (function () {
+    "use strict";
+
+    var vars =
+      window.__hyperframes && window.__hyperframes.getVariables
+        ? window.__hyperframes.getVariables()
+        : {};
+
+    // Unrecognised overrides return to their declared defaults.
+    function pick(table, value, fallback) {
+      return Object.prototype.hasOwnProperty.call(table, value) ? value : fallback;
+    }
+
+    var pivots = {
+      "top-center": "50% 0%",
+      "top-left": "0% 0%",
+      "top-right": "100% 0%",
+    };
+    var amplitudes = { gentle: "18deg", standard: "34deg", wide: "52deg" };
+    var directions = { right: 1, left: -1 };
+    // Each tone is a fill/text pair so the sign keeps AA contrast on any frame.
+    var tones = {
+      ink: { bg: "#18181b", fg: "#fafafa" },
+      paper: { bg: "#fafafa", fg: "#18181b" },
+      accent: { bg: "var(--brand, #34d399)", fg: "#0b0b0c" },
+    };
+
+    var origin = pivots[pick(pivots, vars.pivot, "top-center")];
+    var maxAngle = amplitudes[pick(amplitudes, vars.amplitude, "standard")];
+    var dir = directions[pick(directions, vars.direction, "right")];
+    var tone = tones[pick(tones, vars.tone, "ink")];
+
+    var roots = document.querySelectorAll(".hf-catalog-pendulum-swing");
+    for (var i = 0; i < roots.length; i += 1) {
+      var root = roots[i];
+      root.style.setProperty("--hf-swing-origin", origin);
+      root.style.setProperty("--hf-swing-max", maxAngle);
+      root.style.setProperty("--hf-swing-dir", String(dir));
+      root.style.setProperty("--hf-swing-bg", tone.bg);
+      root.style.setProperty("--hf-swing-fg", tone.fg);
+    }
+  })();
+</script>
+
+<!--
+  Timeline integration:
+  tl.fromTo('.hf-catalog-pendulum-swing', { '--hf-swing-angle': 1 }, { '--hf-swing-angle': 0, duration: 2.6, ease: 'elastic.out(1, 0.35)' }, startTime);
+-->
+```
+
+</Accordion>
+
+{/* hf:generated-footer */}
+
+Tagged `motion-primitive` `physics` `swing` `settle` `reveal`.
+
+## Related topics
+
+- [Browse the complete Catalog](/catalog)
+- [Add assets and Catalog items in Studio](/studio/assets-and-blocks)
+- [Build a richer composition](/go-further)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -571,6 +571,7 @@
                   "catalog/components/outline-draw",
                   "catalog/components/oversized-cursor",
                   "catalog/components/particle-image-reveal",
+                  "catalog/components/pendulum-swing",
                   "catalog/components/physical-exit",
                   "catalog/components/radial-surround",
                   "catalog/components/scroll-feed",

--- a/docs/public/catalog-index.json
+++ b/docs/public/catalog-index.json
@@ -3407,6 +3407,21 @@
     "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/particle-text-dissolve.png"
   },
   {
+    "name": "pendulum-swing",
+    "type": "component",
+    "title": "Pendulum Swing",
+    "description": "Content hangs from a fixed pivot and swings into rest with gravity-damped oscillation, like a hanging sign settling on its hook.",
+    "tags": [
+      "motion-primitive",
+      "physics",
+      "swing",
+      "settle",
+      "reveal"
+    ],
+    "href": "/catalog/components/pendulum-swing",
+    "preview": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/pendulum-swing.png"
+  },
+  {
     "name": "per-word-crossfade",
     "type": "component",
     "title": "Per-Word Crossfade",

--- a/registry/components/pendulum-swing/demo.html
+++ b/registry/components/pendulum-swing/demo.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1920, height=1080" />
+    <title>Pendulum Swing - Demo</title>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        width: 1920px;
+        height: 1080px;
+        overflow: hidden;
+      }
+      #demo {
+        width: 1920px;
+        height: 1080px;
+        display: grid;
+        place-items: center;
+        background: #f7f7f8;
+        font-family: Inter, system-ui, sans-serif;
+      }
+      .demo-frame {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 40px;
+        /* ponytail: scale on non-GSAP wrapper — safe, GSAP only animates
+           --hf-swing-angle on the pendulum root below. */
+        transform: scale(1.4);
+        transform-origin: center center;
+      }
+      /* The hook the sign hangs from, drawn above the pivot for context. */
+      .swing-rig {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+      .swing-hook {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: #a1a1aa;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+      }
+      .swing-label {
+        margin-top: 8px;
+        font-size: 11px;
+        font-weight: 500;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #71717a;
+      }
+      .hf-catalog-pendulum-swing {
+        display: inline-block;
+        transform-origin: var(--hf-swing-origin, 50% 0%);
+        transform: rotate(
+          calc(
+            var(--hf-swing-angle, 0) * var(--hf-swing-dir, 1) *
+              var(--hf-swing-max, 34deg)
+          )
+        );
+      }
+      .hf-catalog-pendulum-swing__body {
+        display: inline-block;
+        padding: 22px 40px;
+        border-radius: 14px;
+        background: var(--hf-swing-bg, #18181b);
+        color: var(--hf-swing-fg, #fafafa);
+        font-family: Inter, system-ui, sans-serif;
+        font-weight: 800;
+        font-size: 54px;
+        letter-spacing: -0.02em;
+        white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="demo"
+      data-composition-id="pendulum-swing-demo"
+      data-start="0"
+      data-width="1920"
+      data-height="1080"
+      data-duration="5"
+    >
+      <div class="demo-frame">
+        <div class="swing-label">Pendulum Swing</div>
+        <div class="swing-rig">
+          <div class="swing-hook"></div>
+          <div
+            class="hf-catalog-pendulum-swing"
+            data-composition-variables='[
+    { "id": "pivot", "type": "enum", "role": "layout", "label": "Pivot", "description": "Where the content hangs from. The swing rotates about this point, so the top edge stays pinned.", "default": "top-center", "options": [{ "value": "top-center", "label": "Top center" }, { "value": "top-left", "label": "Top left" }, { "value": "top-right", "label": "Top right" }] },
+    { "id": "amplitude", "type": "enum", "role": "motion", "label": "Amplitude", "description": "How far the first swing reaches before it settles. Every later swing scales with it, so the pendulum still comes to rest upright.", "default": "standard", "options": [{ "value": "gentle", "label": "Gentle" }, { "value": "standard", "label": "Standard" }, { "value": "wide", "label": "Wide" }] },
+    { "id": "direction", "type": "enum", "role": "motion", "label": "Direction", "description": "Which side the pendulum swings in from: right lifts the first swing clockwise, left mirrors it.", "default": "right", "options": [{ "value": "right", "label": "Right" }, { "value": "left", "label": "Left" }] },
+    { "id": "tone", "type": "enum", "role": "style", "label": "Tone", "description": "Content colour: ink for light frames, paper for dark ones, accent rides --brand.", "default": "ink", "options": [{ "value": "ink", "label": "Ink" }, { "value": "paper", "label": "Paper" }, { "value": "accent", "label": "Accent" }] }
+  ]'
+          >
+            <span class="hf-catalog-pendulum-swing__body">Hanging&nbsp;Sign</span>
+          </div>
+        </div>
+      </div>
+      <script>
+        (function () {
+          "use strict";
+
+          var vars =
+            window.__hyperframes && window.__hyperframes.getVariables
+              ? window.__hyperframes.getVariables()
+              : {};
+
+          // Unrecognised overrides return to their declared defaults.
+          function pick(table, value, fallback) {
+            return Object.prototype.hasOwnProperty.call(table, value) ? value : fallback;
+          }
+
+          var pivots = {
+            "top-center": "50% 0%",
+            "top-left": "0% 0%",
+            "top-right": "100% 0%",
+          };
+          var amplitudes = { gentle: "18deg", standard: "34deg", wide: "52deg" };
+          var directions = { right: 1, left: -1 };
+          // Each tone is a fill/text pair so the sign keeps AA contrast.
+          var tones = {
+            ink: { bg: "#18181b", fg: "#fafafa" },
+            paper: { bg: "#fafafa", fg: "#18181b" },
+            accent: { bg: "var(--brand, #34d399)", fg: "#0b0b0c" },
+          };
+
+          var origin = pivots[pick(pivots, vars.pivot, "top-center")];
+          var maxAngle = amplitudes[pick(amplitudes, vars.amplitude, "standard")];
+          var dir = directions[pick(directions, vars.direction, "right")];
+          var tone = tones[pick(tones, vars.tone, "ink")];
+
+          var roots = document.querySelectorAll(".hf-catalog-pendulum-swing");
+          for (var i = 0; i < roots.length; i += 1) {
+            var root = roots[i];
+            root.style.setProperty("--hf-swing-origin", origin);
+            root.style.setProperty("--hf-swing-max", maxAngle);
+            root.style.setProperty("--hf-swing-dir", String(dir));
+            root.style.setProperty("--hf-swing-bg", tone.bg);
+            root.style.setProperty("--hf-swing-fg", tone.fg);
+          }
+        })();
+      </script>
+      <script>
+        const tl = gsap.timeline({ paused: true });
+        const startTime = 0.4;
+        // A pendulum does not snap upright in a single overshoot; it swings
+        // through the rest point several times, each pass smaller, until
+        // friction stills it. This ease is that motion: a cosine (the swings)
+        // inside an exponential decay (the damping). It is normalised so the
+        // tween still lands exactly upright (angle 0) at the end, and rotation
+        // stays sub-pixel under the seek-by-frame capture engine.
+        const swingSettle = (p) =>
+          1 - Math.exp(-2.3 * p) * Math.cos(3.5 * Math.PI * p);
+        tl.fromTo(
+          ".hf-catalog-pendulum-swing",
+          { "--hf-swing-angle": 1 },
+          {
+            "--hf-swing-angle": 0,
+            duration: 2.9,
+            ease: swingSettle,
+          },
+          startTime,
+        );
+        tl.set({}, {}, 5);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["pendulum-swing-demo"] = tl;
+      </script>
+    </div>
+  </body>
+</html>

--- a/registry/components/pendulum-swing/pendulum-swing.html
+++ b/registry/components/pendulum-swing/pendulum-swing.html
@@ -1,0 +1,133 @@
+<!--
+  Pendulum Swing - motion primitive for HyperFrames.
+
+  Paste the markup, CSS and script into a composition. Drive the timeline
+  integration from a paused GSAP timeline so renders remain deterministic.
+
+  Variables. The script reads each one, falls back to the declared default on
+  anything missing or unrecognised, and writes the result as a custom property
+  the CSS below consumes. The timeline recipe stays untouched by them: it keeps
+  easing one unitless swing value from 1 down to 0, and these decide where the
+  content hangs from, how far the first swing reaches, which way it enters and
+  what colour it is.
+
+    - pivot (top-center | top-left | top-right, default top-center): where the
+      content hangs from. The swing rotates about this point, so the pinned top
+      edge never drifts.
+    - amplitude (gentle | standard | wide, default standard): how far the first
+      swing reaches, 18deg, 34deg or 52deg. Every later swing scales with it, so
+      whatever the reach the pendulum still comes to rest upright.
+    - direction (right | left, default right): which side the pendulum swings in
+      from. right lifts the first swing clockwise, left mirrors it.
+    - tone (ink | paper | accent, default ink): content colour. ink is
+      near-black for light frames, paper near-white for dark ones, accent rides
+      --brand.
+
+  On every default the result is identical to the original: a near-black sign
+  hanging from its top centre, entering from the right through a 34deg swing.
+
+  Motion note. The swing is a damped oscillation about the pivot: the content
+  passes through upright several times, each pass smaller, until it settles.
+  It rides a single unitless custom property (--hf-swing-angle) that the recipe
+  eases 1 -> 0, so rotation interpolates sub-pixel and stays smooth under the
+  seek-by-frame capture engine; nothing here animates a layout or reflow
+  property.
+-->
+
+<div
+  class="hf-catalog-pendulum-swing"
+  data-composition-variables='[
+    { "id": "pivot", "type": "enum", "role": "layout", "label": "Pivot", "description": "Where the content hangs from. The swing rotates about this point, so the top edge stays pinned.", "default": "top-center", "options": [{ "value": "top-center", "label": "Top center" }, { "value": "top-left", "label": "Top left" }, { "value": "top-right", "label": "Top right" }] },
+    { "id": "amplitude", "type": "enum", "role": "motion", "label": "Amplitude", "description": "How far the first swing reaches before it settles. Every later swing scales with it, so the pendulum still comes to rest upright.", "default": "standard", "options": [{ "value": "gentle", "label": "Gentle" }, { "value": "standard", "label": "Standard" }, { "value": "wide", "label": "Wide" }] },
+    { "id": "direction", "type": "enum", "role": "motion", "label": "Direction", "description": "Which side the pendulum swings in from: right lifts the first swing clockwise, left mirrors it.", "default": "right", "options": [{ "value": "right", "label": "Right" }, { "value": "left", "label": "Left" }] },
+    { "id": "tone", "type": "enum", "role": "style", "label": "Tone", "description": "Content colour: ink for light frames, paper for dark ones, accent rides --brand.", "default": "ink", "options": [{ "value": "ink", "label": "Ink" }, { "value": "paper", "label": "Paper" }, { "value": "accent", "label": "Accent" }] }
+  ]'
+>
+  <span class="hf-catalog-pendulum-swing__body">Hanging&nbsp;Sign</span>
+</div>
+
+<style>
+  .hf-catalog-pendulum-swing {
+    display: inline-block;
+    /* The pendulum swings about the hanging pivot. The angle stays a unitless
+       factor so the timeline can ease it 1 -> 0 (a damped oscillation through
+       upright) while amplitude and direction, set once from the variables,
+       decide the reach and the side. */
+    transform-origin: var(--hf-swing-origin, 50% 0%);
+    transform: rotate(
+      calc(
+        var(--hf-swing-angle, 0) * var(--hf-swing-dir, 1) *
+          var(--hf-swing-max, 34deg)
+      )
+    );
+  }
+  .hf-catalog-pendulum-swing__body {
+    display: inline-block;
+    padding: 22px 40px;
+    border-radius: 14px;
+    /* Tone sets a background/foreground pair so the sign stays legible whatever
+       the frame: the fill is the tone colour, the text its paired contrast. */
+    background: var(--hf-swing-bg, #18181b);
+    color: var(--hf-swing-fg, #fafafa);
+    font-family: Inter, system-ui, sans-serif;
+    font-weight: 800;
+    font-size: 54px;
+    letter-spacing: -0.02em;
+    white-space: nowrap;
+  }
+</style>
+
+<script>
+  (function () {
+    "use strict";
+
+    var vars =
+      window.__hyperframes && window.__hyperframes.getVariables
+        ? window.__hyperframes.getVariables()
+        : {};
+
+    // Unrecognised overrides return to their declared defaults.
+    function pick(table, value, fallback) {
+      return Object.prototype.hasOwnProperty.call(table, value) ? value : fallback;
+    }
+
+    var pivots = {
+      "top-center": "50% 0%",
+      "top-left": "0% 0%",
+      "top-right": "100% 0%",
+    };
+    var amplitudes = { gentle: "18deg", standard: "34deg", wide: "52deg" };
+    var directions = { right: 1, left: -1 };
+    // Each tone is a fill/text pair so the sign keeps AA contrast on any frame.
+    var tones = {
+      ink: { bg: "#18181b", fg: "#fafafa" },
+      paper: { bg: "#fafafa", fg: "#18181b" },
+      accent: { bg: "var(--brand, #34d399)", fg: "#0b0b0c" },
+    };
+
+    var origin = pivots[pick(pivots, vars.pivot, "top-center")];
+    var maxAngle = amplitudes[pick(amplitudes, vars.amplitude, "standard")];
+    var dir = directions[pick(directions, vars.direction, "right")];
+    var tone = tones[pick(tones, vars.tone, "ink")];
+
+    var roots = document.querySelectorAll(".hf-catalog-pendulum-swing");
+    for (var i = 0; i < roots.length; i += 1) {
+      var root = roots[i];
+      root.style.setProperty("--hf-swing-origin", origin);
+      root.style.setProperty("--hf-swing-max", maxAngle);
+      root.style.setProperty("--hf-swing-dir", String(dir));
+      root.style.setProperty("--hf-swing-bg", tone.bg);
+      root.style.setProperty("--hf-swing-fg", tone.fg);
+    }
+  })();
+</script>
+
+<!--
+  Timeline integration. The swing settles like a real pendulum: it passes
+  through upright several times, each pass smaller, until it comes to rest. That
+  is a cosine (the swings) inside an exponential decay (the damping), normalised
+  so the tween still lands exactly upright at the end.
+
+    const swingSettle = (p) => 1 - Math.exp(-2.3 * p) * Math.cos(3.5 * Math.PI * p);
+    tl.fromTo('.hf-catalog-pendulum-swing', { '--hf-swing-angle': 1 }, { '--hf-swing-angle': 0, duration: 2.9, ease: swingSettle }, startTime);
+-->

--- a/registry/components/pendulum-swing/registry-item.json
+++ b/registry/components/pendulum-swing/registry-item.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "pendulum-swing",
+  "type": "hyperframes:component",
+  "title": "Pendulum Swing",
+  "description": "Content hangs from a fixed pivot and swings into rest with gravity-damped oscillation, like a hanging sign settling on its hook.",
+  "tags": ["motion-primitive", "physics", "swing", "settle", "reveal"],
+  "files": [
+    {
+      "path": "pendulum-swing.html",
+      "target": "compositions/components/pendulum-swing.html",
+      "type": "hyperframes:snippet"
+    }
+  ],
+  "variables": [
+    {
+      "id": "pivot",
+      "type": "enum",
+      "role": "layout",
+      "label": "Pivot",
+      "description": "Where the content hangs from. The swing rotates about this point, so the top edge stays pinned.",
+      "default": "top-center",
+      "options": [
+        { "value": "top-center", "label": "Top center" },
+        { "value": "top-left", "label": "Top left" },
+        { "value": "top-right", "label": "Top right" }
+      ]
+    },
+    {
+      "id": "amplitude",
+      "type": "enum",
+      "role": "motion",
+      "label": "Amplitude",
+      "description": "How far the first swing reaches before it settles. Every later swing scales with it, so the pendulum still comes to rest upright.",
+      "default": "standard",
+      "options": [
+        { "value": "gentle", "label": "Gentle" },
+        { "value": "standard", "label": "Standard" },
+        { "value": "wide", "label": "Wide" }
+      ]
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "motion",
+      "label": "Direction",
+      "description": "Which side the pendulum swings in from: right lifts the first swing clockwise, left mirrors it.",
+      "default": "right",
+      "options": [
+        { "value": "right", "label": "Right" },
+        { "value": "left", "label": "Left" }
+      ]
+    },
+    {
+      "id": "tone",
+      "type": "enum",
+      "role": "style",
+      "label": "Tone",
+      "description": "Content colour: ink for light frames, paper for dark ones, accent rides --brand.",
+      "default": "ink",
+      "options": [
+        { "value": "ink", "label": "Ink" },
+        { "value": "paper", "label": "Paper" },
+        { "value": "accent", "label": "Accent" }
+      ]
+    }
+  ],
+  "preview": {
+    "poster": "https://static.heygen.ai/hyperframes-oss/docs/images/catalog/components/pendulum-swing.png"
+  }
+}

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -1172,6 +1172,10 @@
       "type": "hyperframes:component"
     },
     {
+      "name": "pendulum-swing",
+      "type": "hyperframes:component"
+    },
+    {
       "name": "per-word-crossfade",
       "type": "hyperframes:component"
     },


### PR DESCRIPTION
## What

Add a new registry **component**, `pendulum-swing`: a motion primitive that hangs content from a fixed pivot and lets it settle with a damped oscillation, like a hanging sign coming to rest on its hook.

## Why

The catalog has plenty of "arrive" primitives (slam, pop, slide, dissolve) but none that reads as a physical *hanging* object settling. `pendulum-swing` fills that gap with a small, composable primitive that pins a top edge and swings the content in.

## How

- **Recipe-only snippet.** `pendulum-swing.html` owns no timeline. It reads its variables, writes CSS custom props, and rotates about a `transform-origin` pinned to the pivot. All motion rides a single unitless custom property `--hf-swing-angle` that the host timeline eases `1 → 0`, so only `transform: rotate()` animates — sub-pixel, no layout/reflow property, safe under the seek-by-frame capture engine.
- **Damped-oscillation ease.** The demo drives the swing with `1 - exp(-2.3·p)·cos(3.5π·p)` — a cosine (the swings) inside an exponential decay (the damping), normalised so the tween lands exactly upright. The sign passes through center several times, each pass smaller, before resting — a real pendulum settle rather than a single overshoot.
- **Four enum variables:** `pivot` (top-center/left/right), `amplitude` (gentle/standard/wide), `direction` (right/left), `tone` (ink/paper/accent — each a bg/fg pair to keep AA contrast on any frame). Unrecognised overrides fall back to declared defaults.
- Component manifest carries no `dimensions`/`duration` (per schema). The demo carries the same variable declaration as the snippet.

## Preview

The sign swings right → left → right, each pass smaller, settling upright.

https://github.com/user-attachments/assets/f8da7873-69e7-4693-b374-c0d261d2e5ad

## Test plan

- [x] `npx hyperframes lint` + `npx hyperframes validate` on both HTML files — clean (only ignore-level `root_missing_*` rules fire on the bare snippet, expected)
- [x] Demo validates 0 errors / 0 warnings
- [x] `snippet == demo` variable declaration parity verified
- [x] `registry.json` regenerated via `scripts/generate-registry-items.ts` (not hand-edited); `catalogArtifact.revision` untouched
- [x] Docs regenerated via `scripts/generate-catalog-pages.ts` (mdx + `catalog-index.json` + `docs.json` nav)
- [x] Rendered the demo locally via the demo's own GSAP timeline to confirm the motion
- [ ] Unit tests — n/a (registry data + HTML, no package code changed)

## Notes for maintainers (the two contributor-can't-finish steps)

Per `CONTRIBUTING.md`, these need assets an outside contributor isn't expected to install; neither blocks review:

1. **Search index** (`registry/catalog-artifact/local-vectors.*`) — not regenerated here (needs the 32 MB on-device embedding model). The `Catalog: search index covers the registry` CI job will name the gap; it's a deterministic rebuild from this registry, so it's regenerated before merge. Until then the item is findable by word search, just not by meaning.
2. **Catalog preview image/MP4** — `preview.poster` in the manifest points at the conventional CDN path (`static.heygen.ai/.../catalog/components/pendulum-swing.png`); the actual asset is published by `scripts/upload-docs-images.sh` (HeyGen AWS creds), so a maintainer runs the official preview + upload before merge. The MP4 above is a local render for review.
