### PR TITLE
chore: release v0.8.33

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -7,6 +7,20 @@ rss: true
 Recent HyperFrames releases, including user-facing features, fixes, and migration notes.
 
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
+<Update
+  label="HyperFrames v0.8.33"
+  description="Released - 2026-09-09"
+  tags={["Release", "Engine"]}
+>
+Patch release: fixes static-frame dedup freezing motion driven by timeline `onUpdate` callbacks in tween-free windows.
+
+## Fixes
+
+- **Engine:** Detect `onUpdate` callbacks on timelines and exclude their spans from static-frame prediction; enable events during verification seeks so callback-driven motion is visible to the verifier ([1aaa35d07](https://github.com/heygen-com/hyperframes/commit/1aaa35d073), [#3794](https://github.com/heygen-com/hyperframes/pull/3794)). Fixes [#3793](https://github.com/heygen-com/hyperframes/issues/3793).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.32...v0.8.33).
+</Update>
+
 
 <Update
   label="HyperFrames v0.8.32"

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.32",
+  "version": "0.8.33",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.33.md
+++ b/releases/v0.8.33.md
@@ -1,0 +1,7 @@
+# v0.8.33
+
+Patch release — fixes static-frame dedup freezing `onUpdate`-driven motion.
+
+## Fixes
+
+- **Engine:** Detect `onUpdate` callbacks on timelines and exclude their spans from static-frame prediction; enable events during verification seeks so callback-driven motion is visible to the verifier (#3794). Fixes #3793.


### PR DESCRIPTION
## Release v0.8.33

Patch release — fixes static-frame dedup freezing `onUpdate`-driven motion in tween-free windows.

**1 commit** since v0.8.32:
- fix(engine): detect onUpdate callbacks and enable verification events (#3794) — fixes #3793

[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.32...release/v0.8.33).

— Miga