### PR TITLE
fix(engine): cap auto workers by parent heap budget

### DIFF
--- a/packages/engine/src/services/parallelCoordinator.heap.test.ts
+++ b/packages/engine/src/services/parallelCoordinator.heap.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { getHeapStatistics } from "v8";
+import { computeWorkerSizing } from "./parallelCoordinator.js";
+
+vi.mock("os", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("os")>()),
+  cpus: () =>
+    Array.from({ length: 18 }, () => ({
+      model: "test",
+      speed: 3000,
+      times: { user: 0, nice: 0, sys: 0, idle: 0, irq: 0 },
+    })),
+}));
+vi.mock("./systemMemory.js", () => ({ getSystemTotalMb: () => 24576 }));
+vi.mock("v8", async (importOriginal) => {
+  const original = await importOriginal<typeof import("v8")>();
+  return { ...original, getHeapStatistics: vi.fn(original.getHeapStatistics) };
+});
+
+function withHeapLimit(mb: number): void {
+  vi.mocked(getHeapStatistics).mockReturnValueOnce({
+    ...getHeapStatistics(),
+    heap_size_limit: mb * 1024 * 1024,
+  });
+}
+
+describe("parent heap worker cap", () => {
+  it("caps the reported 18-core/24GB host at four workers with a 4GB heap", () => {
+    withHeapLimit(4096);
+    const result = computeWorkerSizing(1800);
+    expect(result).toMatchObject({
+      workers: 4,
+      heapBasedWorkers: 4,
+      boundBy: "heap",
+      exceedsHeapAdvisory: false,
+    });
+  });
+
+  it("allows one worker below the heap reserve despite the parallel floor", () => {
+    withHeapLimit(512);
+    expect(computeWorkerSizing(1800)).toMatchObject({ workers: 1, boundBy: "heap" });
+  });
+
+  it("keeps the CPU contention cap when the heap has sufficient room", () => {
+    withHeapLimit(16384);
+    expect(computeWorkerSizing(1800)).toMatchObject({ workers: 6 });
+  });
+
+  it("honors explicit workers and retains the exceeded-budget diagnostic", () => {
+    withHeapLimit(1024);
+    expect(computeWorkerSizing(1800, 6)).toMatchObject({
+      workers: 6,
+      boundBy: "explicit",
+      exceedsHeapAdvisory: true,
+    });
+  });
+
+  it("does not let configured concurrency bypass the heap budget", () => {
+    withHeapLimit(1024);
+    expect(computeWorkerSizing(1800, undefined, { concurrency: 12 })).toMatchObject({
+      workers: 1,
+      boundBy: "heap",
+    });
+  });
+});

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -141,8 +141,18 @@ const MEMORY_PER_WORKER_MB = 1536;
 const HEAP_RESERVED_MB = 1024;
 // Parent-process V8 heap consumed per worker (protocol buffers + in-flight
 // frame buffers). Derived from the field OOM: 6 workers exhausted a ~4GB
-// default heap ⇒ >~500MB/worker + base. Validate this estimate against the
-// workers_heap_* fleet telemetry before rollout (PRINFRA-341).
+// default heap ⇒ >~500MB/worker + base. ENFORCED as a cap on auto-sizing
+// below; an explicit `--workers N` bypasses it and stays authoritative.
+//
+// This and HEAP_RESERVED_MB come from a single field report, so know what
+// they cost fleet-wide before trusting or changing them:
+//   - a default ~4GB Node heap selects 4 workers for EVERY auto-sized render
+//     regardless of core count — a 32-core host the contention path would
+//     size to 10 also lands at 4;
+//   - any host whose heap_size_limit is under ~1664MB selects 1 worker, which
+//     overrides the two-worker parallel floor and serializes long renders.
+// PRINFRA-341 validates both figures against workers_heap_* fleet telemetry
+// before this leaves draft; replace this note with what validated them.
 const HEAP_PER_WORKER_MB = 640;
 const MIN_WORKERS = 1;
 const MAX_WORKER_DIAGNOSTIC_LINES = 8;

--- a/packages/engine/src/services/parallelCoordinator.ts
+++ b/packages/engine/src/services/parallelCoordinator.ts
@@ -141,10 +141,8 @@ const MEMORY_PER_WORKER_MB = 1536;
 const HEAP_RESERVED_MB = 1024;
 // Parent-process V8 heap consumed per worker (protocol buffers + in-flight
 // frame buffers). Derived from the field OOM: 6 workers exhausted a ~4GB
-// default heap ⇒ >~500MB/worker + base. ponytail: advisory-only until the
-// workers_heap_* telemetry added alongside this constant validates the figure
-// — enforcing a guessed budget could silently cut worker counts fleet-wide.
-// TODO(PRINFRA-341): decide enforcement after ~2 weeks of fleet soak.
+// default heap ⇒ >~500MB/worker + base. Validate this estimate against the
+// workers_heap_* fleet telemetry before rollout (PRINFRA-341).
 const HEAP_PER_WORKER_MB = 640;
 const MIN_WORKERS = 1;
 const MAX_WORKER_DIAGNOSTIC_LINES = 8;
@@ -272,6 +270,7 @@ export type WorkerSizingBound =
   | "too_few_frames"
   | "cpu"
   | "memory"
+  | "heap"
   | "frames"
   | "max_workers"
   | "min_parallel_floor"
@@ -290,9 +289,8 @@ export interface WorkerSizing {
   frameBasedWorkers: number;
   effectiveMaxWorkers: number;
   /**
-   * ADVISORY, not enforced (see HEAP_PER_WORKER_MB): how many workers the
-   * parent process's V8 heap could feed. Compare against `workers` in
-   * telemetry to validate the budget before enforcement.
+   * Auto-sizing cap: how many workers the parent process's V8 heap could
+   * feed. Explicit worker requests may exceed this budget.
    */
   heapBasedWorkers: number;
   /** V8 `heap_size_limit` for the parent process, MB. */
@@ -300,7 +298,7 @@ export interface WorkerSizing {
   totalMemoryMb: number;
   cpuCount: number;
   captureCostMultiplier: number;
-  /** true when the chosen count exceeds the advisory heap budget. */
+  /** true when an explicit worker count exceeds the heap budget. */
   exceedsHeapAdvisory: boolean;
 }
 
@@ -403,6 +401,14 @@ export function computeWorkerSizing(
       finalWorkers = cpuScaledMax;
       boundBy = "contention";
     }
+  }
+
+  // Apply after the two-worker parallel floor and CPU contention cap so a
+  // small parent heap can select one worker even for a long render. Chrome's
+  // RSS budget above does not account for buffers retained by the parent.
+  if (finalWorkers > heapBasedWorkers) {
+    finalWorkers = heapBasedWorkers;
+    boundBy = "heap";
   }
 
   return finish(finalWorkers, boundBy, effectiveMaxWorkers);

--- a/packages/producer/src/services/render/captureCost.ts
+++ b/packages/producer/src/services/render/captureCost.ts
@@ -116,11 +116,8 @@ function combineCaptureCostEstimates(
  * - Auto-sized renders only (`requestedWorkers === undefined`) — the field
  *   failure was auto sizing, and an explicit `--workers N` is the operator's
  *   own call.
- * - Not enforced as a cap yet — the per-worker budget constant is derived
- *   from one field report; the `workers_heap_*` telemetry emitted with the
- *   sizing decides whether to enforce (see the TODO on HEAP_PER_WORKER_MB in
- *   @hyperframes/engine's parallelCoordinator). The message gives the
- *   operator the actionable knobs today.
+ * - Auto-sizing now applies the heap cap. Keep this defensive warning for
+ *   sizing values supplied by older callers or a future alternate policy.
  *
  * Pure so the message shape + firing condition are unit-testable with a
  * synthetic `WorkerSizing` (the real one depends on the host's heap).

--- a/packages/producer/src/services/render/captureCost.ts
+++ b/packages/producer/src/services/render/captureCost.ts
@@ -116,8 +116,20 @@ function combineCaptureCostEstimates(
  * - Auto-sized renders only (`requestedWorkers === undefined`) — the field
  *   failure was auto sizing, and an explicit `--workers N` is the operator's
  *   own call.
- * - Auto-sizing now applies the heap cap. Keep this defensive warning for
- *   sizing values supplied by older callers or a future alternate policy.
+ * - Only when the chosen count exceeds the heap budget.
+ *
+ * Those two conditions are now mutually exclusive, so this returns undefined
+ * for every real render: auto-sizing enforces the heap cap, so the auto path
+ * can no longer exceed `heapBasedWorkers`, and the explicit `--workers N`
+ * path — the only one that still can — is guarded out by the first condition.
+ *
+ * Kept rather than deleted because enforcement is PRINFRA-341's open
+ * question: if fleet telemetry rejects the 640MB/worker + 1024MB reserve
+ * figures and the cap reverts to advisory, this is the live path again.
+ * Delete it once enforcement ships validated. The `exceedsHeapAdvisory` flag
+ * it reads stays live either way — CLI telemetry reports it as
+ * `workersExceedHeapAdvisory`, and it is still true for an over-budget
+ * explicit `--workers N`.
  *
  * Pure so the message shape + firing condition are unit-testable with a
  * synthetic `WorkerSizing` (the real one depends on the host's heap).


### PR DESCRIPTION
The reported 18-core/24GB host selected six capture workers despite a roughly 4GB parent V8 heap. Raising the Chrome RSS budget alone still selects six. Apply the existing parent-heap estimate after the parallel floor and contention cap; that host now selects four workers, and a heap below the reserve selects one. Explicit `--workers` remains authoritative, and sizing telemetry reports `boundBy: heap`.

Related: [PRINFRA-338](https://linear.app/heygen/issue/PRINFRA-338), [PRINFRA-341](https://linear.app/heygen/issue/PRINFRA-341).

---

## Why this is still a draft: the gate ran but the instrument was blind

Both draft blockers were executed. The honest outcome is **"not decidable yet"** — not a pass, and not the "this is wrong" I briefly concluded and have since retracted on PRINFRA-341.

### The original report is worker-causal

From PRINFRA-300 fault mode #8: darwin/arm64 18c/24GB, `--quality high --fps 30 --strict-all`, auto-selected 6 workers, `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`, and **`--workers 1` produced correct output**. Lowering the worker count fixed it. The mechanism this PR targets is real.

### What the fleet could and could not tell us

Queried the Hyperframes project (2,676,589 `render_complete`, 317,253 `render_error`, 2026-07-21 → 2026-09-11):

- **25.1%** of renders cross the advisory line and would be throttled by enforcement.
- Heap limits: p05 2,240MB, p50 4,192MB, p95 4,288MB. 9,292 renders (0.35%) sit under 1,664MB and would be forced to a single worker.
- A local 6-vs-4-worker benchmark measured **~+21% wall** — but at 540p/600 frames, far lighter than the reporter's `--quality high` workload.
- **Zero heap OOMs** in 317,253 failures — uninformative, because a fatal V8 OOM aborts before telemetry flushes.

**What I cannot tell you is whether 640MB/worker is the right magnitude**, because `peak_memory_mb` is `process.memoryUsage.rss()` sampled at completion — after per-frame buffering has drained. Worker-driven parent buffering is a mid-render phenomenon, so the field is blind to it by construction. An earlier revision of this description leaned on that data to argue the constant was wrong by ~250×; that claim is withdrawn.

### Telemetry gap, now fixed separately

`workers_bound_by`, `workers_heap_based`, `workers_heap_limit_mb` and `workers_exceed_heap_advisory` ship on `render_complete` only — 0 of 317,253 `render_error` events carry them, so advisory-true renders can never be correlated with failures.

Both problems are addressed in `fix/render-error-sizing-telemetry`: sizing on the failure path, and the existing sampler's true running peak instead of the teardown snapshot (plus `peak_heap_used_mb`). That branch is independent of this one and worth landing regardless of what happens here.

### What would settle this PR

1. Land the telemetry branch.
2. Reproduce the reporter's shape locally — 1080p, `--quality high`, long render, 6 workers, ~4GB heap — reading the true peak. That directly tests the constant and needs no fleet data.
3. Retune `HEAP_PER_WORKER_MB` to whatever that measures, then merge or drop this.

The mechanism is sound and the code implements it correctly; the open question is purely the magnitude of the constant.

---

## Validation performed

56 coordinator tests passed, including five deterministic heap-budget cases; engine and producer typechecks, scoped oxlint/oxfmt, and the fallow new-issue gate passed. CI green 60/60.

Review feedback applied in `df205869`: the `HEAP_PER_WORKER_MB` comment no longer says "validate before rollout" next to live enforcement, and the `buildHeapAdvisoryWarning` doc block is corrected — its `requestedWorkers !== undefined` guard and the newly enforced cap are mutually exclusive, so the warning is **unreachable** rather than "live only for explicit `--workers`". The `exceedsHeapAdvisory` flag it reads stays live via CLI telemetry.

### What the constants would do fleet-wide, for the record

- Default ~4GB heap → **4 workers for every auto-sized render regardless of core count** (a 32-core host the contention path would size to 10 also lands at 4).
- Heap under ~1664MB → **1 worker**, overriding the two-worker parallel floor.
