### PR TITLE
fix(core): contain generated HTML CSS and script contexts

### DIFF
--- a/docs/packages/core.mdx
+++ b/docs/packages/core.mdx
@@ -75,6 +75,19 @@ const html = generateHyperframesHtml(elements, 6, {
 The second argument is the requested duration in seconds. Pass a stable
 `compositionId` when output must be reproducible.
 
+Composition generators require trusted authors for code-bearing inputs. `styles` and
+`generateHyperframesStyles` preserve authored CSS, which can load external resources.
+`animations` may contain `__raw:` values that are emitted as JavaScript;
+`includeScripts: true` includes executable timeline code. `serializeGsapAnimations`
+also accepts raw `preamble`, `postamble`, and a code-bearing `timelineVar`. Never fill
+these inputs with untrusted data. Attribute encoding and closing-tag containment
+are not a sandbox; render untrusted compositions in an appropriately isolated
+execution environment and never serve them on a privileged origin.
+
+Text content retains the supported inline-formatting sanitizer contract. The clip
+parser intentionally flattens inner formatting to text, so parse/generate is not
+a lossless replacement for editing the source HTML.
+
 ## Read and validate variables
 
 Inside a composition script, `getVariables()` reads declared defaults plus the

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -22,6 +22,21 @@ npm install @hyperframes/core
 | **Runtime**        | IIFE script injected into the browser — manages seek, media playback, and the `window.__hf` protocol |
 | **Frame Adapters** | Pluggable animation drivers (GSAP, Lottie, CSS, or custom)                                           |
 
+## Generated composition trust
+
+Composition generators require trusted authors for code-bearing inputs. `styles` and
+`generateHyperframesStyles` preserve authored CSS, which can load external resources.
+`animations` may contain `__raw:` values that are emitted as JavaScript;
+`includeScripts: true` includes executable timeline code. `serializeGsapAnimations`
+also accepts raw `preamble`, `postamble`, and a code-bearing `timelineVar`. Never fill
+these inputs with untrusted data. Attribute encoding and closing-tag containment
+are not a sandbox; render untrusted compositions in an appropriately isolated
+execution environment and never serve them on a privileged origin.
+
+Text content retains the supported inline-formatting sanitizer contract. The clip
+parser intentionally flattens inner formatting to text, so parse/generate is not
+a lossless replacement for editing the source HTML.
+
 ## Frame Adapters
 
 A frame adapter tells the engine how to seek your animation to a specific frame:

--- a/packages/core/src/generators/hyperframes.test.ts
+++ b/packages/core/src/generators/hyperframes.test.ts
@@ -37,6 +37,28 @@ function makeVideoElement(overrides: Partial<TimelineMediaElement> = {}): Timeli
 }
 
 describe("generateHyperframesHtml", () => {
+  it("keeps composition identifiers inside their attribute and round-trips entities", () => {
+    const compositionId = `x" autofocus onfocus="alert(1)'><script>bad()</script>&quot;&`;
+    const doc = new DOMParser().parseFromString(
+      generateHyperframesHtml([], 1, { compositionId }),
+      "text/html",
+    );
+    expect(doc.documentElement.getAttribute("data-composition-id")).toBe(compositionId);
+    expect(doc.documentElement.hasAttribute("autofocus")).toBe(false);
+    expect(doc.documentElement.hasAttribute("onfocus")).toBe(false);
+    expect(doc.querySelector("script")).toBeNull();
+  });
+
+  it("round-trips entity-bearing CSS through the JSON metadata attribute", () => {
+    const styles = `.x::after { content: "&quot; &#39; &amp; < > '"; }`;
+    const doc = new DOMParser().parseFromString(
+      generateHyperframesHtml([], 1, { styles }),
+      "text/html",
+    );
+    expect(JSON.parse(doc.documentElement.getAttribute("data-custom-styles")!)).toBe(styles);
+    expect(doc.querySelector("style")).toBeNull();
+  });
+
   it("generates valid HTML with proper data attributes", () => {
     const elements = [makeTextElement()];
     const html = generateHyperframesHtml(elements, 5);
@@ -153,7 +175,7 @@ describe("generateHyperframesHtml", () => {
     const elements = [makeTextElement({ id: "text-kf" })];
     const keyframes = {
       "text-kf": [
-        { id: "kf1", time: 0, properties: { opacity: 0 } },
+        { id: "kf1 &quot; &#39; < >", time: 0, properties: { opacity: 0 } },
         { id: "kf2", time: 1, properties: { opacity: 1 } },
       ],
     };
@@ -162,17 +184,25 @@ describe("generateHyperframesHtml", () => {
     expect(html).toContain("data-keyframes=");
     expect(html).toContain("kf1");
     expect(html).toContain("kf2");
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    expect(JSON.parse(doc.getElementById("text-kf")!.getAttribute("data-keyframes")!)).toEqual(
+      keyframes["text-kf"],
+    );
   });
 
   it("serializes zoom keyframes on zoom container", () => {
     const elements = [makeTextElement()];
     const stageZoomKeyframes = [
-      { id: "z1", time: 0, zoom: { scale: 1, focusX: 960, focusY: 540 } },
+      { id: "z1 &quot; &#39; < >", time: 0, zoom: { scale: 1, focusX: 960, focusY: 540 } },
       { id: "z2", time: 5, zoom: { scale: 2, focusX: 400, focusY: 300 } },
     ];
     const html = generateHyperframesHtml(elements, 10, { stageZoomKeyframes });
 
     expect(html).toContain("data-zoom-keyframes=");
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    expect(
+      JSON.parse(doc.getElementById("stage-zoom-container")!.getAttribute("data-zoom-keyframes")!),
+    ).toEqual(stageZoomKeyframes);
   });
 
   it("includes x, y, scale data attributes for non-default values", () => {

--- a/packages/core/src/generators/hyperframes.test.ts
+++ b/packages/core/src/generators/hyperframes.test.ts
@@ -114,6 +114,9 @@ describe("generateHyperframesHtml", () => {
       const html = generateHyperframesHtml([makeTextElement({ content })], 1);
       const doc = new DOMParser().parseFromString(html, "text/html");
       expect(doc.querySelector("#text-1")?.textContent).toBe(content ? "&quot; &#39; &lt;" : "");
+      expect(parseHtml(html).elements[0]).toMatchObject({
+        content: content ? "&quot; &#39; &lt;" : "",
+      });
     },
   );
 

--- a/packages/core/src/generators/hyperframes.test.ts
+++ b/packages/core/src/generators/hyperframes.test.ts
@@ -42,6 +42,108 @@ function makeVideoElement(overrides: Partial<TimelineMediaElement> = {}): Timeli
 }
 
 describe("generateHyperframesHtml", () => {
+  it("contains mixed-case style closing tags in authored CSS", () => {
+    const styles = '.label::after { content: "</StYlE><script>bad()</script>"; }';
+    const doc = new DOMParser().parseFromString(
+      generateHyperframesHtml([], 1, { styles, includeStyles: true }),
+      "text/html",
+    );
+    expect(doc.querySelectorAll("style")).toHaveLength(2);
+    expect(doc.querySelector("script")).toBeNull();
+    expect(doc.querySelector("style[data-hf-custom]")?.textContent).toContain("StYlE");
+  });
+
+  it("contains script closing tags while retaining JS string values and raw expressions", () => {
+    const targetSelector = '#x"</ScRiPt><script>bad()</script>';
+    const position = 'label"; bad(); //';
+    const doc = new DOMParser().parseFromString(
+      generateHyperframesHtml([], 1, {
+        includeScripts: true,
+        animations: [
+          { targetSelector, method: "to", position, properties: { x: "__raw:1 < 2 ? 3 : 4" } },
+        ],
+      }),
+      "text/html",
+    );
+    expect(doc.querySelectorAll("script")).toHaveLength(2);
+    const script = doc.querySelector("script:not([src])")?.textContent ?? "";
+    const calls: unknown[][] = [];
+    const gsap = { timeline: () => ({ to: (...args: unknown[]) => calls.push(args) }) };
+    new Function("gsap", script)(gsap);
+    expect(calls).toEqual([[targetSelector, { x: 3 }, position]]);
+  });
+
+  it("round-trips element attribute values without creating event handlers", () => {
+    const marker = `x" onmouseover="bad()&quot;<`;
+    const element = makeVideoElement({ id: marker, name: marker, src: marker });
+    const doc = new DOMParser().parseFromString(generateHyperframesHtml([element], 1), "text/html");
+    const video = doc.querySelector("video");
+    for (const name of ["id", "data-hf-id", "data-name", "src"])
+      expect(video?.getAttribute(name)).toBe(marker);
+    expect(video?.hasAttribute("onmouseover")).toBe(false);
+    expect(doc.querySelector("script")).toBeNull();
+  });
+
+  it("keeps special IDs targeted by generated visibility animations", () => {
+    const element = makeTextElement({ id: '9 title"[x],#other', name: "Title" });
+    const doc = new DOMParser().parseFromString(generateHyperframesHtml([element], 1), "text/html");
+    const targets: string[] = [];
+    const gsap = { timeline: () => ({ set: (selector: string) => targets.push(selector) }) };
+    new Function("gsap", generateGsapTimelineScript([element], 1))(gsap);
+    expect(targets.length).toBeGreaterThan(0);
+    for (const selector of targets) expect(doc.querySelector(selector)?.id).toBe(element.id);
+  });
+
+  it("preserves supported rich text while removing executable markup", () => {
+    const content =
+      '<strong>A<span style="font-size: 32px; color: red" onclick="bad()">B</span></strong><br><sup>C</sup><script>bad()</script><svg onload="bad()"></svg><span style="background-color: url(evil)">D</span>';
+    const html = generateHyperframesHtml([makeTextElement({ content })], 1);
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    expect(doc.querySelector("strong span")?.getAttribute("style")).toContain("font-size: 32px");
+    expect(doc.querySelector("strong span")?.hasAttribute("onclick")).toBe(false);
+    expect(doc.querySelector("br")).not.toBeNull();
+    expect(doc.querySelector("script,svg,sup,[onclick]")).toBeNull();
+    expect(doc.querySelector("#text-1")?.textContent).toBe("ABCD");
+    expect(html).not.toContain("url(evil)");
+    expect(parseHtml(html).elements[0]).toMatchObject({ content: "ABCD" });
+  });
+
+  it.each(["", "&amp;quot; &amp;#39; &amp;lt;"])(
+    "preserves empty and entity-looking caption content: %s",
+    (content) => {
+      const html = generateHyperframesHtml([makeTextElement({ content })], 1);
+      const doc = new DOMParser().parseFromString(html, "text/html");
+      expect(doc.querySelector("#text-1")?.textContent).toBe(content ? "&quot; &#39; &lt;" : "");
+    },
+  );
+
+  it.each([
+    "javascript:bad()",
+    "java\nscript:bad()",
+    "vbscript:bad()",
+    "data:text/html,<script>bad()</script>",
+  ])("rejects executable source URLs: %s", (src) => {
+    expect(() => generateHyperframesHtml([makeVideoElement({ src })], 1)).toThrow(
+      "Unsafe media or composition source URL",
+    );
+  });
+
+  it("rejects JavaScript supplied through a numeric element field", () => {
+    const element = { ...makeTextElement(), startTime: "0); bad(); //" };
+    expect(() => Reflect.apply(generateGsapTimelineScript, undefined, [[element], 1])).toThrow(
+      "finite generator numeric value",
+    );
+  });
+
+  it("rejects declaration breakouts in generated color values", () => {
+    expect(() =>
+      generateHyperframesStyles(
+        [makeTextElement({ color: "red; } body { color: blue" })],
+        "landscape",
+      ),
+    ).toThrow("Invalid generated CSS value");
+  });
+
   it("keeps composition identifiers inside their attribute and round-trips entities", () => {
     const compositionId = `x" autofocus onfocus="alert(1)'><script>bad()</script>&quot;&`;
     const doc = new DOMParser().parseFromString(

--- a/packages/core/src/generators/hyperframes.test.ts
+++ b/packages/core/src/generators/hyperframes.test.ts
@@ -54,6 +54,20 @@ describe("generateHyperframesHtml", () => {
     expect(doc.querySelector("script")).toBeNull();
   });
 
+  it("contains resolution values supplied by JavaScript callers inside their attribute", () => {
+    const resolution = `x" autofocus onfocus="alert(1)'><script>bad()</script>&quot;&`;
+    const html = Reflect.apply(generateHyperframesHtml, undefined, [
+      [],
+      1,
+      { resolution, includeStyles: false, includeScripts: false },
+    ]);
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    expect(doc.documentElement.getAttribute("data-resolution")).toBe(resolution);
+    expect(doc.documentElement.hasAttribute("autofocus")).toBe(false);
+    expect(doc.documentElement.hasAttribute("onfocus")).toBe(false);
+    expect(doc.querySelector("script")).toBeNull();
+  });
+
   it("round-trips entity-bearing CSS through the JSON metadata attribute", () => {
     const styles = `.x::after { content: "&quot; &#39; &amp; < > '"; }`;
     const doc = new DOMParser().parseFromString(

--- a/packages/core/src/generators/hyperframes.test.ts
+++ b/packages/core/src/generators/hyperframes.test.ts
@@ -7,8 +7,13 @@ import {
   generateGsapTimelineScript,
   generateHyperframesStyles,
 } from "./hyperframes.js";
+import { parseHtml } from "@hyperframes/parsers";
 import { GSAP_CDN } from "../templates/constants.js";
-import type { TimelineTextElement, TimelineMediaElement } from "../core.types";
+import type {
+  TimelineTextElement,
+  TimelineMediaElement,
+  TimelineCompositionElement,
+} from "../core.types";
 
 function makeTextElement(overrides: Partial<TimelineTextElement> = {}): TimelineTextElement {
   return {
@@ -57,6 +62,31 @@ describe("generateHyperframesHtml", () => {
     );
     expect(JSON.parse(doc.documentElement.getAttribute("data-custom-styles")!)).toBe(styles);
     expect(doc.querySelector("style")).toBeNull();
+    expect(parseHtml(generateHyperframesHtml([], 1, { styles })).styles).toBe(styles);
+  });
+
+  it("round-trips composition variable metadata through the public parser", () => {
+    const variableValues = { label: `&quot; &#39; &amp; < > '`, count: 2, enabled: true };
+    const element: TimelineCompositionElement = {
+      id: "nested",
+      type: "composition",
+      name: "Nested",
+      startTime: 0,
+      duration: 1,
+      zIndex: 0,
+      src: "nested.html",
+      compositionId: "nested-comp",
+      variableValues,
+    };
+    const html = generateHyperframesHtml([element], 1);
+    const parsed = parseHtml(html).elements[0];
+    expect(parsed?.type).toBe("composition");
+    if (parsed?.type !== "composition") throw new Error("Expected composition");
+    expect(parsed.variableValues).toEqual(variableValues);
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    expect(JSON.parse(doc.getElementById("nested")!.getAttribute("data-variable-values")!)).toEqual(
+      variableValues,
+    );
   });
 
   it("generates valid HTML with proper data attributes", () => {
@@ -184,6 +214,7 @@ describe("generateHyperframesHtml", () => {
     expect(html).toContain("data-keyframes=");
     expect(html).toContain("kf1");
     expect(html).toContain("kf2");
+    expect(parseHtml(html).keyframes["text-kf"]?.[0]?.id).toBe(keyframes["text-kf"][0]!.id);
     const doc = new DOMParser().parseFromString(html, "text/html");
     expect(JSON.parse(doc.getElementById("text-kf")!.getAttribute("data-keyframes")!)).toEqual(
       keyframes["text-kf"],
@@ -199,6 +230,7 @@ describe("generateHyperframesHtml", () => {
     const html = generateHyperframesHtml(elements, 10, { stageZoomKeyframes });
 
     expect(html).toContain("data-zoom-keyframes=");
+    expect(parseHtml(html).stageZoomKeyframes?.[0]?.id).toBe(stageZoomKeyframes[0]!.id);
     const doc = new DOMParser().parseFromString(html, "text/html");
     expect(
       JSON.parse(doc.getElementById("stage-zoom-container")!.getAttribute("data-zoom-keyframes")!),

--- a/packages/core/src/generators/hyperframes.ts
+++ b/packages/core/src/generators/hyperframes.ts
@@ -1,3 +1,5 @@
+import { isSafeAttributeValue } from "../utils/htmlAttrSafety";
+import { richTextHtml } from "./richTextHtml";
 import type { TimelineElement, CanvasResolution, Keyframe, StageZoomKeyframe } from "../core.types";
 import {
   CANVAS_DIMENSIONS,
@@ -17,6 +19,41 @@ function escapeHtmlAttributeValue(value: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
+}
+
+function elementSelector(id: string): string {
+  // Hex escapes preserve ID identity without letting punctuation add selectors.
+  const escaped = id.replace(/[^a-zA-Z0-9_-]|^-?\d/g, (match) =>
+    Array.from(match, (char) => `\\${char.codePointAt(0)?.toString(16)} `).join(""),
+  );
+  return `#${escaped}`;
+}
+
+function cssString(value: string): string {
+  return value.replace(/[\\'\r\n\f]/g, (char) => `\\${char.codePointAt(0)?.toString(16)} `);
+}
+
+function sourceAttribute(src: string, composition = false): string {
+  // URL parsing ignores embedded ASCII tabs/newlines before detecting a scheme.
+  const normalized = Array.from(src)
+    .filter((char) => char.charCodeAt(0) > 32)
+    .join("");
+  if (!isSafeAttributeValue("src", normalized) || (composition && /^data:/i.test(normalized))) {
+    throw new Error("Unsafe media or composition source URL");
+  }
+  return escapeHtmlAttributeValue(src);
+}
+
+function finiteNumber(value: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error("Expected a finite generator numeric value");
+  }
+  return value;
+}
+
+function cssValue(value: string): string {
+  if (/[;{}<>\r\n]/.test(value)) throw new Error("Invalid generated CSS value");
+  return value;
 }
 
 const GOOGLE_FONTS_BASE = "https://fonts.googleapis.com/css2";
@@ -140,36 +177,36 @@ function generateElementStyles(element: TimelineElement): string {
 
     // Text outline using -webkit-text-stroke
     const textOutline = element.textOutline
-      ? `-webkit-text-stroke: ${element.textOutlineWidth ?? 2}px ${
-          element.textOutlineColor ?? "#000000"
-        }; paint-order: stroke fill;`
+      ? `-webkit-text-stroke: ${finiteNumber(element.textOutlineWidth ?? 2)}px ${cssValue(
+          element.textOutlineColor ?? "#000000",
+        )}; paint-order: stroke fill;`
       : "";
 
     // Text highlight using background
     const textHighlight = element.textHighlight
-      ? `background-color: ${element.textHighlightColor ?? "yellow"}; padding: ${element.textHighlightPadding ?? 4}px ${
-          (element.textHighlightPadding ?? 4) * 1.5
-        }px; border-radius: ${
-          element.textHighlightRadius ?? 4
-        }px; box-decoration-break: clone; -webkit-box-decoration-break: clone;`
+      ? `background-color: ${cssValue(element.textHighlightColor ?? "yellow")}; padding: ${finiteNumber(element.textHighlightPadding ?? 4)}px ${finiteNumber(
+          (element.textHighlightPadding ?? 4) * 1.5,
+        )}px; border-radius: ${finiteNumber(
+          element.textHighlightRadius ?? 4,
+        )}px; box-decoration-break: clone; -webkit-box-decoration-break: clone;`
       : "";
 
-    return `    #${element.id} { ${baseStyles} width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; pointer-events: none; }
-    #${element.id} > div { font-family: '${fontFamily}', sans-serif; font-size: ${fontSize}px; font-weight: ${fontWeight}; color: ${color}; ${textShadow} ${textOutline} ${textHighlight} pointer-events: auto; cursor: grab; white-space: pre-wrap; text-align: center; }`;
+    return `    ${elementSelector(element.id)} { ${baseStyles} width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; pointer-events: none; }
+    ${elementSelector(element.id)} > div { font-family: '${cssString(fontFamily)}', sans-serif; font-size: ${finiteNumber(fontSize)}px; font-weight: ${finiteNumber(fontWeight)}; color: ${cssValue(color)}; ${textShadow} ${textOutline} ${textHighlight} pointer-events: auto; cursor: grab; white-space: pre-wrap; text-align: center; }`;
   }
 
   switch (element.type) {
     case "video":
       // Videos fill the stage with standard CSS positioning (0,0 = top-left)
-      return `    #${element.id} { ${baseStyles} width: 100%; height: 100%; object-fit: contain; transform-origin: center center; }`;
+      return `    ${elementSelector(element.id)} { ${baseStyles} width: 100%; height: 100%; object-fit: contain; transform-origin: center center; }`;
     case "image":
       // Images use standard CSS positioning (0,0 = top-left)
-      return `    #${element.id} { ${baseStyles} max-width: 100%; max-height: 100%; transform-origin: center center; }`;
+      return `    ${elementSelector(element.id)} { ${baseStyles} max-width: 100%; max-height: 100%; transform-origin: center center; }`;
     case "audio":
-      return `    #${element.id} { ${baseStyles} }`;
+      return `    ${elementSelector(element.id)} { ${baseStyles} }`;
     case "composition":
       // Compositions use standard CSS positioning (0,0 = top-left)
-      return `    #${element.id} { ${baseStyles} width: 100%; height: 100%; position: absolute; }`;
+      return `    ${elementSelector(element.id)} { ${baseStyles} width: 100%; height: 100%; position: absolute; }`;
   }
 }
 
@@ -209,7 +246,12 @@ export function generateGsapTimelineScript(
             scale: baseScale,
           },
         );
-        keyframeAnimations = keyframeAnimations.concat(converted);
+        keyframeAnimations = keyframeAnimations.concat(
+          converted.map((animation) => ({
+            ...animation,
+            targetSelector: elementSelector(element.id),
+          })),
+        );
       }
     }
   }
@@ -277,7 +319,7 @@ export function generateGsapTimelineScript(
   } else {
     gsapScript = `
     const tl = gsap.timeline({ paused: true });
-${initialPositionSets ? initialPositionSets + "\n" : ""}    tl.to({}, { duration: ${totalDuration || 1} });
+${initialPositionSets ? initialPositionSets + "\n" : ""}    tl.to({}, { duration: ${finiteNumber(totalDuration || 1)} });
     `;
     // Append zoom animations
     if (zoomAnimations) {
@@ -338,12 +380,18 @@ export function generateHyperframesHtml(
     styleTags = [
       styles.coreCss
         ? `  <style data-hf-core="true">
-    ${styles.coreCss.split("\n").join("\n    ")}
+    ${styles.coreCss
+      .replace(/<\/style/gi, (match) => `<\\${match.slice(1)}`)
+      .split("\n")
+      .join("\n    ")}
   </style>`
         : "",
       styles.customCss
         ? `  <style data-hf-custom="true">
-    ${styles.customCss.split("\n").join("\n    ")}
+    ${styles.customCss
+      .replace(/<\/style/gi, (match) => `<\\${match.slice(1)}`)
+      .split("\n")
+      .join("\n    ")}
   </style>`
         : "",
     ]
@@ -365,7 +413,7 @@ export function generateHyperframesHtml(
 
   const gsapScriptTag = includeScripts
     ? `  <script>
-${gsapScript}
+${gsapScript.replace(/<\/script/gi, (match) => `<\\${match.slice(1)}`)}
   </script>`
     : "";
 
@@ -436,15 +484,15 @@ function generateZoomGsapAnimations(
 
     if (i === 0) {
       animations.push(
-        `    tl.set("#stage-zoom-container", { scale: ${kf.zoom.scale}, x: ${x}, y: ${y} }, ${kf.time});`,
+        `    tl.set("#stage-zoom-container", { scale: ${finiteNumber(kf.zoom.scale)}, x: ${finiteNumber(x)}, y: ${finiteNumber(y)} }, ${finiteNumber(kf.time)});`,
       );
     } else {
       const prevKf = sortedKeyframes[i - 1];
       if (!prevKf) continue;
       const duration = kf.time - prevKf.time;
-      const ease = kf.ease ? `, ease: "${kf.ease}"` : "";
+      const ease = kf.ease ? `, ease: ${JSON.stringify(kf.ease)}` : "";
       animations.push(
-        `    tl.to("#stage-zoom-container", { scale: ${kf.zoom.scale}, x: ${x}, y: ${y}, duration: ${duration}${ease} }, ${prevKf.time});`,
+        `    tl.to("#stage-zoom-container", { scale: ${finiteNumber(kf.zoom.scale)}, x: ${finiteNumber(x)}, y: ${finiteNumber(y)}, duration: ${finiteNumber(duration)}${ease} }, ${finiteNumber(prevKf.time)});`,
       );
     }
   }
@@ -454,26 +502,26 @@ function generateZoomGsapAnimations(
 
 function generateElementHtml(element: TimelineElement, keyframes?: Keyframe[]): string {
   const baseAttrs = [
-    `id="${element.id}"`,
-    `data-hf-id="${element.id}"`,
-    `${COMPOSITION_ATTRIBUTES.start}="${element.startTime}"`,
-    `${COMPOSITION_ATTRIBUTES.duration}="${element.duration}"`,
-    `${COMPOSITION_ATTRIBUTES.trackIndex}="${element.zIndex}"`,
-    `data-name="${element.name}"`,
+    `id="${escapeHtmlAttributeValue(String(element.id))}"`,
+    `data-hf-id="${escapeHtmlAttributeValue(String(element.id))}"`,
+    `${COMPOSITION_ATTRIBUTES.start}="${escapeHtmlAttributeValue(String(element.startTime))}"`,
+    `${COMPOSITION_ATTRIBUTES.duration}="${escapeHtmlAttributeValue(String(element.duration))}"`,
+    `${COMPOSITION_ATTRIBUTES.trackIndex}="${escapeHtmlAttributeValue(String(element.zIndex))}"`,
+    `data-name="${escapeHtmlAttributeValue(String(element.name))}"`,
   ];
 
   // Serialize transform properties (x, y, scale, opacity) if non-default
   if (element.x !== undefined && element.x !== 0) {
-    baseAttrs.push(`data-x="${element.x}"`);
+    baseAttrs.push(`data-x="${escapeHtmlAttributeValue(String(element.x))}"`);
   }
   if (element.y !== undefined && element.y !== 0) {
-    baseAttrs.push(`data-y="${element.y}"`);
+    baseAttrs.push(`data-y="${escapeHtmlAttributeValue(String(element.y))}"`);
   }
   if (element.scale !== undefined && element.scale !== 1) {
-    baseAttrs.push(`data-scale="${element.scale}"`);
+    baseAttrs.push(`data-scale="${escapeHtmlAttributeValue(String(element.scale))}"`);
   }
   if (element.opacity !== undefined && element.opacity !== 1) {
-    baseAttrs.push(`data-opacity="${element.opacity}"`);
+    baseAttrs.push(`data-opacity="${escapeHtmlAttributeValue(String(element.opacity))}"`);
   }
 
   // Serialize keyframes to data attribute if present
@@ -485,16 +533,16 @@ function generateElementHtml(element: TimelineElement, keyframes?: Keyframe[]): 
   if (isTextElement(element)) {
     const textAttrs = [...baseAttrs, `data-type="text"`];
     if (element.color) {
-      textAttrs.push(`data-color="${element.color}"`);
+      textAttrs.push(`data-color="${escapeHtmlAttributeValue(String(element.color))}"`);
     }
     if (element.fontSize) {
-      textAttrs.push(`data-font-size="${element.fontSize}"`);
+      textAttrs.push(`data-font-size="${escapeHtmlAttributeValue(String(element.fontSize))}"`);
     }
     if (element.fontWeight) {
-      textAttrs.push(`data-font-weight="${element.fontWeight}"`);
+      textAttrs.push(`data-font-weight="${escapeHtmlAttributeValue(String(element.fontWeight))}"`);
     }
     if (element.fontFamily) {
-      textAttrs.push(`data-font-family="${element.fontFamily}"`);
+      textAttrs.push(`data-font-family="${escapeHtmlAttributeValue(String(element.fontFamily))}"`);
     }
     if (element.textShadow === false) {
       textAttrs.push(`data-text-shadow="false"`);
@@ -502,25 +550,35 @@ function generateElementHtml(element: TimelineElement, keyframes?: Keyframe[]): 
     if (element.textOutline) {
       textAttrs.push(`data-text-outline="true"`);
       if (element.textOutlineColor) {
-        textAttrs.push(`data-text-outline-color="${element.textOutlineColor}"`);
+        textAttrs.push(
+          `data-text-outline-color="${escapeHtmlAttributeValue(String(element.textOutlineColor))}"`,
+        );
       }
       if (element.textOutlineWidth) {
-        textAttrs.push(`data-text-outline-width="${element.textOutlineWidth}"`);
+        textAttrs.push(
+          `data-text-outline-width="${escapeHtmlAttributeValue(String(element.textOutlineWidth))}"`,
+        );
       }
     }
     if (element.textHighlight) {
       textAttrs.push(`data-text-highlight="true"`);
       if (element.textHighlightColor) {
-        textAttrs.push(`data-text-highlight-color="${element.textHighlightColor}"`);
+        textAttrs.push(
+          `data-text-highlight-color="${escapeHtmlAttributeValue(String(element.textHighlightColor))}"`,
+        );
       }
       if (element.textHighlightPadding) {
-        textAttrs.push(`data-text-highlight-padding="${element.textHighlightPadding}"`);
+        textAttrs.push(
+          `data-text-highlight-padding="${escapeHtmlAttributeValue(String(element.textHighlightPadding))}"`,
+        );
       }
       if (element.textHighlightRadius) {
-        textAttrs.push(`data-text-highlight-radius="${element.textHighlightRadius}"`);
+        textAttrs.push(
+          `data-text-highlight-radius="${escapeHtmlAttributeValue(String(element.textHighlightRadius))}"`,
+        );
       }
     }
-    const content = element.content || element.name;
+    const content = richTextHtml(element.content ?? element.name);
     return `<div ${textAttrs.join(" ")}><div>${content}</div></div>`;
   }
 
@@ -528,16 +586,22 @@ function generateElementHtml(element: TimelineElement, keyframes?: Keyframe[]): 
     const compositionAttrs = [
       ...baseAttrs,
       `data-type="composition"`,
-      `data-composition-id="${element.compositionId}"`,
+      `data-composition-id="${escapeHtmlAttributeValue(String(element.compositionId))}"`,
     ];
     if (element.sourceDuration) {
-      compositionAttrs.push(`data-source-duration="${element.sourceDuration}"`);
+      compositionAttrs.push(
+        `data-source-duration="${escapeHtmlAttributeValue(String(element.sourceDuration))}"`,
+      );
     }
     if (element.sourceWidth) {
-      compositionAttrs.push(`data-source-width="${element.sourceWidth}"`);
+      compositionAttrs.push(
+        `data-source-width="${escapeHtmlAttributeValue(String(element.sourceWidth))}"`,
+      );
     }
     if (element.sourceHeight) {
-      compositionAttrs.push(`data-source-height="${element.sourceHeight}"`);
+      compositionAttrs.push(
+        `data-source-height="${escapeHtmlAttributeValue(String(element.sourceHeight))}"`,
+      );
     }
     if (element.variableValues && Object.keys(element.variableValues).length > 0) {
       const varJson = JSON.stringify(element.variableValues);
@@ -546,7 +610,7 @@ function generateElementHtml(element: TimelineElement, keyframes?: Keyframe[]): 
     const attrs = compositionAttrs.join(" ");
     // Build iframe src with variable values as query params if present
     // Strip any existing query params first to avoid duplication
-    let iframeSrc = element.src.split("?")[0];
+    let iframeSrc = element.src.split("?")[0] ?? "";
     if (element.variableValues && Object.keys(element.variableValues).length > 0) {
       const params = new URLSearchParams();
       for (const [key, value] of Object.entries(element.variableValues)) {
@@ -558,23 +622,27 @@ function generateElementHtml(element: TimelineElement, keyframes?: Keyframe[]): 
     // The motion design HTML handles its own internal positioning
     // Wrap iframe in container with click overlay for selection
     return `<div ${attrs} style="width: 100%; height: 100%;">
-      <iframe src="${iframeSrc}" sandbox="allow-scripts allow-same-origin" style="width: 100%; height: 100%; border: none; pointer-events: none;"></iframe>
+      <iframe src="${sourceAttribute(iframeSrc, true)}" sandbox="allow-scripts allow-same-origin" style="width: 100%; height: 100%; border: none; pointer-events: none;"></iframe>
       <div class="composition-click-overlay" style="position: absolute; inset: 0; cursor: pointer;"></div>
     </div>`;
   }
 
   if (isMediaElement(element)) {
     if (element.mediaStartTime) {
-      baseAttrs.push(`data-media-start="${element.mediaStartTime}"`);
+      baseAttrs.push(
+        `data-media-start="${escapeHtmlAttributeValue(String(element.mediaStartTime))}"`,
+      );
     }
     if (element.sourceDuration) {
-      baseAttrs.push(`data-source-duration="${element.sourceDuration}"`);
+      baseAttrs.push(
+        `data-source-duration="${escapeHtmlAttributeValue(String(element.sourceDuration))}"`,
+      );
     }
     if (element.isAroll) {
       baseAttrs.push(`data-aroll="true"`);
     }
     if (element.volume !== undefined && element.volume !== 1) {
-      baseAttrs.push(`data-volume="${element.volume}"`);
+      baseAttrs.push(`data-volume="${escapeHtmlAttributeValue(String(element.volume))}"`);
     }
     if (element.type === "video" && element.hasAudio) {
       baseAttrs.push(`data-has-audio="true"`);
@@ -585,11 +653,11 @@ function generateElementHtml(element: TimelineElement, keyframes?: Keyframe[]): 
 
   switch (element.type) {
     case "video":
-      return `<video ${attrs} src="${element.src}" playsinline></video>`;
+      return `<video ${attrs} src="${sourceAttribute(element.src)}" playsinline></video>`;
     case "image":
-      return `<img ${attrs} src="${element.src}" alt="${element.name}" />`;
+      return `<img ${attrs} src="${sourceAttribute(element.src)}" alt="${escapeHtmlAttributeValue(String(element.name))}" />`;
     case "audio":
-      return `<audio ${attrs} src="${element.src}"></audio>`;
+      return `<audio ${attrs} src="${sourceAttribute(element.src)}"></audio>`;
     default:
       return "";
   }
@@ -642,9 +710,13 @@ function generateInitialPositionSets(
 
     // Set position and scale (xPercent/yPercent applied at player init)
     if (scaleVal !== 1) {
-      sets.push(`    tl.set("#${el.id}", { x: ${xVal}, y: ${yVal}, scale: ${scaleVal} }, 0);`);
+      sets.push(
+        `    tl.set(${JSON.stringify(elementSelector(el.id))}, { x: ${finiteNumber(xVal)}, y: ${finiteNumber(yVal)}, scale: ${finiteNumber(scaleVal)} }, 0);`,
+      );
     } else if (xVal !== 0 || yVal !== 0) {
-      sets.push(`    tl.set("#${el.id}", { x: ${xVal}, y: ${yVal} }, 0);`);
+      sets.push(
+        `    tl.set(${JSON.stringify(elementSelector(el.id))}, { x: ${finiteNumber(xVal)}, y: ${finiteNumber(yVal)} }, 0);`,
+      );
     }
   }
 
@@ -671,9 +743,10 @@ function generateVisibilityForElementsWithoutKeyframes(
     const start = el.startTime;
     const end = el.startTime + el.duration;
 
-    const safeName = el.name.replace(/[\r\n]+/g, " ");
-    animations.push(`    // ${safeName} (visibility)`);
-    animations.push(`    tl.set("#${el.id}", { visibility: "hidden" }, 0);`);
+    animations.push("    // Element visibility");
+    animations.push(
+      `    tl.set(${JSON.stringify(elementSelector(el.id))}, { visibility: "hidden" }, 0);`,
+    );
 
     let elementOpacity = el.opacity ?? 1;
     if (opacityKeyframes.length > 0) {
@@ -686,13 +759,17 @@ function generateVisibilityForElementsWithoutKeyframes(
     const needsOpacity = elementOpacity !== 1 || opacityKeyframes.length > 0;
     if (needsOpacity) {
       animations.push(
-        `    tl.set("#${el.id}", { visibility: "visible", opacity: ${elementOpacity} }, ${start});`,
+        `    tl.set(${JSON.stringify(elementSelector(el.id))}, { visibility: "visible", opacity: ${finiteNumber(elementOpacity)} }, ${finiteNumber(start)});`,
       );
     } else {
-      animations.push(`    tl.set("#${el.id}", { visibility: "visible" }, ${start});`);
+      animations.push(
+        `    tl.set(${JSON.stringify(elementSelector(el.id))}, { visibility: "visible" }, ${finiteNumber(start)});`,
+      );
     }
 
-    animations.push(`    tl.set("#${el.id}", { visibility: "hidden" }, ${end});`);
+    animations.push(
+      `    tl.set(${JSON.stringify(elementSelector(el.id))}, { visibility: "hidden" }, ${finiteNumber(end)});`,
+    );
   }
 
   return animations.length > 0 ? animations.join("\n") : "";
@@ -708,7 +785,7 @@ function generateDefaultGsapAnimations(
   if (elements.length === 0 && (!stageZoomKeyframes || stageZoomKeyframes.length === 0)) {
     return `
     const tl = gsap.timeline({ paused: true });
-    tl.to({}, { duration: ${totalDuration || 1} });
+    tl.to({}, { duration: ${finiteNumber(totalDuration || 1)} });
     `;
   }
 
@@ -724,19 +801,24 @@ function generateDefaultGsapAnimations(
     const start = el.startTime;
     const end = el.startTime + el.duration;
 
-    const safeName = el.name.replace(/[\r\n]+/g, " ");
     const elementOpacity = el.opacity ?? 1;
-    animations.push(`    // ${safeName}`);
-    animations.push(`    tl.set("#${el.id}", { visibility: "hidden" }, 0);`);
+    animations.push("    // Element visibility");
+    animations.push(
+      `    tl.set(${JSON.stringify(elementSelector(el.id))}, { visibility: "hidden" }, 0);`,
+    );
     // Only include opacity if non-default
     if (elementOpacity !== 1) {
       animations.push(
-        `    tl.set("#${el.id}", { visibility: "visible", opacity: ${elementOpacity} }, ${start});`,
+        `    tl.set(${JSON.stringify(elementSelector(el.id))}, { visibility: "visible", opacity: ${finiteNumber(elementOpacity)} }, ${finiteNumber(start)});`,
       );
     } else {
-      animations.push(`    tl.set("#${el.id}", { visibility: "visible" }, ${start});`);
+      animations.push(
+        `    tl.set(${JSON.stringify(elementSelector(el.id))}, { visibility: "visible" }, ${finiteNumber(start)});`,
+      );
     }
-    animations.push(`    tl.set("#${el.id}", { visibility: "hidden" }, ${end});`);
+    animations.push(
+      `    tl.set(${JSON.stringify(elementSelector(el.id))}, { visibility: "hidden" }, ${finiteNumber(end)});`,
+    );
   }
 
   const mediaElements = elements.filter((el) => el.type === "video" || el.type === "audio");

--- a/packages/core/src/generators/hyperframes.ts
+++ b/packages/core/src/generators/hyperframes.ts
@@ -373,7 +373,7 @@ ${gsapScript}
     ? ` data-custom-styles='${escapeHtmlAttributeValue(JSON.stringify(customStyles))}'`
     : "";
 
-  const resolutionAttr = ` data-resolution="${resolution}"`;
+  const resolutionAttr = ` data-resolution="${escapeHtmlAttributeValue(resolution)}"`;
 
   return `<!DOCTYPE html>
 <html data-composition-id="${escapeHtmlAttributeValue(compositionId)}" data-composition-duration="${calculatedDuration}"${resolutionAttr}${customStylesAttr}>

--- a/packages/core/src/generators/hyperframes.ts
+++ b/packages/core/src/generators/hyperframes.ts
@@ -10,6 +10,15 @@ import { serializeGsapAnimations, keyframesToGsapAnimations } from "@hyperframes
 import { GSAP_CDN, BASE_STYLES, ZOOM_CONTAINER_STYLES } from "../templates/constants";
 import { COMPOSITION_ATTRIBUTES } from "../compositionContract.js";
 
+function escapeHtmlAttributeValue(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 const GOOGLE_FONTS_BASE = "https://fonts.googleapis.com/css2";
 const FONT_WEIGHTS: Record<string, string> = {
   Inter: "400;500;600;700;800;900",
@@ -318,7 +327,7 @@ export function generateHyperframesHtml(
   // Serialize zoom keyframes to data attribute
   const zoomKeyframesAttr =
     stageZoomKeyframes && stageZoomKeyframes.length > 0
-      ? ` data-zoom-keyframes='${JSON.stringify(stageZoomKeyframes).replace(/'/g, "&#39;")}'`
+      ? ` data-zoom-keyframes='${escapeHtmlAttributeValue(JSON.stringify(stageZoomKeyframes))}'`
       : "";
 
   let styleTags = "";
@@ -361,13 +370,13 @@ ${gsapScript}
     : "";
 
   const customStylesAttr = customStyles
-    ? ` data-custom-styles='${JSON.stringify(customStyles).replace(/'/g, "&#39;")}'`
+    ? ` data-custom-styles='${escapeHtmlAttributeValue(JSON.stringify(customStyles))}'`
     : "";
 
   const resolutionAttr = ` data-resolution="${resolution}"`;
 
   return `<!DOCTYPE html>
-<html data-composition-id="${compositionId}" data-composition-duration="${calculatedDuration}"${resolutionAttr}${customStylesAttr}>
+<html data-composition-id="${escapeHtmlAttributeValue(compositionId)}" data-composition-duration="${calculatedDuration}"${resolutionAttr}${customStylesAttr}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -470,7 +479,7 @@ function generateElementHtml(element: TimelineElement, keyframes?: Keyframe[]): 
   // Serialize keyframes to data attribute if present
   if (keyframes && keyframes.length > 0) {
     const kfJson = JSON.stringify(keyframes);
-    baseAttrs.push(`data-keyframes='${kfJson.replace(/'/g, "&#39;")}'`);
+    baseAttrs.push(`data-keyframes='${escapeHtmlAttributeValue(kfJson)}'`);
   }
 
   if (isTextElement(element)) {
@@ -532,7 +541,7 @@ function generateElementHtml(element: TimelineElement, keyframes?: Keyframe[]): 
     }
     if (element.variableValues && Object.keys(element.variableValues).length > 0) {
       const varJson = JSON.stringify(element.variableValues);
-      compositionAttrs.push(`data-variable-values='${varJson.replace(/'/g, "&#39;")}'`);
+      compositionAttrs.push(`data-variable-values='${escapeHtmlAttributeValue(varJson)}'`);
     }
     const attrs = compositionAttrs.join(" ");
     // Build iframe src with variable values as query params if present

--- a/packages/core/src/generators/hyperframes.ts
+++ b/packages/core/src/generators/hyperframes.ts
@@ -88,13 +88,16 @@ function generateGoogleFontsUrl(fontFamilies: string[]): string | null {
 }
 
 export interface SerializeOptions {
+  /** Trusted animations: __raw: values are emitted as executable JavaScript. */
   animations?: GsapAnimation[];
+  /** Trusted authored CSS, preserved as code; may load external resources. */
   styles?: string;
   generateDefaultAnimations?: boolean;
   resolution?: CanvasResolution;
   compositionId?: string;
   keyframes?: Record<string, Keyframe[]>;
   stageZoomKeyframes?: StageZoomKeyframe[];
+  /** Emit executable timeline code; animations and __raw: expressions must be trusted. */
   includeScripts?: boolean;
   includeStyles?: boolean;
 }
@@ -128,6 +131,7 @@ function sortElements(elements: TimelineElement[]): TimelineElement[] {
   });
 }
 
+/** Generate CSS from trusted authors. customStyles is authored code, not sanitized CSS. */
 export function generateHyperframesStyles(
   elements: TimelineElement[],
   resolution: CanvasResolution,
@@ -210,6 +214,7 @@ function generateElementStyles(element: TimelineElement): string {
   }
 }
 
+/** Generate executable JavaScript. Animation __raw: expressions require trusted authors. */
 export function generateGsapTimelineScript(
   elements: TimelineElement[],
   totalDuration: number,
@@ -330,6 +335,7 @@ ${initialPositionSets ? initialPositionSets + "\n" : ""}    tl.to({}, { duration
   return gsapScript;
 }
 
+/** Generate a document for trusted authors. Authored CSS and animation __raw: expressions retain their executable capabilities. Context encoding is not a sandbox: do not supply untrusted code-bearing options or serve untrusted compositions in a privileged origin. Text uses the inline-formatting sanitizer; parseHtml flattens inner formatting to text. */
 export function generateHyperframesHtml(
   elements: TimelineElement[],
   totalDuration: number,

--- a/packages/core/src/generators/richTextHtml.ts
+++ b/packages/core/src/generators/richTextHtml.ts
@@ -1,0 +1,43 @@
+import { parseHTML } from "linkedom";
+import { sanitizeRichTextChildren } from "../utils/richTextSanitize";
+
+function escape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Preserve the existing inline-formatting contract, with one safe serialization. */
+export function richTextHtml(content: string): string {
+  const { document } = parseHTML("<html><body></body></html>");
+  const host = document.createElement("div");
+  host.innerHTML = content;
+  sanitizeRichTextChildren(host);
+  // Linkedom does not re-escape entity-looking ampersands in attributes.
+  // Serialize the sanitized tree explicitly so a browser parse preserves values.
+  const result: string[] = [];
+  const pending: Array<Node | string> = Array.from(host.childNodes).reverse();
+  for (let node = pending.pop(); node !== undefined; node = pending.pop()) {
+    if (typeof node === "string") {
+      result.push(node);
+      continue;
+    }
+    if (node.nodeType === 3) {
+      result.push(escape(node.textContent ?? ""));
+      continue;
+    }
+    if (node.nodeType !== 1) continue;
+    const element = node as Element;
+    const tag = element.tagName.toLowerCase();
+    const attrs = Array.from(
+      element.attributes,
+      (attr) => ` ${attr.name}="${escape(attr.value)}"`,
+    ).join("");
+    result.push(`<${tag}${attrs}>`);
+    if (tag === "br") continue;
+    pending.push(`</${tag}>`, ...Array.from(element.childNodes).reverse());
+  }
+  return result.join("");
+}

--- a/packages/parsers/src/gsapSerialize.ts
+++ b/packages/parsers/src/gsapSerialize.ts
@@ -236,7 +236,7 @@ export function serializeGsapAnimations(
   });
   // fallow-ignore-next-line complexity
   const lines = sorted.map((anim) => {
-    const selector = `"${anim.targetSelector}"`;
+    const selector = JSON.stringify(anim.targetSelector);
     const props: Record<string, number | string> = { ...anim.properties };
     if (anim.duration !== undefined) props.duration = anim.duration;
     if (anim.ease) props.ease = anim.ease;
@@ -250,7 +250,7 @@ export function serializeGsapAnimations(
         propsStr = propsStr.slice(0, -2) + `, ${extrasStr} }`;
       }
     }
-    const posStr = typeof anim.position === "string" ? `"${anim.position}"` : anim.position;
+    const posStr = JSON.stringify(anim.position);
     switch (anim.method) {
       case "set":
         // A global set is a base `gsap.set` — off the timeline, no position arg.

--- a/packages/parsers/src/gsapSerialize.ts
+++ b/packages/parsers/src/gsapSerialize.ts
@@ -222,6 +222,12 @@ export interface SplitAnimationsResult {
 
 // ── Serialization ───────────────────────────────────────────────────────────
 
+/**
+ * Construct executable JavaScript from trusted composition-author inputs.
+ * __raw: values, preamble, postamble, and timelineVar are code-bearing inputs
+ * and are deliberately not sanitized. Never populate them from untrusted data.
+ * Quoting ordinary values does not sandbox authored code or its side effects.
+ */
 export function serializeGsapAnimations(
   animations: GsapAnimation[],
   timelineVar = "tl",

--- a/packages/parsers/src/hfIdAssignment.ts
+++ b/packages/parsers/src/hfIdAssignment.ts
@@ -39,12 +39,22 @@ function ownText(el: Element): string {
   return text.trim();
 }
 
+function attributeName(el: Element, name: string): string {
+  return el.namespaceURI === "http://www.w3.org/1999/xhtml" ? name.toLowerCase() : name;
+}
+
+function getContractAttribute(el: Element, name: string): string | null {
+  return (
+    Array.from(el.attributes).find((attr) => attributeName(el, attr.name) === name)?.value ?? null
+  );
+}
+
 function contentKey(el: Element): string {
   // Exclude all data-hf-* attrs (ids, studio state) — they must not influence the hash.
   // Use \x00 / \x01 separators (invalid in HTML attrs) to prevent ambiguous serialization.
   const attrs = Array.from(el.attributes)
-    .filter((a) => !a.name.startsWith("data-hf-"))
-    .map((a) => `${a.name}\x00${a.value}`)
+    .filter((a) => !attributeName(el, a.name).startsWith("data-hf-"))
+    .map((a) => `${attributeName(el, a.name)}\x00${a.value}`)
     .sort()
     .join("\x01");
   return `${el.tagName.toLowerCase()}|${attrs}|${ownText(el)}`;
@@ -60,7 +70,7 @@ function contentKey(el: Element): string {
  * `data-hf-id` to source the attribute is physically bound to its element.
  * Reordering identical siblings carries the attribute along → zero
  * order-dependence post-persist. `ensureHfIds` skips pinned elements
- * (`if (el.getAttribute("data-hf-id")) continue`), so normal operation
+ * (`if (getContractAttribute(el, "data-hf-id")) continue`), so normal operation
  * never re-exposes the ordering after first persist.
  */
 // WIRE CONTRACT: id minting is content-keyed (FNV1a of innerHTML + tag). R7's
@@ -112,9 +122,9 @@ function getChildElements(parent: Element): Element[] {
 
 export function isCompositionTemplate(el: Element): boolean {
   if (el.tagName.toLowerCase() !== "template") return false;
-  if (el.getAttribute("data-composition-id") !== null) return true;
+  if (getContractAttribute(el, "data-composition-id") !== null) return true;
   for (const child of getChildElements(el)) {
-    if (child.getAttribute("data-composition-id") !== null) return true;
+    if (getContractAttribute(child, "data-composition-id") !== null) return true;
   }
   return false;
 }
@@ -149,12 +159,12 @@ export function walkCompositionDescendants(
 export function assignHfIds(body: Element): void {
   const assigned = new Set<string>();
   walkCompositionDescendants(body, (el) => {
-    const existing = el.getAttribute("data-hf-id");
+    const existing = getContractAttribute(el, "data-hf-id");
     if (existing) assigned.add(existing);
   });
   walkCompositionDescendants(body, (el) => {
     if (EXCLUDED_TAGS.has(el.tagName.toLowerCase())) return;
-    if (el.getAttribute("data-hf-id")) return;
+    if (getContractAttribute(el, "data-hf-id")) return;
     el.setAttribute("data-hf-id", mintHfId(el, assigned));
   });
 }

--- a/packages/parsers/src/hfIdAssignment.ts
+++ b/packages/parsers/src/hfIdAssignment.ts
@@ -1,0 +1,160 @@
+// Non-editable / non-visual elements that should never receive a stable id.
+export const EXCLUDED_TAGS = new Set([
+  "script",
+  "style",
+  "template",
+  "meta",
+  "link",
+  "noscript",
+  "base",
+]);
+
+// 32-bit FNV-1a. Pure, deterministic, no crypto, no Math.random.
+function fnv1a(str: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+// 4 base-36 chars · 36^4 ≈ 1.68M ids per document. Birthday-paradox collision
+// ≈ N²/(2·36^4): well under 1% per document after dup rehash at realistic
+// clip-model sizes (≤ a few hundred elements). The dup-rehash in mintHfId
+// resolves the rare collision; width is deliberately small for readable ids.
+function toHfId(hash: number): string {
+  const s = (hash >>> 0).toString(36);
+  // Use suffix (most-avalanched bits) for better distribution within the 4-char window.
+  const four = s.length >= 4 ? s.slice(-4) : s.padStart(4, "0");
+  return `hf-${four}`;
+}
+
+// Element's own direct text (TEXT_NODE children), not descendants'.
+function ownText(el: Element): string {
+  let text = "";
+  el.childNodes.forEach((n) => {
+    if (n.nodeType === 3) text += (n as Text).nodeValue ?? "";
+  });
+  return text.trim();
+}
+
+function contentKey(el: Element): string {
+  // Exclude all data-hf-* attrs (ids, studio state) — they must not influence the hash.
+  // Use \x00 / \x01 separators (invalid in HTML attrs) to prevent ambiguous serialization.
+  const attrs = Array.from(el.attributes)
+    .filter((a) => !a.name.startsWith("data-hf-"))
+    .map((a) => `${a.name}\x00${a.value}`)
+    .sort()
+    .join("\x01");
+  return `${el.tagName.toLowerCase()}|${attrs}|${ownText(el)}`;
+}
+
+/**
+ * Collision tiebreak for byte-identical siblings: document-order dup counter
+ * (`hash(key#N)`). This IS order-dependent — two identical `<span></span>`
+ * get different ids based on which comes first in the DOM. This is unavoidable:
+ * unique ids for byte-identical elements require a positional signal.
+ *
+ * Why this is safe in practice: once `ensureHfIds` write-back persists
+ * `data-hf-id` to source the attribute is physically bound to its element.
+ * Reordering identical siblings carries the attribute along → zero
+ * order-dependence post-persist. `ensureHfIds` skips pinned elements
+ * (`if (el.getAttribute("data-hf-id")) continue`), so normal operation
+ * never re-exposes the ordering after first persist.
+ */
+// WIRE CONTRACT: id minting is content-keyed (FNV1a of innerHTML + tag). R7's
+// preview route relies on mintHfId producing identical ids across mint contexts
+// (disk-persist pass vs. in-memory bundle pass) — see preview.test.ts
+// "bundle returning untagged HTML gets same ids as disk". Any change that adds
+// positional, session, or random input to the hash breaks that invariant and
+// makes hf- ids diverge between disk and served HTML, silently corrupting
+// drag-to-edit targeting.
+export function mintHfId(el: Element, assigned: Set<string>): string {
+  const key = contentKey(el);
+  let id = toHfId(fnv1a(key));
+  let dup = 0;
+  while (assigned.has(id)) {
+    dup += 1;
+    // Graceful fallback instead of a hard throw: rehashing only fails to find a
+    // free 4-char slot in a pathological document (~1.6M identical elements).
+    // Rather than crash the whole parse, widen the id with the dup counter —
+    // still deterministic and unique, just longer than the 4-char norm.
+    if (dup > 10000) {
+      id = `hf-${(fnv1a(key) >>> 0).toString(36)}-${dup}`;
+      break;
+    }
+    id = toHfId(fnv1a(`${key}#${dup}`));
+  }
+  assigned.add(id);
+  return id;
+}
+
+/**
+ * True for a sub-composition authoring template whose content the studio preview
+ * unwraps into the served body. Two accepted forms:
+ *   A) `<template data-composition-id="X">…` — the id on the template itself.
+ *   B) `<template id="X-template"><div data-composition-id="X">…` — the id on the
+ *      wrapped root div (the form `hyperframes add` scaffolds and registry blocks use).
+ * Only these are treated as transparent containers for hf-id purposes. A plain
+ * `<template>` (runtime clone-source: list item, particle, etc.) must NOT get
+ * inner ids — its content is cloned N times into the live DOM, so a persisted
+ * inner id would be duplicated across every clone. Form B is distinguished from
+ * a clone-source by the presence of a direct `[data-composition-id]` child.
+ */
+function getChildElements(parent: Element): Element[] {
+  const directChildren = Array.from(parent.children);
+  if (directChildren.length || parent.tagName.toLowerCase() !== "template") return directChildren;
+  const content = (parent as HTMLTemplateElement).content;
+  if (content?.children.length) return Array.from(content.children);
+  return directChildren;
+}
+
+export function isCompositionTemplate(el: Element): boolean {
+  if (el.tagName.toLowerCase() !== "template") return false;
+  if (el.getAttribute("data-composition-id") !== null) return true;
+  for (const child of getChildElements(el)) {
+    if (child.getAttribute("data-composition-id") !== null) return true;
+  }
+  return false;
+}
+
+/**
+ * Walk document-order descendants, descending through composition templates
+ * while keeping plain templates inert. linkedom's querySelectorAll does not
+ * expose template contents, so callers that model the served composition use
+ * this traversal instead.
+ */
+export function walkCompositionDescendants(
+  root: Document | Element,
+  visit: (el: Element) => void,
+): void {
+  const rootElement: Element | null =
+    root.nodeType === 9 ? (root as Document).documentElement : (root as Element);
+  if (!rootElement) return;
+
+  const walk = (parent: Element): void => {
+    for (const child of getChildElements(parent)) {
+      const isTemplate = child.tagName.toLowerCase() === "template";
+      if (isTemplate && !isCompositionTemplate(child)) continue;
+      visit(child);
+      walk(child);
+    }
+  };
+
+  walk(rootElement);
+}
+
+// Internal DOM-only assignment: callers retain their parser and document identity.
+export function assignHfIds(body: Element): void {
+  const assigned = new Set<string>();
+  walkCompositionDescendants(body, (el) => {
+    const existing = el.getAttribute("data-hf-id");
+    if (existing) assigned.add(existing);
+  });
+  walkCompositionDescendants(body, (el) => {
+    if (EXCLUDED_TAGS.has(el.tagName.toLowerCase())) return;
+    if (el.getAttribute("data-hf-id")) return;
+    el.setAttribute("data-hf-id", mintHfId(el, assigned));
+  });
+}

--- a/packages/parsers/src/hfIdAssignment.ts
+++ b/packages/parsers/src/hfIdAssignment.ts
@@ -39,22 +39,18 @@ function ownText(el: Element): string {
   return text.trim();
 }
 
-function attributeName(el: Element, name: string): string {
-  return el.namespaceURI === "http://www.w3.org/1999/xhtml" ? name.toLowerCase() : name;
-}
-
 function getContractAttribute(el: Element, name: string): string | null {
-  return (
-    Array.from(el.attributes).find((attr) => attributeName(el, attr.name) === name)?.value ?? null
-  );
+  return Array.from(el.attributes).find((attr) => attr.name.toLowerCase() === name)?.value ?? null;
 }
 
 function contentKey(el: Element): string {
+  // HTML parsers normalize foreign-content attribute names differently too.
+  // Canonicalize only the hash input; retain actual SVG attribute spelling.
   // Exclude all data-hf-* attrs (ids, studio state) — they must not influence the hash.
   // Use \x00 / \x01 separators (invalid in HTML attrs) to prevent ambiguous serialization.
   const attrs = Array.from(el.attributes)
-    .filter((a) => !attributeName(el, a.name).startsWith("data-hf-"))
-    .map((a) => `${attributeName(el, a.name)}\x00${a.value}`)
+    .filter((a) => !a.name.toLowerCase().startsWith("data-hf-"))
+    .map((a) => `${a.name.toLowerCase()}\x00${a.value}`)
     .sort()
     .join("\x01");
   return `${el.tagName.toLowerCase()}|${attrs}|${ownText(el)}`;

--- a/packages/parsers/src/hfIds.test.ts
+++ b/packages/parsers/src/hfIds.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { ensureHfIds, mintHfId } from "./hfIds.js";
+import { ensureHfIds, mintHfId, walkCompositionDescendants } from "./hfIds.js";
 import { parseHTML } from "linkedom";
+import { assignHfIds } from "./hfIdAssignment.js";
 
 function ids(html: string): string[] {
   const { document } = parseHTML(html);
@@ -18,6 +19,40 @@ function idOf(html: string, selector: string): string | null {
 const doc = (body: string) => `<!doctype html><html><body>${body}</body></html>`;
 
 describe("ensureHfIds", () => {
+  it("ignores HTML attribute case and editor state while retaining pinned IDs", () => {
+    const lower = doc(`<div id="x" data-start="2" data-hf-state="a">hello</div>`);
+    const upper = doc(`<DIV ID="x" DATA-START="2" DATA-HF-STATE="b">hello</DIV>`);
+    expect(ids(ensureHfIds(upper))).toEqual(ids(ensureHfIds(lower)));
+    const pinned = ensureHfIds(doc(`<DIV DATA-HF-ID="pinned" DATA-START="2">hello</DIV>`));
+    expect(
+      new DOMParser()
+        .parseFromString(pinned, "text/html")
+        .querySelector("[data-start]")
+        ?.getAttribute("data-hf-id"),
+    ).toBe("pinned");
+  });
+
+  it.each([
+    `<TEMPLATE DATA-COMPOSITION-ID="sub"><DIV ID="x" DATA-START="2">hello</DIV></TEMPLATE>`,
+    `<TEMPLATE><DIV DATA-COMPOSITION-ID="sub"><DIV ID="x" DATA-START="2">hello</DIV></DIV></TEMPLATE>`,
+  ])("assigns matching IDs inside mixed-case composition templates: %s", (body) => {
+    const html = doc(body);
+    const native = new DOMParser().parseFromString(html, "text/html");
+    assignHfIds(native.body);
+    const persisted = new DOMParser().parseFromString(ensureHfIds(html), "text/html");
+    const collect = (document: Document): string[] => {
+      const result: string[] = [];
+      walkCompositionDescendants(document.body, (el) => {
+        if (el.tagName.toLowerCase() !== "template")
+          result.push(el.getAttribute("data-hf-id") ?? "missing");
+      });
+      return result;
+    };
+    expect(collect(native).length).toBeGreaterThan(0);
+    expect(collect(native)).not.toContain("missing");
+    expect(collect(native)).toEqual(collect(persisted));
+  });
+
   it("mints a hf- id on every editable element node in body", () => {
     const html = `<!doctype html><html><body>
       <div class="card"><h1>Hi</h1><img src="a.png"><span>x</span></div>

--- a/packages/parsers/src/hfIds.test.ts
+++ b/packages/parsers/src/hfIds.test.ts
@@ -53,6 +53,29 @@ describe("ensureHfIds", () => {
     expect(collect(native)).toEqual(collect(persisted));
   });
 
+  it.each([
+    '<svg><linearGradient VIEWBOX="0 0 1 1"></linearGradient></svg>',
+    '<svg><linearGradient GRADIENTUNITS="userSpaceOnUse"></linearGradient></svg>',
+    '<svg><linearGradient ID="g" CLASS="paint" ARIA-LABEL="Gradient" DATA-HF-STATE="ignored"></linearGradient></svg>',
+    '<svg><linearGradient DATA-HF-ID="pinned" VIEWBOX="0 0 1 1"></linearGradient></svg>',
+  ])("matches persisted IDs for mixed-case SVG attributes: %s", (body) => {
+    const html = doc(body);
+    const native = new DOMParser().parseFromString(html, "text/html");
+    assignHfIds(native.body);
+    const persisted = new DOMParser().parseFromString(ensureHfIds(html), "text/html");
+    const collect = (document: Document) =>
+      Array.from(document.querySelectorAll("svg, linearGradient")).map((el) =>
+        el.getAttribute("data-hf-id"),
+      );
+    expect(collect(native)).toHaveLength(2);
+    expect(collect(native)).not.toContain(null);
+    expect(collect(native)).toEqual(collect(persisted));
+    expect(ensureHfIds(ensureHfIds(html))).toBe(ensureHfIds(html));
+    const gradient = persisted.querySelector("linearGradient");
+    if (body.includes("VIEWBOX")) expect(gradient?.getAttribute("viewBox")).toBe("0 0 1 1");
+    if (body.includes("DATA-HF-ID")) expect(gradient?.getAttribute("data-hf-id")).toBe("pinned");
+  });
+
   it("mints a hf- id on every editable element node in body", () => {
     const html = `<!doctype html><html><body>
       <div class="card"><h1>Hi</h1><img src="a.png"><span>x</span></div>

--- a/packages/parsers/src/hfIds.ts
+++ b/packages/parsers/src/hfIds.ts
@@ -169,7 +169,7 @@ function walkElements(root: Element, visit: (el: Element) => void): void {
   walkCompositionDescendants(root, visit);
 }
 
-export function ensureHfIds(html: string): string {
+export function parseHtmlWithHfIds(html: string): Document {
   // Mirror parseSourceDocument's fragment-wrapping so bare fragments don't land
   // outside <body> in linkedom, which would cause body.querySelectorAll to return [].
   const hasDocumentShell = /<!doctype|<html[\s>]/i.test(html);
@@ -178,7 +178,7 @@ export function ensureHfIds(html: string): string {
     ? parseHTML(`<!DOCTYPE html><html><head></head><body>${html}</body></html>`)
     : parseHTML(html);
   const body = document.body;
-  if (!body) return html;
+  if (!body) return document;
 
   const assigned = new Set<string>();
   // Seed with already-present ids (pin) so fresh mints never collide with them.
@@ -195,5 +195,11 @@ export function ensureHfIds(html: string): string {
     el.setAttribute("data-hf-id", mintHfId(el, assigned));
   });
 
-  return wrapped ? document.body.innerHTML || "" : document.toString();
+  return document;
+}
+
+export function ensureHfIds(html: string): string {
+  const document = parseHtmlWithHfIds(html);
+  if (!document.body) return html;
+  return /<!doctype|<html[\s>]/i.test(html) ? document.toString() : document.body.innerHTML || "";
 }

--- a/packages/parsers/src/hfIds.ts
+++ b/packages/parsers/src/hfIds.ts
@@ -9,197 +9,21 @@
  * so inserting a non-identical sibling never shifts another element's id.
  */
 import { parseHTML } from "linkedom";
+import { assignHfIds } from "./hfIdAssignment.js";
+export {
+  EXCLUDED_TAGS,
+  mintHfId,
+  isCompositionTemplate,
+  walkCompositionDescendants,
+} from "./hfIdAssignment.js";
 
-// Non-editable / non-visual elements that should never receive a stable id.
-export const EXCLUDED_TAGS = new Set([
-  "script",
-  "style",
-  "template",
-  "meta",
-  "link",
-  "noscript",
-  "base",
-]);
-
-// 32-bit FNV-1a. Pure, deterministic, no crypto, no Math.random.
-function fnv1a(str: string): number {
-  let h = 0x811c9dc5;
-  for (let i = 0; i < str.length; i++) {
-    h ^= str.charCodeAt(i);
-    h = Math.imul(h, 0x01000193);
-  }
-  return h >>> 0;
-}
-
-// 4 base-36 chars · 36^4 ≈ 1.68M ids per document. Birthday-paradox collision
-// ≈ N²/(2·36^4): well under 1% per document after dup rehash at realistic
-// clip-model sizes (≤ a few hundred elements). The dup-rehash in mintHfId
-// resolves the rare collision; width is deliberately small for readable ids.
-function toHfId(hash: number): string {
-  const s = (hash >>> 0).toString(36);
-  // Use suffix (most-avalanched bits) for better distribution within the 4-char window.
-  const four = s.length >= 4 ? s.slice(-4) : s.padStart(4, "0");
-  return `hf-${four}`;
-}
-
-// Element's own direct text (TEXT_NODE children), not descendants'.
-function ownText(el: Element): string {
-  let text = "";
-  el.childNodes.forEach((n) => {
-    if (n.nodeType === 3) text += (n as Text).nodeValue ?? "";
-  });
-  return text.trim();
-}
-
-function contentKey(el: Element): string {
-  // Exclude all data-hf-* attrs (ids, studio state) — they must not influence the hash.
-  // Use \x00 / \x01 separators (invalid in HTML attrs) to prevent ambiguous serialization.
-  const attrs = Array.from(el.attributes)
-    .filter((a) => !a.name.startsWith("data-hf-"))
-    .map((a) => `${a.name}\x00${a.value}`)
-    .sort()
-    .join("\x01");
-  return `${el.tagName.toLowerCase()}|${attrs}|${ownText(el)}`;
-}
-
-/**
- * Collision tiebreak for byte-identical siblings: document-order dup counter
- * (`hash(key#N)`). This IS order-dependent — two identical `<span></span>`
- * get different ids based on which comes first in the DOM. This is unavoidable:
- * unique ids for byte-identical elements require a positional signal.
- *
- * Why this is safe in practice: once `ensureHfIds` write-back persists
- * `data-hf-id` to source the attribute is physically bound to its element.
- * Reordering identical siblings carries the attribute along → zero
- * order-dependence post-persist. `ensureHfIds` skips pinned elements
- * (`if (el.getAttribute("data-hf-id")) continue`), so normal operation
- * never re-exposes the ordering after first persist.
- */
-// WIRE CONTRACT: id minting is content-keyed (FNV1a of innerHTML + tag). R7's
-// preview route relies on mintHfId producing identical ids across mint contexts
-// (disk-persist pass vs. in-memory bundle pass) — see preview.test.ts
-// "bundle returning untagged HTML gets same ids as disk". Any change that adds
-// positional, session, or random input to the hash breaks that invariant and
-// makes hf- ids diverge between disk and served HTML, silently corrupting
-// drag-to-edit targeting.
-export function mintHfId(el: Element, assigned: Set<string>): string {
-  const key = contentKey(el);
-  let id = toHfId(fnv1a(key));
-  let dup = 0;
-  while (assigned.has(id)) {
-    dup += 1;
-    // Graceful fallback instead of a hard throw: rehashing only fails to find a
-    // free 4-char slot in a pathological document (~1.6M identical elements).
-    // Rather than crash the whole parse, widen the id with the dup counter —
-    // still deterministic and unique, just longer than the 4-char norm.
-    if (dup > 10000) {
-      id = `hf-${(fnv1a(key) >>> 0).toString(36)}-${dup}`;
-      break;
-    }
-    id = toHfId(fnv1a(`${key}#${dup}`));
-  }
-  assigned.add(id);
-  return id;
-}
-
-/**
- * True for a sub-composition authoring template whose content the studio preview
- * unwraps into the served body. Two accepted forms:
- *   A) `<template data-composition-id="X">…` — the id on the template itself.
- *   B) `<template id="X-template"><div data-composition-id="X">…` — the id on the
- *      wrapped root div (the form `hyperframes add` scaffolds and registry blocks use).
- * Only these are treated as transparent containers for hf-id purposes. A plain
- * `<template>` (runtime clone-source: list item, particle, etc.) must NOT get
- * inner ids — its content is cloned N times into the live DOM, so a persisted
- * inner id would be duplicated across every clone. Form B is distinguished from
- * a clone-source by the presence of a direct `[data-composition-id]` child.
- */
-function getChildElements(parent: Element): Element[] {
-  const directChildren = Array.from(parent.children);
-  if (directChildren.length || parent.tagName.toLowerCase() !== "template") return directChildren;
-  const content = (parent as HTMLTemplateElement).content;
-  if (content?.children.length) return Array.from(content.children);
-  return directChildren;
-}
-
-export function isCompositionTemplate(el: Element): boolean {
-  if (el.tagName.toLowerCase() !== "template") return false;
-  if (el.getAttribute("data-composition-id") !== null) return true;
-  for (const child of getChildElements(el)) {
-    if (child.getAttribute("data-composition-id") !== null) return true;
-  }
-  return false;
-}
-
-/**
- * Walk document-order descendants, descending through composition templates
- * while keeping plain templates inert. linkedom's querySelectorAll does not
- * expose template contents, so callers that model the served composition use
- * this traversal instead.
- */
-export function walkCompositionDescendants(
-  root: Document | Element,
-  visit: (el: Element) => void,
-): void {
-  const rootElement: Element | null =
-    root.nodeType === 9 ? (root as Document).documentElement : (root as Element);
-  if (!rootElement) return;
-
-  const walk = (parent: Element): void => {
-    for (const child of getChildElements(parent)) {
-      const isTemplate = child.tagName.toLowerCase() === "template";
-      if (isTemplate && !isCompositionTemplate(child)) continue;
-      visit(child);
-      walk(child);
-    }
-  };
-
-  walk(rootElement);
-}
-
-/**
- * Document-order walk of every element under `root`, descending into
- * composition `<template>` subtrees — linkedom's querySelectorAll does not, so
- * template-based sub-comps would otherwise never get inner ids (the preview
- * unwraps the template and stamps the SAME content, so skipping here splits
- * the id space between the served DOM and the raw file). Plain templates are
- * skipped entirely (see isCompositionTemplate).
- */
-function walkElements(root: Element, visit: (el: Element) => void): void {
-  walkCompositionDescendants(root, visit);
-}
-
-export function parseHtmlWithHfIds(html: string): Document {
-  // Mirror parseSourceDocument's fragment-wrapping so bare fragments don't land
-  // outside <body> in linkedom, which would cause body.querySelectorAll to return [].
-  const hasDocumentShell = /<!doctype|<html[\s>]/i.test(html);
-  const wrapped = !hasDocumentShell;
+export function ensureHfIds(html: string): string {
+  // Wrap fragments so every body element participates in stable ID assignment.
+  const wrapped = !/<!doctype|<html[\s>]/i.test(html);
   const { document } = wrapped
     ? parseHTML(`<!DOCTYPE html><html><head></head><body>${html}</body></html>`)
     : parseHTML(html);
-  const body = document.body;
-  if (!body) return document;
-
-  const assigned = new Set<string>();
-  // Seed with already-present ids (pin) so fresh mints never collide with them.
-  // Scope to <body> to match the mint walk below — a stray data-hf-id in <head>
-  // must not pin an id into the set that a body element would then be bumped off.
-  walkElements(body, (el) => {
-    const existing = el.getAttribute("data-hf-id");
-    if (existing) assigned.add(existing);
-  });
-
-  walkElements(body, (el) => {
-    if (EXCLUDED_TAGS.has(el.tagName.toLowerCase())) return;
-    if (el.getAttribute("data-hf-id")) return; // pinned
-    el.setAttribute("data-hf-id", mintHfId(el, assigned));
-  });
-
-  return document;
-}
-
-export function ensureHfIds(html: string): string {
-  const document = parseHtmlWithHfIds(html);
   if (!document.body) return html;
-  return /<!doctype|<html[\s>]/i.test(html) ? document.toString() : document.body.innerHTML || "";
+  assignHfIds(document.body);
+  return wrapped ? document.body.innerHTML || "" : document.toString();
 }

--- a/packages/parsers/src/htmlParser.test.ts
+++ b/packages/parsers/src/htmlParser.test.ts
@@ -12,6 +12,21 @@ import {
 } from "./htmlParser.js";
 
 describe("parseHtml", () => {
+  it("preserves runtime HTML normalization for mixed-case attributes", () => {
+    const result = parseHtml(`<!doctype html><HTML DATA-RESOLUTION="square"><BODY>
+      <DIV ID="x" DATA-START="2" DATA-DURATION="3" DATA-TRACK-INDEX="4" DATA-NAME="UP"><DIV>hello</DIV></DIV>
+    </BODY></HTML>`);
+    expect(result.resolution).toBe("square");
+    expect(result.elements).toHaveLength(1);
+    expect(result.elements[0]).toMatchObject({
+      startTime: 2,
+      duration: 3,
+      zIndex: 4,
+      name: "UP",
+      content: "hello",
+    });
+  });
+
   it("extracts elements with data-start and data-end", () => {
     const html = `
       <html>

--- a/packages/parsers/src/htmlParser.test.ts
+++ b/packages/parsers/src/htmlParser.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect } from "vitest";
+import { ensureHfIds } from "./hfIds.js";
 import {
   parseHtml,
   updateElementInHtml,
@@ -25,6 +26,19 @@ describe("parseHtml", () => {
       name: "UP",
       content: "hello",
     });
+  });
+
+  it.each([
+    `<DIV ID="x" DATA-START="2" DATA-DURATION="3" DATA-NAME="UP"><DIV>hello</DIV></DIV>`,
+    `<DIV ID="x" DATA-START="2" DATA-HF-ID="pinned" DATA-HF-STATE="ignored"><DIV>hello</DIV></DIV>`,
+  ])("matches persisted and runtime IDs for mixed-case HTML: %s", (body) => {
+    const html = `<!doctype html><html><body>${body}</body></html>`;
+    const first = parseHtml(html);
+    const persisted = parseHtml(ensureHfIds(html));
+    expect(first.elements.length).toBeGreaterThan(0);
+    expect(first.elements.map((element) => element.id)).toEqual(
+      persisted.elements.map((element) => element.id),
+    );
   });
 
   it("extracts elements with data-start and data-end", () => {

--- a/packages/parsers/src/htmlParser.ts
+++ b/packages/parsers/src/htmlParser.ts
@@ -269,7 +269,7 @@ export function parseHtml(html: string): ParsedHtml {
 
     if (type === "text") {
       const textEl = el.firstElementChild;
-      const content = textEl?.textContent || name;
+      const content = textEl?.textContent ?? name;
       const color = el.getAttribute("data-color") || undefined;
       const fontSizeAttr = el.getAttribute("data-font-size");
       const fontSize = fontSizeAttr ? parseInt(fontSizeAttr, 10) : undefined;

--- a/packages/parsers/src/htmlParser.ts
+++ b/packages/parsers/src/htmlParser.ts
@@ -13,7 +13,8 @@ import type {
 } from "./types.js";
 import { validateCompositionGsap } from "./gsapSerialize";
 import { parseCompositionVariables } from "./compositionVariables.js";
-import { parseHtmlWithHfIds, walkCompositionDescendants } from "./hfIds.js";
+import { walkCompositionDescendants } from "./hfIds.js";
+import { assignHfIds } from "./hfIdAssignment.js";
 import { parseGsapScriptAcornForWrite } from "./gsapParserAcorn.js";
 import { queryByAttr } from "./utils/cssSelector.js";
 import { removeAnimationFromScript } from "./gsapWriterAcorn.js";
@@ -178,16 +179,18 @@ function resolveResolutionFromDimensions(width: number, height: number): CanvasR
 }
 
 export function parseHtml(html: string): ParsedHtml {
-  const doc = parseHtmlWithHfIds(html);
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
 
   const elements: TimelineElement[] = [];
   const keyframes: Record<string, Keyframe[]> = {};
   let idCounter = 0;
 
   const htmlEl = doc.documentElement;
-  if (!htmlEl || (!/<!doctype|<html[\s>]/i.test(html) && !doc.body.firstElementChild)) {
+  if (!htmlEl) {
     throw new CompositionHtmlParseError("parseHtml: input HTML is empty or could not be parsed");
   }
+  if (doc.body) assignHfIds(doc.body);
   const customStylesAttr = htmlEl.getAttribute("data-custom-styles");
   let customStyles: string | null = null;
   if (customStylesAttr) {

--- a/packages/parsers/src/htmlParser.ts
+++ b/packages/parsers/src/htmlParser.ts
@@ -13,7 +13,7 @@ import type {
 } from "./types.js";
 import { validateCompositionGsap } from "./gsapSerialize";
 import { parseCompositionVariables } from "./compositionVariables.js";
-import { ensureHfIds, walkCompositionDescendants } from "./hfIds.js";
+import { parseHtmlWithHfIds, walkCompositionDescendants } from "./hfIds.js";
 import { parseGsapScriptAcornForWrite } from "./gsapParserAcorn.js";
 import { queryByAttr } from "./utils/cssSelector.js";
 import { removeAnimationFromScript } from "./gsapWriterAcorn.js";
@@ -178,16 +178,14 @@ function resolveResolutionFromDimensions(width: number, height: number): CanvasR
 }
 
 export function parseHtml(html: string): ParsedHtml {
-  const withIds = ensureHfIds(html);
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(withIds, "text/html");
+  const doc = parseHtmlWithHfIds(html);
 
   const elements: TimelineElement[] = [];
   const keyframes: Record<string, Keyframe[]> = {};
   let idCounter = 0;
 
   const htmlEl = doc.documentElement;
-  if (!htmlEl) {
+  if (!htmlEl || (!/<!doctype|<html[\s>]/i.test(html) && !doc.body.firstElementChild)) {
     throw new CompositionHtmlParseError("parseHtml: input HTML is empty or could not be parsed");
   }
   const customStylesAttr = htmlEl.getAttribute("data-custom-styles");


### PR DESCRIPTION
Generated composition metadata, element attributes, CSS, and timeline JavaScript previously allowed plain input values to escape their output context. This change encodes attributes, contains raw-text closing tags, serializes JS strings, and validates generated numeric/CSS values. It targets CodeQL alerts #437–441 and the resolution breakout found during review (#904).

Rich text uses the existing inline-formatting sanitizer: supported nested formatting and typography survive, unsafe opaque content is removed, unsupported structural tags retain their words, and empty captions stay empty. Executable source URLs are rejected. Authored CSS and explicit `__raw:` JavaScript remain supported. The clip parser continues to flatten inner formatting to text.

The parser now parses once with its runtime DOMParser and assigns stable IDs in that same document. Shared assignment keeps native and persisted IDs consistent across mixed-case HTML/SVG, pinned IDs, and composition templates, avoiding metadata double-decoding.

Validation: 46 generator tests, 62 rich-text sanitizer tests, and 940 parser tests pass; core/runtime typechecks, lint/format and signed commit hooks pass. Twelve expanded regression cases fail against the prior generator. Magi independently verified earlier parser changes against 843 checked-in HTML files with no semantic differences. The expanded head requires fresh independent review and CodeQL verification before merge.

Alert #905 was dismissed separately as a false positive after Magi's exact source-to-sink review (5150508416); no broad suppressions or workflow changes.
