### PR TITLE
docs(render): explain alpha-aware WebM inspection

### DIFF
--- a/docs/guides/rendering.mdx
+++ b/docs/guides/rendering.mdx
@@ -81,6 +81,19 @@ MP4 is the normal opaque delivery format. After rendering transparency, inspect
 the file over a contrasting background rather than trusting a player that
 always shows black behind alpha.
 
+For VP9 WebM, `ffprobe` reporting `pix_fmt=yuv420p` does not by itself mean
+transparency was lost. FFmpeg's default VP9 decoder can also produce an opaque
+image from a file that contains alpha. To inspect a frame, explicitly select
+the alpha-aware decoder **before** the input:
+
+```bash
+ffmpeg -c:v libvpx-vp9 -i overlay.webm -frames:v 1 -pix_fmt rgba overlay-frame.png
+```
+
+View the PNG over a checkerboard or contrasting background. If it is still
+opaque, compare it with the composition's PNG-sequence output to check whether
+transparency was already missing before video encoding.
+
 ## Input video codecs
 
 Studio, preview, `check`, and published projects normally create cached browser


### PR DESCRIPTION
A VP9 WebM with valid alpha can report `pix_fmt=yuv420p` in ffprobe and decode opaque with FFmpeg's default VP9 decoder. Document an explicit `libvpx-vp9` input decoder, placed before `-i`, so users can inspect an RGBA frame before concluding the encoder lost transparency. If that frame is still opaque, compare the composition's PNG-sequence output to separate capture from encoding.

Related: [PRINFRA-345](https://linear.app/heygen/issue/PRINFRA-345). Diagnosis confidence: 80% for a misleading decoder/probe result in the reported diagnosis. The existing CLI alpha check and source extractor already force the alpha-aware decoder; this fills the user-facing guidance gap. It does not claim that every WebM alpha report is a decoder issue.

Validation: executed the documented FFmpeg command on the investigation fixture; the PNG was RGBA 64x64, alpha ranged 0–255, and 3,072 pixels remained transparent. `mint broken-links` passed. `git diff --check` passed. Local `mint validate` was blocked by EPERM while renaming Mintlify's user-home preview cache; the PR's Validate docs CI job must pass before merge. No generated files or dependencies changed.
