### PR TITLE
fix(release): use portable Git paths in release guards

### DIFF
--- a/scripts/set-version.ts
+++ b/scripts/set-version.ts
@@ -15,7 +15,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { join, posix } from "path";
 import { execFileSync } from "child_process";
 import { pathToFileURL } from "url";
 import { CLI_SEMVER_PATTERN } from "./cli-options.ts";
@@ -259,7 +259,8 @@ export function missingChangelogArtifacts(version: string) {
 }
 
 export function changelogArtifacts(version: string) {
-  return [join("releases", `v${version}.md`), `docs/changelog.mdx#HyperFrames v${version}`];
+  // Git paths are always slash-separated, including when release tooling runs on Windows.
+  return [posix.join("releases", `v${version}.md`), `docs/changelog.mdx#HyperFrames v${version}`];
 }
 
 export function unreviewedChangelogArtifacts(version: string) {
@@ -310,10 +311,11 @@ export function docsChangelogEntryHasGeneratedTodo(content: string, marker: stri
 
 export function releaseAllowedPaths(version: string) {
   return [
-    ...PACKAGES.map((pkg) => join(pkg, "package.json")),
-    ...PLUGINS.map((plugin) => join(plugin, "plugin.json")),
+    // These values are compared with Git's slash-separated path output.
+    ...PACKAGES.map((pkg) => posix.join(pkg, "package.json")),
+    ...PLUGINS.map((plugin) => posix.join(plugin, "plugin.json")),
     "docs/changelog.mdx",
-    join("releases", `v${version}.md`),
+    posix.join("releases", `v${version}.md`),
   ];
 }
 


### PR DESCRIPTION
Fixes #3765\n\n## Summary\n- use POSIX joins for Git-relative release artifact and allowlist paths\n- keep filesystem access platform-native\n\n## Validation\n- un test scripts/set-version.test.ts (17 pass)\n- oxlint pre-commit check passed for the changed file\n\nThe full repository hook's typecheck remains blocked by missing generated runtime modules in the checkout; no generated files were added.