### PR TITLE
fix(cli): assign w{index} ids when loading JSON transcripts

### DIFF
--- a/packages/cli/src/whisper/normalize.test.ts
+++ b/packages/cli/src/whisper/normalize.test.ts
@@ -103,8 +103,8 @@ describe("loadTranscript", () => {
     const { words, format } = loadTranscript(path);
     expect(format).toBe("whisper-cpp");
     expect(words).toEqual([
-      { text: "Hello,", start: 0, end: 0.55 },
-      { text: "world.", start: 0.6, end: 1.25 },
+      { text: "Hello,", start: 0, end: 0.55, id: "w0" },
+      { text: "world.", start: 0.6, end: 1.25, id: "w1" },
     ]);
   });
 
@@ -142,8 +142,8 @@ describe("loadTranscript", () => {
     const { words, format } = loadTranscript(path);
     expect(format).toBe("openai");
     expect(words).toEqual([
-      { text: "Hello", start: 0, end: 0.5 },
-      { text: "world", start: 0.6, end: 1.2 },
+      { text: "Hello", start: 0, end: 0.5, id: "w0" },
+      { text: "world", start: 0.6, end: 1.2, id: "w1" },
     ]);
   });
 
@@ -205,7 +205,7 @@ Short format
     expect(words[0]?.text).toBe("Bold and italic");
   });
 
-  it("passes through normalized word arrays", () => {
+  it("assigns w{index} ids to normalized word arrays", () => {
     const input = [
       { text: "Hello", start: 0.0, end: 0.5 },
       { text: "world", start: 0.6, end: 1.2 },
@@ -214,9 +214,20 @@ Short format
     const { words, format } = loadTranscript(path);
     expect(format).toBe("words-json");
     expect(words).toEqual([
-      { text: "Hello", start: 0, end: 0.5, id: "" },
-      { text: "world", start: 0.6, end: 1.2, id: "" },
+      { text: "Hello", start: 0, end: 0.5, id: "w0" },
+      { text: "world", start: 0.6, end: 1.2, id: "w1" },
     ]);
+  });
+
+  it("preserves existing ids and repairs empty-string ids from legacy files", () => {
+    const input = [
+      { text: "Hello", start: 0.0, end: 0.5, id: "keep-me" },
+      { text: "world", start: 0.6, end: 1.2, id: "" },
+      { text: "again", start: 1.3, end: 1.8 },
+    ];
+    const path = tmpFile("legacy.json", JSON.stringify(input));
+    const { words } = loadTranscript(path);
+    expect(words.map((w) => w.id)).toEqual(["keep-me", "w1", "w2"]);
   });
 });
 
@@ -375,9 +386,9 @@ describe("whisper-cpp contraction merging", () => {
     );
     const { words } = loadTranscript(path);
     expect(words).toEqual([
-      { text: "I", start: 0, end: 0.2 },
-      { text: "didn't", start: 0.2, end: 0.7 },
-      { text: "know", start: 0.7, end: 1 },
+      { text: "I", start: 0, end: 0.2, id: "w0" },
+      { text: "didn't", start: 0.2, end: 0.7, id: "w1" },
+      { text: "know", start: 0.7, end: 1, id: "w2" },
     ]);
   });
 

--- a/packages/cli/src/whisper/normalize.ts
+++ b/packages/cli/src/whisper/normalize.ts
@@ -503,17 +503,21 @@ export function loadTranscript(filePath: string): { words: Word[]; format: Trans
   const parsed = JSON.parse(content);
   const format = detectJsonFormat(parsed);
 
-  const words =
+  // JSON parsers never set id — assign w{index} like the srt/vtt branches above
+  // so caption overrides always have a stable key. `||` (not `??`) also repairs
+  // the empty-string ids older CLIs wrote to words-json transcript files.
+  const words = (
     format === "whisper-cpp"
       ? parseWhisperCpp(parsed)
       : format === "openai"
         ? parseOpenAI(parsed)
         : (parsed as Word[]).map((w) => ({
-            id: w.id ?? "",
+            id: w.id,
             text: w.text.trim(),
             start: round3(w.start),
             end: round3(w.end),
-          }));
+          }))
+  ).map((w, i) => ({ ...w, id: w.id || `w${i}` }));
 
   return { words, format };
 }


### PR DESCRIPTION
Continuation of #3461, closed in the 2026-09-08 stale-PR sweep with "please reopen with a rebased version if still relevant." This is that rebased version — GitHub blocks author-reopens on PRs closed by a maintainer, so it is filed fresh. Rebased onto current main (`d66cd6dcc`); the words-json loader on main still defaults missing ids to `""`, so the fix applies unchanged.

Fixes #3442

## What

`loadTranscript` now assigns `id: w{i}` on the JSON branches (whisper-cpp, OpenAI, words-json), matching what the srt/vtt branches already do. The words-json branch also stops defaulting missing ids to `""` — it repairs them to `w{i}` instead.

## Why

`audio/references/transcribe.md` documents that word ids (`w0`, `w1`, …) are "added during normalization for stable references in caption overrides", but every JSON path dropped them: `parseWhisperCpp` and `parseOpenAI` never set `id`, and the flat words-json branch defaulted it to `""`, collapsing every word onto the same empty key. All engines funnel through `loadTranscript` — `transcribeAudio` rewrites `transcript.json` from its output — so CLI-produced transcripts ship without ids and per-word caption overrides have nothing to key on (#3442 has the full breakdown, including the SRT round-trip workaround users currently need).

## How

Single normalization point: after the existing format-specific parsing in `loadTranscript`, map `id: w.id || \`w{i}\`` over the words. `||` rather than `??` so the empty-string ids written by older CLIs into words-json files are repaired on load, not preserved. SRT/VTT branches keep their existing assignment; the `Word.id` doc comment already describes exactly this behavior.

## Test plan

- [x] `packages/cli`: `bunx vitest run src/whisper/` on the rebased head (`c1f87c64b`) — **108/108 pass**, including updated expectations (whisper-cpp / openai / words-json now carry `w0…` ids) and the regression test that preserves existing ids (`keep-me`) while repairing empty (`"" → w1`) and missing (`→ w2`) ones. The count includes 4 newer tests from #3436 on the rebased base.
- [x] `tsc --noEmit` in `packages/cli` — clean on the rebased head.
- [x] Original submission (prior base, see #3461): full `packages/cli` vitest suite green apart from the same 20 pre-existing environmental failures as clean main, plus `oxlint` / `oxfmt --check` green.

This change is AI-assisted; the bug analysis, fix, and tests were verified against the reproduction in #3442.
