### PR TITLE
fix(deps): bump hono, tar, dompurify, sharp to patch known CVEs

### DIFF
--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -76,7 +76,7 @@
     "ffmpeg-static": "^5.2.0",
     "ffprobe-static": "^3.1.0",
     "puppeteer-core": "^25.8.0",
-    "tar": "^7.4.3"
+    "tar": "^7.5.21"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.146",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,14 +39,14 @@
     "esbuild": "^0.25.12",
     "fontkit": "^2.0.4",
     "giget": "^3.2.0",
-    "hono": "^4.0.0",
+    "hono": "^4.13.5",
     "ignore": "^5.3.2",
     "onnxruntime-node": "1.21.1",
     "open": "^10.0.0",
     "postcss": "^8.5.8",
     "prettier": "^3.8.1",
     "puppeteer-core": "^25.8.0",
-    "sharp": "^0.35.0"
+    "sharp": "^0.35.4"
   },
   "devDependencies": {
     "@clack/prompts": "^1.1.0",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -61,7 +61,7 @@
     "@hono/node-server": "^2.0.5",
     "@hyperframes/core": "workspace:^",
     "@hyperframes/parsers": "workspace:^",
-    "hono": "^4.6.0",
+    "hono": "^4.13.5",
     "linkedom": "^0.18.12",
     "puppeteer": "^25.8.0",
     "puppeteer-core": "^25.8.0"

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -72,9 +72,9 @@
     "@google-cloud/workflows": "^4.2.0",
     "@hono/node-server": "^2.0.5",
     "@hyperframes/producer": "workspace:^",
-    "hono": "^4.6.0",
+    "hono": "^4.13.5",
     "puppeteer-core": "^25.8.0",
-    "tar": "^7.4.3"
+    "tar": "^7.5.21"
   },
   "devDependencies": {
     "@types/node": "^25.0.10",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -93,7 +93,7 @@
     "@hyperframes/lint": "workspace:^",
     "@hyperframes/parsers": "workspace:^",
     "@hyperframes/studio-server": "workspace:^",
-    "hono": "^4.6.0",
+    "hono": "^4.13.5",
     "linkedom": "^0.18.12",
     "postcss": "^8.4.0",
     "puppeteer": "^25.2.1",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -136,7 +136,7 @@
   "dependencies": {
     "@hyperframes/core": "workspace:*",
     "@hyperframes/parsers": "workspace:*",
-    "hono": "^4.0.0",
+    "hono": "^4.13.5",
     "linkedom": "^0.18.12",
     "postcss": "^8.5.8",
     "postcss-selector-parser": "^7.1.2"

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -76,7 +76,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "@tanstack/react-virtual": "^3.14.6",
     "bpm-detective": "^2.0.5",
-    "dompurify": "^3.2.4",
+    "dompurify": "^3.4.13",
     "gsap": "^3.13.0",
     "marked": "^14.1.4",
     "mediabunny": "^1.45.3"


### PR DESCRIPTION
Automated dependency bump to address several disclosed CVEs found via `osv-scanner`.

## Packages bumped

| Package | From | To | Advisories closed | Highest severity |
|---|---|---|---|---|
| `hono` | `^4.0.0`/`^4.6.0` (cli, engine, gcp-cloud-run, producer, studio-server) | `^4.13.5` | 19 (GHSA list below) | HIGH — [GHSA-88fw-hqm2-52qc](https://github.com/advisories/GHSA-88fw-hqm2-52qc) (CORS middleware reflects any Origin with credentials) |
| `tar` | `^7.4.3` (aws-lambda, gcp-cloud-run) | `^7.5.21` | 6 | CRITICAL — [GHSA-23hp-3jrh-7fpw](https://github.com/advisories/GHSA-23hp-3jrh-7fpw) |
| `dompurify` | `^3.2.4` (studio) | `^3.4.13` | 3 | MODERATE — sanitizer-bypass class |
| `sharp` | `^0.35.0` (cli) | `^0.35.4` | 1 | HIGH — [GHSA-rgj7-g3m4-5g8c](https://github.com/advisories/GHSA-rgj7-g3m4-5g8c) |

All four target versions are OSV-verified clean (`api.osv.dev` query against the bumped version returns zero vulnerabilities) and stay within the current major, so this should be a drop-in bump.

## Reachability notes

- **hono**: none of this repo's own code imports the specific vulnerable surfaces (`hono/cors`, `hono/jwt`, `serve-static`, the AWS Lambda / Lambda@Edge adapters) — grepped the whole `packages/*/src` tree and found no usage. hono is still the HTTP framework underpinning every network-facing surface here (the Studio/CLI preview server, the Cloud Run distributed-render handler), so this is defense-in-depth rather than a confirmed-reachable fix.
- **tar**: used by `aws-lambda`/`gcp-cloud-run` to pack/unpack distributed-render artifacts — a real, shipped runtime path.
- **dompurify**: this is the project's XSS sanitizer (`packages/studio/src/components/storyboard/StoryboardSourceEditor.tsx`'s markdown preview). Checked the one call site against the three advisories' preconditions — it calls `DOMPurify.sanitize(html)` with no `IN_PLACE` option and no `setConfig()`/`uponSanitizeAttribute` hook, so it isn't hit by any of the three bypass classes today. Bumping anyway since it's the sanitizer of record.
- **sharp**: used in the CLI's image-processing/capture pipeline.

## Not bumped

`adm-zip@0.6.0` also has an open advisory ([GHSA-vwc7-r8mq-g2x9](https://github.com/advisories/GHSA-vwc7-r8mq-g2x9), extraction follows destination symlinks) but **no fixed version exists yet upstream** — nothing to bump to, flagging for awareness only.

## Caveat

Manifest-only (`package.json`) — `bun`/`bun install` wasn't available in this run's sandbox to regenerate `bun.lock`. Please run `bun install` (root) to refresh the lockfile; the caret ranges above already resolve to a clean version once regenerated.

Detected by [osv-scanner](https://google.github.io/osv-scanner/), cross-checked against `api.osv.dev`. No code changes outside dependency manifests.

---
Filed by [Aeon](https://github.com/aeonfun/aeon).