### PR TITLE
chore: release v0.8.32

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,61 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.32"
+  description="Released - 2026-09-08"
+  tags={["Release", "Skills", "Studio", "Catalog"]}
+>
+Render stability, lint coverage, and skill reliability all improved. Capture stalls now recover automatically, and six new lint rules catch animation pitfalls earlier.
+
+## Features
+
+- **Check:** Flag connectors that point at nothing and stylesheets that leak into the frame ([e5d89f770](https://github.com/heygen-com/hyperframes/commit/e5d89f770fbe01d8c243999dac59f3c39a62d66d), [#3736](https://github.com/heygen-com/hyperframes/pull/3736)).
+
+## Fixes
+
+- **Skills:** Stage media downloads in private directories ([efe2404cb](https://github.com/heygen-com/hyperframes/commit/efe2404cbdeb86111d78a2f555aacf44b71f15fe), [#3787](https://github.com/heygen-com/hyperframes/pull/3787)).
+- **Studio:** Claim upload filenames exclusively ([91a34ffc8](https://github.com/heygen-com/hyperframes/commit/91a34ffc8a6ecea34f67c0bc7ba0437ac82fd432), [#3786](https://github.com/heygen-com/hyperframes/pull/3786)).
+- **Skills:** Retain audio metadata file identity during generation ([a7bf0d23d](https://github.com/heygen-com/hyperframes/commit/a7bf0d23d9c3ced59877585c7adeeef090b6c319), [#3778](https://github.com/heygen-com/hyperframes/pull/3778)).
+- **Skills:** Read BGM logs without pathname prechecks ([a92dc6865](https://github.com/heygen-com/hyperframes/commit/a92dc6865e392540a566ee157f7877ee7f9dd78f), [#3769](https://github.com/heygen-com/hyperframes/pull/3769)).
+- **Shader:** Keep vertex shaders within their WebGL context ([65cc1d602](https://github.com/heygen-com/hyperframes/commit/65cc1d602341ec96be9c37f65fb9a889ba674e71), [#3672](https://github.com/heygen-com/hyperframes/pull/3672)).
+- **Engine:** Use supported VideoToolbox quality options ([e1fda7866](https://github.com/heygen-com/hyperframes/commit/e1fda7866ed94486b1b6c040b2f6fcf52f79fb86), [#3687](https://github.com/heygen-com/hyperframes/pull/3687)).
+- **Runtime:** Preserve fractional final-frame visibility ([0ce0bb13e](https://github.com/heygen-com/hyperframes/commit/0ce0bb13eb6468529b08df882f990e6c14a9ddcf), [#3696](https://github.com/heygen-com/hyperframes/pull/3696)).
+- **Lint:** Flag autoAlpha on clip elements ([6c0ee41ac](https://github.com/heygen-com/hyperframes/commit/6c0ee41ac4e293153847e197f000b9218a0be45c), [#3692](https://github.com/heygen-com/hyperframes/pull/3692)).
+- **Check:** Retry system Chrome after managed launch crash ([c5b7f6aea](https://github.com/heygen-com/hyperframes/commit/c5b7f6aeab689e68642ce7dd0ac18fe574f8888c), [#3701](https://github.com/heygen-com/hyperframes/pull/3701)).
+- **Player:** Pause the hidden loader sheen ([4a72a98a4](https://github.com/heygen-com/hyperframes/commit/4a72a98a495ca5484a4079661793cc1b524ae666), [#3673](https://github.com/heygen-com/hyperframes/pull/3673)).
+- **Media:** Unify nested start coordinate mapping ([01744f2b0](https://github.com/heygen-com/hyperframes/commit/01744f2b0c014bc583964221de69a31c0c036780), [#3732](https://github.com/heygen-com/hyperframes/pull/3732)).
+- **Skills:** Guard canonical stores from mirror aliases ([e5a602322](https://github.com/heygen-com/hyperframes/commit/e5a60232289d3bffb07a305800ed7cbacab007db), [#3714](https://github.com/heygen-com/hyperframes/pull/3714)).
+- **Keyframes:** Resolve helper-returned DOM targets ([400925f43](https://github.com/heygen-com/hyperframes/commit/400925f4322134ddfd32b96abae6698d6e668409), [#3688](https://github.com/heygen-com/hyperframes/pull/3688)).
+- **Render:** Probe runtime media source mutations ([5c44cd212](https://github.com/heygen-com/hyperframes/commit/5c44cd212cd4bf1030ca8899852fd187710b79e7), [#3729](https://github.com/heygen-com/hyperframes/pull/3729)).
+- **Render:** Bound and recover capture stalls ([9308eadcf](https://github.com/heygen-com/hyperframes/commit/9308eadcfc76a98dd23fb9c8948f866f90a4e339), [#3700](https://github.com/heygen-com/hyperframes/pull/3700)).
+- **Skills:** Accept durationless transition roots ([78dacc828](https://github.com/heygen-com/hyperframes/commit/78dacc828c0b1b483efa2c1ef123a7009305d579), [#3683](https://github.com/heygen-com/hyperframes/pull/3683)).
+- **Check:** Clip overlap geometry to visible fragments ([776c291f4](https://github.com/heygen-com/hyperframes/commit/776c291f423eb3b0324db6fa88dd482b51d9b436), [#3698](https://github.com/heygen-com/hyperframes/pull/3698)).
+- **Lint:** Flag hidden-style opacity guards ([2c14438bb](https://github.com/heygen-com/hyperframes/commit/2c14438bb038fd1b0dfd853c2004f89a8e6c6d18), [#3694](https://github.com/heygen-com/hyperframes/pull/3694)).
+- **Lint:** Warn on undefined GSAP color variables ([4958a9fba](https://github.com/heygen-com/hyperframes/commit/4958a9fba56dbcde26a6a155dca1379a6ad1a339), [#3723](https://github.com/heygen-com/hyperframes/pull/3723)).
+- **Check:** Allow missing caption overrides ([00c91d680](https://github.com/heygen-com/hyperframes/commit/00c91d6807f57819c46528e0202ef9488268a349), [#3716](https://github.com/heygen-com/hyperframes/pull/3716)).
+- **Render:** Reject unsupported ProRes rate controls ([2f7b7a952](https://github.com/heygen-com/hyperframes/commit/2f7b7a95293bd8c21219604f3a05622df3eaeec9), [#3702](https://github.com/heygen-com/hyperframes/pull/3702)).
+- **Lint:** Flag repeated fromTo state leaks ([e1ff7e6f5](https://github.com/heygen-com/hyperframes/commit/e1ff7e6f530736f696ca55a2f1360f71404cb6e7), [#3699](https://github.com/heygen-com/hyperframes/pull/3699)).
+- **Skills:** Bootstrap npm safely on Windows ([131336f5d](https://github.com/heygen-com/hyperframes/commit/131336f5dc20bc2cc5af30b168693d795d2e4453), [#3705](https://github.com/heygen-com/hyperframes/pull/3705)).
+- **CLI:** Reject confirmed unsupported SDR encoders ([63182f6a9](https://github.com/heygen-com/hyperframes/commit/63182f6a93b7006fa629a7424d7238baa89ad962), [#3679](https://github.com/heygen-com/hyperframes/pull/3679)).
+- **Studio:** Preserve timeline DOM identity during hydration ([ab07d6738](https://github.com/heygen-com/hyperframes/commit/ab07d67380529c3db5776245f189ad172ab469af), [#3681](https://github.com/heygen-com/hyperframes/pull/3681)).
+- **Engine:** Isolate static dedup verification seeks ([e02722098](https://github.com/heygen-com/hyperframes/commit/e02722098ec699fee5f73d7c81bac0347d5a3fa9), [#3768](https://github.com/heygen-com/hyperframes/pull/3768)).
+- **Slideshow:** Retry init at DOMContentLoaded when the children were not parsed yet ([dc9fb6732](https://github.com/heygen-com/hyperframes/commit/dc9fb673203dda0a2c0951f3b698cf8cd0ea8d61), [#3750](https://github.com/heygen-com/hyperframes/pull/3750)).
+- **Producer:** Try Windows junctions before copying cached frames ([b9aae16d6](https://github.com/heygen-com/hyperframes/commit/b9aae16d6dd0353d9ee3749e61b3bcecacc12b0a), [#3740](https://github.com/heygen-com/hyperframes/pull/3740)).
+
+## Docs & Examples
+
+- Clarify paused composition roots in project instructions ([8fc8294db](https://github.com/heygen-com/hyperframes/commit/8fc8294dbddc82479c87f0e704854160e3412981), [#3670](https://github.com/heygen-com/hyperframes/pull/3670)).
+- Fix broken Claude Design guide link ([250afc313](https://github.com/heygen-com/hyperframes/commit/250afc313b2fc7cf2bc96c77ff175a7884d049d2), [#3584](https://github.com/heygen-com/hyperframes/pull/3584)).
+- **Changelog:** Weekly digest 2026-08-31–2026-09-07 ([bb89f7507](https://github.com/heygen-com/hyperframes/commit/bb89f7507dc8049ad02b29402ab1d05634ca39d3), [#3749](https://github.com/heygen-com/hyperframes/pull/3749)).
+
+## Catalog
+
+- **Catalog:** Publish cache assets without overwriting entries ([d66cd6dcc](https://github.com/heygen-com/hyperframes/commit/d66cd6dcc856a35c3a2f213e0c418aa9f194c4a0), [#3739](https://github.com/heygen-com/hyperframes/pull/3739)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.31...v0.8.32).
+</Update>
+
+<Update
   label="HyperFrames v0.8.31"
   description="Released - 2026-09-07"
   tags={["Release", "Studio Server", "Lint", "Check"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.31",
+  "version": "0.8.32",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.32.md
+++ b/releases/v0.8.32.md
@@ -1,0 +1,54 @@
+# HyperFrames v0.8.32
+
+Released on 2026-09-08.
+
+Render stability, lint coverage, and skill reliability all improved. Capture stalls now recover automatically, and six new lint rules catch animation pitfalls earlier.
+
+## Features
+
+- **Check:** Flag connectors that point at nothing and stylesheets that leak into the frame ([e5d89f770](https://github.com/heygen-com/hyperframes/commit/e5d89f770fbe01d8c243999dac59f3c39a62d66d), [#3736](https://github.com/heygen-com/hyperframes/pull/3736)).
+
+## Fixes
+
+- **Skills:** Stage media downloads in private directories ([efe2404cb](https://github.com/heygen-com/hyperframes/commit/efe2404cbdeb86111d78a2f555aacf44b71f15fe), [#3787](https://github.com/heygen-com/hyperframes/pull/3787)).
+- **Studio:** Claim upload filenames exclusively ([91a34ffc8](https://github.com/heygen-com/hyperframes/commit/91a34ffc8a6ecea34f67c0bc7ba0437ac82fd432), [#3786](https://github.com/heygen-com/hyperframes/pull/3786)).
+- **Skills:** Retain audio metadata file identity during generation ([a7bf0d23d](https://github.com/heygen-com/hyperframes/commit/a7bf0d23d9c3ced59877585c7adeeef090b6c319), [#3778](https://github.com/heygen-com/hyperframes/pull/3778)).
+- **Skills:** Read BGM logs without pathname prechecks ([a92dc6865](https://github.com/heygen-com/hyperframes/commit/a92dc6865e392540a566ee157f7877ee7f9dd78f), [#3769](https://github.com/heygen-com/hyperframes/pull/3769)).
+- **Shader:** Keep vertex shaders within their WebGL context ([65cc1d602](https://github.com/heygen-com/hyperframes/commit/65cc1d602341ec96be9c37f65fb9a889ba674e71), [#3672](https://github.com/heygen-com/hyperframes/pull/3672)).
+- **Engine:** Use supported VideoToolbox quality options ([e1fda7866](https://github.com/heygen-com/hyperframes/commit/e1fda7866ed94486b1b6c040b2f6fcf52f79fb86), [#3687](https://github.com/heygen-com/hyperframes/pull/3687)).
+- **Runtime:** Preserve fractional final-frame visibility ([0ce0bb13e](https://github.com/heygen-com/hyperframes/commit/0ce0bb13eb6468529b08df882f990e6c14a9ddcf), [#3696](https://github.com/heygen-com/hyperframes/pull/3696)).
+- **Lint:** Flag autoAlpha on clip elements ([6c0ee41ac](https://github.com/heygen-com/hyperframes/commit/6c0ee41ac4e293153847e197f000b9218a0be45c), [#3692](https://github.com/heygen-com/hyperframes/pull/3692)).
+- **Check:** Retry system Chrome after managed launch crash ([c5b7f6aea](https://github.com/heygen-com/hyperframes/commit/c5b7f6aeab689e68642ce7dd0ac18fe574f8888c), [#3701](https://github.com/heygen-com/hyperframes/pull/3701)).
+- **Player:** Pause the hidden loader sheen ([4a72a98a4](https://github.com/heygen-com/hyperframes/commit/4a72a98a495ca5484a4079661793cc1b524ae666), [#3673](https://github.com/heygen-com/hyperframes/pull/3673)).
+- **Media:** Unify nested start coordinate mapping ([01744f2b0](https://github.com/heygen-com/hyperframes/commit/01744f2b0c014bc583964221de69a31c0c036780), [#3732](https://github.com/heygen-com/hyperframes/pull/3732)).
+- **Skills:** Guard canonical stores from mirror aliases ([e5a602322](https://github.com/heygen-com/hyperframes/commit/e5a60232289d3bffb07a305800ed7cbacab007db), [#3714](https://github.com/heygen-com/hyperframes/pull/3714)).
+- **Keyframes:** Resolve helper-returned DOM targets ([400925f43](https://github.com/heygen-com/hyperframes/commit/400925f4322134ddfd32b96abae6698d6e668409), [#3688](https://github.com/heygen-com/hyperframes/pull/3688)).
+- **Render:** Probe runtime media source mutations ([5c44cd212](https://github.com/heygen-com/hyperframes/commit/5c44cd212cd4bf1030ca8899852fd187710b79e7), [#3729](https://github.com/heygen-com/hyperframes/pull/3729)).
+- **Render:** Bound and recover capture stalls ([9308eadcf](https://github.com/heygen-com/hyperframes/commit/9308eadcfc76a98dd23fb9c8948f866f90a4e339), [#3700](https://github.com/heygen-com/hyperframes/pull/3700)).
+- **Skills:** Accept durationless transition roots ([78dacc828](https://github.com/heygen-com/hyperframes/commit/78dacc828c0b1b483efa2c1ef123a7009305d579), [#3683](https://github.com/heygen-com/hyperframes/pull/3683)).
+- **Check:** Clip overlap geometry to visible fragments ([776c291f4](https://github.com/heygen-com/hyperframes/commit/776c291f423eb3b0324db6fa88dd482b51d9b436), [#3698](https://github.com/heygen-com/hyperframes/pull/3698)).
+- **Lint:** Flag hidden-style opacity guards ([2c14438bb](https://github.com/heygen-com/hyperframes/commit/2c14438bb038fd1b0dfd853c2004f89a8e6c6d18), [#3694](https://github.com/heygen-com/hyperframes/pull/3694)).
+- **Lint:** Warn on undefined GSAP color variables ([4958a9fba](https://github.com/heygen-com/hyperframes/commit/4958a9fba56dbcde26a6a155dca1379a6ad1a339), [#3723](https://github.com/heygen-com/hyperframes/pull/3723)).
+- **Check:** Allow missing caption overrides ([00c91d680](https://github.com/heygen-com/hyperframes/commit/00c91d6807f57819c46528e0202ef9488268a349), [#3716](https://github.com/heygen-com/hyperframes/pull/3716)).
+- **Render:** Reject unsupported ProRes rate controls ([2f7b7a952](https://github.com/heygen-com/hyperframes/commit/2f7b7a95293bd8c21219604f3a05622df3eaeec9), [#3702](https://github.com/heygen-com/hyperframes/pull/3702)).
+- **Lint:** Flag repeated fromTo state leaks ([e1ff7e6f5](https://github.com/heygen-com/hyperframes/commit/e1ff7e6f530736f696ca55a2f1360f71404cb6e7), [#3699](https://github.com/heygen-com/hyperframes/pull/3699)).
+- **Skills:** Bootstrap npm safely on Windows ([131336f5d](https://github.com/heygen-com/hyperframes/commit/131336f5dc20bc2cc5af30b168693d795d2e4453), [#3705](https://github.com/heygen-com/hyperframes/pull/3705)).
+- **CLI:** Reject confirmed unsupported SDR encoders ([63182f6a9](https://github.com/heygen-com/hyperframes/commit/63182f6a93b7006fa629a7424d7238baa89ad962), [#3679](https://github.com/heygen-com/hyperframes/pull/3679)).
+- **Studio:** Preserve timeline DOM identity during hydration ([ab07d6738](https://github.com/heygen-com/hyperframes/commit/ab07d67380529c3db5776245f189ad172ab469af), [#3681](https://github.com/heygen-com/hyperframes/pull/3681)).
+- **Engine:** Isolate static dedup verification seeks ([e02722098](https://github.com/heygen-com/hyperframes/commit/e02722098ec699fee5f73d7c81bac0347d5a3fa9), [#3768](https://github.com/heygen-com/hyperframes/pull/3768)).
+- **Slideshow:** Retry init at DOMContentLoaded when the children were not parsed yet ([dc9fb6732](https://github.com/heygen-com/hyperframes/commit/dc9fb673203dda0a2c0951f3b698cf8cd0ea8d61), [#3750](https://github.com/heygen-com/hyperframes/pull/3750)).
+- **Producer:** Try Windows junctions before copying cached frames ([b9aae16d6](https://github.com/heygen-com/hyperframes/commit/b9aae16d6dd0353d9ee3749e61b3bcecacc12b0a), [#3740](https://github.com/heygen-com/hyperframes/pull/3740)).
+
+## Docs & Examples
+
+- Clarify paused composition roots in project instructions ([8fc8294db](https://github.com/heygen-com/hyperframes/commit/8fc8294dbddc82479c87f0e704854160e3412981), [#3670](https://github.com/heygen-com/hyperframes/pull/3670)).
+- Fix broken Claude Design guide link ([250afc313](https://github.com/heygen-com/hyperframes/commit/250afc313b2fc7cf2bc96c77ff175a7884d049d2), [#3584](https://github.com/heygen-com/hyperframes/pull/3584)).
+- **Changelog:** Weekly digest 2026-08-31–2026-09-07 ([bb89f7507](https://github.com/heygen-com/hyperframes/commit/bb89f7507dc8049ad02b29402ab1d05634ca39d3), [#3749](https://github.com/heygen-com/hyperframes/pull/3749)).
+
+## Catalog
+
+- **Catalog:** Publish cache assets without overwriting entries ([d66cd6dcc](https://github.com/heygen-com/hyperframes/commit/d66cd6dcc856a35c3a2f213e0c418aa9f194c4a0), [#3739](https://github.com/heygen-com/hyperframes/pull/3739)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.31...v0.8.32


### PR DESCRIPTION
## Release v0.8.32

Version bump and changelog for v0.8.32.

**33 commits** since v0.8.31, including:
- 20 merged fixes from miguel-heygen (render stability, lint rules, check improvements, skill handling, Windows compatibility, shader/player/keyframe/media/runtime fixes)
- 5 fixes from jrusso1020 (cache assets, BGM logs, audio metadata identity, upload filenames, media downloads)
- External fixes: slideshow init retry (#3750), connector/stylesheet leak check (#3736), static dedup verifier isolation (#3768), Windows junction fix (#3740), docs link fix (#3584)

[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.31...release/v0.8.32).

— Miga