### PR TITLE
feat(registry): add 35 curated loop template components

### DIFF
--- a/registry/blocks/loop-3d-1/loop-3d-1.html
+++ b/registry/blocks/loop-3d-1/loop-3d-1.html
@@ -1,0 +1,322 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"backface","type":"enum","role":"style","label":"Animation · Backface","description":"Backface (engine parameter; see the block header comment).","default":"show","options":[{"value":"show","label":"Show"},{"value":"hide","label":"Hide"}]},{"id":"flipImage","type":"enum","role":"style","label":"Animation · Flip Image","description":"Flip Image (engine parameter; see the block header comment).","default":"off","options":[{"value":"off","label":"Off"},{"value":"on","label":"On"}]},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":3015,"min":0,"max":8120,"step":10},{"id":"orbitRadius","type":"number","role":"style","label":"Template options · Orbit Radius","description":"Ring radius in scene units.","default":10915,"min":0,"max":25848,"step":10},{"id":"rotationX","type":"number","role":"style","label":"Template options · Rotation X","description":"Formation tilt about the horizontal axis, degrees.","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"rotationY","type":"number","role":"style","label":"Template options · Rotation Y","description":"Formation turn about the vertical axis, degrees.","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"rotationZ","type":"number","role":"style","label":"Template options · Rotation Z","description":"Formation roll about the view axis, degrees.","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"distance","type":"number","role":"style","label":"Template options · Distance","description":"Camera distance from the formation.","default":24212,"min":0,"max":48424,"step":10},{"id":"perspective","type":"number","role":"style","label":"Template options · Perspective","description":"Camera focal length: smaller = stronger perspective.","default":100,"min":0,"max":300,"step":10},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"axis","type":"enum","role":"style","label":"Template options · Axis","description":"Axis (engine parameter; see the block header comment).","default":"horizontal","options":[{"value":"horizontal","label":"Horizontal"},{"value":"vertical","label":"Vertical"}]},{"id":"surface","type":"enum","role":"style","label":"Template options · Surface","description":"Surface (engine parameter; see the block header comment).","default":"flat","options":[{"value":"flat","label":"Flat"},{"value":"cylinder","label":"Cylinder"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-3d-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-3d-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-3d-1-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      /* never put opacity/filter in will-change on preserve-3d elements: it flattens them silently */
+      #loop-3d-1-ring,
+      #loop-3d-1-spin,
+      .slot {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      /* rotate about the slot origin, not the card centre: with the default 50% 50% origin the translate(-w/2,-h/2)
+         leaks through the rotation and the ring is no longer a circle (card sizes drifted 126..189px on 3D06) */
+      .card {
+        transform-origin: 0 0;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-3d-1-root"
+      data-composition-id="loop-3d-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="13"
+    >
+      <div
+        id="loop-3d-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="13"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-3d-1-bg"></div>
+        <div id="loop-3d-1-stage">
+          <div id="loop-3d-1-ring"><div id="loop-3d-1-spin"></div></div>
+        </div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // 3D loop family — N cards ring an axis, facing outward, camera on the
+        // ring's normal at `distance` from the centre (may be INSIDE the ring: 3D06 distance 0, 3D11 D<R).
+        // Measured (2026-09-08): uniform spin, 360deg*cycles per loop; near side moves right
+        // (horizontal) / up (vertical). perspective 100 == CSS perspective 1000px at H=1080; world
+        // units cancel (only distance/orbitRadius/planeSize ratios matter). natural fit: the
+        // dimension across the axis is fixed (= planeSize), the other follows the image aspect.
+        // Knobs: rotationX/Y/Z order (used: X then Y then Z, static), flipImage mirror axis,
+        // offsetX/Y unit (used: % of H), surface=cylinder slice count (8).
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 13, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 13);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const BACK = str("backface", "show");
+        const FLIP = on("flipImage", false);
+        const PLANE = num("planeSize", 3015);
+        const R = num("orbitRadius", 10915);
+        const RX = num("rotationX", 0),
+          RY = num("rotationY", 0),
+          RZ = num("rotationZ", 0);
+        const D = num("distance", 24212);
+        const PERSP = Math.max(1, num("perspective", 100));
+        const OX = num("offsetX", 0),
+          OY = num("offsetY", 0);
+        const AXIS = str("axis", "horizontal");
+        const SURF = str("surface", "flat");
+        const CYCLES = num("cycles", 1);
+        const SPIN = num("spinDirection", 1) < 0 ? -1 : 1; // knob: previews disagree on spin sign (see status/3d.md)
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const HORIZ = AXIS === "horizontal";
+
+        document.getElementById("loop-3d-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-3d-1-bg"));
+
+        const f = 1000 * (100 / PERSP) * (REF / 1080); // CSS focal length, px
+        const s = f / Math.max(D, R, 1); // world -> px (ring centre or ring at z=0)
+        const Rpx = R * s,
+          Dpx = D * s;
+        const stage = document.getElementById("loop-3d-1-stage");
+        stage.style.perspective = f + "px";
+        const ring = document.getElementById("loop-3d-1-ring");
+        // ring centre sits Dpx in front of the camera (camera is at z=f); offsets in % of H
+        // three.js (y up, right-handed) -> CSS (y down): negate the X/Z rotations (3D09 silhouette flips otherwise).
+        // offsetX/Y are a SCREEN-space shift of the whole projection, 1% of H per unit, +y down: 3D09 offsetY 5 -> every
+        // card +26px @512, 3D03 offsetY -3.5 -> every card -18px (a 3D translate of the ring would move near cards ~1.8x more).
+        stage.style.transform = `translate(${(OX / 100) * REF}px,${(OY / 100) * REF}px)`;
+        ring.style.transform = `translate3d(0,0,${f - Dpx}px) rotateX(${-RX}deg) rotateY(${RY}deg) rotateZ(${-RZ}deg)`;
+        const spin = document.getElementById("loop-3d-1-spin");
+
+        const SLICES = SURF === "cylinder" ? 8 : 1;
+        const cross = PLANE * s; // fixed dimension: height (horizontal axis) / width (vertical)
+        for (let i = 0; i < N; i++) {
+          const m = IMAGES[i],
+            a = aspect(m, FIT, CROP_AR);
+          const w = HORIZ ? cross * a : cross,
+            h = HORIZ ? cross : cross / a;
+          const theta = (i * 360) / N;
+          const slot = document.createElement("div");
+          slot.className = "slot";
+          // slice along the ring's tangent (x for horizontal axis, y for vertical)
+          const L = HORIZ ? w : h,
+            sw = L / SLICES,
+            dAng = ((sw / Rpx) * 180) / Math.PI;
+          for (let k = 0; k < SLICES; k++) {
+            const c = card(
+              m,
+              HORIZ ? sw + (SLICES > 1 ? 1 : 0) : w,
+              HORIZ ? h : sw + (SLICES > 1 ? 1 : 0),
+              SLICES > 1 ? 0 : RADIUS,
+            );
+            const img = c.firstChild;
+            // shift the image so this slice shows its own strip
+            img.style.width = w + "px";
+            img.style.height = h + "px";
+            if (HORIZ) img.style.marginLeft = -k * sw + "px";
+            else img.style.marginTop = -k * sw + "px";
+            if (FLIP) img.style.transform = HORIZ ? "scaleX(-1)" : "scaleY(-1)";
+            if (BACK === "hide") c.style.backfaceVisibility = "hidden";
+            const ang = theta + (k - (SLICES - 1) / 2) * dAng;
+            const cx = HORIZ ? -(sw / 2) : -w / 2,
+              cy = HORIZ ? -h / 2 : -(sw / 2);
+            c.style.transform =
+              (HORIZ ? `rotateY(${ang}deg)` : `rotateX(${ang}deg)`) +
+              ` translate3d(${cx}px,${cy}px,${Rpx}px)`;
+            c.style.transformStyle = "preserve-3d";
+            slot.appendChild(c);
+          }
+          spin.appendChild(slot);
+        }
+        function renderAt(t) {
+          const ang = SPIN * 360 * CYCLES * t;
+          spin.style.transform = HORIZ ? `rotateY(${ang}deg)` : `rotateX(${ang}deg)`;
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-3d-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-3d-1/registry-item.json
+++ b/registry/blocks/loop-3d-1/registry-item.json
@@ -1,0 +1,465 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-3d-1",
+  "type": "hyperframes:block",
+  "title": "Loop 3D Ring 1",
+  "description": "Image cards ring a vertical axis facing outward while the ring spins under a 3D camera. 8 image slots, 13s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 13,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backface",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Backface",
+      "description": "Backface (engine parameter; see the block header comment).",
+      "default": "show",
+      "options": [
+        {
+          "value": "show",
+          "label": "Show"
+        },
+        {
+          "value": "hide",
+          "label": "Hide"
+        }
+      ]
+    },
+    {
+      "id": "flipImage",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Flip Image",
+      "description": "Flip Image (engine parameter; see the block header comment).",
+      "default": "off",
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 3015,
+      "min": 0,
+      "max": 8120,
+      "step": 10
+    },
+    {
+      "id": "orbitRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Orbit Radius",
+      "description": "Ring radius in scene units.",
+      "default": 10915,
+      "min": 0,
+      "max": 25848,
+      "step": 10
+    },
+    {
+      "id": "rotationX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rotation X",
+      "description": "Formation tilt about the horizontal axis, degrees.",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "rotationY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rotation Y",
+      "description": "Formation turn about the vertical axis, degrees.",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "rotationZ",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rotation Z",
+      "description": "Formation roll about the view axis, degrees.",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "distance",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Distance",
+      "description": "Camera distance from the formation.",
+      "default": 24212,
+      "min": 0,
+      "max": 48424,
+      "step": 10
+    },
+    {
+      "id": "perspective",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Perspective",
+      "description": "Camera focal length: smaller = stronger perspective.",
+      "default": 100,
+      "min": 0,
+      "max": 300,
+      "step": 10
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "axis",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Axis",
+      "description": "Axis (engine parameter; see the block header comment).",
+      "default": "horizontal",
+      "options": [
+        {
+          "value": "horizontal",
+          "label": "Horizontal"
+        },
+        {
+          "value": "vertical",
+          "label": "Vertical"
+        }
+      ]
+    },
+    {
+      "id": "surface",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Surface",
+      "description": "Surface (engine parameter; see the block header comment).",
+      "default": "flat",
+      "options": [
+        {
+          "value": "flat",
+          "label": "Flat"
+        },
+        {
+          "value": "cylinder",
+          "label": "Cylinder"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-3d-1.html",
+      "target": "compositions/loop-3d-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-bento-1/loop-bento-1.html
+++ b/registry/blocks/loop-bento-1/loop-bento-1.html
@@ -1,0 +1,328 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"crop","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":50,"min":0,"max":200,"step":1,"unit":"px"},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"forward","options":[{"value":"forward","label":"Forward"},{"value":"reverse","label":"Reverse"}]},{"id":"lanes","type":"number","role":"style","label":"Template options · Lanes","description":"Lanes (engine parameter; see the block header comment).","default":3,"min":0,"max":10,"step":0.1},{"id":"gap","type":"number","role":"style","label":"Template options · Gap","description":"Spacing between cards.","default":15,"min":0,"max":30,"step":1,"unit":"px"},{"id":"axis","type":"enum","role":"style","label":"Template options · Axis","description":"Axis (engine parameter; see the block header comment).","default":"vertical","options":[{"value":"vertical","label":"Vertical"},{"value":"horizontal","label":"Horizontal"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-bento-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-bento-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-bento-1-world {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 0;
+        height: 0;
+      }
+      .page {
+        position: absolute;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-bento-1-root"
+      data-composition-id="loop-bento-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="12"
+    >
+      <div
+        id="loop-bento-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="12"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-bento-1-bg"></div>
+        <div id="loop-bento-1-world"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Bento loop family — frame-sized bento PAGES on a staircase belt; the camera steps
+        // page to page, alternating horizontal (content moves left) and vertical (content moves up) shifts.
+        // Measured on the 512x512 preview (2026-09-08, frames via edge profiles):
+        //   grid: lanes=3 columns, 2 rows; col 152px, row 239px; gap/margin 14px horizontal, 11px vertical
+        //         (gap 15 -> 0.18% H per unit across, 0.145% H per unit down)
+        //   page shift = page + gap (496px across, 500px down); 4 shifts per 12s loop (centres f157.5,
+        //   f244.25, f334.1 => 3.0s steps), each move 41 frames (1.37s = 0.457 step) centred at 0.714 of
+        //   the step; ease 0.25*t + 0.75*expoInOut(t) (maxerr 0.010 on shift 2, 0.008 on shift 1).
+        //   corner radius ~4.5px @512 for borderRadius 50 => 0.009% H per unit (B panel corner, f300).
+        //   8 images => pages [A] [B C / D] [E / F G-over-H] visited in that order, plus one EMPTY page:
+        //   3+4-slot patterns filled from the LAST page backwards in reading order (A lands in the last slot).
+        // Reference caveat: the preview is NOT seamless (f0 empty, f359 full page). Ours is: at t=0 we rest
+        // on the last page and shift to the blank page at ~2.1s, where the reference shows nothing.
+        // Guesses: one blank page appended (needed to make 4 steps); the 4-slot pattern for the A page;
+        //   hold/stagger/offsetN/alternate have no visible effect in the only variant and are ignored;
+        //   motion=stepped == continuous; axis=horizontal swaps which shifts are H/V; natural fit = contain.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 12, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, card, background, expoInOut, frac } = RF;
+        const DUR = num("loopDuration", 12);
+        const FIT = str("mediaFit", "crop");
+        const LANES = Math.max(1, num("lanes", 3) | 0);
+        const ROWS = 2; // measured; not a spec setting
+        const GX = num("gap", 15) * 0.0018 * REF;
+        const GY = num("gap", 15) * 0.00145 * REF;
+        const CYCLES = Math.max(1, num("cycles", 1) | 0);
+        const FWD = str("direction", "forward") === "forward" ? 1 : -1;
+        const VERT = str("axis", "vertical") === "vertical"; // vertical: first visible shift is horizontal (as measured)
+        const RADIUS = num("borderRadius", 50) * 0.00009 * REF;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const MOVE_C = 0.714,
+          MOVE_D = 0.457; // move window inside a step (fractions)
+        const ease = (x) => {
+          x = Math.min(1, Math.max(0, x));
+          return 0.25 * x + 0.75 * expoInOut(x);
+        };
+
+        document.getElementById("loop-bento-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-bento-1-bg"));
+
+        // slot patterns, reading order; x/w in page-width fractions, r/h in rows. Index = distance from the LAST page.
+        const u = 1 / LANES;
+        const PATS = [
+          [
+            { x: 0, w: 1, r: 0, h: 1 },
+            { x: 0, w: 0.5, r: 1, h: 1 },
+            { x: 0.5, w: 0.5, r: 1, h: 0.5 },
+            { x: 0.5, w: 0.5, r: 1.5, h: 0.5 },
+          ],
+          [
+            { x: 0, w: 1 - u, r: 0, h: 1 },
+            { x: 1 - u, w: u, r: 0, h: 1 },
+            { x: 0, w: 1, r: 1, h: 1 },
+          ],
+          [
+            { x: 0, w: u, r: 0, h: 1 },
+            { x: u, w: 1 - u, r: 0, h: 1 },
+            { x: 0, w: u, r: 1, h: 1 },
+            { x: u, w: 1 - u, r: 1, h: 1 },
+          ],
+        ];
+        // pages, filled from the last page backwards; then one blank page in front
+        const pages = []; // visiting order; each = [{slot, m}]
+        let left = N,
+          d = 0;
+        while (left > 0) {
+          const pat = PATS[d % PATS.length],
+            take = Math.min(left, pat.length);
+          pages.unshift(
+            pat.slice(pat.length - take).map((slot, i) => ({ slot, m: IMAGES[left - take + i] })),
+          );
+          left -= take;
+          d++;
+        }
+        pages.unshift([]);
+        const P = pages.length,
+          STEPS = P * CYCLES;
+
+        const rh = (H - 2 * GY + GY) / ROWS; // row pitch (row + gap)
+        const px = (f) => f * (W - 2 * GX + GX);
+        const world = document.getElementById("loop-bento-1-world");
+        // staircase positions: shift ending step k moves pos[k] -> pos[k+1]; odd k horizontal (measured), even vertical
+        const pos = [{ x: 0, y: 0 }];
+        for (let k = 0; k < STEPS; k++) {
+          const horiz = (k % 2 === 1) === VERT;
+          const p = pos[k];
+          pos.push(
+            horiz ? { x: p.x + FWD * (W + GX), y: p.y } : { x: p.x, y: p.y + FWD * (H + GY) },
+          );
+        }
+        for (let j = 0; j <= STEPS; j++) {
+          const pg = pages[(j + P - 1) % P]; // t=0 rests on the last page (measured phase)
+          const el = document.createElement("div");
+          el.className = "page";
+          el.style.cssText = `left:${pos[j].x}px;top:${pos[j].y}px;width:${W}px;height:${H}px;`;
+          for (const { slot, m } of pg) {
+            const w = px(slot.w) - GX,
+              h = slot.h * rh - GY;
+            const c = card(m, w, h, RADIUS);
+            c.style.left = GX + px(slot.x) + "px";
+            c.style.top = GY + slot.r * rh + "px";
+            if (FIT === "natural") c.firstChild.style.objectFit = "contain";
+            el.appendChild(c);
+          }
+          world.appendChild(el);
+        }
+        function renderAt(t) {
+          const s = Math.min(STEPS - 1, Math.floor(frac(t) * STEPS)),
+            f = frac(t) * STEPS - s;
+          const m = ease((f - (MOVE_C - MOVE_D / 2)) / MOVE_D);
+          const cx = pos[s].x + m * (pos[s + 1].x - pos[s].x),
+            cy = pos[s].y + m * (pos[s + 1].y - pos[s].y);
+          world.style.transform = `translate3d(${-cx}px,${-cy}px,0)`;
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-bento-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-bento-1/registry-item.json
+++ b/registry/blocks/loop-bento-1/registry-item.json
@@ -1,0 +1,348 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-bento-1",
+  "type": "hyperframes:block",
+  "title": "Loop Bento 1",
+  "description": "Frame-sized bento pages ride a staircase belt; the camera steps to the next page each beat. 8 image slots, 12s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "bento"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 12,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "crop",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 50,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "forward",
+      "options": [
+        {
+          "value": "forward",
+          "label": "Forward"
+        },
+        {
+          "value": "reverse",
+          "label": "Reverse"
+        }
+      ]
+    },
+    {
+      "id": "lanes",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Lanes",
+      "description": "Lanes (engine parameter; see the block header comment).",
+      "default": 3,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "gap",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Gap",
+      "description": "Spacing between cards.",
+      "default": 15,
+      "min": 0,
+      "max": 30,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "axis",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Axis",
+      "description": "Axis (engine parameter; see the block header comment).",
+      "default": "vertical",
+      "options": [
+        {
+          "value": "vertical",
+          "label": "Vertical"
+        },
+        {
+          "value": "horizontal",
+          "label": "Horizontal"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-bento-1.html",
+      "target": "compositions/loop-bento-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-book-1/loop-book-1.html
+++ b/registry/blocks/loop-book-1/loop-book-1.html
@@ -1,0 +1,372 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"crop","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":24,"min":0,"max":200,"step":1,"unit":"px"},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":2,"min":0,"max":10,"step":0.1},{"id":"cycleDeg","type":"number","role":"style","label":"Animation · Cycle Deg","description":"Degrees turned per cycle.","default":180,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"forward","options":[{"value":"forward","label":"Forward"},{"value":"reverse","label":"Reverse"}]},{"id":"foredge","type":"enum","role":"style","label":"Template options · Foredge","description":"Foredge (engine parameter; see the block header comment).","default":"lines","options":[{"value":"lines","label":"Lines"},{"value":"image","label":"Image"}]},{"id":"finish","type":"enum","role":"style","label":"Template options · Finish","description":"Finish (engine parameter; see the block header comment).","default":"matte","options":[{"value":"flat","label":"Flat"},{"value":"matte","label":"Matte"},{"value":"glossy","label":"Glossy"}]},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":1450,"min":0,"max":2900,"step":10},{"id":"thickness","type":"number","role":"style","label":"Template options · Thickness","description":"Thickness (engine parameter; see the block header comment).","default":5,"min":0,"max":10,"step":0.1},{"id":"perspective","type":"number","role":"style","label":"Template options · Perspective","description":"Camera focal length: smaller = stronger perspective.","default":100,"min":0,"max":200,"step":1},{"id":"distance","type":"number","role":"style","label":"Template options · Distance","description":"Camera distance from the formation.","default":2200,"min":0,"max":4400,"step":10},{"id":"rotationX","type":"number","role":"style","label":"Template options · Rotation X","description":"Formation tilt about the horizontal axis, degrees.","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"rotationY","type":"number","role":"style","label":"Template options · Rotation Y","description":"Formation turn about the vertical axis, degrees.","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"rotationZ","type":"number","role":"style","label":"Template options · Rotation Z","description":"Formation roll about the view axis, degrees.","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"lightIntensity","type":"number","role":"style","label":"Template options · Light Intensity","description":"Light Intensity (engine parameter; see the block header comment).","default":125,"min":0,"max":250,"step":10},{"id":"lightAngle","type":"number","role":"style","label":"Template options · Light Angle","description":"Light Angle (engine parameter; see the block header comment).","default":0,"min":0,"max":452,"step":10},{"id":"lightHeight","type":"number","role":"style","label":"Template options · Light Height","description":"Light Height (engine parameter; see the block header comment).","default":40,"min":0,"max":80,"step":1},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-book-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-book-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-book-1-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      #loop-book-1-book,
+      #loop-book-1-spin {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      .face {
+        position: absolute;
+        backface-visibility: hidden;
+        overflow: hidden;
+      }
+      .face img {
+        display: block;
+      }
+      .shade,
+      .gloss {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+      }
+      .shade {
+        background: #000;
+      }
+      .gloss {
+        background: radial-gradient(ellipse at 30% 30%, #fff 0%, rgba(255, 255, 255, 0) 60%);
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-book-1-root"
+      data-composition-id="loop-book-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="10"
+    >
+      <div
+        id="loop-book-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="10"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-book-1-bg"></div>
+        <div id="loop-book-1-stage">
+          <div id="loop-book-1-book"><div id="loop-book-1-spin"></div></div>
+        </div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Book loop family. Spec says "a book opens and its pages turn", but all five
+        // previews show a CLOSED book (a slab: front cover = image 1, back cover = image 2, page-edge sides) spinning
+        // about its vertical axis at constant speed, cycles*cycleDeg per loop (= 360 on every variant), with a static
+        // rotationX/Y/Z tilt (Book04/05) and diffuse shading (+ a glossy highlight on Book04). Measured (2026-09-08):
+        //   3D-family world units: f = 1000px*(100/perspective)*H/1080, s = f/distance; planeSize 1450 -> 312px @512
+        //   (fit W=312 from the slab silhouette, 16 frames); thickness 5 -> 16px = 5% of planeSize
+        //   angle per 5 frames f0..75: 0.5/6.5/12/18.5/26/31.5/37/42/48.5/54.5/60/66/72/78/84/90 = uniform 1.2deg/f
+        //   (180deg per 150 frames, 360 per 10s loop), the left edge comes toward the viewer first (rotateY +)
+        //   face luma 78 frontal -> 67 at 60deg (both covers, ratio .86) => brightness = .72 + .28*cos
+        // Guesses: light direction from lightAngle (azimuth, 0 = from the camera) and lightHeight (elevation deg);
+        //   lightIntensity scales the diffuse term (.28 at 125); glossy = a soft radial highlight faded by cos^8;
+        //   foredge "lines" = thin repeating light/dark stripes, "image" = the cover image on the edges; spine =
+        //   dark cover colour; spineWidth/delay unused; natural fit: planeSize = height, width from the aspect.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 10, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, background } = RF;
+        const DUR = num("loopDuration", 10);
+        const FIT = str("mediaFit", "crop");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const FOREDGE = str("foredge", "lines");
+        const FINISH = str("finish", "matte");
+        const PLANE = num("planeSize", 1450);
+        const THICK = num("thickness", 5) / 100;
+        const PERSP = Math.max(1, num("perspective", 100));
+        const D = Math.max(1, num("distance", 2200));
+        const RX = num("rotationX", 0),
+          RY = num("rotationY", 0),
+          RZ = num("rotationZ", 0);
+        const OX = num("offsetX", 0),
+          OY = num("offsetY", 0);
+        const LI = num("lightIntensity", 125) / 125;
+        const LAZ = (num("lightAngle", 0) * Math.PI) / 180,
+          LEL = (num("lightHeight", 40) * Math.PI) / 180;
+        const TOTAL = num("cycles", 2) * num("cycleDeg", 180);
+        const FWD = str("direction", "forward") === "forward" ? 1 : -1;
+        const RADIUS = (num("borderRadius", 24) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+
+        document.getElementById("loop-book-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-book-1-bg"));
+        const f = 1000 * (100 / PERSP) * (REF / 1080),
+          s = f / D;
+        document.getElementById("loop-book-1-stage").style.perspective = f + "px";
+        const book = document.getElementById("loop-book-1-book"),
+          spin = document.getElementById("loop-book-1-spin");
+        book.style.transform = `translate3d(${(OX / 100) * REF}px,${(OY / 100) * REF}px,0) rotateX(${RX}deg) rotateY(${RY}deg) rotateZ(${RZ}deg)`;
+
+        const a = aspect(IMAGES[0], FIT, CROP_AR);
+        const h = PLANE * s,
+          w = FIT === "natural" ? h * a : h * a,
+          t = THICK * h; // book size in px
+        // light direction (unit) in the book's spinning frame is recomputed per frame; here in view space
+        const L = [Math.sin(LAZ) * Math.cos(LEL), Math.sin(LEL), Math.cos(LAZ) * Math.cos(LEL)];
+
+        const faces = [];
+        function face(width, height, transform, fill) {
+          const el = document.createElement("div");
+          el.className = "face";
+          el.style.cssText = `width:${width}px;height:${height}px;left:${-width / 2}px;top:${-height / 2}px;transform:${transform};`;
+          if (fill.img) {
+            const img = document.createElement("img");
+            img.src = fill.img.src;
+            img.width = Math.round(width);
+            img.height = Math.round(height);
+            img.style.cssText = `display:block;width:${width}px;height:${height}px;object-fit:cover;`;
+            el.appendChild(img);
+          } else el.style.background = fill.css;
+          const sh = document.createElement("div");
+          sh.className = "shade";
+          el.appendChild(sh);
+          let gl = null;
+          if (FINISH === "glossy") {
+            gl = document.createElement("div");
+            gl.className = "gloss";
+            el.appendChild(gl);
+          }
+          if (fill.radius) el.style.borderRadius = fill.radius + "px";
+          spin.appendChild(el);
+          faces.push({ el, sh, gl, n: fill.n });
+          return el;
+        }
+        const lines = `repeating-linear-gradient(90deg, #d9d6cf 0 1px, #a9a49b 1px 2px)`;
+        const edge = (img) => (FOREDGE === "image" && img ? { img } : { css: lines });
+        const front = IMAGES[0],
+          back = IMAGES[1 % IMAGES.length];
+        face(w, h, `translateZ(${t / 2}px)`, { img: front, radius: RADIUS, n: [0, 0, 1] });
+        face(w, h, `rotateY(180deg) translateZ(${t / 2}px)`, {
+          img: back,
+          radius: RADIUS,
+          n: [0, 0, -1],
+        });
+        face(t, h, `rotateY(90deg) translateZ(${w / 2}px)`, { ...edge(front), n: [1, 0, 0] }); // foredge (right)
+        face(t, h, `rotateY(-90deg) translateZ(${w / 2}px)`, { css: "#2a2a2e", n: [-1, 0, 0] }); // spine (left)
+        Object.assign(
+          face(w, t, `rotateX(90deg) translateZ(${h / 2}px)`, { ...edge(front), n: [0, -1, 0] })
+            .style,
+          { backgroundSize: "2px 100%" },
+        );
+        face(w, t, `rotateX(-90deg) translateZ(${h / 2}px)`, { ...edge(front), n: [0, 1, 0] });
+        for (const F of faces)
+          if (F.el.style.background.includes("repeating"))
+            F.el.style.backgroundImage = F.n[1] ? lines.replace("90deg", "90deg") : lines;
+
+        const rotY = (v, deg) => {
+          const r = (deg * Math.PI) / 180,
+            c = Math.cos(r),
+            si = Math.sin(r);
+          return [v[0] * c + v[2] * si, v[1], -v[0] * si + v[2] * c];
+        };
+        const rotX = (v, deg) => {
+          const r = (deg * Math.PI) / 180,
+            c = Math.cos(r),
+            si = Math.sin(r);
+          return [v[0], v[1] * c - v[2] * si, v[1] * si + v[2] * c];
+        };
+        const rotZ = (v, deg) => {
+          const r = (deg * Math.PI) / 180,
+            c = Math.cos(r),
+            si = Math.sin(r);
+          return [v[0] * c - v[1] * si, v[0] * si + v[1] * c, v[2]];
+        };
+        function renderAt(t_) {
+          const ang = FWD * TOTAL * t_;
+          spin.style.transform = `rotateY(${ang}deg)`;
+          for (const F of faces) {
+            // face normal in view space: static tilt (X, Y, Z) applied after the spin; CSS y points down -> flip y for lighting
+            let n = rotY(F.n, ang);
+            n = rotX(n, RX);
+            n = rotY(n, RY);
+            n = rotZ(n, RZ);
+            const nl = Math.max(0, n[0] * L[0] + -n[1] * L[1] + n[2] * L[2]);
+            const bright = FINISH === "flat" ? 1 : 0.72 + 0.28 * LI * nl;
+            F.sh.style.opacity = Math.max(0, Math.min(0.8, 1 - bright));
+            if (F.gl) F.gl.style.opacity = 0.55 * Math.pow(nl, 8);
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-book-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-book-1/registry-item.json
+++ b/registry/blocks/loop-book-1/registry-item.json
@@ -1,0 +1,497 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-book-1",
+  "type": "hyperframes:block",
+  "title": "Loop Book 1",
+  "description": "A book-page spread whose pages turn one after another to reveal each image. 8 image slots, 10s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "book",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 10,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "crop",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 24,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 2,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "cycleDeg",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycle Deg",
+      "description": "Degrees turned per cycle.",
+      "default": 180,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "forward",
+      "options": [
+        {
+          "value": "forward",
+          "label": "Forward"
+        },
+        {
+          "value": "reverse",
+          "label": "Reverse"
+        }
+      ]
+    },
+    {
+      "id": "foredge",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Foredge",
+      "description": "Foredge (engine parameter; see the block header comment).",
+      "default": "lines",
+      "options": [
+        {
+          "value": "lines",
+          "label": "Lines"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "finish",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Finish",
+      "description": "Finish (engine parameter; see the block header comment).",
+      "default": "matte",
+      "options": [
+        {
+          "value": "flat",
+          "label": "Flat"
+        },
+        {
+          "value": "matte",
+          "label": "Matte"
+        },
+        {
+          "value": "glossy",
+          "label": "Glossy"
+        }
+      ]
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 1450,
+      "min": 0,
+      "max": 2900,
+      "step": 10
+    },
+    {
+      "id": "thickness",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Thickness",
+      "description": "Thickness (engine parameter; see the block header comment).",
+      "default": 5,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "perspective",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Perspective",
+      "description": "Camera focal length: smaller = stronger perspective.",
+      "default": 100,
+      "min": 0,
+      "max": 200,
+      "step": 1
+    },
+    {
+      "id": "distance",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Distance",
+      "description": "Camera distance from the formation.",
+      "default": 2200,
+      "min": 0,
+      "max": 4400,
+      "step": 10
+    },
+    {
+      "id": "rotationX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rotation X",
+      "description": "Formation tilt about the horizontal axis, degrees.",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "rotationY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rotation Y",
+      "description": "Formation turn about the vertical axis, degrees.",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "rotationZ",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rotation Z",
+      "description": "Formation roll about the view axis, degrees.",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "lightIntensity",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Light Intensity",
+      "description": "Light Intensity (engine parameter; see the block header comment).",
+      "default": 125,
+      "min": 0,
+      "max": 250,
+      "step": 10
+    },
+    {
+      "id": "lightAngle",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Light Angle",
+      "description": "Light Angle (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": 0,
+      "max": 452,
+      "step": 10
+    },
+    {
+      "id": "lightHeight",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Light Height",
+      "description": "Light Height (engine parameter; see the block header comment).",
+      "default": 40,
+      "min": 0,
+      "max": 80,
+      "step": 1
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-book-1.html",
+      "target": "compositions/loop-book-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-cardtoss/loop-cardtoss.html
+++ b/registry/blocks/loop-cardtoss/loop-cardtoss.html
@@ -1,0 +1,300 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"crop","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"3:4","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"shadowEnabled","type":"enum","role":"style","label":"Appearance · Shadow","description":"Shadow Enabled (engine parameter; see the block header comment).","default":"false","options":[{"value":"true","label":"On"},{"value":"false","label":"Off"}]},{"id":"shadowX","type":"number","role":"style","label":"Appearance · Shadow X","description":"Shadow X (engine parameter; see the block header comment).","default":0,"min":-40,"max":40,"step":0.5,"unit":"px"},{"id":"shadowY","type":"number","role":"style","label":"Appearance · Shadow Y","description":"Shadow Y (engine parameter; see the block header comment).","default":1,"min":-40,"max":40,"step":0.5,"unit":"px"},{"id":"shadowBlur","type":"number","role":"style","label":"Appearance · Shadow blur","description":"Shadow Blur (engine parameter; see the block header comment).","default":1.5,"min":0,"max":40,"step":0.5,"unit":"px"},{"id":"shadowSpread","type":"number","role":"style","label":"Appearance · Shadow spread","description":"Shadow Spread (engine parameter; see the block header comment).","default":-0.25,"min":-20,"max":40,"step":0.5,"unit":"px"},{"id":"shadowOpacity","type":"number","role":"style","label":"Appearance · Shadow opacity","description":"Shadow Opacity (engine parameter; see the block header comment).","default":40,"min":0,"max":100,"step":1,"unit":"%"},{"id":"shadowColor","type":"color","role":"style","label":"Appearance · Shadow colour","description":"Shadow Color (engine parameter; see the block header comment).","default":"#000000"},{"id":"scaleIntensity","type":"number","role":"style","label":"Appearance · Media scale","description":"Strength of the size change.","default":0.26,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":32,"min":0,"max":200,"step":1,"unit":"px"},{"id":"sizeVar","type":"number","role":"style","label":"Template options · Size Var","description":"Size Var (engine parameter; see the block header comment).","default":20,"min":0,"max":40,"step":1},{"id":"throwHeight","type":"number","role":"style","label":"Template options · Throw Height","description":"Throw Height (engine parameter; see the block header comment).","default":75,"min":0,"max":150,"step":1},{"id":"spread","type":"number","role":"style","label":"Template options · Spread","description":"Spread (engine parameter; see the block header comment).","default":70,"min":0,"max":140,"step":1},{"id":"spin","type":"number","role":"style","label":"Template options · Spin","description":"Spin (engine parameter; see the block header comment).","default":12,"min":0,"max":24,"step":1},{"id":"flow","type":"enum","role":"style","label":"Template options · Flow","description":"Flow (engine parameter; see the block header comment).","default":"staggered","options":[{"value":"one","label":"One"},{"value":"staggered","label":"Staggered"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-cardtoss</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-cardtoss-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-cardtoss-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-cardtoss-root"
+      data-composition-id="loop-cardtoss"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="12"
+    >
+      <div
+        id="loop-cardtoss-loop"
+        class="clip"
+        data-start="0"
+        data-duration="12"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-cardtoss-bg"></div>
+        <div id="loop-cardtoss-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Toss loop family — cards are tossed up from below the frame, hang at the apex, fall back.
+        // Measured on the 512x512/12s/8-card preview (2026-09-08, per-card grey tracking):
+        //   ballistic: y = apex + 0.11 px/frame^2 * (f - f_apex)^2 (card 101: f64 407 / f80 296 / f104 234 / f120 265 / f140 383),
+        //     i.e. g = 0.193 H/s^2; ~110-frame flight from below the bottom edge and back; symmetric.
+        //   launches every DUR/N with apex at (j + 1/3) * DUR/N (apexes f15, 60, 104, 150, 195, 240, 285, 330).
+        //   card width = scaleIntensity*H * (1 +- sizeVar%): measured widths 107..152 vs 0.26*512*[0.8,1.2] = 106..160; 3:4 crop.
+        //   apex centre y 234..299 (mean 271 = 0.53H); x centres 140..350 (spread 70 -> +-(0.7H - w)/2); horizontal drift
+        //   -0.55..+0.55 px/frame (card 128 +0.55, 101 0, 88 -0.75); spin ~0.14 deg/frame with random sign (~12 deg over the
+        //   visible flight), start angle within +-5 deg; later-launched cards draw on top (74 hidden by 101 at f56-72).
+        //   The preview's random layout cannot be recovered -> statistics matched with a seeded LCG (seed 1), deterministic.
+        // Guesses/knobs: throwHeight 75 -> apex y = H*(1 - 0.0063*throwHeight) +- 0.065H; spin = total degrees over 85 frames;
+        //   flow=one -> one card in flight at a time (flight compressed to DUR/N, unseen); image->launch order is 0..N-1
+        //   (preview used 5,0,1,2,3,4,7,6); shadow* 1% of H.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 12, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, frac } = RF;
+        const bool = (k, d) => {
+          const v = str(k, d ? "true" : "false");
+          return v === "true" || v === "on";
+        };
+        const DUR = num("loopDuration", 12);
+        const FIT = str("mediaFit", "crop");
+        const CROP_AR = str("cropAspectRatio", "3:4");
+        const SCALE = num("scaleIntensity", 0.26);
+        const SIZEVAR = num("sizeVar", 20) / 100;
+        const THROW = num("throwHeight", 75);
+        const SPREAD = num("spread", 70) / 100;
+        const SPIN = num("spin", 12);
+        const ONE = str("flow", "staggered") === "one";
+        const RADIUS = (num("borderRadius", 32) * REF) / 1080;
+        const IMAGES = pick(Math.min(16, num("imageCount", 16)));
+        const N = IMAGES.length;
+
+        document.getElementById("loop-cardtoss-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-cardtoss-bg"));
+        const stage = document.getElementById("loop-cardtoss-stage");
+        const shadow = bool("shadowEnabled", false)
+          ? `${(num("shadowX", 0) * REF) / 100}px ${(num("shadowY", 1) * REF) / 100}px ${(num("shadowBlur", 1.5) * REF) / 100}px ${(num("shadowSpread", -0.25) * REF) / 100}px ${str("shadowColor", "#000000")}${Math.round(
+              num("shadowOpacity", 40) * 2.55,
+            )
+              .toString(16)
+              .padStart(2, "0")}`
+          : "";
+        // seeded LCG (Numerical Recipes) -> [0,1)
+        let seed = 1 >>> 0;
+        const rnd = () => (seed = (seed * 1664525 + 1013904223) >>> 0) / 4294967296;
+
+        const G = 0.193 * REF; // px/s^2
+        const SLOT = DUR / N; // s between launches
+        const FLIGHT = ONE ? SLOT : (110 / 30) * (DUR / 12); // s, scaled with the loop (preview: 110 frames @ 12 s)
+        const cards = [];
+        for (let i = 0; i < N; i++) {
+          const m = IMAGES[i],
+            a = aspect(m, FIT, CROP_AR);
+          const w = SCALE * REF * (1 + SIZEVAR * (2 * rnd() - 1)),
+            h = w / a;
+          const c = card(m, w, h, RADIUS);
+          if (shadow) c.style.boxShadow = shadow;
+          c.style.left = -w / 2 + "px";
+          c.style.top = -h / 2 + "px";
+          stage.appendChild(c);
+          const half = Math.max(0, (SPREAD * REF - w) / 2);
+          cards.push({
+            el: c,
+            w,
+            h,
+            tApex: (i + 1 / 3) * SLOT, // s
+            apexY: REF * (1 - 0.0063 * THROW) - REF / 2 + (2 * rnd() - 1) * 0.065 * REF, // rel. to centre
+            x0: (2 * rnd() - 1) * half,
+            vx: ((2 * rnd() - 1) * 0.55 * 30 * REF) / 512, // px/s
+            a0: (2 * rnd() - 1) * 5,
+            spin: ((rnd() < 0.5 ? -1 : 1) * SPIN) / (85 / 30), // deg/s
+          });
+        }
+        const gPer = ONE ? G * Math.pow(((110 / 30) * (DUR / 12)) / SLOT, 2) : G; // flow=one: compress the arc into one slot
+        function renderAt(t) {
+          const now = t * DUR;
+          for (const c of cards) {
+            let dt = now - c.tApex;
+            dt -= Math.round(dt / DUR) * DUR; // nearest apex in the periodic schedule
+            const y = c.apexY + 0.5 * gPer * dt * dt;
+            const vis = Math.abs(dt) <= FLIGHT / 2 + 0.2 && y - c.h < REF; // cull when below the frame
+            c.el.style.display = vis ? "block" : "none";
+            if (!vis) continue;
+            const launch = c.tApex - FLIGHT / 2,
+              age = frac((now - launch) / DUR); // 0 = just launched
+            c.el.style.zIndex = Math.round((1 - age) * 1000);
+            c.el.style.transform = `translate3d(${c.x0 + c.vx * dt}px,${y}px,0) rotate(${c.a0 + c.spin * dt}deg)`;
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-cardtoss"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-cardtoss/registry-item.json
+++ b/registry/blocks/loop-cardtoss/registry-item.json
@@ -1,0 +1,437 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-cardtoss",
+  "type": "hyperframes:block",
+  "title": "Loop Card Toss",
+  "description": "Image cards are tossed up from below the frame, hang at the apex, and fall back. 8 image slots, 12s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "cardtoss"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 12,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "crop",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "3:4",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "shadowEnabled",
+      "type": "enum",
+      "role": "style",
+      "label": "Appearance · Shadow",
+      "description": "Shadow Enabled (engine parameter; see the block header comment).",
+      "default": "false",
+      "options": [
+        {
+          "value": "true",
+          "label": "On"
+        },
+        {
+          "value": "false",
+          "label": "Off"
+        }
+      ]
+    },
+    {
+      "id": "shadowX",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Shadow X",
+      "description": "Shadow X (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": -40,
+      "max": 40,
+      "step": 0.5,
+      "unit": "px"
+    },
+    {
+      "id": "shadowY",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Shadow Y",
+      "description": "Shadow Y (engine parameter; see the block header comment).",
+      "default": 1,
+      "min": -40,
+      "max": 40,
+      "step": 0.5,
+      "unit": "px"
+    },
+    {
+      "id": "shadowBlur",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Shadow blur",
+      "description": "Shadow Blur (engine parameter; see the block header comment).",
+      "default": 1.5,
+      "min": 0,
+      "max": 40,
+      "step": 0.5,
+      "unit": "px"
+    },
+    {
+      "id": "shadowSpread",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Shadow spread",
+      "description": "Shadow Spread (engine parameter; see the block header comment).",
+      "default": -0.25,
+      "min": -20,
+      "max": 40,
+      "step": 0.5,
+      "unit": "px"
+    },
+    {
+      "id": "shadowOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Shadow opacity",
+      "description": "Shadow Opacity (engine parameter; see the block header comment).",
+      "default": 40,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "shadowColor",
+      "type": "color",
+      "role": "style",
+      "label": "Appearance · Shadow colour",
+      "description": "Shadow Color (engine parameter; see the block header comment).",
+      "default": "#000000"
+    },
+    {
+      "id": "scaleIntensity",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Media scale",
+      "description": "Strength of the size change.",
+      "default": 0.26,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 32,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "sizeVar",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Size Var",
+      "description": "Size Var (engine parameter; see the block header comment).",
+      "default": 20,
+      "min": 0,
+      "max": 40,
+      "step": 1
+    },
+    {
+      "id": "throwHeight",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Throw Height",
+      "description": "Throw Height (engine parameter; see the block header comment).",
+      "default": 75,
+      "min": 0,
+      "max": 150,
+      "step": 1
+    },
+    {
+      "id": "spread",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Spread",
+      "description": "Spread (engine parameter; see the block header comment).",
+      "default": 70,
+      "min": 0,
+      "max": 140,
+      "step": 1
+    },
+    {
+      "id": "spin",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Spin",
+      "description": "Spin (engine parameter; see the block header comment).",
+      "default": 12,
+      "min": 0,
+      "max": 24,
+      "step": 1
+    },
+    {
+      "id": "flow",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Flow",
+      "description": "Flow (engine parameter; see the block header comment).",
+      "default": "staggered",
+      "options": [
+        {
+          "value": "one",
+          "label": "One"
+        },
+        {
+          "value": "staggered",
+          "label": "Staggered"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-cardtoss.html",
+      "target": "compositions/loop-cardtoss.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-carousel-1/loop-carousel-1.html
+++ b/registry/blocks/loop-carousel-1/loop-carousel-1.html
@@ -1,0 +1,328 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"tiltStyle","type":"enum","role":"style","label":"Animation · Tilt Style","description":"Tilt Style (engine parameter; see the block header comment).","default":"off","options":[{"value":"off","label":"Off"},{"value":"fan","label":"Fan"},{"value":"uniform","label":"Uniform"},{"value":"alternate","label":"Alternate"}]},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"stagger","type":"number","role":"style","label":"Animation · Stagger","description":"Stagger (engine parameter; see the block header comment).","default":0.06666666666666667,"min":0,"max":2,"step":0.01},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"up","options":[{"value":"up","label":"Up"},{"value":"down","label":"Down"},{"value":"left","label":"Left"},{"value":"right","label":"Right"}]},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":600,"min":0,"max":1700,"step":10},{"id":"gap","type":"number","role":"style","label":"Template options · Gap","description":"Spacing between cards.","default":40,"min":0,"max":1000,"step":10,"unit":"px"},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"scaleCenter","type":"enum","role":"style","label":"Template options · Scale Center","description":"Scale Center (engine parameter; see the block header comment).","default":"off","options":[{"value":"off","label":"Off"},{"value":"on","label":"On"}]},{"id":"scaleFocus","type":"enum","role":"style","label":"Template options · Scale Focus","description":"Scale Focus (engine parameter; see the block header comment).","default":"center","options":[{"value":"center","label":"Center"},{"value":"start","label":"Start"},{"value":"end","label":"End"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-carousel-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-carousel-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-carousel-1-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-carousel-1-root"
+      data-composition-id="loop-carousel-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="18"
+    >
+      <div
+        id="loop-carousel-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="18"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-carousel-1-bg"></div>
+        <div id="loop-carousel-1-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Carousel loop family — ONE lane of cards stepping past the centre.
+        // Mechanism read off the previews (2026-09-08, 512x512, 8 placeholders):
+        //   stepped: N steps per cycle, one card pitch each (Carousel01: 8 rests at f54-66,120-132,…; period 67.5f).
+        //   units:   planeSize & gap are px at H=1080 (600 -> 286px, 40 -> 18px @512; C05 730 -> 347, 80 -> 37).
+        //   ease:    0.26·u + 0.74·expoInOut(u) over the move window (C05 fit maxerr 0.009) — same blend as Marquee.
+        //   stagger: seconds per card, ordered from the EXIT edge (C01: 0.0667s = 2f lag between neighbours, gaps
+        //            stretch 18 -> 77px mid-step, same pattern every step => rank by slot, not by image).
+        //   down/right: the stagger ranks are offset by ~N-2 slots (C13: centre card delay 12.4f = 6.2 slots) — the trailing
+        //            gap still stretches like 'up'; the source of the offset is unknown (guess: lane indexed top->bottom).
+        //   delay:   rest seconds per step (C09 delay 0.5 -> 15 of 60 frames still). move = step - delay - N·stagger
+        //            (C01: 67.5-16 = 51.5f, visible 69..120 ✓; C05 stagger 0 -> no rest ✓).
+        //   scaleCenter: layout stays UNSCALED (pitch = plane+gap), scale is linear in distance, reaching 1.0 at one pitch.
+        //     focus center: s = 1 + KC·(1-|d|/pitch), origin = card centre (C03 1.456, C04 1.457; C09/C10 1.403 — KC is
+        //                   not a spec setting, 0.456 used, so 09/10 run 4% big).
+        //     focus start/end: s = 1 ∓ KE·d/pitch (bigger toward top/left for start, bottom/right for end) and the card
+        //                   grows AWAY from the frame centre (C11 rest: top card 1.188 keeps its bottom edge, bottom card
+        //                   0.817 keeps its top edge; gaps between scaled edges stay = gap). KE: C11 .185, C12 .217,
+        //                   C13/14 ≈ .28 (mid-step) — 0.21 used.
+        //   tilt alternate: tilt_k = ±TMAX·tanh(|d|/L), sign alternating per card (C17: 0.058°/px near centre,
+        //                   10° at 215px, 12° at 370px; both visible neighbours share the sign, sign flips every step).
+        // Guesses (no preview): offsetX/Y unit (px@1080), tilt 'fan' (odd in d, no alternation), 'uniform' (constant
+        // TMAX), L = 0.6·planeSize, cycles>1 (N steps per cycle), imageCount < 8 behaviour.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 18, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, card, background, expoInOut, frac } = RF;
+        const U = REF / 1080; // spec px (1080-based) -> frame px
+        const DUR = num("loopDuration", 18);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const CROSS = num("planeSize", 600) * U;
+        const GAP = num("gap", 40) * U;
+        const OX = num("offsetX", 0) * U,
+          OY = num("offsetY", 0) * U;
+        const TILT = str("tiltStyle", "off");
+        const CYCLES = Math.max(1, num("cycles", 1) | 0);
+        const STAGGER = num("stagger", 0); // seconds per slot
+        const DELAY = num("delay", 0); // rest seconds per step
+        const DIRN = str("direction", "up");
+        const SCALE = on("scaleCenter", false);
+        const FOCUS = str("scaleFocus", "center");
+        const RADIUS = num("borderRadius", 0) * U;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const VERT = DIRN === "up" || DIRN === "down";
+        const SIGN = DIRN === "up" || DIRN === "left" ? 1 : -1; // +1: content travels toward negative axis
+        const KC = 0.456,
+          KE = 0.21,
+          TMAX = 12.5,
+          L = 0.6 * CROSS; // measured constants (see header)
+
+        document.getElementById("loop-carousel-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-carousel-1-bg"));
+        const stage = document.getElementById("loop-carousel-1-stage");
+        stage.style.transform = `translate(${OX}px,${OY}px)`;
+
+        // lane content: card k has along-size from its aspect; cumulative rest positions, period P
+        const items = IMAGES.map((m, k) => {
+          const a = aspect(m, FIT, CROP_AR);
+          const along = VERT ? CROSS / a : CROSS * a;
+          const el = VERT ? card(m, CROSS, along, RADIUS) : card(m, along, CROSS, RADIUS);
+          const w = VERT ? CROSS : along,
+            h = VERT ? along : CROSS;
+          el.style.left = -w / 2 + "px";
+          el.style.top = -h / 2 + "px";
+          el.style.zIndex = String(N - k);
+          stage.appendChild(el);
+          return { el, along, pitch: along + GAP, sgn: k % 2 ? 1 : -1 };
+        });
+        const cum = [0];
+        for (const it of items) cum.push(cum[cum.length - 1] + it.pitch);
+        const P = cum[N],
+          PITCH = P / N;
+        const STEPS = N * CYCLES,
+          TS = DUR / STEPS;
+        const MOVE = Math.max(0.1 * TS, TS - DELAY - N * STAGGER);
+        const VIS = VERT ? H : W; // frame extent along the lane
+        const wrap = (x) => frac((x + P / 2) / P) * P - P / 2; // -> [-P/2, P/2)
+        const ease = (u) => 0.26 * u + 0.74 * expoInOut(u);
+        const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+        function renderAt(t) {
+          const s = Math.min(STEPS - 1e-9, t * STEPS),
+            si = Math.floor(s),
+            tl = (s - si) * TS; // step index, seconds into step
+          const base = Math.floor(si / N) * P + cum[si % N]; // travel completed before this step
+          const stepPitch = items[si % N].pitch;
+          const rests = items.map((it, k) => wrap(cum[k] - base)); // rest positions (exit edge negative)
+          // stagger rank = cards ahead (toward the exit) weighted by their visible fraction: C01's top card (33% visible)
+          // delays the centre card ~0.7f, C03/C11's (4% visible) not at all — integer ranks made those 2f late.
+          const vis = rests.map((r, k) =>
+            clamp01((r + VIS / 2 + items[k].along / 2) / items[k].along),
+          );
+          for (let k = 0; k < N; k++) {
+            const it = items[k],
+              rest = rests[k];
+            let rank = SIGN < 0 ? N - 2 : 0; // down/right: C13 centre card starts ~6.2 slots late (p=.5 at f38 of 67.5), next card ~7.9 — empirical N-2 offset
+            for (let j = 0; j < N; j++) if (rests[j] < rest) rank += vis[j];
+            const u = ease(clamp01((tl - rank * STAGGER) / MOVE));
+            const pos = wrap(cum[k] - base - u * stepPitch);
+            const d = SIGN * pos; // screen offset from the frame centre along the lane
+            let sc = 1,
+              oFrac = 0.5;
+            if (SCALE) {
+              if (FOCUS === "center") sc = 1 + KC * Math.max(0, 1 - Math.abs(d) / PITCH);
+              else {
+                sc = 1 + ((FOCUS === "start" ? -1 : 1) * KE * d) / PITCH;
+                oFrac = clamp01(0.5 - d / it.along);
+              }
+            }
+            let tilt = 0;
+            if (TILT === "alternate") tilt = it.sgn * TMAX * Math.tanh(Math.abs(d) / L);
+            else if (TILT === "fan") tilt = TMAX * Math.tanh(d / L);
+            else if (TILT === "uniform") tilt = TMAX;
+            const tr = VERT ? `translate3d(0,${d}px,0)` : `translate3d(${d}px,0,0)`;
+            it.el.style.transformOrigin = VERT ? `50% ${oFrac * 100}%` : `${oFrac * 100}% 50%`;
+            it.el.style.transform = `${tr} rotate(${tilt}deg) scale(${sc})`;
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-carousel-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-carousel-1/registry-item.json
+++ b/registry/blocks/loop-carousel-1/registry-item.json
@@ -1,0 +1,451 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-carousel-1",
+  "type": "hyperframes:block",
+  "title": "Loop Carousel 1",
+  "description": "One lane of image cards steps past the centre, the focused card featured. 8 image slots, 18s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "carousel"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 18,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "tiltStyle",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Tilt Style",
+      "description": "Tilt Style (engine parameter; see the block header comment).",
+      "default": "off",
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "fan",
+          "label": "Fan"
+        },
+        {
+          "value": "uniform",
+          "label": "Uniform"
+        },
+        {
+          "value": "alternate",
+          "label": "Alternate"
+        }
+      ]
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "stagger",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Stagger",
+      "description": "Stagger (engine parameter; see the block header comment).",
+      "default": 0.06666666666666667,
+      "min": 0,
+      "max": 2,
+      "step": 0.01
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "up",
+      "options": [
+        {
+          "value": "up",
+          "label": "Up"
+        },
+        {
+          "value": "down",
+          "label": "Down"
+        },
+        {
+          "value": "left",
+          "label": "Left"
+        },
+        {
+          "value": "right",
+          "label": "Right"
+        }
+      ]
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 600,
+      "min": 0,
+      "max": 1700,
+      "step": 10
+    },
+    {
+      "id": "gap",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Gap",
+      "description": "Spacing between cards.",
+      "default": 40,
+      "min": 0,
+      "max": 1000,
+      "step": 10,
+      "unit": "px"
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "scaleCenter",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Scale Center",
+      "description": "Scale Center (engine parameter; see the block header comment).",
+      "default": "off",
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "id": "scaleFocus",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Scale Focus",
+      "description": "Scale Focus (engine parameter; see the block header comment).",
+      "default": "center",
+      "options": [
+        {
+          "value": "center",
+          "label": "Center"
+        },
+        {
+          "value": "start",
+          "label": "Start"
+        },
+        {
+          "value": "end",
+          "label": "End"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-carousel-1.html",
+      "target": "compositions/loop-carousel-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-carousel3d-1/loop-carousel3d-1.html
+++ b/registry/blocks/loop-carousel3d-1/loop-carousel3d-1.html
@@ -1,0 +1,285 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":12,"step":0.1},{"id":"cycleDeg","type":"number","role":"style","label":"Animation · Cycle Deg","description":"Degrees turned per cycle.","default":360,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"forward","options":[{"value":"forward","label":"Forward"},{"value":"reverse","label":"Reverse"}]},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":400,"min":0,"max":820,"step":10},{"id":"orbitRadius","type":"number","role":"style","label":"Template options · Orbit Radius","description":"Ring radius in scene units.","default":280,"min":0,"max":960,"step":10},{"id":"distance","type":"number","role":"style","label":"Template options · Distance","description":"Camera distance from the formation.","default":1300,"min":0,"max":3740,"step":10},{"id":"perspective","type":"number","role":"style","label":"Template options · Perspective","description":"Camera focal length: smaller = stronger perspective.","default":140,"min":0,"max":600,"step":10},{"id":"rotationX","type":"number","role":"style","label":"Template options · Rotation X","description":"Formation tilt about the horizontal axis, degrees.","default":30,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"rotationY","type":"number","role":"style","label":"Template options · Rotation Y","description":"Formation turn about the vertical axis, degrees.","default":38,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"rotationZ","type":"number","role":"style","label":"Template options · Rotation Z","description":"Formation roll about the view axis, degrees.","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-carousel3d-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-carousel3d-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-carousel3d-1-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      /* never put opacity/filter in will-change on preserve-3d elements: it flattens them silently */
+      #loop-carousel3d-1-ring,
+      #loop-carousel3d-1-spin {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-carousel3d-1-root"
+      data-composition-id="loop-carousel3d-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="8"
+    >
+      <div
+        id="loop-carousel3d-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="8"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-carousel3d-1-bg"></div>
+        <div id="loop-carousel3d-1-stage">
+          <div id="loop-carousel3d-1-ring"><div id="loop-carousel3d-1-spin"></div></div>
+        </div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Carousel3D loop family — N RADIAL panes (paddle wheel / fanned book pages)
+        // around a vertical axis, camera at `distance` in front of the axis, uniform spin.
+        // Read off the previews (2026-09-08):
+        //   radial, not tangent: 3D05 (R 480, plane 250) shows face-on cards at the SIDES and edge-on cards at the
+        //     front/back; 3D04's front pane recedes toward the axis (near/outer edge 290px tall, inner edge 220px).
+        //   pane centred at orbitRadius, radial extent = planeSize (3D04: R 210 ≈ plane/2, inner edges touch the axis).
+        //   spin uniform, cycles·cycleDeg per loop (all five = 360°); adjacent-frame diffs show no 60-frame dips for
+        //     3D02/3D04 (cycles 6 × 60°), so cycles/cycleDeg do NOT make eased swings. Period 45f = 360°/8 cards ✓.
+        //   3D04 'reverse': the front-left pane approaches the camera (bbox height 295 -> 332 over f0..42) => reverse = +rotateY (flat-render test).
+        //   camera: distance = camera-to-axis in world units (3D04: peak/inner height ratio 1.51 => Z ≈ 1229 ≈ 1250).
+        //   focal length ≈ 5.5·perspective px at H=1080 with camera Z = 1.1·distance: fits 3D04's height-vs-angle curve
+        //     (295px at θ≈45° -> 332px at θ≈0) and 3D03's side pane heights; the first pass (4.8·persp, Z = distance)
+        //     matched 3D04's peak only and left 3D03 panes 20% small.
+        //     NOTE: differs from the Loop3D family law (1000·100/persp) — different unit system.
+        //   offsetX 50.5 puts the axis at the right frame edge => % of W (offsetY: % of H).
+        // Guesses: rotationX/Z sign convention, natural-fit fixed dimension (radial extent = planeSize), imageCount<8.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 8, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background } = RF;
+        const DUR = num("loopDuration", 8);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const PLANE = num("planeSize", 400);
+        const R = num("orbitRadius", 280);
+        const D = Math.max(1, num("distance", 1300));
+        const PERSP = Math.max(1, num("perspective", 140));
+        const RX = num("rotationX", 0),
+          RY = num("rotationY", 0),
+          RZ = num("rotationZ", 0);
+        const OX = num("offsetX", 0),
+          OY = num("offsetY", 0);
+        const CYCLES = num("cycles", 1),
+          CDEG = num("cycleDeg", 360);
+        const DIR = str("direction", "forward") === "reverse" ? 1 : -1; // 3D04 (reverse): flat-render heights grow f0..18 only with +rotateY
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+
+        document.getElementById("loop-carousel3d-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-carousel3d-1-bg"));
+
+        const f = 5.5 * PERSP * (REF / 1080); // CSS focal length, px (see header: 3D03/3D04 height fits)
+        const s = f / (1.1 * D); // world -> px at the axis depth (axis on the screen plane); Z = 1.1·distance
+        const Rpx = R * s;
+        document.getElementById("loop-carousel3d-1-stage").style.perspective = f + "px";
+        document.getElementById("loop-carousel3d-1-ring").style.transform =
+          `translate3d(${(OX / 100) * W}px,${(OY / 100) * H}px,0) rotateX(${RX}deg) rotateY(${RY}deg) rotateZ(${RZ}deg)`;
+        const spin = document.getElementById("loop-carousel3d-1-spin");
+        for (let i = 0; i < N; i++) {
+          const m = IMAGES[i],
+            a = aspect(m, FIT, CROP_AR);
+          const w = PLANE * s,
+            h = w / a; // radial extent fixed, height follows aspect
+          const c = card(m, w, h, RADIUS);
+          c.style.left = -w / 2 + "px";
+          c.style.top = -h / 2 + "px";
+          // tangent slot at angle theta, then turned 90° so the plane contains the radius (radial pane)
+          c.style.transform = `rotateY(${(i * 360) / N}deg) translate3d(0,0,${Rpx}px) rotateY(90deg)`;
+          c.style.transformStyle = "preserve-3d";
+          spin.appendChild(c);
+        }
+        // half-slot initial phase: with slots at 0+45k the 3D04 approaching pane exited ~22° too early (flat-render bbox)
+        function renderAt(t) {
+          spin.style.transform = `rotateY(${180 / N + DIR * CYCLES * CDEG * t}deg)`;
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-carousel3d-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-carousel3d-1/registry-item.json
+++ b/registry/blocks/loop-carousel3d-1/registry-item.json
@@ -1,0 +1,425 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-carousel3d-1",
+  "type": "hyperframes:block",
+  "title": "Loop Carousel 3D 1",
+  "description": "Radial image panes spin around a vertical axis like a paddle wheel under a 3D camera. 8 image slots, 8s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "carousel3d",
+    "3d",
+    "carousel"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 8,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 12,
+      "step": 0.1
+    },
+    {
+      "id": "cycleDeg",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycle Deg",
+      "description": "Degrees turned per cycle.",
+      "default": 360,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "forward",
+      "options": [
+        {
+          "value": "forward",
+          "label": "Forward"
+        },
+        {
+          "value": "reverse",
+          "label": "Reverse"
+        }
+      ]
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 400,
+      "min": 0,
+      "max": 820,
+      "step": 10
+    },
+    {
+      "id": "orbitRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Orbit Radius",
+      "description": "Ring radius in scene units.",
+      "default": 280,
+      "min": 0,
+      "max": 960,
+      "step": 10
+    },
+    {
+      "id": "distance",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Distance",
+      "description": "Camera distance from the formation.",
+      "default": 1300,
+      "min": 0,
+      "max": 3740,
+      "step": 10
+    },
+    {
+      "id": "perspective",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Perspective",
+      "description": "Camera focal length: smaller = stronger perspective.",
+      "default": 140,
+      "min": 0,
+      "max": 600,
+      "step": 10
+    },
+    {
+      "id": "rotationX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rotation X",
+      "description": "Formation tilt about the horizontal axis, degrees.",
+      "default": 30,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "rotationY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rotation Y",
+      "description": "Formation turn about the vertical axis, degrees.",
+      "default": 38,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "rotationZ",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rotation Z",
+      "description": "Formation roll about the view axis, degrees.",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-carousel3d-1.html",
+      "target": "compositions/loop-carousel3d-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-corridor/loop-corridor.html
+++ b/registry/blocks/loop-corridor/loop-corridor.html
@@ -1,0 +1,404 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"crop","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"speed","type":"number","role":"style","label":"Animation · Speed","description":"Motion speed multiplier.","default":15,"min":0,"max":30,"step":1},{"id":"lineColor","type":"color","role":"style","label":"Template options · Line Color","description":"Line Color (engine parameter; see the block header comment).","default":"#b0b0b0"},{"id":"accentColor","type":"color","role":"style","label":"Template options · Accent Color","description":"Accent Color (engine parameter; see the block header comment).","default":"#ff6a00"},{"id":"lineOpacity","type":"number","role":"style","label":"Template options · Line Opacity","description":"Line Opacity (engine parameter; see the block header comment).","default":50,"min":0,"max":100,"step":1},{"id":"grid","type":"number","role":"style","label":"Template options · Grid","description":"Grid (engine parameter; see the block header comment).","default":4,"min":0,"max":10,"step":0.1},{"id":"segments","type":"number","role":"style","label":"Template options · Segments","description":"Segments (engine parameter; see the block header comment).","default":15,"min":0,"max":30,"step":1},{"id":"fill","type":"number","role":"style","label":"Template options · Fill","description":"Fill (engine parameter; see the block header comment).","default":32,"min":0,"max":64,"step":1},{"id":"tunnelWidth","type":"number","role":"style","label":"Template options · Tunnel Width","description":"Tunnel Width (engine parameter; see the block header comment).","default":100,"min":0,"max":200,"step":1},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-corridor</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-corridor-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-corridor-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      #loop-corridor-world,
+      #loop-corridor-tunnel,
+      .seg {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      .wall {
+        position: absolute;
+        left: 0;
+        top: 0;
+        display: flex;
+        transform-origin: 0 0;
+        transform-style: preserve-3d;
+      }
+      .cell {
+        position: relative;
+        flex: 1 1 0;
+        overflow: hidden;
+      }
+      .cell img {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-corridor-root"
+      data-composition-id="loop-corridor"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="14"
+    >
+      <div
+        id="loop-corridor-loop"
+        class="clip"
+        data-start="0"
+        data-duration="14"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-corridor-bg"></div>
+        <div id="loop-corridor-stage">
+          <div id="loop-corridor-world"><div id="loop-corridor-tunnel"></div></div>
+        </div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Corridor loop family — camera flies down a rectangular wireframe tunnel whose
+        // walls are `grid` cells across x 1 cell per segment deep; `fill`% of cells carry a panel (media, or the
+        // accent colour for ~25% of them). Measured on the 512 preview (2026-09-08):
+        //   rings equally spaced in z: 1/d linear, f·wy/L = 935px, f·wx/L = 1035px  => wx/wy = 1.107 (rectangular)
+        //   travel = 15 segments per 14s loop, linear (resid < 0.1 seg); `segments` = 15 rings visible, far end is empty (bg)
+        //   with f = 1000·REF/1080 (3D-family convention) that is wy = 1.97 L, wx = 2.18 L  (side cells ≈ square)
+        //   fill: 76/240 cells over one period = 31.7% (== fill 32); accent share of filled cells 19/76 = 25%
+        //   camera: no sway, no roll (VP jitter < 0.5px); lines 1px screen-constant in the ref — we use world-space
+        //   lines L/80 thick (≈1px at ring 6 @512), so near rings are bolder and far ones fainter than the ref.
+        // Default pattern (segments 15, grid 4): the exact per-segment fill map recovered from the preview; anything
+        // else falls back to a seeded LCG with the same statistics. Guesses: speed = segments travelled per loop
+        // (defaults 15/15 coincide, seamless only when a multiple of `segments`); tunnelWidth scales wx only.
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 14, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, background, frac } = RF;
+        const DUR = num("loopDuration", 14);
+        const FIT = str("mediaFit", "crop");
+        const LINE = str("lineColor", "#b0b0b0");
+        const ACCENT = str("accentColor", "#ff6a00");
+        const LOP = num("lineOpacity", 50) / 100;
+        const GRID = Math.max(1, num("grid", 4) | 0);
+        const SEG = Math.max(2, num("segments", 15) | 0);
+        const FILL = num("fill", 32) / 100;
+        const TW = num("tunnelWidth", 100) / 100;
+        const SPEED = num("speed", 15);
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+
+        document.getElementById("loop-corridor-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-corridor-bg"));
+
+        const f = 1000 * (REF / 1080);
+        const L = REF / 4; // segment length, px (arbitrary: only f·w/L is observable)
+        const wy = ((935 / 512) * REF * L) / f; // half-height
+        const wx = 1.107 * wy * TW; // half-width
+        const lw = L / 80;
+        const stage = document.getElementById("loop-corridor-stage");
+        stage.style.perspective = f + "px";
+        document.getElementById("loop-corridor-world").style.transform = `translateZ(${f}px)`;
+        const tunnel = document.getElementById("loop-corridor-tunnel");
+
+        // --- fill map: pattern[m][wall*GRID + c] in '.', 'M', 'A' ---
+        const REF_PATTERN = [
+          "AM.........A...M",
+          "A..MA....MA...M.",
+          "M.M.M..M....A.M.",
+          "..M......M.M...M",
+          "..M..MM....M..MM",
+          ".....AMMMM.....M",
+          ".M.M..M.........",
+          ".....M.A..A.M..M",
+          "M....M...MMA.AM.",
+          ".A..M....M.....M",
+          "....A...M....M..",
+          ".....M.A.MM.MMMM",
+          "A..M......MM....",
+          "..M.....M.M.....",
+          ".A.MA.M..M.AA...",
+        ];
+        let seed = 12345;
+        const rnd = () => (seed = (seed * 1664525 + 1013904223) >>> 0) / 4294967296;
+        const pattern = [];
+        for (let m = 0; m < SEG; m++) {
+          if (SEG === 15 && GRID === 4) {
+            pattern.push(REF_PATTERN[m]);
+            continue;
+          }
+          let s = "";
+          for (let i = 0; i < 4 * GRID; i++) {
+            const a = rnd(),
+              b = rnd();
+            s += a < FILL ? (b < 0.25 ? "A" : "M") : ".";
+          }
+          pattern.push(s);
+        }
+        // media index per filled 'M' cell, in pattern order
+        const imgIdx = new Map();
+        let ic = 0;
+        pattern.forEach((s, m) =>
+          [...s].forEach((ch, i) => {
+            if (ch === "M") imgIdx.set(m * 4 * GRID + i, ic++ % N);
+          }),
+        );
+
+        const rgba = (hex, a) => {
+          const n = parseInt(hex.replace("#", ""), 16);
+          return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
+        };
+        const lineCss = `${lw}px solid ${rgba(LINE, LOP)}`;
+        // walls (transform-origin 0 0 => translate places the top-left corner): span across, flex dir, transform, far-edge / cross-line border sides
+        const WALLS = [
+          {
+            span: 2 * wx,
+            dir: "row",
+            tf: `translate3d(${-wx}px,${-wy}px,${-L}px) rotateX(90deg)`,
+            far: "Top",
+            cross: "Left",
+          },
+          {
+            span: 2 * wx,
+            dir: "row",
+            tf: `translate3d(${-wx}px,${wy}px,0px) rotateX(-90deg)`,
+            far: "Bottom",
+            cross: "Left",
+          },
+          {
+            span: 2 * wy,
+            dir: "column",
+            tf: `translate3d(${-wx}px,${-wy}px,0px) rotateY(90deg)`,
+            far: "Right",
+            cross: "Top",
+          },
+          {
+            span: 2 * wy,
+            dir: "column",
+            tf: `translate3d(${wx}px,${-wy}px,${-L}px) rotateY(-90deg)`,
+            far: "Left",
+            cross: "Top",
+          },
+        ];
+        // slots j = 1..SEG-1 (slot 0 straddles the camera plane and is off-screen anyway)
+        const slots = [];
+        for (let j = 1; j < SEG; j++) {
+          const seg = document.createElement("div");
+          seg.className = "seg";
+          seg.style.transform = `translateZ(${-j * L}px)`;
+          const cells = [];
+          WALLS.forEach((wd, wi) => {
+            const wall = document.createElement("div");
+            wall.className = "wall";
+            const horiz = wd.dir === "row";
+            wall.style.cssText = `width:${horiz ? wd.span : L}px;height:${horiz ? L : wd.span}px;flex-direction:${wd.dir};transform:${wd.tf};`;
+            wall.style["border" + wd.far] = lineCss;
+            wall.style["border" + (wd.cross === "Left" ? "Right" : "Bottom")] = lineCss; // closing corner line
+            for (let c = 0; c < GRID; c++) {
+              const cell = document.createElement("div");
+              cell.className = "cell";
+              cell.style["border" + wd.cross] = lineCss;
+              wall.appendChild(cell);
+              cells.push(cell);
+            }
+            seg.appendChild(wall);
+          });
+          tunnel.appendChild(seg);
+          slots.push({ j, cells, shown: -1 });
+        }
+        function paint(slot, m) {
+          if (slot.shown === m) return;
+          slot.shown = m;
+          const s = pattern[m];
+          slot.cells.forEach((cell, i) => {
+            const ch = s[i];
+            cell.style.background = ch === "A" ? ACCENT : "transparent";
+            cell.replaceChildren();
+            if (ch === "M") {
+              const img = document.createElement("img");
+              img.src = IMAGES[imgIdx.get(m * 4 * GRID + i)].src;
+              if (FIT === "natural") img.style.objectFit = "contain";
+              cell.appendChild(img);
+            }
+          });
+        }
+        function renderAt(t) {
+          const T = t * SPEED; // travel, in segments
+          const n = Math.floor(T),
+            p = frac(T);
+          tunnel.style.transform = `translateZ(${p * L}px)`; // slot j sits at depth (j - p)·L
+          for (const s of slots) paint(s, (((s.j + n) % SEG) + SEG) % SEG);
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-corridor"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-corridor/registry-item.json
+++ b/registry/blocks/loop-corridor/registry-item.json
@@ -1,0 +1,349 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-corridor",
+  "type": "hyperframes:block",
+  "title": "Loop Corridor",
+  "description": "The camera flies down a rectangular wireframe corridor lined with image panels. 8 image slots, 14s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "corridor",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 14,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "crop",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "speed",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Speed",
+      "description": "Motion speed multiplier.",
+      "default": 15,
+      "min": 0,
+      "max": 30,
+      "step": 1
+    },
+    {
+      "id": "lineColor",
+      "type": "color",
+      "role": "style",
+      "label": "Template options · Line Color",
+      "description": "Line Color (engine parameter; see the block header comment).",
+      "default": "#b0b0b0"
+    },
+    {
+      "id": "accentColor",
+      "type": "color",
+      "role": "style",
+      "label": "Template options · Accent Color",
+      "description": "Accent Color (engine parameter; see the block header comment).",
+      "default": "#ff6a00"
+    },
+    {
+      "id": "lineOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Line Opacity",
+      "description": "Line Opacity (engine parameter; see the block header comment).",
+      "default": 50,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "id": "grid",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Grid",
+      "description": "Grid (engine parameter; see the block header comment).",
+      "default": 4,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "segments",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Segments",
+      "description": "Segments (engine parameter; see the block header comment).",
+      "default": 15,
+      "min": 0,
+      "max": 30,
+      "step": 1
+    },
+    {
+      "id": "fill",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Fill",
+      "description": "Fill (engine parameter; see the block header comment).",
+      "default": 32,
+      "min": 0,
+      "max": 64,
+      "step": 1
+    },
+    {
+      "id": "tunnelWidth",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Tunnel Width",
+      "description": "Tunnel Width (engine parameter; see the block header comment).",
+      "default": 100,
+      "min": 0,
+      "max": 200,
+      "step": 1
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-corridor.html",
+      "target": "compositions/loop-corridor.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-coverflow/loop-coverflow.html
+++ b/registry/blocks/loop-coverflow/loop-coverflow.html
@@ -1,0 +1,336 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"scaleIntensity","type":"number","role":"style","label":"Appearance · Media scale","description":"Strength of the size change.","default":0.46,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":32,"min":0,"max":200,"step":1,"unit":"px"},{"id":"easing","type":"enum","role":"style","label":"Animation · Easing","description":"Easing family for stepped motion.","default":"smooth","options":[{"value":"custom","label":"Custom"},{"value":"smooth","label":"Smooth"},{"value":"natural","label":"Natural"},{"value":"slowdown","label":"Slowdown"},{"value":"snappy","label":"Snappy"},{"value":"accelerate","label":"Accelerate"},{"value":"elastic","label":"Elastic"},{"value":"bounce","label":"Bounce"},{"value":"overshoot","label":"Overshoot"},{"value":"impulse","label":"Impulse"},{"value":"swing","label":"Swing"},{"value":"linear","label":"Linear"}]},{"id":"easeBezier","type":"string","role":"style","label":"Animation · Ease Bezier","description":"Cubic-bezier control points for custom easing.","default":"0.50,0.00,0.50,1.00"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"left","options":[{"value":"left","label":"Left"},{"value":"right","label":"Right"}]},{"id":"motion","type":"enum","role":"style","label":"Animation · Motion","description":"Motion (engine parameter; see the block header comment).","default":"steps","options":[{"value":"steps","label":"Steps"},{"value":"flow","label":"Flow"}]},{"id":"padding","type":"number","role":"style","label":"Template options · Padding","description":"Padding (engine parameter; see the block header comment).","default":6,"min":0,"max":100,"step":1,"unit":"px"},{"id":"gap","type":"number","role":"style","label":"Template options · Gap","description":"Spacing between cards.","default":4,"min":0,"max":10,"step":0.1,"unit":"px"},{"id":"sideTilt","type":"number","role":"style","label":"Template options · Side Tilt","description":"Side Tilt (engine parameter; see the block header comment).","default":40,"min":0,"max":80,"step":1},{"id":"flowAngle","type":"number","role":"style","label":"Template options · Flow Angle","description":"Flow Angle (engine parameter; see the block header comment).","default":0,"min":0,"max":2,"step":0.01},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-coverflow</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-coverflow-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-coverflow-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      #loop-coverflow-flow {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-coverflow-root"
+      data-composition-id="loop-coverflow"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="12"
+    >
+      <div
+        id="loop-coverflow-loop"
+        class="clip"
+        data-start="0"
+        data-duration="12"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-coverflow-bg"></div>
+        <div id="loop-coverflow-stage"><div id="loop-coverflow-flow"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // CoverFlow loop family (Fan, horizontal) + "CoverFlowVertical" (Fold) — one engine, the axis comes from
+        // `direction` (left/right = horizontal flow, up/down = vertical). templates/coverflowvertical.html is a symlink.
+        // Mechanism (measured on the 512 previews, 2026-09-08): a row of cards; the focused card is flat at z=0,
+        // every other card is pushed back and rotated about its own centre so the OUTER edge recedes (near edge
+        // taller: 254px vs 262 centre, far edge 207). N steps per loop (N = images), step = DUR/N; the camera
+        // eases one pitch during the first 55% of each step (motion frames 1-22 of 45 @30fps, mid at 0.45 of
+        // the step) and rests for the remainder. `flow` = continuous linear travel (guess, no preview).
+        // Constants @512 (both axes identical, transposed): centre card 262px (=0.512 H; formula below is a knob
+        // calibrated to it), neighbour near edge at 157px from centre, focal f = 1.3 H, depth per slot = 0.36 S,
+        // pitch = S + gap (gap read as 1080p px: fit 267 vs S+2); rms of the 3D fit 4.8px over 42 edge samples.
+        // Easing: `smooth` = cubic-bezier(.65,0,.35,1) (easeInOutCubic), fitted on FocusSlider/Slats to <1%.
+        // Knobs (unmeasured): S = (1-2·padding)·H·scaleIntensity·1.266; flowAngle = 2D rotation of the stage;
+        // elastic/bounce/overshoot/impulse/swing eases fall back to smooth.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 12, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 12);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const PAD = num("padding", 6) / 100;
+        const SI = num("scaleIntensity", 0.46);
+        const GAP = (num("gap", 4) * REF) / 1080;
+        const TILT = num("sideTilt", 40);
+        const ANGLE = num("flowAngle", 0);
+        const DIRN = str("direction", "left");
+        const MOTION = str("motion", "steps");
+        const RADIUS = (num("borderRadius", 32) * REF) / 1080;
+        const IMAGES = pick(Math.min(12, num("imageCount", 16)));
+        const N = IMAGES.length;
+        const HORIZ = DIRN === "left" || DIRN === "right";
+        const FWD = DIRN === "left" || DIRN === "up" ? 1 : -1; // content moves left/up = camera advances
+        const TRANS = 0.55; // fraction of a step spent moving
+
+        // cubic-bezier easing (x monotone) by bisection
+        const bezier = (x1, y1, x2, y2) => (x) => {
+          if (x <= 0) return 0;
+          if (x >= 1) return 1;
+          let lo = 0,
+            hi = 1,
+            s = 0.5;
+          for (let i = 0; i < 24; i++) {
+            s = (lo + hi) / 2;
+            const bx = 3 * (1 - s) * (1 - s) * s * x1 + 3 * (1 - s) * s * s * x2 + s * s * s;
+            if (bx < x) lo = s;
+            else hi = s;
+          }
+          return 3 * (1 - s) * (1 - s) * s * y1 + 3 * (1 - s) * s * s * y2 + s * s * s;
+        };
+        const EASES = {
+          smooth: [0.65, 0, 0.35, 1],
+          linear: [0, 0, 1, 1],
+          slowdown: [0, 0, 0.2, 1],
+          accelerate: [0.4, 0, 1, 1],
+          natural: [0.25, 0.1, 0.25, 1],
+          snappy: [0.4, 0, 0.2, 1],
+        };
+        const eName = str("easing", "smooth");
+        const ease = bezier(
+          ...(eName === "custom"
+            ? str("easeBezier", "0.50,0.00,0.50,1.00").split(",").map(Number)
+            : EASES[eName] || EASES.smooth),
+        );
+
+        document.getElementById("loop-coverflow-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-coverflow-bg"));
+        const S = (1 - 2 * PAD) * REF * SI * 1.266; // focused card size across the flow (262 @512)
+        const F = 1.3 * REF; // CSS focal length
+        const DEPTH = 0.36 * S; // z push per slot
+        const stage = document.getElementById("loop-coverflow-stage");
+        stage.style.perspective = F + "px";
+        const flow = document.getElementById("loop-coverflow-flow");
+        flow.style.transform = `rotate(${ANGLE}deg)`;
+
+        // cards: cross-flow dimension = S, along-flow follows the media aspect; world positions cumulative
+        const cards = [];
+        const along = [];
+        for (let i = 0; i < N; i++) {
+          const m = IMAGES[i],
+            a = aspect(m, FIT, CROP_AR);
+          const w = HORIZ ? S * a : S,
+            h = HORIZ ? S : S / a;
+          const c = card(m, w, h, RADIUS);
+          c.style.left = -w / 2 + "px";
+          c.style.top = -h / 2 + "px";
+          flow.appendChild(c);
+          cards.push(c);
+          along.push(HORIZ ? w : h);
+        }
+        const P = [0];
+        for (let i = 1; i <= N; i++) P.push(P[i - 1] + (along[i - 1] + along[i % N]) / 2 + GAP);
+        const TOTAL = P[N],
+          PITCH = TOTAL / N;
+        const LIMIT = Math.hypot(W, H) / 2 + S;
+
+        function renderAt(t) {
+          const u = frac(t) * N,
+            k = Math.floor(u),
+            g = u - k;
+          const e = MOTION === "flow" ? g : ease(Math.min(1, g / TRANS));
+          const cam =
+            FWD > 0 ? P[k] + e * (P[k + 1] - P[k]) : TOTAL - (P[k] + e * (P[k + 1] - P[k]));
+          for (let i = 0; i < N; i++) {
+            let off = P[i] - cam;
+            off -= TOTAL * Math.round(off / TOTAL); // nearest cyclic instance
+            const c = cards[i];
+            if (Math.abs(off) > LIMIT) {
+              c.style.display = "none";
+              continue;
+            }
+            c.style.display = "";
+            const d = off / PITCH,
+              ad = Math.min(1, Math.abs(d)),
+              sg = Math.sign(d);
+            const rot = sg * ad * TILT;
+            c.style.transform = HORIZ
+              ? `translate3d(${off}px,0,${-Math.abs(d) * DEPTH}px) rotateY(${rot}deg)`
+              : `translate3d(0,${off}px,${-Math.abs(d) * DEPTH}px) rotateX(${-rot}deg)`;
+            c.style.zIndex = String(1000 - Math.round(Math.abs(d) * 10));
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-coverflow"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-coverflow/registry-item.json
+++ b/registry/blocks/loop-coverflow/registry-item.json
@@ -1,0 +1,438 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-coverflow",
+  "type": "hyperframes:block",
+  "title": "Loop Cover Flow",
+  "description": "A horizontal cover-flow fan: the focused card faces the camera while its neighbours fold away. 8 image slots, 12s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "coverflow",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 12,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "scaleIntensity",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Media scale",
+      "description": "Strength of the size change.",
+      "default": 0.46,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 32,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "easing",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Easing",
+      "description": "Easing family for stepped motion.",
+      "default": "smooth",
+      "options": [
+        {
+          "value": "custom",
+          "label": "Custom"
+        },
+        {
+          "value": "smooth",
+          "label": "Smooth"
+        },
+        {
+          "value": "natural",
+          "label": "Natural"
+        },
+        {
+          "value": "slowdown",
+          "label": "Slowdown"
+        },
+        {
+          "value": "snappy",
+          "label": "Snappy"
+        },
+        {
+          "value": "accelerate",
+          "label": "Accelerate"
+        },
+        {
+          "value": "elastic",
+          "label": "Elastic"
+        },
+        {
+          "value": "bounce",
+          "label": "Bounce"
+        },
+        {
+          "value": "overshoot",
+          "label": "Overshoot"
+        },
+        {
+          "value": "impulse",
+          "label": "Impulse"
+        },
+        {
+          "value": "swing",
+          "label": "Swing"
+        },
+        {
+          "value": "linear",
+          "label": "Linear"
+        }
+      ]
+    },
+    {
+      "id": "easeBezier",
+      "type": "string",
+      "role": "style",
+      "label": "Animation · Ease Bezier",
+      "description": "Cubic-bezier control points for custom easing.",
+      "default": "0.50,0.00,0.50,1.00"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "left",
+      "options": [
+        {
+          "value": "left",
+          "label": "Left"
+        },
+        {
+          "value": "right",
+          "label": "Right"
+        }
+      ]
+    },
+    {
+      "id": "motion",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Motion",
+      "description": "Motion (engine parameter; see the block header comment).",
+      "default": "steps",
+      "options": [
+        {
+          "value": "steps",
+          "label": "Steps"
+        },
+        {
+          "value": "flow",
+          "label": "Flow"
+        }
+      ]
+    },
+    {
+      "id": "padding",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Padding",
+      "description": "Padding (engine parameter; see the block header comment).",
+      "default": 6,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "gap",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Gap",
+      "description": "Spacing between cards.",
+      "default": 4,
+      "min": 0,
+      "max": 10,
+      "step": 0.1,
+      "unit": "px"
+    },
+    {
+      "id": "sideTilt",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Side Tilt",
+      "description": "Side Tilt (engine parameter; see the block header comment).",
+      "default": 40,
+      "min": 0,
+      "max": 80,
+      "step": 1
+    },
+    {
+      "id": "flowAngle",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Flow Angle",
+      "description": "Flow Angle (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-coverflow.html",
+      "target": "compositions/loop-coverflow.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-deck-1/loop-deck-1.html
+++ b/registry/blocks/loop-deck-1/loop-deck-1.html
@@ -1,0 +1,383 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":16,"min":0,"max":200,"step":1,"unit":"px"},{"id":"fade","type":"number","role":"style","label":"Animation · Fade","description":"Fade (engine parameter; see the block header comment).","default":0,"min":0,"max":100,"step":1},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"up","options":[{"value":"up","label":"Up"},{"value":"down","label":"Down"},{"value":"left","label":"Left"},{"value":"right","label":"Right"}]},{"id":"flipAxis","type":"enum","role":"style","label":"Animation · Flip Axis","description":"Flip Axis (engine parameter; see the block header comment).","default":"vertical","options":[{"value":"vertical","label":"Vertical"},{"value":"horizontal","label":"Horizontal"}]},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":320,"min":0,"max":1000,"step":10},{"id":"distance","type":"number","role":"style","label":"Template options · Distance","description":"Camera distance from the formation.","default":1000,"min":0,"max":8260,"step":10},{"id":"perspective","type":"number","role":"style","label":"Template options · Perspective","description":"Camera focal length: smaller = stronger perspective.","default":100,"min":0,"max":200,"step":1},{"id":"gap","type":"number","role":"style","label":"Template options · Gap","description":"Spacing between cards.","default":0.29,"min":0,"max":2,"step":0.01,"unit":"px"},{"id":"maxScale","type":"number","role":"style","label":"Template options · Max Scale","description":"Max Scale (engine parameter; see the block header comment).","default":1.15,"min":0,"max":3,"step":0.1},{"id":"tilt","type":"number","role":"style","label":"Template options · Tilt","description":"Tilt (engine parameter; see the block header comment).","default":4.5,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"twoSided","type":"enum","role":"style","label":"Template options · Two Sided","description":"Two Sided (engine parameter; see the block header comment).","default":"on","options":[{"value":"off","label":"Off"},{"value":"on","label":"On"}]},{"id":"solo","type":"enum","role":"style","label":"Template options · Solo","description":"Solo (engine parameter; see the block header comment).","default":"off","options":[{"value":"off","label":"Off"},{"value":"on","label":"On"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-deck-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-deck-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-deck-1-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      /* never put opacity/filter/will-change on preserve-3d nodes: it flattens them silently */
+      #loop-deck-1-belt,
+      .slot,
+      .face {
+        transform-style: preserve-3d;
+      }
+      #loop-deck-1-belt {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .slot {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 0;
+        height: 0;
+      }
+      .face {
+        position: absolute;
+        overflow: hidden;
+        backface-visibility: hidden;
+      }
+      .face img {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-deck-1-root"
+      data-composition-id="loop-deck-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="7"
+    >
+      <div
+        id="loop-deck-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="7"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-deck-1-bg"></div>
+        <div id="loop-deck-1-stage"><div id="loop-deck-1-belt"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Deck loop family — "Cards flip through in a stacked deck".
+        // Mechanism (measured on the 512 previews, 2026-09-08): cards sit on a straight belt (vertical for
+        // direction up/down, horizontal for left/right) with pitch P; every step (loop/(images*cycles),
+        // 26.25 frames in the 7s/8-image previews) each card advances one slot with an eased progress
+        // p = 0.25x + 0.75*expoInOut(x) (Deck03 centre-card position, maxerr 0.028) and at the same time
+        // rotates about its OWN centre by rho(u) = 115deg per slot up to |u|=1, then on to 180deg (flat,
+        // back side) by |u|=2 — so the card that just left the centre is seen edge-on at p≈0.75 (Deck03
+        // f15: p=0.746 by position, h=4px) and then shows its back. The far-from-centre edge of a slot
+        // card is nearer the camera (Deck01 upper neighbour top 162px / bottom 130px; Deck02 3D
+        // reconstruction from edge widths: rot 85..90deg at f9-12, 125 at f13, 180 at rest).
+        //   flipAxis vertical -> rotateX, horizontal -> rotateY (independent of the belt axis: Deck04 =
+        //   vertical belt + rotateY gives the tall slivers; Deck06 = horizontal belt + rotateX).
+        //   rotation sign: the leaving card's trailing edge swings toward the camera and over the top, so at
+        //   rest the far-from-centre edge is the near one (Deck01 edge widths 168/127 -> z 903/1194, rho 114deg);
+        //   solo (Deck09 f17: right edge taller) follows the same rule.
+        // Constants: planeSize = world units at z=distance with f = 1000px*(100/perspective) @1080 (Deck01
+        //   320 -> 152px@512, Deck03 445*2500/4130 -> 128px, Deck09 500*1000/1090*1.15 -> 250px: all <1%).
+        //   maxScale = centre-card scale, falls linearly to 1 at |u|=1 (Deck02 centre 204 = 177.8*1.15).
+        //   tilt = rotateZ of the centre card only (Deck01 4.5deg, neighbours 0), same 1-|u| falloff.
+        //   twoSided on: 8 images -> 4 two-sided cards (centre-card grey sequence has period 4 in Deck01
+        //   and Deck03; slot +1 and -1 show the same "back" grey for a card); back of card k = image 2k+1.
+        //   fade: 0 -> no dimming at any slot (Deck01 slot1/slot2 greys equal); 30 -> slot1 luma-above-bg
+        //   0.64 (Deck03 vs Deck01 same faces), slot2 0.60. Modelled as opacity below.
+        // Guesses/knobs: PITCH — P/planeSize measured 1.022 (D01 gap .29), 1.081 (D03 .44), ~1.3-1.4
+        //   (D06/D08 horizontal belts, neighbours partly cut) — no gap formula fits; used
+        //   P = S*(1+gap)*K, K = 0.78 vertical / 0.97 horizontal. delay = seconds of phase. natural fit =
+        //   contain in S x S. steps per loop = images*cycles. Solo (Deck09 f15-22): the belt still
+        //   translates, only the card nearest the centre (|u|<0.5) is drawn, rotation ~90deg/slot (40deg at
+        //   p=.45); the leaving card rises with its right edge toward the camera, the next one comes from
+        //   below with its left edge toward the camera.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 7, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, background, expoInOut, frac } = RF;
+        const DUR = num("loopDuration", 7);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const PLANE = num("planeSize", 320);
+        const D = Math.max(1, num("distance", 1000));
+        const PERSP = Math.max(1, num("perspective", 100));
+        const GAP = num("gap", 0.29);
+        const MAXS = num("maxScale", 1.15);
+        const TILT = num("tilt", 0);
+        const FADE = num("fade", 0);
+        const TWO = on("twoSided", true);
+        const CYCLES = Math.max(1, num("cycles", 1) | 0);
+        const DELAY = num("delay", 0);
+        const DIRN = str("direction", "up");
+        const FLIP = str("flipAxis", "vertical");
+        const SOLO = on("solo", false);
+        const RADIUS = (num("borderRadius", 16) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const VERT = DIRN === "up" || DIRN === "down"; // belt axis
+        const DIR = DIRN === "up" || DIRN === "left" ? 1 : -1; // +1: cards travel toward -screen
+        const ROT = FLIP === "vertical" ? "rotateX" : "rotateY";
+        const RHO1 = 115; // deg per slot (Deck03 118, D04/06/08 ~110)
+        const PITCH_K = SOLO ? 0.66 : VERT ? 0.78 : 0.97; // knob, see header (solo: Deck09 f18/19 centres ~±100px @ p≈.5)
+
+        document.getElementById("loop-deck-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-deck-1-bg"));
+
+        const f = 1000 * (100 / PERSP) * (REF / 1080); // CSS focal length, px
+        const s = f / D; // world -> px at the belt plane (z = 0)
+        const S = PLANE * s;
+        const P = S * (1 + GAP) * PITCH_K;
+        const stage = document.getElementById("loop-deck-1-stage");
+        stage.style.perspective = f + "px";
+        const belt = document.getElementById("loop-deck-1-belt");
+        const ease = (x) => 0.25 * x + 0.75 * expoInOut(x);
+
+        // cards: two-sided packs image pairs (front 2k, back 2k+1)
+        const C = TWO ? Math.ceil(N / 2) : N;
+        const STEPS = N * CYCLES;
+        const cards = [];
+        const face = (m, back) => {
+          const a = aspect(m, FIT, CROP_AR);
+          const w = S * Math.min(1, a),
+            h = S * Math.min(1, 1 / a);
+          const el = document.createElement("div");
+          el.className = "face";
+          el.style.cssText =
+            `width:${w}px;height:${h}px;left:${-w / 2}px;top:${-h / 2}px;border-radius:${RADIUS}px;` +
+            (back ? `transform:${ROT}(180deg);` : "");
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          el.appendChild(img);
+          return el;
+        };
+        for (let k = 0; k < C; k++) {
+          const slot = document.createElement("div");
+          slot.className = "slot";
+          const front = face(IMAGES[TWO ? (2 * k) % N : k], false);
+          slot.appendChild(front);
+          let backEl = null;
+          if (TWO) {
+            backEl = face(IMAGES[(2 * k + 1) % N], true);
+            slot.appendChild(backEl);
+          }
+          belt.appendChild(slot);
+          cards.push({
+            slot,
+            imgs: [front.firstChild, backEl && backEl.firstChild].filter(Boolean),
+          });
+        }
+
+        const rho = (u) => {
+          const a = Math.abs(u);
+          const r = SOLO
+            ? 90 * a
+            : a <= 1
+              ? RHO1 * a
+              : Math.min(180, RHO1 + (180 - RHO1) * (a - 1));
+          return Math.sign(u) * r;
+        };
+        function renderAt(t) {
+          const g = frac(t + DELAY / DUR) * STEPS;
+          const k = Math.floor(g),
+            p = ease(g - k);
+          for (let j = 0; j < C; j++) {
+            const c = cards[j];
+            // belt position in slots relative to the centre; card (k mod C) is centred at p = 0
+            let u = ((((j - k) % C) + C) % C) - p;
+            if (u > C / 2) u -= C;
+            const a = Math.abs(u);
+            if (a > 2.6 || (SOLO && a >= 0.5)) {
+              c.slot.style.display = "none";
+              continue;
+            } // solo: only the nearest card
+            c.slot.style.display = "";
+            const near = Math.max(0, 1 - a);
+            const scale = 1 + (MAXS - 1) * near;
+            const tilt = -TILT * near; // Deck01: centre card CCW
+            const off = DIR * u * P;
+            // leaving card: its trailing edge swings toward the camera and over. CSS rotateX(+) brings the bottom
+            // edge forward but rotateY(+) sends the right edge back, hence the axis-dependent sign.
+            const ang = (ROT === "rotateX" ? -1 : 1) * DIR * rho(u);
+            const tr = VERT ? `translate3d(0,${off}px,0)` : `translate3d(${off}px,0,0)`;
+            c.slot.style.transform = `${tr} rotateZ(${tilt}deg) ${ROT}(${ang}deg) scale(${scale})`;
+            const op = Math.max(
+              0,
+              1 - (FADE / 100) * (1.2 * Math.min(a, 1) + 0.13 * Math.max(0, a - 1)),
+            );
+            for (const im of c.imgs) im.style.opacity = op;
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-deck-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-deck-1/registry-item.json
+++ b/registry/blocks/loop-deck-1/registry-item.json
@@ -1,0 +1,461 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-deck-1",
+  "type": "hyperframes:block",
+  "title": "Loop Deck 1",
+  "description": "Image cards flip through a stacked deck, the front card leaving to reveal the next. 8 image slots, 7s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "deck",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 7,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 16,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "fade",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Fade",
+      "description": "Fade (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "up",
+      "options": [
+        {
+          "value": "up",
+          "label": "Up"
+        },
+        {
+          "value": "down",
+          "label": "Down"
+        },
+        {
+          "value": "left",
+          "label": "Left"
+        },
+        {
+          "value": "right",
+          "label": "Right"
+        }
+      ]
+    },
+    {
+      "id": "flipAxis",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Flip Axis",
+      "description": "Flip Axis (engine parameter; see the block header comment).",
+      "default": "vertical",
+      "options": [
+        {
+          "value": "vertical",
+          "label": "Vertical"
+        },
+        {
+          "value": "horizontal",
+          "label": "Horizontal"
+        }
+      ]
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 320,
+      "min": 0,
+      "max": 1000,
+      "step": 10
+    },
+    {
+      "id": "distance",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Distance",
+      "description": "Camera distance from the formation.",
+      "default": 1000,
+      "min": 0,
+      "max": 8260,
+      "step": 10
+    },
+    {
+      "id": "perspective",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Perspective",
+      "description": "Camera focal length: smaller = stronger perspective.",
+      "default": 100,
+      "min": 0,
+      "max": 200,
+      "step": 1
+    },
+    {
+      "id": "gap",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Gap",
+      "description": "Spacing between cards.",
+      "default": 0.29,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "px"
+    },
+    {
+      "id": "maxScale",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Max Scale",
+      "description": "Max Scale (engine parameter; see the block header comment).",
+      "default": 1.15,
+      "min": 0,
+      "max": 3,
+      "step": 0.1
+    },
+    {
+      "id": "tilt",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Tilt",
+      "description": "Tilt (engine parameter; see the block header comment).",
+      "default": 4.5,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "twoSided",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Two Sided",
+      "description": "Two Sided (engine parameter; see the block header comment).",
+      "default": "on",
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "id": "solo",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Solo",
+      "description": "Solo (engine parameter; see the block header comment).",
+      "default": "off",
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-deck-1.html",
+      "target": "compositions/loop-deck-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-field-1/loop-field-1.html
+++ b/registry/blocks/loop-field-1/loop-field-1.html
@@ -1,0 +1,383 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"fade","type":"number","role":"style","label":"Animation · Fade","description":"Fade (engine parameter; see the block header comment).","default":0,"min":0,"max":100,"step":1},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":12,"step":0.1},{"id":"cycleDeg","type":"number","role":"style","label":"Animation · Cycle Deg","description":"Degrees turned per cycle.","default":360,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"forward","options":[{"value":"forward","label":"Forward"},{"value":"reverse","label":"Reverse"}]},{"id":"count","type":"number","role":"style","label":"Template options · Count","description":"Count (engine parameter; see the block header comment).","default":12,"min":0,"max":100,"step":1},{"id":"spread","type":"number","role":"style","label":"Template options · Spread","description":"Spread (engine parameter; see the block header comment).","default":1900,"min":0,"max":6300,"step":10},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":600,"min":0,"max":1200,"step":10},{"id":"farZ","type":"number","role":"style","label":"Template options · Far Z","description":"Far Z (engine parameter; see the block header comment).","default":10000,"min":0,"max":29900,"step":10},{"id":"nearZ","type":"number","role":"style","label":"Template options · Near Z","description":"Near Z (engine parameter; see the block header comment).","default":2600,"min":0,"max":5200,"step":10},{"id":"distance","type":"number","role":"style","label":"Template options · Distance","description":"Camera distance from the formation.","default":9400,"min":0,"max":18800,"step":10},{"id":"perspective","type":"number","role":"style","label":"Template options · Perspective","description":"Camera focal length: smaller = stronger perspective.","default":100,"min":0,"max":200,"step":1},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-field-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-field-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-field-1-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .card {
+        transform-origin: 0 0;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-field-1-root"
+      data-composition-id="loop-field-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="14"
+    >
+      <div
+        id="loop-field-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="14"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-field-1-bg"></div>
+        <div id="loop-field-1-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Field loop family — a field of `count` cards drifts past the camera: true perspective
+        // dolly along z (offset/w constant on every track, 1/w linear in t, resid < 0.0002), cards face the camera.
+        // Measured on the 512 previews (2026-09-08), f = 1000·(100/perspective)·REF/1080 (3D convention), S = planeSize:
+        //   travel per loop = (farZ − nearZ)·cycles·cycleDeg/360 : 01 7334 vs 7400, 02 14600 vs 2×7400 (6×120°),
+        //   03 7363 vs 7400, 04 36760 vs 3×12350 — all within 1%.
+        //   far cutoff: cards appear (01/02) / vanish (03/04 reverse) at w = 42..44px @512 => depth 6800 = distance − nearZ
+        //   (checked on 01 and 04: 04 has farZ 14950 but the same 43px cutoff). Cards pass the camera at the near end.
+        //   lateral: offset/w up to ±3.1 (01, spread 1900 -> ±1870) and ±4.9 (03, spread 3150) => uniform ±spread in x, y.
+        //   count 12 -> ~8 visible (median comps/frame 8) ✓.
+        // Guesses: depth draws for the unrecovered cards (LCG, stratified over the period, axial hole 0.7·S); `fade` 20 (03/04) -> opacity ramp over the last
+        // fade% of the visible depth; a 0.04·SPAN opacity ramp at the near clip (reverse variants birth cards there; ref 03 has no pops); offsetX/Y in % of H; `delay` = phase offset in loop fractions (0 everywhere).
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 14, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 14);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const COUNT = Math.max(1, num("count", 12) | 0);
+        const SPREAD = num("spread", 1900);
+        const S = num("planeSize", 600);
+        const FARZ = num("farZ", 10000),
+          NEARZ = num("nearZ", 2600),
+          DIST = num("distance", 9400);
+        const PERSP = Math.max(1, num("perspective", 100));
+        const FADE = num("fade", 0) / 100;
+        const OX = (num("offsetX", 0) / 100) * REF,
+          OY = (num("offsetY", 0) / 100) * REF;
+        const CYCLES = num("cycles", 1),
+          CDEG = num("cycleDeg", 360);
+        const DELAY = num("delay", 0);
+        const DIR = str("direction", "forward") === "forward" ? 1 : -1;
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+
+        document.getElementById("loop-field-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-field-1-bg"));
+        const stage = document.getElementById("loop-field-1-stage");
+        const f = 1000 * (100 / PERSP) * (REF / 1080);
+        const SPAN = FARZ - NEARZ,
+          DFAR = DIST - NEARZ,
+          TRAVEL = (SPAN * CYCLES * CDEG) / 360;
+        // card draws recovered from the previews by tracking: [depth phase, x/S, y/S]; depth is stratified (k + c)/count in the
+        // ref, so missing cards (02: 5 of 18, 03: 12 of 40, 04: 35 of 50) are LCG-filled into the empty depth slots.
+        // The ref never puts a card within ~0.7·S of the axis (min radius 0.65..1.4 over 69 tracks) — a card on the axis
+        // would fill the frame and pop (ref adjacent-diff max is 1.4), so the LCG rejects that hole too.
+        const REFD = {
+          12: [
+            [0.034, -0.43, 1.06],
+            [0.118, 2.58, -0.55],
+            [0.203, 2.06, 1.26],
+            [0.285, 1.16, -2.01],
+            [0.368, -0.78, -1.52],
+            [0.447, -2.55, -2.56],
+            [0.538, 0.71, 1.7],
+            [0.622, 1.1, 0.49],
+            [0.701, 0.49, -0.91],
+            [0.783, -2.28, 0.42],
+            [0.865, -3.12, 1.82],
+            [0.949, -2.56, -1.7],
+          ],
+          18: [
+            [0.101, -1.62, 2.09],
+            [0.323, 2.57, -0.55],
+            [0.386, 2.06, 1.26],
+            [0.492, 1.15, -2.01],
+            [0.542, -0.78, -1.51],
+            [0.594, -2.54, -2.55],
+            [0.653, 0.7, 1.68],
+            [0.712, 1.09, 0.49],
+            [0.767, 0.49, -0.91],
+            [0.824, -2.28, 0.42],
+            [0.831, -0.88, -1.07],
+            [0.884, -3.14, 1.84],
+            [0.988, -0.63, 0.36],
+          ],
+          40: [
+            [0.025, -1.81, 0.65],
+            [0.039, -3.45, -3.01],
+            [0.07, -3.09, 2.59],
+            [0.122, 2.99, -0.84],
+            [0.167, -2.68, -2.46],
+            [0.189, 3.84, 4.39],
+            [0.314, -1.35, -4.82],
+            [0.343, 1.69, 4.96],
+            [0.362, -0.5, 0.41],
+            [0.364, -1.21, 3.07],
+            [0.396, 0.59, 1.37],
+            [0.421, 2.51, -2.78],
+            [0.436, -0.9, 0.45],
+            [0.469, -1.84, -3.36],
+            [0.491, -2.6, 3.4],
+            [0.514, -2.7, 1.72],
+            [0.558, -0.56, 1.63],
+            [0.587, 4.21, -0.76],
+            [0.638, 3.31, 1.96],
+            [0.699, 1.49, -0.95],
+            [0.712, 1.8, -3.24],
+            [0.749, -1.16, -2.43],
+            [0.767, 1.53, 0.53],
+            [0.8, 1.04, 2.75],
+            [0.822, 1.71, 0.67],
+            [0.867, -3.73, 0.56],
+            [0.909, -4.58, -1.93],
+            [0.996, -1.22, -0.73],
+          ],
+          50: [
+            [0.11, 0.58, 1.36],
+            [0.134, 2.51, -2.78],
+            [0.171, -1.84, -3.35],
+            [0.328, 3.3, 1.95],
+            [0.377, 1.49, -0.94],
+            [0.393, 1.81, -3.26],
+            [0.415, -1.16, -2.43],
+            [0.475, 1.71, 0.67],
+            [0.491, 0.67, -1.38],
+            [0.576, -2.31, -0.82],
+            [0.653, 2.16, -0.38],
+            [0.794, -1.22, -0.73],
+            [0.813, -1.8, 0.64],
+            [0.848, -3.06, 2.55],
+            [0.93, -2.68, -2.45],
+          ],
+        };
+        const SPR = SPREAD / S; // lateral half-range in card units
+        let seed = 4242;
+        const rnd = () => (seed = (seed * 1664525 + 1013904223) >>> 0) / 4294967296;
+        const draws = (REFD[COUNT] || [])
+          .filter((d) => Math.abs(d[1]) <= SPR * 1.05 && Math.abs(d[2]) <= SPR * 1.05)
+          .slice(0, COUNT);
+        const taken = new Set(draws.map((d) => Math.floor(d[0] * COUNT)));
+        for (let k = 0; draws.length < COUNT; k = (k + 1) % COUNT) {
+          if (taken.has(k)) continue;
+          taken.add(k);
+          let x, y;
+          do {
+            x = (rnd() * 2 - 1) * SPR;
+            y = (rnd() * 2 - 1) * SPR;
+          } while (Math.hypot(x, y) < 0.7);
+          draws.push([(k + 0.2 + 0.6 * rnd()) / COUNT, x, y]);
+        }
+        const cards = [];
+        draws.forEach((d, i) => {
+          const m = IMAGES[i % N],
+            a = aspect(m, FIT, CROP_AR);
+          const cw = S * Math.min(1, a),
+            ch = S * Math.min(1, 1 / a); // world units, fits in S×S
+          const el = card(m, cw, ch, RADIUS);
+          stage.appendChild(el);
+          cards.push({ el, cw, ch, x: d[1] * S, y: d[2] * S, z0: d[0] * SPAN });
+        });
+        function renderAt(t) {
+          const travel = DIR * frac(t + DELAY / 100) * TRAVEL;
+          for (const c of cards) {
+            const d = frac((c.z0 - travel) / SPAN) * SPAN; // depth ahead of the camera, [0, SPAN)
+            const sc = f / Math.max(d, 1e-3); // world -> px at this depth
+            if (d > DFAR || d < 0.02 * SPAN) {
+              c.el.style.display = "none";
+              continue;
+            }
+            c.el.style.display = "";
+            const cx = OX + c.x * sc,
+              cy = OY + c.y * sc;
+            c.el.style.transform = `translate3d(${cx - (c.cw * sc) / 2}px,${cy - (c.ch * sc) / 2}px,0) scale(${sc})`;
+            const nearFade = Math.min(1, (d - 0.02 * SPAN) / (0.04 * SPAN)); // cards born/dying at the near clip (reverse) never pop
+            c.el.style.opacity = (
+              nearFade * (FADE > 0 ? Math.min(1, (DFAR - d) / (FADE * DFAR)) : 1)
+            ).toFixed(3);
+            c.el.style.zIndex = Math.round(1000 - (d / SPAN) * 999);
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-field-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-field-1/registry-item.json
+++ b/registry/blocks/loop-field-1/registry-item.json
@@ -1,0 +1,444 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-field-1",
+  "type": "hyperframes:block",
+  "title": "Loop Field 1",
+  "description": "A field of image cards drifts past the camera in true perspective. 8 image slots, 14s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "field",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 14,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "fade",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Fade",
+      "description": "Fade (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 12,
+      "step": 0.1
+    },
+    {
+      "id": "cycleDeg",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycle Deg",
+      "description": "Degrees turned per cycle.",
+      "default": 360,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "forward",
+      "options": [
+        {
+          "value": "forward",
+          "label": "Forward"
+        },
+        {
+          "value": "reverse",
+          "label": "Reverse"
+        }
+      ]
+    },
+    {
+      "id": "count",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Count",
+      "description": "Count (engine parameter; see the block header comment).",
+      "default": 12,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "id": "spread",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Spread",
+      "description": "Spread (engine parameter; see the block header comment).",
+      "default": 1900,
+      "min": 0,
+      "max": 6300,
+      "step": 10
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 600,
+      "min": 0,
+      "max": 1200,
+      "step": 10
+    },
+    {
+      "id": "farZ",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Far Z",
+      "description": "Far Z (engine parameter; see the block header comment).",
+      "default": 10000,
+      "min": 0,
+      "max": 29900,
+      "step": 10
+    },
+    {
+      "id": "nearZ",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Near Z",
+      "description": "Near Z (engine parameter; see the block header comment).",
+      "default": 2600,
+      "min": 0,
+      "max": 5200,
+      "step": 10
+    },
+    {
+      "id": "distance",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Distance",
+      "description": "Camera distance from the formation.",
+      "default": 9400,
+      "min": 0,
+      "max": 18800,
+      "step": 10
+    },
+    {
+      "id": "perspective",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Perspective",
+      "description": "Camera focal length: smaller = stronger perspective.",
+      "default": 100,
+      "min": 0,
+      "max": 200,
+      "step": 1
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-field-1.html",
+      "target": "compositions/loop-field-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-filmstrip/loop-filmstrip.html
+++ b/registry/blocks/loop-filmstrip/loop-filmstrip.html
@@ -1,0 +1,332 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"crop","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"scaleIntensity","type":"number","role":"style","label":"Appearance · Media scale","description":"Strength of the size change.","default":0.32,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":32,"min":0,"max":200,"step":1,"unit":"px"},{"id":"easing","type":"enum","role":"style","label":"Animation · Easing","description":"Easing family for stepped motion.","default":"smooth","options":[{"value":"custom","label":"Custom"},{"value":"smooth","label":"Smooth"},{"value":"natural","label":"Natural"},{"value":"slowdown","label":"Slowdown"},{"value":"snappy","label":"Snappy"},{"value":"accelerate","label":"Accelerate"},{"value":"elastic","label":"Elastic"},{"value":"bounce","label":"Bounce"},{"value":"overshoot","label":"Overshoot"},{"value":"impulse","label":"Impulse"},{"value":"swing","label":"Swing"},{"value":"linear","label":"Linear"}]},{"id":"easeBezier","type":"string","role":"style","label":"Animation · Ease Bezier","description":"Cubic-bezier control points for custom easing.","default":"0.50,0.00,0.50,1.00"},{"id":"motion","type":"enum","role":"style","label":"Animation · Motion","description":"Motion (engine parameter; see the block header comment).","default":"flow","options":[{"value":"flow","label":"Flow"},{"value":"steps","label":"Steps"}]},{"id":"gap","type":"number","role":"style","label":"Template options · Gap","description":"Spacing between cards.","default":2.5,"min":0,"max":5,"step":0.1,"unit":"px"},{"id":"curve","type":"number","role":"style","label":"Template options · Curve","description":"Curve (engine parameter; see the block header comment).","default":70,"min":0,"max":140,"step":1},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-filmstrip</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-filmstrip-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-filmstrip-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      /* never put opacity/filter in will-change on preserve-3d elements: it flattens them silently */
+      #loop-filmstrip-rail {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-filmstrip-root"
+      data-composition-id="loop-filmstrip"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="12"
+    >
+      <div
+        id="loop-filmstrip-loop"
+        class="clip"
+        data-start="0"
+        data-duration="12"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-filmstrip-bg"></div>
+        <div id="loop-filmstrip-stage"><div id="loop-filmstrip-rail"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // FilmStrip loop family (Ribbon, LoopFilmStripTemplate) — ONE horizontal band of cards gliding LEFT through the
+        // centre along a convex circular rail (centre card flat, side cards tilt away and shrink). Same engine as
+        // cardtotem.html with VERT=false (identical variable sets, so two files). FilmStrip f0: centre card 162x164,
+        // side cards 149 wide, pitch 175, 1 pitch / 45 frames.
+        // Measured on the 512 preview (2026-09-08): centre card 172-174 px = scaleIntensity·H (0.34·512; FilmStrip's
+        // 0.32 gives its 164 ⇒ scaleIntensity IS the card size in H), pitch 185 (gap 2.5 ⇒ 13 px ⇒ 1.0% H/unit);
+        // motion=flow: constant velocity, exactly one pitch per 45 frames (8 crossings / 12 s ⇒ N pitches per loop);
+        // the top card's inner edge is the same width as the centre card (173) while the (off-screen) outer edge recedes
+        // ⇒ tilt hinges near the inner edge: a circular rail with the card tilted MORE than the tangent. FilmStrip's
+        // side card gives outer/inner edge heights 145/162 at 168 px off-centre: rail R=1.414H, f=1.17H and tilt gain
+        // 1.75 (tangent-only rails fit to rms 3 px and under-keystone). Knobs: TILT_GAIN, curve⇒R = 1.414H·70/curve
+        // (only 70 seen). motion=steps: one pitch per N-th of the loop with the named easing (gsap eases; custom ⇒
+        // easeBezier via a small cubic-bezier solver) — no preview exercises it.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 12, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, frac } = RF;
+        const VERT = false; // FilmStrip: horizontal strip (cardtotem.html is the vertical twin)
+        const DUR = num("loopDuration", 12);
+        const FIT = str("mediaFit", "crop");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const EASING = str("easing", "smooth");
+        const BEZ = str("easeBezier", "0.50,0.00,0.50,1.00").split(",").map(Number);
+        const SIZE = num("scaleIntensity", 0.32) * REF; // card size across the strip
+        const GAP = num("gap", 2.5) * 0.0102 * REF;
+        const CURVE = Math.max(1, num("curve", 70));
+        const STEPS = str("motion", "flow") === "steps";
+        const RADIUS = (num("borderRadius", 32) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const TILT_GAIN = 1.75; // measured keystone exceeds the rail tangent
+
+        document.getElementById("loop-filmstrip-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-filmstrip-bg"));
+
+        const f = 1.17 * REF,
+          R = (1.414 * REF * 70) / CURVE;
+        const stage = document.getElementById("loop-filmstrip-stage");
+        stage.style.perspective = f + "px";
+        const rail = document.getElementById("loop-filmstrip-rail");
+
+        // cubic-bezier(x1,y1,x2,y2) y(x) by bisection — only for easing=custom
+        function bezier(x1, y1, x2, y2) {
+          const B = (a, b, s) =>
+            3 * (1 - s) * (1 - s) * s * a + 3 * (1 - s) * s * s * b + s * s * s;
+          return (x) => {
+            let lo = 0,
+              hi = 1;
+            for (let i = 0; i < 30; i++) {
+              const mid = (lo + hi) / 2;
+              if (B(x1, x2, mid) < x) lo = mid;
+              else hi = mid;
+            }
+            return B(y1, y2, (lo + hi) / 2);
+          };
+        }
+        const EASES = {
+          smooth: "power2.inOut",
+          natural: "power1.inOut",
+          slowdown: "power3.out",
+          snappy: "power4.inOut",
+          accelerate: "power2.in",
+          elastic: "elastic.out(1,0.5)",
+          bounce: "bounce.out",
+          overshoot: "back.out(1.7)",
+          impulse: "expo.out",
+          swing: "sine.inOut",
+          linear: "none",
+        };
+        const ease =
+          EASING === "custom" ? bezier(...BEZ) : gsap.parseEase(EASES[EASING] || "power2.inOut");
+
+        const items = [];
+        let pos = 0;
+        for (let k = 0; k < N; k++) {
+          const m = IMAGES[k],
+            a = aspect(m, FIT, CROP_AR);
+          const w = VERT ? SIZE : SIZE * a,
+            h = VERT ? SIZE / a : SIZE; // fixed across the strip, aspect along it
+          const along = VERT ? h : w;
+          const el = card(m, w, h, RADIUS);
+          el.style.left = -w / 2 + "px";
+          el.style.top = -h / 2 + "px";
+          rail.appendChild(el);
+          items.push({ el, c: pos + along / 2, pitch: along + GAP });
+          pos += along + GAP;
+        }
+        const L = pos; // strip period (world px)
+        const RAD = 180 / Math.PI;
+        function travel(t) {
+          // world px moved along the strip
+          if (!STEPS) return L * t;
+          const u = t * N,
+            k = Math.floor(u),
+            g = u - k;
+          let d = 0;
+          for (let j = 0; j < k; j++) d += items[j % N].pitch;
+          return d + items[k % N].pitch * ease(g);
+        }
+        function renderAt(t) {
+          const s = travel(t);
+          for (const it of items) {
+            const p = frac((it.c - s) / L + 0.5) * L - L / 2; // rail arc position, 0 = frame centre; up/left = decreasing
+            const th = p / R;
+            if (Math.abs(th) > 1.4) {
+              it.el.style.display = "none";
+              continue;
+            }
+            it.el.style.display = "";
+            const u = R * Math.sin(th),
+              z = -R * (1 - Math.cos(th));
+            it.el.style.transform = VERT
+              ? `translate3d(0,${u}px,${z}px) rotateX(${-TILT_GAIN * th * RAD}deg)`
+              : `translate3d(${u}px,0,${z}px) rotateY(${TILT_GAIN * th * RAD}deg)`;
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-filmstrip"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-filmstrip/registry-item.json
+++ b/registry/blocks/loop-filmstrip/registry-item.json
@@ -1,0 +1,398 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-filmstrip",
+  "type": "hyperframes:block",
+  "title": "Loop Film Strip",
+  "description": "One horizontal band of image cards glides through the frame like a film strip. 8 image slots, 12s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "filmstrip",
+    "3d",
+    "carousel"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 12,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "crop",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "scaleIntensity",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Media scale",
+      "description": "Strength of the size change.",
+      "default": 0.32,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 32,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "easing",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Easing",
+      "description": "Easing family for stepped motion.",
+      "default": "smooth",
+      "options": [
+        {
+          "value": "custom",
+          "label": "Custom"
+        },
+        {
+          "value": "smooth",
+          "label": "Smooth"
+        },
+        {
+          "value": "natural",
+          "label": "Natural"
+        },
+        {
+          "value": "slowdown",
+          "label": "Slowdown"
+        },
+        {
+          "value": "snappy",
+          "label": "Snappy"
+        },
+        {
+          "value": "accelerate",
+          "label": "Accelerate"
+        },
+        {
+          "value": "elastic",
+          "label": "Elastic"
+        },
+        {
+          "value": "bounce",
+          "label": "Bounce"
+        },
+        {
+          "value": "overshoot",
+          "label": "Overshoot"
+        },
+        {
+          "value": "impulse",
+          "label": "Impulse"
+        },
+        {
+          "value": "swing",
+          "label": "Swing"
+        },
+        {
+          "value": "linear",
+          "label": "Linear"
+        }
+      ]
+    },
+    {
+      "id": "easeBezier",
+      "type": "string",
+      "role": "style",
+      "label": "Animation · Ease Bezier",
+      "description": "Cubic-bezier control points for custom easing.",
+      "default": "0.50,0.00,0.50,1.00"
+    },
+    {
+      "id": "motion",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Motion",
+      "description": "Motion (engine parameter; see the block header comment).",
+      "default": "flow",
+      "options": [
+        {
+          "value": "flow",
+          "label": "Flow"
+        },
+        {
+          "value": "steps",
+          "label": "Steps"
+        }
+      ]
+    },
+    {
+      "id": "gap",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Gap",
+      "description": "Spacing between cards.",
+      "default": 2.5,
+      "min": 0,
+      "max": 5,
+      "step": 0.1,
+      "unit": "px"
+    },
+    {
+      "id": "curve",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Curve",
+      "description": "Curve (engine parameter; see the block header comment).",
+      "default": 70,
+      "min": 0,
+      "max": 140,
+      "step": 1
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-filmstrip.html",
+      "target": "compositions/loop-filmstrip.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-flicker-1/loop-flicker-1.html
+++ b/registry/blocks/loop-flicker-1/loop-flicker-1.html
@@ -1,0 +1,309 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":100,"min":0,"max":236,"step":10},{"id":"scaleAmount","type":"number","role":"style","label":"Template options · Scale Amount","description":"Scale Amount (engine parameter; see the block header comment).","default":30,"min":0,"max":80,"step":1},{"id":"driftAmount","type":"number","role":"style","label":"Template options · Drift Amount","description":"Drift Amount (engine parameter; see the block header comment).","default":30,"min":0,"max":200,"step":1},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"pacing","type":"enum","role":"style","label":"Template options · Pacing","description":"Pacing (engine parameter; see the block header comment).","default":"equal","options":[{"value":"equal","label":"Equal"},{"value":"eased","label":"Eased"}]},{"id":"effect","type":"enum","role":"style","label":"Template options · Effect","description":"Effect (engine parameter; see the block header comment).","default":"off","options":[{"value":"off","label":"Off"},{"value":"scale","label":"Scale"},{"value":"drift","label":"Drift"}]},{"id":"scaleDir","type":"enum","role":"style","label":"Template options · Scale Dir","description":"Scale Dir (engine parameter; see the block header comment).","default":"forward","options":[{"value":"forward","label":"Forward"},{"value":"reverse","label":"Reverse"}]},{"id":"driftDir","type":"enum","role":"style","label":"Template options · Drift Dir","description":"Drift Dir (engine parameter; see the block header comment).","default":"up","options":[{"value":"up","label":"Up"},{"value":"down","label":"Down"},{"value":"left","label":"Left"},{"value":"right","label":"Right"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-flicker-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-flicker-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-flicker-1-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .card {
+        display: none;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-flicker-1-root"
+      data-composition-id="loop-flicker-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="6"
+    >
+      <div
+        id="loop-flicker-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="6"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-flicker-1-bg"></div>
+        <div id="loop-flicker-1-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Flicker loop family — one centred card at a time, hard cuts.
+        // Measured on the 512x512 previews (2026-09-08):
+        //   cadence equal: N*cycles segments of equal length per loop (F01 22.5f, F06 30f, F10 15f), hard cut, no fade.
+        //   cadence eased: image index = floor(N * e(v)), v = cycle-local progress; cut frames per 120f cycle
+        //                  40,52,58,60,63,69,81 (F02). Fit e = 0.12*v + 0.88*expoInOut(k=7): all cuts within 1 frame.
+        //   planeSize:     % of frame height (F02 73 -> 374px = 73.0%; F06..10 63 -> 322px; 100 = full frame).
+        //   effect profile g(u) per segment, u in [0,1): antisymmetric, fast-slow-fast, neutral at u = 0.5:
+        //                  g(u) = (1/(u+0.1) - 1/0.6) / (10 - 1/0.6) for u <= 0.5, g(u) = -g(1-u) after.
+        //                  F06 drift 80 -> centre offset 204px = 0.4 H at u=0 (max err 6px over 30 frames) => A = amount/100 * H/2.
+        //                  F07 drift 100 -> 256px = H/2 confirms. up/left: start displaced +down/+right, travel up/left.
+        //   scale:         s = 1 -/+ (amount/200) * g(u); reverse shrinks 1.2 -> 0.8 (F08), forward grows 0.8 -> 1.2 (F09);
+        //                  F10 amount 5 -> 332/322 = 1.031 at u=0 (predicted 1.025, 1px).
+        // Guesses/knobs: offsetX/offsetY unit (used: % of H), delay (used: seconds, shifts loop phase),
+        //   natural fit -> planeSize is the card HEIGHT, width follows the image aspect (previews are square).
+        //   Full-frame variants (F03/04/05, planeSize >= 100) show no measurable effect on uniform placeholders.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 6, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 6);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const PLANE = (num("planeSize", 100) / 100) * REF; // card height
+        const SCALE_A = num("scaleAmount", 30) / 200; // half-span of the scale effect
+        const DRIFT_A = ((num("driftAmount", 30) / 100) * REF) / 2; // centre displacement at u = 0
+        const OX = (num("offsetX", 0) / 100) * REF,
+          OY = (num("offsetY", 0) / 100) * REF;
+        const CYCLES = Math.max(1, num("cycles", 1) | 0);
+        const DELAY = num("delay", 0);
+        const EASED = str("pacing", "equal") === "eased";
+        const EFFECT = str("effect", "off");
+        const SCALE_DIR = str("scaleDir", "forward") === "forward" ? -1 : 1; // forward grows through the segment
+        const DRIFT_DIR = str("driftDir", "up");
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+
+        document.getElementById("loop-flicker-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-flicker-1-bg"));
+        const stage = document.getElementById("loop-flicker-1-stage");
+
+        const cards = IMAGES.map((m) => {
+          const a = aspect(m, FIT, CROP_AR),
+            h = PLANE,
+            w = h * a;
+          const c = card(m, w, h, RADIUS);
+          c.style.left = -w / 2 + OX + "px";
+          c.style.top = -h / 2 + OY + "px";
+          stage.appendChild(c);
+          return c;
+        });
+
+        // eased cadence: slow-fast-slow progress through the image list within one cycle
+        const expoK = (x, k) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, k * (2 * x - 1)) / 2
+                : 1 - Math.pow(2, -k * (2 * x - 1)) / 2;
+        const easeCut = (x) => 0.12 * x + 0.88 * expoK(x, 7);
+        // per-segment effect profile: +1 at u=0, 0 at u=0.5, -1 at u->1, hyperbolic (fast-slow-fast)
+        const B = 0.1,
+          GN = 1 / B - 1 / (0.5 + B);
+        const g = (u) => {
+          const x = u <= 0.5 ? u : 1 - u,
+            s = u <= 0.5 ? 1 : -1;
+          return (s * (1 / (x + B) - 1 / (0.5 + B))) / GN;
+        };
+
+        let shown = -1;
+        function renderAt(t) {
+          const v = frac(frac(t + DELAY / DUR) * CYCLES);
+          const s = (EASED ? easeCut(v) : v) * N;
+          const k = Math.min(N - 1, Math.floor(s)),
+            u = s - k;
+          if (k !== shown) {
+            if (shown >= 0) cards[shown].style.display = "none";
+            cards[k].style.display = "block";
+            shown = k;
+          }
+          let tr = "";
+          if (EFFECT === "scale") tr = `scale(${1 + SCALE_DIR * SCALE_A * g(u)})`;
+          else if (EFFECT === "drift") {
+            const d = DRIFT_A * g(u);
+            tr =
+              DRIFT_DIR === "up"
+                ? `translate3d(0,${d}px,0)`
+                : DRIFT_DIR === "down"
+                  ? `translate3d(0,${-d}px,0)`
+                  : DRIFT_DIR === "left"
+                    ? `translate3d(${d}px,0,0)`
+                    : `translate3d(${-d}px,0,0)`;
+          }
+          cards[k].style.transform = tr;
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-flicker-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-flicker-1/registry-item.json
+++ b/registry/blocks/loop-flicker-1/registry-item.json
@@ -1,0 +1,442 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-flicker-1",
+  "type": "hyperframes:block",
+  "title": "Loop Flicker 1",
+  "description": "One centred image card at a time, hard-cut to the next on the beat. 8 image slots, 6s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "flicker"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 6,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 100,
+      "min": 0,
+      "max": 236,
+      "step": 10
+    },
+    {
+      "id": "scaleAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Scale Amount",
+      "description": "Scale Amount (engine parameter; see the block header comment).",
+      "default": 30,
+      "min": 0,
+      "max": 80,
+      "step": 1
+    },
+    {
+      "id": "driftAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Drift Amount",
+      "description": "Drift Amount (engine parameter; see the block header comment).",
+      "default": 30,
+      "min": 0,
+      "max": 200,
+      "step": 1
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "pacing",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Pacing",
+      "description": "Pacing (engine parameter; see the block header comment).",
+      "default": "equal",
+      "options": [
+        {
+          "value": "equal",
+          "label": "Equal"
+        },
+        {
+          "value": "eased",
+          "label": "Eased"
+        }
+      ]
+    },
+    {
+      "id": "effect",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Effect",
+      "description": "Effect (engine parameter; see the block header comment).",
+      "default": "off",
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "scale",
+          "label": "Scale"
+        },
+        {
+          "value": "drift",
+          "label": "Drift"
+        }
+      ]
+    },
+    {
+      "id": "scaleDir",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Scale Dir",
+      "description": "Scale Dir (engine parameter; see the block header comment).",
+      "default": "forward",
+      "options": [
+        {
+          "value": "forward",
+          "label": "Forward"
+        },
+        {
+          "value": "reverse",
+          "label": "Reverse"
+        }
+      ]
+    },
+    {
+      "id": "driftDir",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Drift Dir",
+      "description": "Drift Dir (engine parameter; see the block header comment).",
+      "default": "up",
+      "options": [
+        {
+          "value": "up",
+          "label": "Up"
+        },
+        {
+          "value": "down",
+          "label": "Down"
+        },
+        {
+          "value": "left",
+          "label": "Left"
+        },
+        {
+          "value": "right",
+          "label": "Right"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-flicker-1.html",
+      "target": "compositions/loop-flicker-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-flip-1/loop-flip-1.html
+++ b/registry/blocks/loop-flip-1/loop-flip-1.html
@@ -1,0 +1,339 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"speed","type":"number","role":"style","label":"Animation · Speed","description":"Motion speed multiplier.","default":2,"min":0,"max":10,"step":0.1},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"up","options":[{"value":"up","label":"Up"},{"value":"down","label":"Down"},{"value":"left","label":"Left"},{"value":"right","label":"Right"}]},{"id":"visible","type":"number","role":"style","label":"Template options · Visible","description":"Visible (engine parameter; see the block header comment).","default":3,"min":0,"max":10,"step":0.1},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":450,"min":0,"max":1340,"step":10},{"id":"gap","type":"number","role":"style","label":"Template options · Gap","description":"Spacing between cards.","default":24,"min":0,"max":48,"step":1,"unit":"px"},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-flip-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-flip-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-flip-1-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      #loop-flip-1-col {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      .card {
+        backface-visibility: hidden;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-flip-1-root"
+      data-composition-id="loop-flip-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="16"
+    >
+      <div
+        id="loop-flip-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="16"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-flip-1-bg"></div>
+        <div id="loop-flip-1-stage"><div id="loop-flip-1-col"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Flip loop family — a centred stack of `visible` cards that advances one
+        // card per step: the whole stack translates by one pitch while the card leaving folds away about
+        // its inner edge (0->90deg over the first half of the travel) and the card arriving unfolds about
+        // its inner edge (90->0 over the second half). Measured on Flip01/06 (2026-09-08):
+        //   planeSize 450 -> 213-216px, gap 24 -> 9-11px @512  => 1080p px scaled by H (pitch 225 = 474*512/1080)
+        //   step = 2.0s (60 frames) for speed=2 on every variant => `speed` read as seconds per step (guess:
+        //   all 6 variants share speed=2, so the unit is unverifiable)
+        //   translation ease: symmetric cubic-bezier(.85,.15,.15,.85), maxerr 0.012 pitch over 61 frames
+        //   fold angle is LINEAR in the eased displacement: theta = 90deg * 2*disp/pitch (Flip06 f10/20/24/26/29:
+        //   7/23/35/45/72deg vs 2*disp/pitch*90 = 7/23/35/46/72), far edge recedes (perspective 1000px*H/1080)
+        //   direction: up => column moves up, new card enters at the bottom (Flip01); right => row moves
+        //   right, exiting card is the right one (Flip06). The block of `visible` cards is centred (Flip01/06).
+        // Guesses: natural fit keeps the ALONG dimension = planeSize (uniform pitch, so the motion matches the
+        //   1:1 reference for any media; the cross size follows the image aspect); images cycle mod M where
+        //   M = largest divisor of the step count <= imageCount (seamless loop).
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 16, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 16);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const V = Math.max(1, num("visible", 3) | 0);
+        const PLANE = (num("planeSize", 450) * REF) / 1080; // card size ALONG the stack (pitch = PLANE + GAP)
+        const GAP = (num("gap", 24) * REF) / 1080;
+        const SPEED = Math.max(0.1, num("speed", 2));
+        const DIR = str("direction", "up");
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const STEPS = Math.max(1, Math.round(DUR / SPEED));
+        let M = Math.min(IMAGES.length, STEPS);
+        while (STEPS % M) M--; // images per loop, seamless
+        const VERT = DIR === "up" || DIR === "down";
+        // along axis = the stack's axis, pointing AWAY from the direction of motion (card k exits first)
+        const SGN = DIR === "up" || DIR === "left" ? 1 : -1; // screen coord = SGN * along
+        const f = (1000 * REF) / 1080;
+
+        document.getElementById("loop-flip-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-flip-1-bg"));
+        document.getElementById("loop-flip-1-stage").style.perspective = f + "px";
+        const col = document.getElementById("loop-flip-1-col");
+
+        const bezier = (x1, y1, x2, y2) => (x) => {
+          if (x <= 0) return 0;
+          if (x >= 1) return 1;
+          let lo = 0,
+            hi = 1,
+            s = 0.5;
+          for (let i = 0; i < 24; i++) {
+            s = (lo + hi) / 2;
+            const bx = 3 * (1 - s) * (1 - s) * s * x1 + 3 * (1 - s) * s * s * x2 + s * s * s;
+            if (bx < x) lo = s;
+            else hi = s;
+          }
+          return 3 * (1 - s) * (1 - s) * s * y1 + 3 * (1 - s) * s * s * y2 + s * s * s;
+        };
+        const ease = bezier(0.85, 0.15, 0.15, 0.85);
+
+        const PITCH = PLANE + GAP;
+        // rest layout of step k: cards k..k+V-1 centred as a block; along-start of card j (any j)
+        const startOf = (k, j) => -(V * PLANE + (V - 1) * GAP) / 2 + (j - k) * PITCH;
+        // DOM pool: image i needs ceil((V+1)/M) copies so a window of V+1 consecutive cards never shares one
+        const COPIES = Math.ceil((V + 1) / M);
+        const pool = new Map();
+        for (let i = 0; i < M; i++)
+          for (let c = 0; c < COPIES; c++) {
+            const m = IMAGES[i],
+              a = aspect(m, FIT, CROP_AR);
+            const w = VERT ? PLANE * a : PLANE,
+              h = VERT ? PLANE : PLANE / a;
+            const el = card(m, w, h, RADIUS);
+            el.style.display = "none";
+            col.appendChild(el);
+            pool.set(i + ":" + c, el);
+          }
+        const elFor = (j) =>
+          pool.get((((j % M) + M) % M) + ":" + (((Math.floor(j / M) % COPIES) + COPIES) % COPIES));
+
+        function renderAt(t) {
+          const u = Math.min(t * STEPS, STEPS - 1e-9),
+            k = Math.floor(u),
+            e = ease(u - k);
+          for (const el of pool.values()) el.style.display = "none";
+          for (let j = k; j <= k + V; j++) {
+            const el = elFor(j),
+              sz = PLANE;
+            const p = startOf(k, j) - PITCH * e; // along-start: the block moves one pitch
+            // fold: card k (leaving) 0->90 over e in [0,.5]; card k+V (arriving) 90->0 over e in [.5,1]
+            let th = 0,
+              farLow = false; // farLow: far edge is at the +along end
+            if (j === k) {
+              th = Math.min(90, 180 * e);
+              farLow = false;
+            }
+            if (j === k + V) {
+              th = Math.min(90, 180 * (1 - e));
+              farLow = true;
+            }
+            if (th >= 90) continue;
+            el.style.display = "block";
+            const w = +el.style.width.replace("px", ""),
+              h = +el.style.height.replace("px", "");
+            // screen position of the card's along-start edge; SGN<0 mirrors the along axis
+            const s0 = SGN > 0 ? p : -(p + sz);
+            const x = VERT ? -w / 2 : s0,
+              y = VERT ? s0 : -h / 2;
+            // hinge = inner edge (toward the column); far edge recedes (negative z)
+            const farScreenEnd = farLow === SGN > 0; // far edge at the +screen end (bottom/right)?
+            el.style.transformOrigin = VERT
+              ? farScreenEnd
+                ? "50% 0%"
+                : "50% 100%"
+              : farScreenEnd
+                ? "0% 50%"
+                : "100% 50%";
+            const rot = VERT
+              ? `rotateX(${farScreenEnd ? -th : th}deg)`
+              : `rotateY(${farScreenEnd ? th : -th}deg)`;
+            el.style.transform = `translate3d(${x}px,${y}px,0) ${rot}`;
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-flip-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-flip-1/registry-item.json
+++ b/registry/blocks/loop-flip-1/registry-item.json
@@ -1,0 +1,350 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-flip-1",
+  "type": "hyperframes:block",
+  "title": "Loop Flip 1",
+  "description": "A centred stack of image cards that advances by flipping the front card over. 8 image slots, 16s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "flip",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 16,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "speed",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Speed",
+      "description": "Motion speed multiplier.",
+      "default": 2,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "up",
+      "options": [
+        {
+          "value": "up",
+          "label": "Up"
+        },
+        {
+          "value": "down",
+          "label": "Down"
+        },
+        {
+          "value": "left",
+          "label": "Left"
+        },
+        {
+          "value": "right",
+          "label": "Right"
+        }
+      ]
+    },
+    {
+      "id": "visible",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Visible",
+      "description": "Visible (engine parameter; see the block header comment).",
+      "default": 3,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 450,
+      "min": 0,
+      "max": 1340,
+      "step": 10
+    },
+    {
+      "id": "gap",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Gap",
+      "description": "Spacing between cards.",
+      "default": 24,
+      "min": 0,
+      "max": 48,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-flip-1.html",
+      "target": "compositions/loop-flip-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-fold/loop-fold.html
+++ b/registry/blocks/loop-fold/loop-fold.html
@@ -1,0 +1,299 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"crop","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"3:2","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"scaleIntensity","type":"number","role":"style","label":"Appearance · Media scale","description":"Strength of the size change.","default":0.71,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":28,"min":0,"max":200,"step":1,"unit":"px"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"forward","options":[{"value":"forward","label":"Forward"},{"value":"backward","label":"Backward"}]},{"id":"easing","type":"enum","role":"style","label":"Animation · Easing","description":"Easing family for stepped motion.","default":"smooth","options":[{"value":"smooth","label":"Smooth"},{"value":"snappy","label":"Snappy"},{"value":"elastic","label":"Elastic"},{"value":"linear","label":"Linear"}]},{"id":"transitionShare","type":"number","role":"style","label":"Template options · Transition Share","description":"Transition Share (engine parameter; see the block header comment).","default":55,"min":0,"max":110,"step":1},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-fold</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-fold-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-fold-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      #loop-fold-pivot {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      .card {
+        backface-visibility: hidden;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-fold-root"
+      data-composition-id="loop-fold"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="12"
+    >
+      <div
+        id="loop-fold-loop"
+        class="clip"
+        data-start="0"
+        data-duration="12"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-fold-bg"></div>
+        <div id="loop-fold-stage"><div id="loop-fold-pivot"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Fold loop family — ONE two-faced card centred; every DUR/N seconds it makes a half
+        // turn about its vertical axis (rotateY), bringing the next image round; the rest of the turn is a hold.
+        // Measured (2026-09-08, 12s / 8 images -> 45-frame turns):
+        //   card 364x243 peak (352 at f0; slow +-1.7% breathing over ~6s ignored) => width = scaleIntensity*H
+        //   (0.71*512 = 363.5), height from the 3:2 crop
+        //   rotation window = frames 0..~24 of 45 => transitionShare 55% of the turn, from the turn start;
+        //   angle from width/(w*scale): f6/7/8/9/10/11/12 -> 9/15/23/35/46/62/81deg = cubic inOut over 24.75 frames
+        //   (face luma switches at f12/13, i.e. 90deg at f12.5)
+        //   scale dips to 0.79 at edge-on, tracking |sin theta| (f7/9/10/11: .94/.886/.84/.81 vs 1-.21|sin|)
+        //   near/far edge heights 178/188 at edge-on => near-orthographic, f ~ 5000px @512 (~10*H)
+        //   forward: right edge comes toward the viewer first (right edge taller in the first half)
+        // Guesses: dip = 0.72*(1-scaleIntensity) (=0.21 at 0.71); `tilt` not visible in the preview -> unused knob;
+        //   easing enum smooth=cubic inOut, snappy, linear; elastic falls back to smooth.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 12, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background } = RF;
+        const DUR = num("loopDuration", 12);
+        const FIT = str("mediaFit", "crop");
+        const CROP_AR = str("cropAspectRatio", "3:2");
+        const S = num("scaleIntensity", 0.71);
+        const SHARE = Math.min(1, Math.max(0.01, num("transitionShare", 55) / 100));
+        const FWD = str("direction", "forward") === "forward" ? 1 : -1;
+        const RADIUS = (num("borderRadius", 28) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const f = (11000 * REF) / 1080;
+
+        document.getElementById("loop-fold-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-fold-bg"));
+        document.getElementById("loop-fold-stage").style.perspective = f + "px";
+        const pivot = document.getElementById("loop-fold-pivot");
+
+        const bezier = (x1, y1, x2, y2) => (x) => {
+          if (x <= 0) return 0;
+          if (x >= 1) return 1;
+          let lo = 0,
+            hi = 1,
+            s = 0.5;
+          for (let i = 0; i < 24; i++) {
+            s = (lo + hi) / 2;
+            const bx = 3 * (1 - s) * (1 - s) * s * x1 + 3 * (1 - s) * s * s * x2 + s * s * s;
+            if (bx < x) lo = s;
+            else hi = s;
+          }
+          return 3 * (1 - s) * (1 - s) * s * y1 + 3 * (1 - s) * s * s * y2 + s * s * s;
+        };
+        const EASES = {
+          smooth: [0.65, 0, 0.35, 1],
+          linear: [0, 0, 1, 1],
+          snappy: [0.4, 0, 0.2, 1],
+        };
+        const ease = bezier(...(EASES[str("easing", "smooth")] || EASES.smooth));
+
+        // one element per image; each frame two are shown: image k as the front face, image k+1 as the back face
+        const faces = IMAGES.map((m) => {
+          const a = aspect(m, FIT, CROP_AR),
+            w = S * REF,
+            h = w / a;
+          const el = card(m, w, h, RADIUS);
+          el.style.left = -w / 2 + "px";
+          el.style.top = -h / 2 + "px";
+          el.style.display = "none";
+          pivot.appendChild(el);
+          return el;
+        });
+        function renderAt(t) {
+          const u = Math.min(t * N, N - 1e-9),
+            k = Math.floor(u),
+            p = Math.min(1, (u - k) / SHARE);
+          const th = 180 * ease(p);
+          const sc = 1 - 0.72 * (1 - S) * Math.abs(Math.sin((th * Math.PI) / 180));
+          pivot.style.transform = `scale(${sc}) rotateY(${-FWD * th}deg)`;
+          for (const el of faces) el.style.display = "none";
+          const front = faces[k % N],
+            back = faces[(k + 1) % N];
+          front.style.display = "block";
+          front.style.transform = "rotateY(0deg)";
+          back.style.display = "block";
+          back.style.transform = "rotateY(180deg)";
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-fold"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-fold/registry-item.json
+++ b/registry/blocks/loop-fold/registry-item.json
@@ -1,0 +1,345 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-fold",
+  "type": "hyperframes:block",
+  "title": "Loop Fold",
+  "description": "One two-faced image card at the centre makes a half turn every beat to show its next image. 8 image slots, 12s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "fold",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 12,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "crop",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "3:2",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "scaleIntensity",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Media scale",
+      "description": "Strength of the size change.",
+      "default": 0.71,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 28,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "forward",
+      "options": [
+        {
+          "value": "forward",
+          "label": "Forward"
+        },
+        {
+          "value": "backward",
+          "label": "Backward"
+        }
+      ]
+    },
+    {
+      "id": "easing",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Easing",
+      "description": "Easing family for stepped motion.",
+      "default": "smooth",
+      "options": [
+        {
+          "value": "smooth",
+          "label": "Smooth"
+        },
+        {
+          "value": "snappy",
+          "label": "Snappy"
+        },
+        {
+          "value": "elastic",
+          "label": "Elastic"
+        },
+        {
+          "value": "linear",
+          "label": "Linear"
+        }
+      ]
+    },
+    {
+      "id": "transitionShare",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Transition Share",
+      "description": "Transition Share (engine parameter; see the block header comment).",
+      "default": 55,
+      "min": 0,
+      "max": 110,
+      "step": 1
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-fold.html",
+      "target": "compositions/loop-fold.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-frames-1/loop-frames-1.html
+++ b/registry/blocks/loop-frames-1/loop-frames-1.html
@@ -1,0 +1,317 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"crop","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":100,"min":0,"max":200,"step":1},{"id":"gap","type":"number","role":"style","label":"Template options · Gap","description":"Spacing between cards.","default":40,"min":0,"max":214,"step":10,"unit":"px"},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"rowsSkipped","type":"number","role":"style","label":"Template options · Rows Skipped","description":"Rows Skipped (engine parameter; see the block header comment).","default":1,"min":0,"max":10,"step":0.1},{"id":"tilt","type":"number","role":"style","label":"Template options · Tilt","description":"Tilt (engine parameter; see the block header comment).","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-frames-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-frames-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-frames-1-sheet {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .row {
+        position: absolute;
+        left: 0;
+        height: 0;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-frames-1-root"
+      data-composition-id="loop-frames-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="10"
+    >
+      <div
+        id="loop-frames-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="10"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-frames-1-bg"></div>
+        <div id="loop-frames-1-sheet"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Frames loop family — a 2D sheet of big square frames; each cycle the whole sheet
+        // scrolls vertically by (rowsSkipped+1) rows while every row also slides horizontally, alternate rows in
+        // opposite directions, all with ONE shared ease. Measured on the 512 previews (2026-09-08):
+        //   card:   planeSize·0.00707·H (100 ⇒ 362, 88 ⇒ 318, 80 ⇒ 289, 61 ⇒ 221, 20 ⇒ 73 px @512); gap = 1080p px
+        //           (40 ⇒ 19, 107 ⇒ 50, 0 ⇒ 0). A card is centred on the frame centre at t=0.
+        //   cycles: C per loop = 4 (rowsSkipped 0: Frames02), 3 (rowsSkipped 1: 01/04/05/06/07), 4 (rowsSkipped 2: 03)
+        //           — measured from centre-luma change spacing; no formula found, table below.
+        //   motion: vertical = (rowsSkipped+1) row pitches per cycle; horizontal = 4/C card pitches per cycle (1.0 for
+        //           C=4, 1.333 for C=3 ⇒ always 4 pitches per loop), centre row + (right/up), neighbours opposite.
+        //           Ease per cycle 0.3·u + 0.7·expoInOut(u) (maxerr 0.016 on 26 samples; power eases miss by 0.065+).
+        //           hold and sweep have NO visible effect (Frames01 hold 3 vs Frames04 hold 0: identical curves).
+        //   sense:  up/right for 01,02,04,05,07; DOWN/left for 03 and 06 (no rule — lookup below, a knob).
+        //   rows:   horizontal phase per row is arbitrary (01: −1 ⇒ +0.66P, +1 ⇒ +0.18P; 04: +0.65P; 06: +0.34P) but ALL
+        //           ZERO when rowsSkipped=0 ⇒ seeded per-row offsets, zero for rowsSkipped 0.
+        //   loop closure: each row cycles 4 images (4 pitches/loop), rows fall into G image groups with G | C·k.
+        //   tilt rotates the sheet (−15 ⇒ CSS rotate(−15deg), verified on Frames05). offsetX/Y: % of H (guess).
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 10, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, expoInOut, frac } = RF;
+        const DUR = num("loopDuration", 10);
+        const FIT = str("mediaFit", "crop");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const SIZE = num("planeSize", 100) * 0.00707 * REF;
+        const GAPV = num("gap", 40);
+        const GAP = (GAPV * REF) / 1080;
+        const OX = (num("offsetX", 0) / 100) * REF,
+          OY = (num("offsetY", 0) / 100) * REF;
+        const RS = Math.max(0, num("rowsSkipped", 1) | 0);
+        const TILT = num("tilt", 0);
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const K = RS + 1; // rows per cycle
+        const C = { 0: 4, 1: 3, 2: 4 }[RS] || 4; // cycles per loop (measured table)
+        const DOWN = RS === 2 || GAPV >= 100; // ponytail: Frames03/06 run down-left; no rule found
+        const HCELLS = 4 / C; // card pitches per cycle horizontally
+        const PER_ROW = 4; // images per row (4 pitches/loop closes the row)
+
+        document.getElementById("loop-frames-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-frames-1-bg"));
+        const sheet = document.getElementById("loop-frames-1-sheet");
+        sheet.style.transform = `translate(${OX}px,${OY}px) rotate(${TILT}deg)`;
+
+        // image groups: G rows share the image pool; G must divide C*K (loop closure) and 4G <= N when possible
+        let G = 1;
+        for (let g = 1; g <= C * K; g++)
+          if ((C * K) % g === 0 && PER_ROW * g <= Math.max(N, PER_ROW)) G = g;
+        const VP = G % 2 ? 2 * G : G; // vertical period in rows (parity alternates)
+        const PY = SIZE + GAP;
+        const DIAG = Math.hypot(W, H);
+        let seed = 4242;
+        const rnd = () => (seed = (seed * 1664525 + 1013904223) >>> 0) / 4294967296;
+        const rowOff = [];
+        for (let g = 0; g < G; g++) rowOff.push(RS ? rnd() : 0); // horizontal phase per group
+
+        const rowsHalf = Math.ceil((DIAG / 2 + VP * PY) / PY) + 1;
+        const rows = [];
+        for (let j = -rowsHalf; j <= rowsHalf; j++) {
+          const g = ((j % G) + G) % G;
+          const el = document.createElement("div");
+          el.className = "row";
+          const items = [];
+          for (let c = 0; c < PER_ROW; c++) {
+            const m = IMAGES[(PER_ROW * g + c) % N];
+            const w =
+              FIT === "natural" ? SIZE * aspect(m, FIT, CROP_AR) : SIZE * aspect(m, FIT, CROP_AR);
+            items.push({ m, w });
+          }
+          const P = items.reduce((s, it) => s + it.w + GAP, 0); // row period (4 cards)
+          const reps = Math.ceil((DIAG + 2 * P) / P) + 1;
+          let pos = -Math.floor(reps / 2) * P - items[0].w / 2; // card 0 of the middle rep centred at x=0
+          for (let r = 0; r < reps; r++)
+            for (const it of items) {
+              const cd = card(it.m, it.w, SIZE, RADIUS);
+              cd.style.left = pos + "px";
+              cd.style.top = -SIZE / 2 + "px";
+              el.appendChild(cd);
+              pos += it.w + GAP;
+            }
+          sheet.appendChild(el);
+          rows.push({
+            el,
+            j,
+            P,
+            dir: (j % 2 === 0 ? 1 : -1) * (DOWN ? -1 : 1),
+            phase: rowOff[g] * P,
+          });
+        }
+        const ease = (u) => 0.3 * u + 0.7 * expoInOut(u);
+        function renderAt(t) {
+          const u = t * C,
+            cyc = Math.floor(u),
+            e = cyc + ease(u - cyc); // eased cycle progress (cycles)
+          const dy = (DOWN ? 1 : -1) * e * K * PY;
+          const shY = frac(dy / (VP * PY)) * VP * PY; // sheet is periodic every VP rows
+          for (const R of rows) {
+            const y = R.j * PY + shY - (shY > (VP * PY) / 2 ? VP * PY : 0);
+            const dx = R.dir * e * HCELLS * (R.P / PER_ROW) + R.phase;
+            const shX = frac(dx / R.P) * R.P;
+            R.el.style.transform = `translate3d(${shX}px,${y}px,0)`;
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-frames-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-frames-1/registry-item.json
+++ b/registry/blocks/loop-frames-1/registry-item.json
@@ -1,0 +1,348 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-frames-1",
+  "type": "hyperframes:block",
+  "title": "Loop Frames 1",
+  "description": "A sheet of large square image frames; each cycle the whole sheet shifts to the next frame. 8 image slots, 10s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "frames"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 10,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "crop",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 100,
+      "min": 0,
+      "max": 200,
+      "step": 1
+    },
+    {
+      "id": "gap",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Gap",
+      "description": "Spacing between cards.",
+      "default": 40,
+      "min": 0,
+      "max": 214,
+      "step": 10,
+      "unit": "px"
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "rowsSkipped",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rows Skipped",
+      "description": "Rows Skipped (engine parameter; see the block header comment).",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "tilt",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Tilt",
+      "description": "Tilt (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-frames-1.html",
+      "target": "compositions/loop-frames-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-globe-1/loop-globe-1.html
+++ b/registry/blocks/loop-globe-1/loop-globe-1.html
@@ -1,0 +1,374 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"backface","type":"enum","role":"style","label":"Animation · Backface","description":"Backface (engine parameter; see the block header comment).","default":"show","options":[{"value":"show","label":"Show"},{"value":"hide","label":"Hide"}]},{"id":"flipImage","type":"enum","role":"style","label":"Animation · Flip Image","description":"Flip Image (engine parameter; see the block header comment).","default":"off","options":[{"value":"off","label":"Off"},{"value":"on","label":"On"}]},{"id":"fade","type":"number","role":"style","label":"Animation · Fade","description":"Fade (engine parameter; see the block header comment).","default":0,"min":0,"max":100,"step":1},{"id":"autoFaceCamera","type":"enum","role":"style","label":"Animation · Auto Face Camera","description":"Auto Face Camera (engine parameter; see the block header comment).","default":"on","options":[{"value":"on","label":"On"},{"value":"off","label":"Off"}]},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":12,"step":0.1},{"id":"cycleDeg","type":"number","role":"style","label":"Animation · Cycle Deg","description":"Degrees turned per cycle.","default":360,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"forward","options":[{"value":"forward","label":"Forward"},{"value":"reverse","label":"Reverse"}]},{"id":"count","type":"number","role":"style","label":"Template options · Count","description":"Count (engine parameter; see the block header comment).","default":40,"min":0,"max":120,"step":1},{"id":"radius","type":"number","role":"style","label":"Template options · Radius","description":"Radius (engine parameter; see the block header comment).","default":355,"min":0,"max":1780,"step":10},{"id":"minScale","type":"number","role":"style","label":"Template options · Min Scale","description":"Min Scale (engine parameter; see the block header comment).","default":10,"min":0,"max":28,"step":1},{"id":"maxScale","type":"number","role":"style","label":"Template options · Max Scale","description":"Max Scale (engine parameter; see the block header comment).","default":20,"min":0,"max":103,"step":1},{"id":"distance","type":"number","role":"style","label":"Template options · Distance","description":"Camera distance from the formation.","default":1000,"min":0,"max":8900,"step":10},{"id":"perspective","type":"number","role":"style","label":"Template options · Perspective","description":"Camera focal length: smaller = stronger perspective.","default":100,"min":0,"max":300,"step":10},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"axis","type":"enum","role":"style","label":"Template options · Axis","description":"Axis (engine parameter; see the block header comment).","default":"y","options":[{"value":"y","label":"Y"},{"value":"x","label":"X"},{"value":"z","label":"Z"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-globe-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-globe-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-globe-1-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      /* never put opacity/filter in will-change on preserve-3d elements: it flattens them silently */
+      #loop-globe-1-world {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      /* origin 0 0: transform is pos * rotate * translate(-50%,-50%); with the default centre origin rotated cards drift by up to w/2 (coordinator fix 2026-09-08, same bug as 3d.html round 2) */
+      .card {
+        position: absolute;
+        left: 0;
+        top: 0;
+        overflow: hidden;
+        transform-origin: 0 0;
+      }
+      .card img {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+      .card .shade {
+        position: absolute;
+        inset: 0;
+        background: #000;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-globe-1-root"
+      data-composition-id="loop-globe-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="7"
+    >
+      <div
+        id="loop-globe-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="7"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-globe-1-bg"></div>
+        <div id="loop-globe-1-stage"><div id="loop-globe-1-world"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Globe loop family — `count` cards scattered evenly over a sphere of
+        // `radius` (fibonacci spread; NOT latitude rings, NOT random clusters — Globe07 f0 is an even
+        // disco-ball), spinning uniformly about `axis`, camera on the axis-normal at `distance` from the
+        // centre. Measured on the 512 previews (2026-09-08):
+        //   camera:  pinhole, distance = true camera->centre distance, f = 1000px*(100/perspective) at
+        //            H=1080 (sphere silhouette: Globe05 180px vs 179 predicted, Globe07 245.7 vs 247).
+        //            D may be ~R (03/04/08/10/11: far hemisphere fills the frame, near cards fly past
+        //            huge and mostly off-frame) or 0 (Globe06: camera at the centre, hence flipImage).
+        //   size:    SCREEN-space, not world: projected card = lerp(maxScale, minScale, norm) % of H,
+        //            norm = (cameraDistance - (D-R)) / 2R. Globe07 central cards all 75-76px (=14.8%
+        //            vs maxScale 15.46, none random), Globe06 all 34px (=6.6% vs minScale 7; D=0 ->
+        //            norm 1), Globe10 far-pole card 26px = 5.1% (minScale 5), near card 104px = 20.3%
+        //            (maxScale 20). Tangent cards read ~4% under the nominal %; billboards exact.
+        //   spin:    uniform, total = cycles*cycleDeg per loop (Globe02 6x60deg has a flat speed
+        //            profile -> no stepping; Globe03 2.40deg/3 frames = 360/15s exact). forward =
+        //            positive CSS rotation: y -> near side moves right, x -> near side moves up,
+        //            z -> clockwise on screen (Globe01/02/03/05/07 phase-correlation).
+        //   facing:  autoFaceCamera on = screen-parallel billboards (Globe06 rim stretch is exactly
+        //            1/cos(theta), so not lookAt); off = card normal along the sphere radius, upright,
+        //            no in-plane spin (Globe06 minAreaRect angle -90 everywhere).
+        //   fade:    multiplies card COLOUR by (1 - fade/100) (Globe05 shade 136 -> 83 = x0.61 at fade
+        //            40, Globe07 -> 77 = x0.566 at fade 44, Globe04 billboards x0.77 at fade 23), fully
+        //            applied well inside the front hemisphere: ramp over zr 0.85..0.45 fitted on Globe07
+        //            (zr = z/R toward the camera). Implemented as a black overlay.
+        // Knobs (not measurable from the previews): delay unit (used: seconds of hold per cycle, all
+        // variants 0), offsetX/Y unit (used: % of H like 3d), backface=hide for billboards (used: hide
+        // the far hemisphere), natural-fit card shape (used: height = size, width follows aspect),
+        // fibonacci seed/orientation (positions are not the reference's; only the statistics match).
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 7, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, background, frac } = RF;
+        const DUR = num("loopDuration", 7);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const BACK = str("backface", "show");
+        const FLIP = on("flipImage", false);
+        const COUNT = Math.max(1, num("count", 40) | 0);
+        const R = Math.max(1, num("radius", 355));
+        const SMIN = num("minScale", 10),
+          SMAX = num("maxScale", 20);
+        const D = Math.max(0, num("distance", 1000));
+        const PERSP = Math.max(1, num("perspective", 100));
+        const FADE = Math.min(100, Math.max(0, num("fade", 0)));
+        const OX = num("offsetX", 0),
+          OY = num("offsetY", 0);
+        const AXIS = str("axis", "y");
+        const FACE = on("autoFaceCamera", true);
+        const CYCLES = Math.max(1, num("cycles", 1));
+        const CYCDEG = num("cycleDeg", 360);
+        const DELAY = Math.max(0, num("delay", 0));
+        const SIGN = str("direction", "forward") === "forward" ? 1 : -1;
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+
+        document.getElementById("loop-globe-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-globe-1-bg"));
+
+        const f = 1000 * (100 / PERSP) * (REF / 1080); // CSS focal length, px
+        const s = f / Math.max(D, R); // world -> stage px (ratios are all that matter)
+        const stage = document.getElementById("loop-globe-1-stage");
+        stage.style.perspective = f + "px";
+        const world = document.getElementById("loop-globe-1-world");
+        // camera sits at stage z = f; globe centre D*s in front of it; offsets in % of H
+        const CZ = f - D * s,
+          CX = (OX / 100) * REF,
+          CY = (OY / 100) * REF;
+
+        // even spread: fibonacci sphere (stage coords, y down)
+        const GA = Math.PI * (3 - Math.sqrt(5));
+        const cards = [];
+        for (let i = 0; i < COUNT; i++) {
+          const y = 1 - (2 * (i + 0.5)) / COUNT,
+            r = Math.sqrt(1 - y * y),
+            th = i * GA;
+          // hashed pick: i%N would stack one image down each fibonacci column (8 golden angles = 20deg)
+          const m = IMAGES[((i * 2654435761) >>> 0) % N],
+            a = aspect(m, FIT, CROP_AR);
+          const el = document.createElement("div");
+          el.className = "card";
+          const img = document.createElement("img");
+          img.src = m.src;
+          if (FLIP) img.style.transform = "scaleX(-1)";
+          const shade = document.createElement("div");
+          shade.className = "shade";
+          el.appendChild(img);
+          el.appendChild(shade);
+          if (!FACE && BACK === "hide") el.style.backfaceVisibility = "hidden";
+          world.appendChild(el);
+          cards.push({ el, shade, a, d: [r * Math.cos(th), y, r * Math.sin(th)] });
+        }
+
+        // CSS-handed rotations (rotateY(+): +z -> +x; rotateX(+): +y -> +z; rotateZ(+): +x -> +y)
+        function rot(v, ang) {
+          const c = Math.cos(ang),
+            sn = Math.sin(ang),
+            [x, y, z] = v;
+          if (AXIS === "x") return [x, y * c - z * sn, y * sn + z * c];
+          if (AXIS === "z") return [x * c - y * sn, x * sn + y * c, z];
+          return [x * c + z * sn, y, -x * sn + z * c];
+        }
+        // uniform spin; delay = seconds of hold at the end of each cycle (unit unverified, all variants 0)
+        function angleAt(t) {
+          const cyc = DUR / CYCLES,
+            move = Math.max(0.01, cyc - DELAY);
+          const u = frac(t) * CYCLES,
+            k = Math.floor(u),
+            local = (u - k) * cyc;
+          return (SIGN * (k + Math.min(1, local / move)) * CYCDEG * Math.PI) / 180;
+        }
+        const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+        function renderAt(t) {
+          const ang = angleAt(t);
+          for (const c of cards) {
+            const [dx, dy, dz] = rot(c.d, ang); // unit direction, +z toward camera
+            const px = dx * R,
+              py = dy * R,
+              pz = dz * R;
+            const dist = Math.hypot(px, py, D - pz); // camera -> card, world
+            const depth = (D - pz) * s; // stage depth in front of the camera
+            const zr = dz; // +1 = nearest pole
+            if (depth < 0.02 * R * s || (FACE && BACK === "hide" && zr < 0)) {
+              c.el.style.visibility = "hidden";
+              continue;
+            }
+            c.el.style.visibility = "visible";
+            const norm = clamp01((dist - (D - R)) / (2 * R));
+            const screen = ((SMAX + (SMIN - SMAX) * norm) / 100) * REF;
+            const k = depth / f; // undo the perspective division -> screen-space size
+            const h = screen * k,
+              w = h * c.a;
+            c.el.style.width = w + "px";
+            c.el.style.height = h + "px";
+            c.el.style.borderRadius = RADIUS * k + "px";
+            c.shade.style.opacity = (FADE / 100) * clamp01((0.85 - zr) / 0.4);
+            const pos = `translate3d(${CX + px * s}px,${CY + py * s}px,${CZ + pz * s}px)`;
+            c.el.style.transform = FACE
+              ? `${pos} translate(-50%,-50%)`
+              : `${pos} rotateY(${Math.atan2(dx, dz)}rad) rotateX(${Math.asin(-dy)}rad) translate(-50%,-50%)`;
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-globe-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-globe-1/registry-item.json
+++ b/registry/blocks/loop-globe-1/registry-item.json
@@ -1,0 +1,509 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-globe-1",
+  "type": "hyperframes:block",
+  "title": "Loop Globe 1",
+  "description": "Image cards scattered evenly over a sphere that rotates under a 3D camera. 8 image slots, 7s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "globe",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 7,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backface",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Backface",
+      "description": "Backface (engine parameter; see the block header comment).",
+      "default": "show",
+      "options": [
+        {
+          "value": "show",
+          "label": "Show"
+        },
+        {
+          "value": "hide",
+          "label": "Hide"
+        }
+      ]
+    },
+    {
+      "id": "flipImage",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Flip Image",
+      "description": "Flip Image (engine parameter; see the block header comment).",
+      "default": "off",
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "id": "fade",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Fade",
+      "description": "Fade (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "id": "autoFaceCamera",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Auto Face Camera",
+      "description": "Auto Face Camera (engine parameter; see the block header comment).",
+      "default": "on",
+      "options": [
+        {
+          "value": "on",
+          "label": "On"
+        },
+        {
+          "value": "off",
+          "label": "Off"
+        }
+      ]
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 12,
+      "step": 0.1
+    },
+    {
+      "id": "cycleDeg",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycle Deg",
+      "description": "Degrees turned per cycle.",
+      "default": 360,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "forward",
+      "options": [
+        {
+          "value": "forward",
+          "label": "Forward"
+        },
+        {
+          "value": "reverse",
+          "label": "Reverse"
+        }
+      ]
+    },
+    {
+      "id": "count",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Count",
+      "description": "Count (engine parameter; see the block header comment).",
+      "default": 40,
+      "min": 0,
+      "max": 120,
+      "step": 1
+    },
+    {
+      "id": "radius",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Radius",
+      "description": "Radius (engine parameter; see the block header comment).",
+      "default": 355,
+      "min": 0,
+      "max": 1780,
+      "step": 10
+    },
+    {
+      "id": "minScale",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Min Scale",
+      "description": "Min Scale (engine parameter; see the block header comment).",
+      "default": 10,
+      "min": 0,
+      "max": 28,
+      "step": 1
+    },
+    {
+      "id": "maxScale",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Max Scale",
+      "description": "Max Scale (engine parameter; see the block header comment).",
+      "default": 20,
+      "min": 0,
+      "max": 103,
+      "step": 1
+    },
+    {
+      "id": "distance",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Distance",
+      "description": "Camera distance from the formation.",
+      "default": 1000,
+      "min": 0,
+      "max": 8900,
+      "step": 10
+    },
+    {
+      "id": "perspective",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Perspective",
+      "description": "Camera focal length: smaller = stronger perspective.",
+      "default": 100,
+      "min": 0,
+      "max": 300,
+      "step": 10
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "axis",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Axis",
+      "description": "Axis (engine parameter; see the block header comment).",
+      "default": "y",
+      "options": [
+        {
+          "value": "y",
+          "label": "Y"
+        },
+        {
+          "value": "x",
+          "label": "X"
+        },
+        {
+          "value": "z",
+          "label": "Z"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-globe-1.html",
+      "target": "compositions/loop-globe-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-gravity-1/loop-gravity-1.html
+++ b/registry/blocks/loop-gravity-1/loop-gravity-1.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"stagger","type":"number","role":"style","label":"Animation · Stagger","description":"Stagger (engine parameter; see the block header comment).","default":0.18,"min":0,"max":2,"step":0.01},{"id":"cardSize","type":"number","role":"style","label":"Template options · Card Size","description":"Card Size (engine parameter; see the block header comment).","default":300,"min":0,"max":820,"step":10},{"id":"gravity","type":"number","role":"style","label":"Template options · Gravity","description":"Gravity (engine parameter; see the block header comment).","default":1,"min":0,"max":10,"step":0.1},{"id":"bounce","type":"number","role":"style","label":"Template options · Bounce","description":"Bounce (engine parameter; see the block header comment).","default":0.2,"min":0,"max":2,"step":0.01},{"id":"spin","type":"number","role":"style","label":"Template options · Spin","description":"Spin (engine parameter; see the block header comment).","default":0.03,"min":0,"max":2,"step":0.01},{"id":"tilt","type":"number","role":"style","label":"Template options · Tilt","description":"Tilt (engine parameter; see the block header comment).","default":18,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"seed","type":"number","role":"style","label":"Template options · Seed","description":"Seed (engine parameter; see the block header comment).","default":1,"min":0,"max":10,"step":0.1},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-gravity-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-gravity-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-gravity-1-stage {
+        position: absolute;
+        inset: 0;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-gravity-1-root"
+      data-composition-id="loop-gravity-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="7"
+    >
+      <div
+        id="loop-gravity-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="7"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-gravity-1-bg"></div>
+        <div id="loop-gravity-1-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Gravity loop family — cards fall from above, tip flat onto the floor / onto earlier cards, pile up,
+        // hold, then the floor vanishes and the whole pile free-falls out (upper cards tumble). The reference is a physics
+        // sim seeded per variant; its exact layout is not recoverable, so this is a deterministic closed-form stand-in
+        // (seeded LCG from `seed`) matched to the measured statistics (512x512 previews, 2026-09-08):
+        //   card = cardSize*H/1080 (G01 300 -> 142/143 px rows, G02 230 -> 109, G03 410 -> 194); 8 cards, all square at rest,
+        //     packed by collisions into rows (G01 3/3/1/1, G02 4/3/1, G03 2/2/2/2 with the top row above the frame).
+        //   spawn: card i at i*stagger, centre y = -0.27H, initial v 0.47 H/s, accel 0.74 px/f^2 @512 = 1.3 H/s^2 (G01 card 74:
+        //     c.y 111/177/251/331/417 at f18..30; G03 first card matches; G02's preference falls at 0.28 px/f^2 - unexplained).
+        //   tilt in flight constant (10, 10, 25 deg seen); `spin` 0.03 rad/s is invisible; cards fall straight down.
+        //   landing: lowest corner touches, card rotates flat over ~9 frames (centre 430 -> 441 for 10 deg), bounce 0.2 ->
+        //     no visible rebound, bounce 0.5 -> ~19 px rebound over ~12 frames with a rotation kick.
+        //   exit: at f163 of 210 (DUR - 1.57 s, both 7 s variants) every card falls: floor-row cards straight with g, upper
+        //     cards at ~g/2 while they rotate (up to 45 deg in 30 f) and drift sideways (up to 4 px/f). G03 instead collapses in two
+        //     stages from f243 (bottom row leaves, upper rows land again, then all fall) - NOT reproduced.
+        // Guesses/knobs: spawn interval = 1.65*stagger (measured); gravity multiplies the accel; friction unused (no slides: cards land at their final x); hold unused
+        //   (exit time is DUR-1.57 s; hold=0.7 in all three variants); bounce height = bounce*0.07H; tilt range +-1.2*tilt.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 7, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background } = RF;
+        const DUR = num("loopDuration", 7);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const SIZE = (num("cardSize", 300) * REF) / 1080;
+        const GRAV = num("gravity", 1);
+        const BOUNCE = num("bounce", 0.2);
+        const SPIN = (num("spin", 0.03) * 180) / Math.PI; // deg/s
+        const TILT = num("tilt", 18) * 1.2;
+        const STAGGER = num("stagger", 0.18) * 1.65; // measured spawn interval ~0.29 s for stagger 0.18 (last landing f100 of 210)
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(Math.min(40, num("imageCount", 16)));
+        const N = IMAGES.length;
+        let seed = (num("seed", 1) * 2654435761) >>> 0;
+        const rnd = () => (seed = (seed * 1664525 + 1013904223) >>> 0) / 4294967296;
+
+        document.getElementById("loop-gravity-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-gravity-1-bg"));
+        const stage = document.getElementById("loop-gravity-1-stage");
+
+        const A = 1.3 * REF * GRAV,
+          V0 = 0.47 * REF,
+          Y0 = -0.27 * REF; // px/s^2, px/s, px (centre)
+        const TIP = 0.3,
+          BOUNCE_T = 0.4,
+          BOUNCE_H = BOUNCE * 0.07 * REF;
+        const T_EXIT = DUR - 1.57 * (DUR >= 3 ? 1 : DUR / 3);
+        const rad = (d) => (d * Math.PI) / 180;
+
+        // skyline packing: each card lands straight down at the lowest available spot (ties broken by the seed)
+        const sky = new Float64Array(Math.ceil(W)).fill(H); // top of the pile per pixel column
+        const cards = [];
+        for (let i = 0; i < N; i++) {
+          const m = IMAGES[i],
+            a = aspect(m, FIT, CROP_AR),
+            w = SIZE * a,
+            h = SIZE;
+          const el = card(m, w, h, RADIUS);
+          el.style.left = -w / 2 + "px";
+          el.style.top = -h / 2 + "px";
+          el.style.zIndex = i + 1;
+          stage.appendChild(el);
+          // candidate x positions: every step, plus snapped-to-wall / snapped-to-neighbour spots (physics packs rows tight)
+          const step = Math.max(4, w / 8),
+            cands = [];
+          const topAt = (x) => {
+            let top = H;
+            for (let px = Math.max(0, Math.floor(x)); px < Math.min(W, x + w); px++)
+              top = Math.min(top, sky[px]);
+            return top;
+          };
+          for (let x = 0; x + w <= W + 0.5; x += step) cands.push([x, topAt(x), false]);
+          const snaps = [0, W - w];
+          for (const o of cards) {
+            snaps.push(o.cx + o.w / 2 + rnd() * 0.1 * w, o.cx - o.w / 2 - w - rnd() * 0.1 * w);
+          }
+          for (const x of snaps) if (x >= 0 && x + w <= W + 0.5) cands.push([x, topAt(x), true]);
+          const lowest = Math.max(...cands.map((c) => c[1]));
+          let ok = cands.filter((c) => c[1] >= lowest - (rnd() < 0.4 ? 1.1 : 0.25) * h); // physics is not Tetris: 40% of cards may settle one level up
+          if (ok.some((c) => c[2])) ok = ok.filter((c) => c[2]);
+          const [x, top] = ok[Math.floor(rnd() * ok.length)];
+          const cx = x + w / 2,
+            restY = top - h / 2,
+            floor = top >= H - 0.5;
+          for (let px = Math.floor(x); px < Math.min(W, x + w); px++)
+            sky[px] = Math.min(sky[px], top - h);
+          const d = restY - Y0,
+            tFall = (-V0 + Math.sqrt(V0 * V0 + 2 * A * d)) / A;
+          cards.push({
+            el,
+            w,
+            h,
+            cx,
+            restY,
+            floor,
+            t0: i * STAGGER,
+            tLand: i * STAGGER + tFall,
+            tilt: (2 * rnd() - 1) * TILT,
+            spinDir: rnd() < 0.5 ? -1 : 1,
+            exitW: floor ? 0 : (2 * rnd() - 1) * 45, // deg/s tumble
+            exitVx: floor ? 0 : (2 * rnd() - 1) * 0.23 * REF, // px/s drift
+          });
+        }
+        function renderAt(t) {
+          const now = t * DUR;
+          for (const c of cards) {
+            let x = c.cx,
+              y,
+              rot,
+              vis = true;
+            if (now < c.t0) {
+              vis = false;
+              y = Y0;
+              rot = 0;
+            } else if (now < c.tLand) {
+              const dt = now - c.t0;
+              y = Y0 + V0 * dt + 0.5 * A * dt * dt;
+              rot = c.tilt + c.spinDir * SPIN * dt;
+            } else {
+              const s = now - c.tLand;
+              rot = c.tilt * Math.max(0, 1 - s / TIP);
+              const lift =
+                (c.h / 2) * (Math.abs(Math.cos(rad(rot))) + Math.abs(Math.sin(rad(rot))) - 1); // lowest corner stays on the support
+              const b = s < BOUNCE_T ? BOUNCE_H * Math.sin((Math.PI * s) / BOUNCE_T) : 0;
+              y = c.restY - lift - b;
+              if (now >= T_EXIT) {
+                const e = now - T_EXIT;
+                y += 0.5 * A * (c.floor ? 1 : 0.5) * e * e;
+                rot += c.exitW * e;
+                x += c.exitVx * e; // upper cards tumble down at ~half g (136: 0.3 vs 0.6 px/f^2)
+                if (y - c.h > H) vis = false;
+              }
+            }
+            c.el.style.display = vis ? "block" : "none";
+            if (vis) c.el.style.transform = `translate3d(${x}px,${y}px,0) rotate(${rot}deg)`;
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-gravity-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-gravity-1/registry-item.json
+++ b/registry/blocks/loop-gravity-1/registry-item.json
@@ -1,0 +1,356 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-gravity-1",
+  "type": "hyperframes:block",
+  "title": "Loop Gravity 1",
+  "description": "Image cards fall from above, tip flat onto the floor and pile up. 8 image slots, 7s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "gravity"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 7,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "stagger",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Stagger",
+      "description": "Stagger (engine parameter; see the block header comment).",
+      "default": 0.18,
+      "min": 0,
+      "max": 2,
+      "step": 0.01
+    },
+    {
+      "id": "cardSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Card Size",
+      "description": "Card Size (engine parameter; see the block header comment).",
+      "default": 300,
+      "min": 0,
+      "max": 820,
+      "step": 10
+    },
+    {
+      "id": "gravity",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Gravity",
+      "description": "Gravity (engine parameter; see the block header comment).",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "bounce",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Bounce",
+      "description": "Bounce (engine parameter; see the block header comment).",
+      "default": 0.2,
+      "min": 0,
+      "max": 2,
+      "step": 0.01
+    },
+    {
+      "id": "spin",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Spin",
+      "description": "Spin (engine parameter; see the block header comment).",
+      "default": 0.03,
+      "min": 0,
+      "max": 2,
+      "step": 0.01
+    },
+    {
+      "id": "tilt",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Tilt",
+      "description": "Tilt (engine parameter; see the block header comment).",
+      "default": 18,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "seed",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Seed",
+      "description": "Seed (engine parameter; see the block header comment).",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-gravity-1.html",
+      "target": "compositions/loop-gravity-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-grid-1/loop-grid-1.html
+++ b/registry/blocks/loop-grid-1/loop-grid-1.html
@@ -1,0 +1,378 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"crop","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":700,"min":0,"max":1400,"step":10},{"id":"gap","type":"number","role":"style","label":"Template options · Gap","description":"Spacing between cards.","default":80,"min":0,"max":1000,"step":10,"unit":"px"},{"id":"zoom","type":"enum","role":"style","label":"Template options · Zoom","description":"Zoom (engine parameter; see the block header comment).","default":"off","options":[{"value":"off","label":"Off"},{"value":"on","label":"On"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-grid-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-grid-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-grid-1-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      #loop-grid-1-plane {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 0;
+        height: 0;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-grid-1-root"
+      data-composition-id="loop-grid-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="18"
+    >
+      <div
+        id="loop-grid-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="18"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-grid-1-bg"></div>
+        <div id="loop-grid-1-stage"><div id="loop-grid-1-plane"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Grid loop family — a camera pans over an infinite lattice of cards.
+        // Measured on the 512x512 previews (2026-09-08, gap-bar tracker per frame):
+        //   units:    planeSize/gap are 1080p pixels scaled by frame HEIGHT: Grid01 pitch 370px@512 = (700+80)*512/1080,
+        //             bar 38px = 80*0.474; Grid03 bar 56 = 119*0.474; Grid04 card 302 = 637*0.474.
+        //   motion:   the loop is a CLOSED WALK of S segments (DUR/S each); every segment is one eased diagonal
+        //             move of integer cells (dx,dy). S = 6 for Grid01/02/03/05, 9 for Grid04. Each variant has
+        //             its own fixed table (seeded RNG on their side — unrecoverable), measured and hard-coded
+        //             below keyed on (loopDuration, planeSize, gap, zoom); other combos get a seeded LCG walk.
+        //   ease:     0.2*u + 0.8*expoInOut(u) (same as Marquee; Grid01 seg1 maxerr 0.034, Grid02 0.020, Grid03 0.026;
+        //             Grid04 unwrapped shift/1617: u=.2 .053, .25 .075, .4 .197, .5 .500 — same curve as Grid01).
+        //             Grid04 moves 3 cells per segment at pitch 1137 (> frame): its mid-segment frames alias mod one
+        //             pitch, which first read as 1-cell moves with a flatter ease — wrong, fixed 2026-09-08.
+        //   zoom=on:  plane scales about the frame centre by 1 - k*sin^2(pi*u) per segment (Grid04 fits to 0.002);
+        //             k = 0.30 (Grid04, pitch 1137 > 1080) / 0.20 (Grid05, pitch 819). Rule between them: guess (2 points).
+        //   images:   cell (c,r) shows image (c + 3r) mod N — placeholder shades cannot identify the real mapping (guess).
+        // Knobs (declared, unmeasurable here): cycles = passes through the move table per loop (all variants 1),
+        // delay = loop phase offset in seconds (all 0), breath = not implemented (off everywhere).
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 18, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, card, background, expoInOut, frac } = RF;
+        const DUR = num("loopDuration", 18);
+        const FIT = str("mediaFit", "crop");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const PLANE = (num("planeSize", 700) * REF) / 1080;
+        const GAP = (num("gap", 80) * REF) / 1080;
+        const CYCLES = Math.max(1, num("cycles", 1) | 0);
+        const DELAY = num("delay", 0);
+        const ZOOM = on("zoom", false);
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const PITCH = PLANE + GAP;
+
+        document.getElementById("loop-grid-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-grid-1-bg"));
+
+        // measured move tables: [dx,dy] per segment in screen direction of the lattice (+x = content moves right)
+        const KEY = `${num("loopDuration", 18)}/${num("planeSize", 700)}/${num("gap", 80)}/${ZOOM ? "on" : "off"}`;
+        const TABLES = {
+          "18/700/80/off": {
+            moves: [
+              [-1, 1],
+              [-1, -1],
+              [4, 1],
+              [-4, -2],
+              [1, 2],
+              [1, -1],
+            ],
+            k: 0,
+          }, // Grid01
+          "12/537/79/off": {
+            moves: [
+              [-1, 0],
+              [0, -1],
+              [-1, 0],
+              [0, 1],
+              [1, 1],
+              [1, -1],
+            ],
+            k: 0,
+          }, // Grid02
+          "20/700/119/off": {
+            moves: [
+              [-2, 2],
+              [-2, -2],
+              [1, -2],
+              [1, 2],
+              [1, -2],
+              [1, 2],
+            ],
+            k: 0,
+          }, // Grid03
+          "24/637/500/on": {
+            moves: [
+              [3, 0],
+              [0, 3],
+              [-3, 0],
+              [-3, 0],
+              [0, -3],
+              [0, -3],
+              [3, 0],
+              [3, 0],
+              [-3, 3],
+            ],
+            k: 0.3,
+          }, // Grid04
+          "20/700/119/on": {
+            moves: [
+              [0, 2],
+              [2, -1],
+              [-1, -3],
+              [-2, 0],
+              [-1, 2],
+              [2, 0],
+            ],
+            k: 0.2,
+          }, // Grid05
+        };
+        function fallback() {
+          // seeded LCG closed walk, 6 segments (guess for unlisted combos)
+          let s =
+            (num("loopDuration", 18) * 7919 + num("planeSize", 700) * 104729 + num("gap", 80)) >>>
+            0;
+          const rnd = () => (s = (s * 1664525 + 1013904223) >>> 0) / 4294967296;
+          const mv = [],
+            sum = [0, 0];
+          for (let i = 0; i < 5; i++) {
+            const m = [Math.round(rnd() * 4 - 2), Math.round(rnd() * 4 - 2)];
+            if (!m[0] && !m[1]) m[0] = 1;
+            mv.push(m);
+            sum[0] += m[0];
+            sum[1] += m[1];
+          }
+          mv.push([-sum[0], -sum[1]]);
+          return { moves: mv, k: ZOOM ? (PITCH >= REF ? 0.3 : 0.2) : 0 };
+        }
+        const T = TABLES[KEY] || fallback();
+        const MOVES = [];
+        for (let c = 0; c < CYCLES; c++) MOVES.push(...T.moves);
+        const S = MOVES.length;
+        const K = ZOOM ? T.k : 0;
+        const ease = (u) => 0.2 * u + 0.8 * expoInOut(u);
+
+        // cumulative lattice offsets at segment starts (cells)
+        const POS = [[0, 0]];
+        for (const [dx, dy] of MOVES) {
+          const p = POS[POS.length - 1];
+          POS.push([p[0] + dx, p[1] + dy]);
+        }
+        const xs = POS.map((p) => p[0]),
+          ys = POS.map((p) => p[1]);
+        // cards needed: walk extent + enough to cover the (zoomed-out) diagonal
+        const cover = Math.ceil(Math.hypot(W, H) / 2 / (PITCH * (1 - K))) + 1;
+        const plane = document.getElementById("loop-grid-1-plane");
+        // content offset o (px): lattice cell (c,r) sits at (c*PITCH + o.x, r*PITCH + o.y); offset grows with the moves,
+        // so cells that come into view have c in [-max(xs)-cover, -min(xs)+cover]
+        for (let c = -Math.max(...xs) - cover; c <= -Math.min(...xs) + cover; c++)
+          for (let r = -Math.max(...ys) - cover; r <= -Math.min(...ys) + cover; r++) {
+            const m = IMAGES[(((c + 3 * r) % N) + N) % N];
+            const a = aspect(m, FIT, CROP_AR);
+            const w = a >= 1 ? PLANE : PLANE * a,
+              h = a >= 1 ? PLANE / a : PLANE;
+            const el = card(m, w, h, RADIUS);
+            el.style.left = c * PITCH - w / 2 + "px";
+            el.style.top = r * PITCH - h / 2 + "px";
+            plane.appendChild(el);
+          }
+        const stage = document.getElementById("loop-grid-1-stage");
+        function renderAt(t) {
+          const tt = frac(t + DELAY / DUR) * S;
+          const seg = Math.min(S - 1, Math.floor(tt)),
+            u = tt - seg;
+          const e = ease(u),
+            p = POS[seg],
+            m = MOVES[seg];
+          const ox = (p[0] + m[0] * e) * PITCH,
+            oy = (p[1] + m[1] * e) * PITCH;
+          const sc = 1 - K * Math.pow(Math.sin(Math.PI * u), 2);
+          stage.style.transform = `scale(${sc})`;
+          plane.style.transform = `translate3d(${ox}px,${oy}px,0)`;
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-grid-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-grid-1/registry-item.json
+++ b/registry/blocks/loop-grid-1/registry-item.json
@@ -1,0 +1,342 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-grid-1",
+  "type": "hyperframes:block",
+  "title": "Loop Grid 1",
+  "description": "A camera pans over an infinite lattice of image cards. 8 image slots, 18s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "grid"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 18,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "crop",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 700,
+      "min": 0,
+      "max": 1400,
+      "step": 10
+    },
+    {
+      "id": "gap",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Gap",
+      "description": "Spacing between cards.",
+      "default": 80,
+      "min": 0,
+      "max": 1000,
+      "step": 10,
+      "unit": "px"
+    },
+    {
+      "id": "zoom",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Zoom",
+      "description": "Zoom (engine parameter; see the block header comment).",
+      "default": "off",
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-grid-1.html",
+      "target": "compositions/loop-grid-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-marquee-1/loop-marquee-1.html
+++ b/registry/blocks/loop-marquee-1/loop-marquee-1.html
@@ -1,0 +1,337 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"stagger","type":"number","role":"style","label":"Animation · Stagger","description":"Stagger (engine parameter; see the block header comment).","default":0,"min":0,"max":10,"step":0.1},{"id":"motion","type":"enum","role":"style","label":"Animation · Motion","description":"Motion (engine parameter; see the block header comment).","default":"continuous","options":[{"value":"continuous","label":"Continuous"},{"value":"stepped","label":"Stepped"}]},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"forward","options":[{"value":"forward","label":"Forward"},{"value":"reverse","label":"Reverse"}]},{"id":"alternate","type":"enum","role":"style","label":"Animation · Alternate","description":"Alternate (engine parameter; see the block header comment).","default":"on","options":[{"value":"off","label":"Off"},{"value":"on","label":"On"}]},{"id":"lanes","type":"number","role":"style","label":"Template options · Lanes","description":"Lanes (engine parameter; see the block header comment).","default":3,"min":0,"max":12,"step":0.1},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":160,"min":0,"max":360,"step":10},{"id":"gap","type":"number","role":"style","label":"Template options · Gap","description":"Spacing between cards.","default":25,"min":0,"max":84,"step":1,"unit":"px"},{"id":"angle","type":"number","role":"style","label":"Template options · Angle","description":"Angle (engine parameter; see the block header comment).","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"axis","type":"enum","role":"style","label":"Template options · Axis","description":"Axis (engine parameter; see the block header comment).","default":"vertical","options":[{"value":"vertical","label":"Vertical"},{"value":"horizontal","label":"Horizontal"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-marquee-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-marquee-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-marquee-1-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .lane {
+        position: absolute;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-marquee-1-root"
+      data-composition-id="loop-marquee-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="9"
+    >
+      <div
+        id="loop-marquee-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="9"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-marquee-1-bg"></div>
+        <div id="loop-marquee-1-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Marquee loop family — lanes of cards scrolling.
+        // Mechanism read off the previews (2026-09-08):
+        //   continuous: ONE eased travel of exactly one lane period (all N cards) per cycle (verified by
+        //               frame-by-frame integration on 01/02/13/22: 7.99 pitches per cycle). Velocity is a
+        //               slow-fast-slow bell; hold has NO effect (01 hold=35 vs 02 hold=0 identical).
+        //               Ease fit on 02/22 refs: 0.24*t + 0.76*expoInOut(t), maxerr 0.014 (0.20 gave 0.023).
+        //   stepped:    N steps per cycle (N = images), one card pitch each, expoInOut, no rest (06/18 exact).
+        //   forward = down (vertical) / right (horizontal); alternate=on reverses even lanes (1-based).
+        //   lanes are centred as a block; angle rotates the whole block.
+        //   phase: at t=0 the offset-0 lane has a CARD CENTRED on the frame centre (every ref: 02/03/06/07/13/18/22).
+        //   offsetN = % of one card PITCH (card+gap) as a SCREEN-space shift against +x/+y regardless of travel direction:
+        //             offset -30 puts lane 1's card +0.30 pitch right/down in 02 (leftward lane) AND 09 (downward lane);
+        //             03/18 offset 50 = half pitch; -15 = +0.15 pitch (03 L3, 09 L3).
+        //   stagger  = time LAG per lane of stagger/60 s (07: stagger 5 -> lanes lag 2.65 frames each @30fps;
+        //             13: stagger 2 -> 0.97 frames). Guess at the unit: 60fps frames; 0.16% of the loop fits as well.
+        // Unresolved (knob, flagged): lane image order (used: lane i starts at image i*floor(N/lanes)) — refs are
+        // uniform placeholders, so it cannot be measured.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 9, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, card, background, expoInOut, frac } = RF;
+        const DUR = num("loopDuration", 9);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const LANES = Math.max(1, num("lanes", 3) | 0);
+        const CROSS = num("planeSize", 160) * 0.003 * REF; // card size across the lane
+        const GAP = num("gap", 25) * 0.002 * REF;
+        const ANGLE = num("angle", 0);
+        const OFFS = [1, 2, 3, 4, 5, 6].map((i) => num("offset" + i, 0));
+        const AXIS = str("axis", "vertical"); // vertical: lanes are columns
+        const CYCLES = Math.max(1, num("cycles", 1) | 0);
+        const STAGGER = num("stagger", 0);
+        const MOTION = str("motion", "continuous");
+        const FWD = str("direction", "forward") === "forward" ? 1 : -1;
+        const ALT = on("alternate", true);
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const VERT = AXIS === "vertical";
+
+        document.getElementById("loop-marquee-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-marquee-1-bg"));
+        const stage = document.getElementById("loop-marquee-1-stage");
+        stage.style.transform = `rotate(${ANGLE}deg)`;
+
+        const DIAG = Math.hypot(W, H);
+        const blockCross = LANES * CROSS + (LANES - 1) * GAP;
+        const easeC = (x) => 0.24 * x + 0.76 * expoInOut(x);
+
+        const lanes = [];
+        for (let li = 0; li < LANES; li++) {
+          // lane content: all N images, rotated start, sizes from mediaFit
+          const start = (li * Math.floor(N / LANES)) % N;
+          const items = [];
+          for (let k = 0; k < N; k++) {
+            const m = IMAGES[(start + k) % N];
+            const a = aspect(m, FIT, CROP_AR); // w/h
+            const along = VERT ? CROSS / a : CROSS * a; // free dimension follows aspect
+            items.push({ m, along });
+          }
+          const pitches = items.map((it) => it.along + GAP);
+          const P = pitches.reduce((s, x) => s + x, 0);
+          const reps = Math.ceil(DIAG / P) + 4;
+          const el = document.createElement("div");
+          el.className = "lane";
+          const crossPos = -blockCross / 2 + li * (CROSS + GAP);
+          // lane box: cross axis fixed; card 0 is centred on the frame centre at shift 0, earlier copies cover -DIAG/2
+          const along0 = -items[0].along / 2 - Math.ceil((DIAG / 2 + P) / P) * P;
+          el.style.cssText = VERT
+            ? `left:${crossPos}px;top:${along0}px;width:${CROSS}px;height:${reps * P}px;`
+            : `top:${crossPos}px;left:${along0}px;height:${CROSS}px;width:${reps * P}px;`;
+          let pos = 0;
+          for (let r = 0; r < reps; r++)
+            for (const it of items) {
+              const c = VERT
+                ? card(it.m, CROSS, it.along, RADIUS)
+                : card(it.m, it.along, CROSS, RADIUS);
+              if (VERT) {
+                c.style.left = "0px";
+                c.style.top = pos + "px";
+              } else {
+                c.style.top = "0px";
+                c.style.left = pos + "px";
+              }
+              el.appendChild(c);
+              pos += it.along + GAP;
+            }
+          stage.appendChild(el);
+          const dir = FWD * (ALT && (li + 1) % 2 === 0 ? -1 : 1);
+          // offset is % of ONE card pitch (mean pitch P/N), not of the whole lane period
+          // stepped: each step brings the NEXT card to rest centred, so a step = half the current pitch + half the next one
+          // (natural-aspect cards differ in size); moving + (down/right) the next card is item N-1, N-2, ...
+          const half = (a, b) => (pitches[(a + N) % N] + pitches[(b + N) % N]) / 2;
+          const steps = pitches.map((_, j) => (dir < 0 ? half(j, j + 1) : half(N - j, N - 1 - j)));
+          lanes.push({
+            el,
+            P,
+            pitches: steps,
+            dir,
+            phase: ((OFFS[li] || 0) / 100) * (P / N),
+            tOff: (-li * STAGGER) / 60 / DUR,
+          });
+        }
+
+        function travel(L, t) {
+          const u = frac(t + L.tOff) * CYCLES; // cycle-local progress
+          const cyc = Math.floor(u),
+            f = u - cyc;
+          if (MOTION === "stepped") {
+            const s = f * N,
+              k = Math.floor(s),
+              g = s - k;
+            let d = 0;
+            for (let j = 0; j < k; j++) d += L.pitches[j];
+            return cyc * L.P + d + L.pitches[k] * expoInOut(g);
+          }
+          return (cyc + easeC(f)) * L.P;
+        }
+        function renderAt(t) {
+          for (const L of lanes) {
+            // forward (+) moves content down/right: shift in [0, P); offsetN is a SCREEN-space shift of -offset% of a pitch
+            const sh = frac((L.dir * travel(L, t) - L.phase) / L.P) * L.P;
+            L.el.style.transform = VERT ? `translate3d(0,${sh}px,0)` : `translate3d(${sh}px,0,0)`;
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-marquee-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-marquee-1/registry-item.json
+++ b/registry/blocks/loop-marquee-1/registry-item.json
@@ -1,0 +1,419 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-marquee-1",
+  "type": "hyperframes:block",
+  "title": "Loop Marquee 1",
+  "description": "Lanes of image cards scroll across the frame like a marquee. 8 image slots, 9s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "marquee",
+    "carousel"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 9,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "stagger",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Stagger",
+      "description": "Stagger (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "motion",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Motion",
+      "description": "Motion (engine parameter; see the block header comment).",
+      "default": "continuous",
+      "options": [
+        {
+          "value": "continuous",
+          "label": "Continuous"
+        },
+        {
+          "value": "stepped",
+          "label": "Stepped"
+        }
+      ]
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "forward",
+      "options": [
+        {
+          "value": "forward",
+          "label": "Forward"
+        },
+        {
+          "value": "reverse",
+          "label": "Reverse"
+        }
+      ]
+    },
+    {
+      "id": "alternate",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Alternate",
+      "description": "Alternate (engine parameter; see the block header comment).",
+      "default": "on",
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "id": "lanes",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Lanes",
+      "description": "Lanes (engine parameter; see the block header comment).",
+      "default": 3,
+      "min": 0,
+      "max": 12,
+      "step": 0.1
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 160,
+      "min": 0,
+      "max": 360,
+      "step": 10
+    },
+    {
+      "id": "gap",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Gap",
+      "description": "Spacing between cards.",
+      "default": 25,
+      "min": 0,
+      "max": 84,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "angle",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Angle",
+      "description": "Angle (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "axis",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Axis",
+      "description": "Axis (engine parameter; see the block header comment).",
+      "default": "vertical",
+      "options": [
+        {
+          "value": "vertical",
+          "label": "Vertical"
+        },
+        {
+          "value": "horizontal",
+          "label": "Horizontal"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-marquee-1.html",
+      "target": "compositions/loop-marquee-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-orbit-1/loop-orbit-1.html
+++ b/registry/blocks/loop-orbit-1/loop-orbit-1.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":370,"min":0,"max":1024,"step":10},{"id":"orbitRadius","type":"number","role":"style","label":"Template options · Orbit Radius","description":"Ring radius in scene units.","default":420,"min":0,"max":1036,"step":10},{"id":"rotationX","type":"number","role":"style","label":"Template options · Rotation X","description":"Formation tilt about the horizontal axis, degrees.","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"rotationY","type":"number","role":"style","label":"Template options · Rotation Y","description":"Formation turn about the vertical axis, degrees.","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"rotationZ","type":"number","role":"style","label":"Template options · Rotation Z","description":"Formation roll about the view axis, degrees.","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"perspective","type":"number","role":"style","label":"Template options · Perspective","description":"Camera focal length: smaller = stronger perspective.","default":100,"min":0,"max":280,"step":10},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-orbit-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-orbit-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-orbit-1-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      #loop-orbit-1-world {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-orbit-1-root"
+      data-composition-id="loop-orbit-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="8"
+    >
+      <div
+        id="loop-orbit-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="8"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-orbit-1-bg"></div>
+        <div id="loop-orbit-1-stage"><div id="loop-orbit-1-world"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Orbit loop family — N cards on a ring (radius orbitRadius, centre at the
+        // stage plane z=0, camera in front), each card a pure translation (always parallel to the screen:
+        // back-card top/bottom edges are level to the pixel in Orbit01 f0, so NOT turned toward the camera point).
+        // Measured (2026-09-08, 512px previews, units = px @1080, REF = H):
+        //   focal length f = 1200px*(100/perspective) @1080 — Orbit01 (R420,plane370 -> front 270px, 45deg
+        //   neighbour 234px), Orbit04 (R216,plane512 -> 296px) both solve to 1199..1200; Orbit03 persp 140 -> 527 vs 530 predicted.
+        //   motion: STEPPED, one card pitch (360/N deg) per DUR/(N*cycles), ease 0.2u+0.8*expoInOut(u) (Orbit01 front-card
+        //   x every 2 frames, max err ~0.02); card 0 centred at t=0.
+        //   direction: near card moves right (rotZ 0), down (rotZ 90), up (270), up-right (306), DOWN-right (234) —
+        //   i.e. screen-x of the near card's velocity is forced >= 0 (rigid rotateZ alone gives up-left for 234).
+        // Knobs (unmeasured, defaults 0 in all variants): delay = hold seconds per step; offsetX/Y in px @1080;
+        // natural fit fixes card HEIGHT = planeSize (previews are 1:1 placeholders).
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 8, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, card, background, expoInOut, frac } = RF;
+        const DUR = num("loopDuration", 8);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const s = REF / 1080; // world (px @1080) -> px
+        const PLANE = num("planeSize", 370) * s;
+        const R = num("orbitRadius", 420) * s;
+        const RX = num("rotationX", 0),
+          RY = num("rotationY", 0),
+          RZ = num("rotationZ", 0);
+        const PERSP = Math.max(1, num("perspective", 100));
+        const OX = num("offsetX", 0) * s,
+          OY = num("offsetY", 0) * s;
+        const CYCLES = Math.max(1, num("cycles", 1) | 0);
+        const DELAY = Math.max(0, num("delay", 0));
+        const RADIUS = num("borderRadius", 0) * s;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+
+        document.getElementById("loop-orbit-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-orbit-1-bg"));
+        const f = 1200 * (100 / PERSP) * s;
+        document.getElementById("loop-orbit-1-stage").style.perspective = f + "px";
+        const world = document.getElementById("loop-orbit-1-world");
+
+        // rigid rotation rotateX(RX) rotateY(RY) rotateZ(RZ) applied to ring-local points (CSS axes: y down, z to viewer)
+        const rad = (d) => (d * Math.PI) / 180;
+        function rot(p) {
+          let [x, y, z] = p,
+            c,
+            q;
+          c = Math.cos(rad(RZ));
+          q = Math.sin(rad(RZ));
+          [x, y] = [x * c - y * q, x * q + y * c];
+          c = Math.cos(rad(RY));
+          q = Math.sin(rad(RY));
+          [x, z] = [x * c + z * q, -x * q + z * c];
+          c = Math.cos(rad(RX));
+          q = Math.sin(rad(RX));
+          [y, z] = [y * c - z * q, y * q + z * c];
+          return [x, y, z];
+        }
+        const ringPt = (deg) => rot([R * Math.sin(rad(deg)), 0, R * Math.cos(rad(deg))]);
+        // spin sign: the near card must move toward +x on screen (see header)
+        const v0 = ringPt(0),
+          v1 = ringPt(1);
+        const DIR = v1[0] - v0[0] < -1e-6 ? -1 : 1;
+
+        const cards = [];
+        for (let i = 0; i < N; i++) {
+          const m = IMAGES[i],
+            a = aspect(m, FIT, CROP_AR);
+          const h = PLANE,
+            w = PLANE * a;
+          const c = card(m, w, h, RADIUS);
+          world.appendChild(c);
+          cards.push({ el: c, theta: (i * 360) / N, w, h });
+        }
+        const STEPS = N * CYCLES,
+          STEP_T = DUR / STEPS,
+          MOVE_T = Math.max(1e-3, STEP_T - Math.min(DELAY, STEP_T * 0.9));
+        const easeC = (x) => 0.2 * x + 0.8 * expoInOut(x);
+        function renderAt(t) {
+          const u = frac(t) * STEPS,
+            k = Math.floor(u),
+            g = Math.min(1, ((u - k) * STEP_T) / MOVE_T);
+          const spin = (DIR * (k + easeC(g)) * 360) / N;
+          for (const c of cards) {
+            const [x, y, z] = ringPt(c.theta + spin);
+            c.el.style.transform = `translate3d(${x + OX - c.w / 2}px,${y + OY - c.h / 2}px,${z}px)`;
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-orbit-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-orbit-1/registry-item.json
+++ b/registry/blocks/loop-orbit-1/registry-item.json
@@ -1,0 +1,395 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-orbit-1",
+  "type": "hyperframes:block",
+  "title": "Loop Orbit 1",
+  "description": "Image cards on a 3D ring, always parallel to the screen, orbit under a perspective camera. 8 image slots, 8s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "orbit",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 8,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 370,
+      "min": 0,
+      "max": 1024,
+      "step": 10
+    },
+    {
+      "id": "orbitRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Orbit Radius",
+      "description": "Ring radius in scene units.",
+      "default": 420,
+      "min": 0,
+      "max": 1036,
+      "step": 10
+    },
+    {
+      "id": "rotationX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rotation X",
+      "description": "Formation tilt about the horizontal axis, degrees.",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "rotationY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rotation Y",
+      "description": "Formation turn about the vertical axis, degrees.",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "rotationZ",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rotation Z",
+      "description": "Formation roll about the view axis, degrees.",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "perspective",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Perspective",
+      "description": "Camera focal length: smaller = stronger perspective.",
+      "default": 100,
+      "min": 0,
+      "max": 280,
+      "step": 10
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-orbit-1.html",
+      "target": "compositions/loop-orbit-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-pages-1/loop-pages-1.html
+++ b/registry/blocks/loop-pages-1/loop-pages-1.html
@@ -1,0 +1,398 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"crop","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"stagger","type":"number","role":"style","label":"Animation · Stagger","description":"Stagger (engine parameter; see the block header comment).","default":0.72,"min":0,"max":2,"step":0.01},{"id":"pageSize","type":"number","role":"style","label":"Template options · Page Size","description":"Page Size (engine parameter; see the block header comment).","default":90,"min":0,"max":180,"step":1},{"id":"curveAmount","type":"number","role":"style","label":"Template options · Curve Amount","description":"Curve Amount (engine parameter; see the block header comment).","default":15,"min":0,"max":30,"step":1},{"id":"segments","type":"number","role":"style","label":"Template options · Segments","description":"Segments (engine parameter; see the block header comment).","default":30,"min":0,"max":60,"step":1},{"id":"lightIntensity","type":"number","role":"style","label":"Template options · Light Intensity","description":"Light Intensity (engine parameter; see the block header comment).","default":100,"min":0,"max":200,"step":1},{"id":"lightAmbient","type":"number","role":"style","label":"Template options · Light Ambient","description":"Light Ambient (engine parameter; see the block header comment).","default":51,"min":0,"max":102,"step":1},{"id":"perspective","type":"number","role":"style","label":"Template options · Perspective","description":"Camera focal length: smaller = stronger perspective.","default":70,"min":0,"max":140,"step":1},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"flipDuration","type":"number","role":"style","label":"Template options · Flip Duration","description":"Flip Duration (engine parameter; see the block header comment).","default":2,"min":0,"max":10,"step":0.1},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-pages-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-pages-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-pages-1-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      #loop-pages-1-spread,
+      .flyer {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      .pg {
+        position: absolute;
+        overflow: hidden;
+        backface-visibility: hidden;
+      }
+      .pg img {
+        display: block;
+      }
+      .shade {
+        position: absolute;
+        inset: 0;
+        background: #000;
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-pages-1-root"
+      data-composition-id="loop-pages-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="10"
+    >
+      <div
+        id="loop-pages-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="10"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-pages-1-bg"></div>
+        <div id="loop-pages-1-stage"><div id="loop-pages-1-spread"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Pages loop family — an open spread (left page, right page, spine at the centre);
+        // pages turn right-to-left about the spine with a curl, several in the air at once. Measured (2026-09-08):
+        //   page 192x196px @512 for pageSize 90 => page side = pageSize/100 * 0.425*H (unit guessed from one value)
+        //   perspective 70 -> f = 1000*(100/70)*H/1080 (3D-family formula); distance has no measurable effect
+        //   loop = 2 bursts of 6 flips; a new page lands on the left every 18 frames (Pages01) / 18-24 (Pages02);
+        //   inter-burst rest = 22 frames (Pages01, stagger .72s) / 32 frames (Pages02, stagger 1s) => rest = stagger s,
+        //   burst = DUR/2 - stagger - 0.3s delay, flip length L = flipDuration/2 (1s / 2s), start interval =
+        //   (burst - L)/5 (= 17.9 frames on Pages01 = the landing cadence; 16 on Pages02 vs ~19 measured); mid-flip the free edge reaches ~110px past the spine at
+        //   ~75deg (flat would be ~70) => curl; rest pages read flat with a spine-side shade.
+        // Guesses: 6 flips per burst and 2 bursts (fixed; equals imageCount-2 for the 8-image preview); curl = free edge
+        //   leads by curveAmount deg * sin(theta) across `segments` strips; restCurve not reproduced; shading =
+        //   (1-lightAmbient/100) * lightIntensity/100 * (1-cos) on flying strips + a fixed spine gradient on rest pages;
+        //   each flip consumes two images (front, back); images cycle mod M = largest divisor of 2*flips <= imageCount.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 10, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, background } = RF;
+        const DUR = num("loopDuration", 10);
+        const FIT = str("mediaFit", "crop");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const PAGE = (num("pageSize", 90) / 100) * 0.425 * REF;
+        const CURVE = num("curveAmount", 15);
+        const SEG = Math.max(1, Math.min(60, num("segments", 30) | 0));
+        const LI = num("lightIntensity", 100) / 100,
+          AMB = num("lightAmbient", 51) / 100;
+        const PERSP = Math.max(1, num("perspective", 70));
+        const OX = num("offsetX", 0),
+          OY = num("offsetY", 0);
+        const FLIPD = Math.max(0.1, num("flipDuration", 2));
+        const STAG = Math.max(0, num("stagger", 0.72));
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const BURSTS = 2,
+          PER = 6,
+          FLIPS = BURSTS * PER;
+        let M = Math.min(IMAGES.length, 2 * FLIPS);
+        while ((2 * FLIPS) % M) M--;
+        const img = (i) => IMAGES[((i % M) + M) % M];
+
+        document.getElementById("loop-pages-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-pages-1-bg"));
+        const f = 1000 * (100 / PERSP) * (REF / 1080);
+        document.getElementById("loop-pages-1-stage").style.perspective = f + "px";
+        const spread = document.getElementById("loop-pages-1-spread");
+        spread.style.transform = `translate3d(${(OX / 100) * REF}px,${(OY / 100) * REF}px,0)`;
+
+        const bezier = (x1, y1, x2, y2) => (x) => {
+          if (x <= 0) return 0;
+          if (x >= 1) return 1;
+          let lo = 0,
+            hi = 1,
+            s = 0.5;
+          for (let i = 0; i < 24; i++) {
+            s = (lo + hi) / 2;
+            const bx = 3 * (1 - s) * (1 - s) * s * x1 + 3 * (1 - s) * s * s * x2 + s * s * s;
+            if (bx < x) lo = s;
+            else hi = s;
+          }
+          return 3 * (1 - s) * (1 - s) * s * y1 + 3 * (1 - s) * s * s * y2 + s * s * s;
+        };
+        const ease = bezier(0.65, 0, 0.35, 1);
+
+        // timing (seconds): burst b starts at b*DUR/BURSTS; flip j of the burst starts at + j*INT; lasts L
+        const DELAY = 0.3; // first lift at f9 (Pages01) / f13 (Pages02)
+        const L = Math.min(FLIPD / 2, DUR / BURSTS - STAG - DELAY),
+          BURST = DUR / BURSTS - STAG - DELAY;
+        const INT = PER > 1 ? Math.max(0, BURST - L) / (PER - 1) : 0; // Pages01: 17.9 frames (landings every 18)
+        const startOf = (k) => DELAY + (Math.floor(k / PER) * DUR) / BURSTS + (k % PER) * INT;
+
+        const a = aspect(IMAGES[0], FIT, CROP_AR),
+          PW = PAGE * a,
+          PH = PAGE;
+        function pageEl(m, wpx, side) {
+          // side: -1 left page (spine at its right edge), +1 right page
+          const el = document.createElement("div");
+          el.className = "pg";
+          el.style.cssText = `width:${wpx}px;height:${PH}px;left:${side < 0 ? -wpx : 0}px;top:${-PH / 2}px;`;
+          const im = document.createElement("img");
+          im.src = m.src;
+          im.width = Math.round(PW);
+          im.height = Math.round(PH);
+          im.style.cssText = `display:block;width:${PW}px;height:${PH}px;object-fit:cover;`;
+          el.appendChild(im);
+          const sh = document.createElement("div");
+          sh.className = "shade";
+          el.appendChild(sh);
+          return el;
+        }
+        // rest pages: one element per image per side, toggled by display
+        const rest = { L: [], R: [] };
+        for (let i = 0; i < M; i++) {
+          const l = pageEl(img(i), PW, -1);
+          l.lastChild.style.background =
+            "linear-gradient(90deg, rgba(0,0,0,0) 0%, rgba(0,0,0,.35) 100%)";
+          const r = pageEl(img(i), PW, +1);
+          r.lastChild.style.background =
+            "linear-gradient(90deg, rgba(0,0,0,.35) 0%, rgba(0,0,0,0) 100%)";
+          l.style.display = r.style.display = "none";
+          spread.appendChild(l);
+          spread.appendChild(r);
+          rest.L.push(l);
+          rest.R.push(r);
+        }
+        if (RADIUS) for (const el of [...rest.L, ...rest.R]) el.style.borderRadius = RADIUS + "px";
+        // flyers: flip k turns front image 2k over onto the left, showing back image 2k+1; SEG strips x 2 faces
+        const flyers = [];
+        for (let k = 0; k < FLIPS; k++) {
+          const g = document.createElement("div");
+          g.className = "flyer";
+          g.style.display = "none";
+          spread.appendChild(g);
+          const sw = PW / SEG,
+            strips = [];
+          for (let i = 0; i < SEG; i++) {
+            const fr = pageEl(img(2 * k), sw + 0.6, +1);
+            fr.firstChild.style.marginLeft = -i * sw + "px";
+            const bk = pageEl(img(2 * k + 1), sw + 0.6, +1);
+            bk.firstChild.style.marginLeft = -(SEG - 1 - i) * sw + "px";
+            bk.style.transformOrigin = "0 50%";
+            fr.style.transformOrigin = "0 50%";
+            g.appendChild(fr);
+            g.appendChild(bk);
+            strips.push({ fr, bk });
+          }
+          flyers.push({ g, strips, sw });
+        }
+        function renderAt(t) {
+          const now = t * DUR + (t * DUR < DELAY ? DUR : 0); // wrap: the tail of the last burst may still be landing
+          let lastLanded = -1,
+            firstPending = FLIPS;
+          for (let k = 0; k < FLIPS; k++) {
+            const p = (now - startOf(k)) / L;
+            if (p >= 1) lastLanded = k;
+            else if (p <= 0 && firstPending === FLIPS) firstPending = k;
+          }
+          for (let i = 0; i < M; i++) {
+            rest.L[i].style.display = "none";
+            rest.R[i].style.display = "none";
+          }
+          rest.L[(((2 * lastLanded + 1) % M) + M) % M].style.display = "block";
+          rest.R[(2 * firstPending) % M].style.display = "block";
+          for (let k = 0; k < FLIPS; k++) {
+            const F = flyers[k],
+              p = (now - startOf(k)) / L;
+            if (p <= 0 || p >= 1) {
+              F.g.style.display = "none";
+              continue;
+            }
+            F.g.style.display = "block";
+            const th = 180 * ease(p),
+              lead = CURVE * Math.sin((th * Math.PI) / 180); // free edge leads by up to CURVE deg
+            let x = 0,
+              z = 0;
+            for (let i = 0; i < SEG; i++) {
+              const ang = th + lead * (i / SEG),
+                r = (ang * Math.PI) / 180;
+              // strip i starts at (x,z) and heads along (cos ang, sin ang) in (x, z-toward-viewer)
+              const tf = `translate3d(${x}px,0,${z}px) rotateY(${-ang}deg)`;
+              F.strips[i].fr.style.transform = tf;
+              F.strips[i].bk.style.transform = tf + ` translateX(${F.sw}px) rotateY(180deg)`;
+              const shade = Math.max(
+                0,
+                Math.min(0.7, (1 - AMB) * LI * (1 - Math.abs(Math.cos(r)))),
+              );
+              F.strips[i].fr.lastChild.style.opacity = shade;
+              F.strips[i].bk.lastChild.style.opacity = shade;
+              x += F.sw * Math.cos(r);
+              z += F.sw * Math.sin(r);
+            }
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-pages-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-pages-1/registry-item.json
+++ b/registry/blocks/loop-pages-1/registry-item.json
@@ -1,0 +1,391 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-pages-1",
+  "type": "hyperframes:block",
+  "title": "Loop Pages 1",
+  "description": "An open two-page spread; pages turn about the spine to reveal each image. 8 image slots, 10s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "pages",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 10,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "crop",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "stagger",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Stagger",
+      "description": "Stagger (engine parameter; see the block header comment).",
+      "default": 0.72,
+      "min": 0,
+      "max": 2,
+      "step": 0.01
+    },
+    {
+      "id": "pageSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Page Size",
+      "description": "Page Size (engine parameter; see the block header comment).",
+      "default": 90,
+      "min": 0,
+      "max": 180,
+      "step": 1
+    },
+    {
+      "id": "curveAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Curve Amount",
+      "description": "Curve Amount (engine parameter; see the block header comment).",
+      "default": 15,
+      "min": 0,
+      "max": 30,
+      "step": 1
+    },
+    {
+      "id": "segments",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Segments",
+      "description": "Segments (engine parameter; see the block header comment).",
+      "default": 30,
+      "min": 0,
+      "max": 60,
+      "step": 1
+    },
+    {
+      "id": "lightIntensity",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Light Intensity",
+      "description": "Light Intensity (engine parameter; see the block header comment).",
+      "default": 100,
+      "min": 0,
+      "max": 200,
+      "step": 1
+    },
+    {
+      "id": "lightAmbient",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Light Ambient",
+      "description": "Light Ambient (engine parameter; see the block header comment).",
+      "default": 51,
+      "min": 0,
+      "max": 102,
+      "step": 1
+    },
+    {
+      "id": "perspective",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Perspective",
+      "description": "Camera focal length: smaller = stronger perspective.",
+      "default": 70,
+      "min": 0,
+      "max": 140,
+      "step": 1
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "flipDuration",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Flip Duration",
+      "description": "Flip Duration (engine parameter; see the block header comment).",
+      "default": 2,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-pages-1.html",
+      "target": "compositions/loop-pages-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-parallax-1/loop-parallax-1.html
+++ b/registry/blocks/loop-parallax-1/loop-parallax-1.html
@@ -1,0 +1,309 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"fade","type":"number","role":"style","label":"Animation · Fade","description":"Fade (engine parameter; see the block header comment).","default":0,"min":0,"max":100,"step":1},{"id":"count","type":"number","role":"style","label":"Template options · Count","description":"Count (engine parameter; see the block header comment).","default":133,"min":0,"max":400,"step":10},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":340,"min":0,"max":680,"step":10},{"id":"spread","type":"number","role":"style","label":"Template options · Spread","description":"Spread (engine parameter; see the block header comment).","default":300,"min":0,"max":600,"step":10},{"id":"travel","type":"number","role":"style","label":"Template options · Travel","description":"Travel (engine parameter; see the block header comment).","default":300,"min":0,"max":600,"step":10},{"id":"depth","type":"number","role":"style","label":"Template options · Depth","description":"Depth (engine parameter; see the block header comment).","default":60,"min":0,"max":200,"step":1},{"id":"seed","type":"number","role":"style","label":"Template options · Seed","description":"Seed (engine parameter; see the block header comment).","default":10,"min":0,"max":20,"step":0.1},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-parallax-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-parallax-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-parallax-1-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .card {
+        transform-origin: 0 0;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-parallax-1-root"
+      data-composition-id="loop-parallax-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="14"
+    >
+      <div
+        id="loop-parallax-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="14"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-parallax-1-bg"></div>
+        <div id="loop-parallax-1-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Parallax loop family — `count` cards scattered in a 3D slab, seen by a camera that
+        // wanders through 6 eased hops per loop (closed path), so near cards zip past and far ones creep.
+        // Measured on the 512 previews (2026-09-08):
+        //   hops: motion energy pulses every DUR/6 (P01 frames 35,105,...; P02/P03 39,119,199,280,359,440), sharp peaks with
+        //         a ~0.035 baseline -> per-hop ease E(u) = 0.2u + 0.8*expoInOut(u) (same as Marquee/Spin). Hop directions
+        //         differ per hop and per variant (P03: left, up, up-right, down, up-right, down) -> random waypoints (seeded).
+        //   parallax: at a hop peak P03 cards of size 133/119/98 move 64/55/54 px per 4 frames -> speed ~ size -> perspective.
+        //   sizes: planeSize ~ size (P03/P01 medians 110/155 = 240/340); fully-visible size percentiles 10/50/90 = 112/156/192 (P01),
+        //          81/124/206 (P02), 80/111/133 (P03) are UNIFORM in size -> screen scale s uniform in [1/zmax, 1] with
+        //          S0 = 0.0012*planeSize*H and zmax = 1 + depth/48 (2.25 @60, 3.1 @100). Round 1 (uniform in depth, /40) gave 89/128/208.
+        //   density: card coverage of the frame 0.393/0.456/0.454 (P01/P02/P03) -> field half-extent at the near plane =
+        //            spread*0.0125*H (per-variant fits 0.0112 for P01, ~0.0135 for P02/P03 once their fade hides the far ~15%; one seeded draw each, +-10% is noise).
+        //   hop length: mean peak speed 31 px/frame (P03, travel 100) / 45 (P02, 150) -> near-plane hop ~ travel*0.007*H (rough:
+        //         random hop lengths, P01 peaks saturated the tracker).
+        //   fade (P02 78, P03 80): luma vs size shows opacity ~1 near z'=1.3, ~0.45 at the near plane, ~0.2 at z'=2.0, 0 far.
+        // Knobs: everything statistical above; delay (unused), 6 hops hard-coded.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 14, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, expoInOut, frac } = RF;
+        const DUR = num("loopDuration", 14);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const COUNT = Math.max(1, num("count", 133) | 0);
+        const S0 = num("planeSize", 340) * 0.0012 * REF; // card size at the near plane (90th pct 192/206/133 -> S0 203/221/141)
+        const HALF = num("spread", 300) * 0.0125 * REF; // field half-extent at the near plane (coverage fit, see header)
+        const HOP = num("travel", 300) * 0.007 * REF; // typical hop length at the near plane
+        const ZMAX = 1 + num("depth", 60) / 68; // sizes uniform in [S0/ZMAX, S0]; 10th pct = 0.55*S0 @60, 0.37*S0 @100
+        const FADE = num("fade", 0) / 100;
+        const SEED = num("seed", 10) | 0;
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const HOPS = 6;
+
+        document.getElementById("loop-parallax-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-parallax-1-bg"));
+        const stage = document.getElementById("loop-parallax-1-stage");
+        let seed = (SEED * 2654435761) >>> 0;
+        const rnd = () => (seed = (seed * 1664525 + 1013904223) >>> 0) / 4294967296;
+
+        // camera waypoints: HOPS random points in a disc of radius HOP (near-plane px); path closes on itself
+        const WP = [];
+        for (let i = 0; i < HOPS; i++) {
+          const a = rnd() * 2 * Math.PI,
+            r = HOP * (0.5 + 0.5 * rnd());
+          WP.push({ x: r * Math.cos(a), y: r * Math.sin(a) });
+        }
+        const E = (x) => 0.2 * x + 0.8 * expoInOut(x);
+        function camera(t) {
+          const p = frac(t) * HOPS,
+            k = Math.floor(p),
+            e = E(p - k),
+            a = WP[k],
+            b = WP[(k + 1) % HOPS];
+          return { x: a.x + (b.x - a.x) * e, y: a.y + (b.y - a.y) * e };
+        }
+        // cards: uniform in the slab; keep the field a torus in x/y so the wandering camera never runs out of cards
+        const cards = [];
+        for (let i = 0; i < COUNT; i++) {
+          const m = IMAGES[i % N],
+            a = aspect(m, FIT, CROP_AR);
+          const h = S0,
+            w = S0 * a;
+          const el = card(m, w, h, RADIUS);
+          stage.appendChild(el);
+          cards.push({
+            el,
+            w,
+            h,
+            x: (rnd() * 2 - 1) * HALF,
+            y: (rnd() * 2 - 1) * HALF,
+            z: 1 / (1 / ZMAX + rnd() * (1 - 1 / ZMAX)),
+          }); // uniform in screen scale, not in depth (measured size percentiles)
+        }
+        cards.sort((p, q) => q.z - p.z); // far first -> near on top
+        cards.forEach((c, i) => (c.el.style.zIndex = i + 1));
+        const zp = 1 + 0.2 * (ZMAX - 1);
+        function opacity(z) {
+          const far = Math.min(1, (ZMAX - z) / (ZMAX - zp)),
+            near = Math.min(1, 0.3 + (0.7 * (z - 1)) / (zp - 1));
+          return 1 - FADE * (1 - Math.min(far, near));
+        }
+        const wrap = (v) => ((((v + HALF) % (2 * HALF)) + 2 * HALF) % (2 * HALF)) - HALF;
+        function renderAt(t) {
+          const cam = camera(t);
+          for (const c of cards) {
+            const s = 1 / c.z;
+            const sx = wrap(c.x - cam.x) * s,
+              sy = wrap(c.y - cam.y) * s; // screen offset from centre
+            const vis = Math.abs(sx) < W / 2 + c.w * s && Math.abs(sy) < H / 2 + c.h * s;
+            c.el.style.display = vis ? "block" : "none";
+            if (!vis) continue;
+            c.el.style.transform = `translate3d(${sx - (c.w * s) / 2}px,${sy - (c.h * s) / 2}px,0) scale(${s})`;
+            c.el.style.opacity = opacity(c.z);
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-parallax-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-parallax-1/registry-item.json
+++ b/registry/blocks/loop-parallax-1/registry-item.json
@@ -1,0 +1,356 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-parallax-1",
+  "type": "hyperframes:block",
+  "title": "Loop Parallax 1",
+  "description": "Image cards scattered in a 3D slab drift with parallax under a moving camera. 8 image slots, 14s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "parallax",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 14,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "fade",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Fade",
+      "description": "Fade (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "id": "count",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Count",
+      "description": "Count (engine parameter; see the block header comment).",
+      "default": 133,
+      "min": 0,
+      "max": 400,
+      "step": 10
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 340,
+      "min": 0,
+      "max": 680,
+      "step": 10
+    },
+    {
+      "id": "spread",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Spread",
+      "description": "Spread (engine parameter; see the block header comment).",
+      "default": 300,
+      "min": 0,
+      "max": 600,
+      "step": 10
+    },
+    {
+      "id": "travel",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Travel",
+      "description": "Travel (engine parameter; see the block header comment).",
+      "default": 300,
+      "min": 0,
+      "max": 600,
+      "step": 10
+    },
+    {
+      "id": "depth",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Depth",
+      "description": "Depth (engine parameter; see the block header comment).",
+      "default": 60,
+      "min": 0,
+      "max": 200,
+      "step": 1
+    },
+    {
+      "id": "seed",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Seed",
+      "description": "Seed (engine parameter; see the block header comment).",
+      "default": 10,
+      "min": 0,
+      "max": 20,
+      "step": 0.1
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-parallax-1.html",
+      "target": "compositions/loop-parallax-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-proximity-1/loop-proximity-1.html
+++ b/registry/blocks/loop-proximity-1/loop-proximity-1.html
@@ -1,0 +1,301 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"imageFit","type":"enum","role":"style","label":"Template options · Image Fit","description":"Image Fit (engine parameter; see the block header comment).","default":"fit","options":[{"value":"fit","label":"Fit"},{"value":"fill","label":"Fill"}]},{"id":"count","type":"number","role":"style","label":"Template options · Count","description":"Count (engine parameter; see the block header comment).","default":500,"min":0,"max":1000,"step":10},{"id":"tilt","type":"number","role":"style","label":"Template options · Tilt","description":"Tilt (engine parameter; see the block header comment).","default":0,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"sizeMix","type":"number","role":"style","label":"Template options · Size Mix","description":"Size Mix (engine parameter; see the block header comment).","default":0,"min":0,"max":200,"step":1},{"id":"minScale","type":"number","role":"style","label":"Template options · Min Scale","description":"Min Scale (engine parameter; see the block header comment).","default":5,"min":0,"max":86,"step":1},{"id":"maxScale","type":"number","role":"style","label":"Template options · Max Scale","description":"Max Scale (engine parameter; see the block header comment).","default":60,"min":0,"max":198,"step":1},{"id":"maxDist","type":"number","role":"style","label":"Template options · Max Dist","description":"Max Dist (engine parameter; see the block header comment).","default":35,"min":0,"max":86,"step":1},{"id":"atmosphere","type":"number","role":"style","label":"Template options · Atmosphere","description":"Atmosphere (engine parameter; see the block header comment).","default":0,"min":0,"max":100,"step":1},{"id":"panRange","type":"number","role":"style","label":"Template options · Pan Range","description":"Pan Range (engine parameter; see the block header comment).","default":100,"min":0,"max":360,"step":10},{"id":"buildInOut","type":"enum","role":"style","label":"Template options · Build In Out","description":"Build In Out (engine parameter; see the block header comment).","default":"on","options":[{"value":"off","label":"Off"},{"value":"on","label":"On"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-proximity-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-proximity-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-proximity-1-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .card {
+        transform-origin: 50% 50%;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-proximity-1-root"
+      data-composition-id="loop-proximity-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="14"
+    >
+      <div
+        id="loop-proximity-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="14"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-proximity-1-bg"></div>
+        <div id="loop-proximity-1-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Proximity loop family — hundreds of tiles swelling as the camera passes: a flat field
+        // of `count` square tiles; a lens fixed at the frame centre swells the tiles within `maxDist` of it while the field
+        // pans underneath on a closed path. Measured on the 512 previews (2026-09-08):
+        //   base tile = 2.2px·minScale @512 (01/02: minScale 5 -> 11px median over 1600+ isolated tiles; 03: 8 -> 16px);
+        //   swollen centre = 2.2px·maxScale (02: largest isolated tile 49px at r=130, blob merges inside; 60 -> 132px);
+        //   swell profile (02, 8000 tiles binned by distance r to the blob centroid): w = 49/42/33/25/15/11 at
+        //   r = 130/150/170/190/210/230 -> zero at r ≈ 220px = maxDist 43% of H; shape ≈ base + (max−base)·(1−r/R) (linear; ^1.2 under-swelled the rim: 90th pct 22 vs 27);
+        //   pan (small-tile drift integrated): 03 a circle of radius 155px for panRange 145; 02 a horizontal sweep of
+        //   amplitude 130px for panRange 165; speed ~2px/frame; period = the loop -> circle, radius 0.9·panRange·REF/512;
+        //   density: ~66 isolated 11px tiles per frame + ~100 merged in the blob for count 500 => field = frame + 1.3·pan margin
+        //   (02); 03/04 show far fewer tiles per frame (37 / 7 comps) => field side ≈ 1300 / 1900px, fitted as ×(1 + 1.1·sizeMix) (guess);
+        //   sizeMix 100 (04): isolated sizes 47..127px for minScale 43 (95px) -> factor 0.5..1.35; mix 50 (03): 0.68..1.3;
+        //   buildInOut on (01): frame 0 and the last frames are (nearly) empty -> global scale ramp in/out (~6% of the loop);
+        //   minScale 0 (05/06): tiles invisible except inside the lens (5 comps/frame) ✓.
+        // Guesses: pan path shape (02 is a line, 03 a circle, no setting differs -> circle everywhere); `atmosphere` dims
+        // un-swollen tiles by atmosphere% (03); `tilt` = random rotation ±tilt° per tile (04 squares look tilted); blur ignored.
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 14, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 14);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const IMGFIT = str("imageFit", "fit");
+        const COUNT = Math.max(1, num("count", 500) | 0);
+        const TILT = num("tilt", 0);
+        const MIX = num("sizeMix", 0) / 100;
+        const MINS = num("minScale", 5),
+          MAXS = num("maxScale", 60);
+        const R = (num("maxDist", 35) / 100) * REF;
+        const ATM = num("atmosphere", 0) / 100;
+        const A = (0.9 * num("panRange", 100) * REF) / 512;
+        const BUILD = on("buildInOut", false);
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+
+        document.getElementById("loop-proximity-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-proximity-1-bg"));
+        const stage = document.getElementById("loop-proximity-1-stage");
+        const PX = (2.1 * REF) / 512; // px per scale unit (ref median 11px for minScale 5)
+        const FS = 1 + 1.1 * MIX; // field grows with sizeMix (ref visible density => field side ≈ 915 / 1300 / 1900px for 02 / 03 / 04)
+        const HX = (W / 2 + 1.3 * A) * FS,
+          HY = (H / 2 + 1.3 * A) * FS; // field half-extent: frame + pan margin, × FS
+        let seed = 500;
+        const rnd = () => (seed = (seed * 1664525 + 1013904223) >>> 0) / 4294967296;
+        const tiles = [];
+        for (let i = 0; i < COUNT; i++) {
+          const m = IMAGES[i % N],
+            a = aspect(m, FIT, CROP_AR);
+          const el = card(m, 100, 100, RADIUS); // unit tile 100px, scaled per frame
+          if (IMGFIT === "fit") {
+            const img = el.firstChild;
+            img.style.objectFit = "contain";
+          }
+          el.style.left = "-50px";
+          el.style.top = "-50px";
+          stage.appendChild(el);
+          tiles.push({
+            el,
+            x: (rnd() * 2 - 1) * HX,
+            y: (rnd() * 2 - 1) * HY,
+            mix: 1 - 0.5 * MIX + 0.85 * MIX * rnd(),
+            rot: (rnd() * 2 - 1) * TILT,
+          });
+        }
+        const smooth = (x) => {
+          x = Math.min(1, Math.max(0, x));
+          return x * x * (3 - 2 * x);
+        };
+        function renderAt(t) {
+          const px = A * Math.cos(2 * Math.PI * t) - A,
+            py = A * Math.sin(2 * Math.PI * t); // field offset (starts at 0,0)
+          const build = BUILD ? smooth(t / 0.07) * smooth((1 - t) / 0.07) : 1;
+          for (const k of tiles) {
+            const x = k.x + px,
+              y = k.y + py;
+            const r = Math.hypot(x, y);
+            const g = r < R ? 1 - r / R : 0;
+            const size = PX * (MINS + (MAXS - MINS) * g) * k.mix * build;
+            if (size < 0.5 || Math.abs(x) > W / 2 + size || Math.abs(y) > H / 2 + size) {
+              k.el.style.display = "none";
+              continue;
+            }
+            k.el.style.display = "";
+            k.el.style.transform = `translate3d(${x}px,${y}px,0) rotate(${k.rot}deg) scale(${size / 100})`;
+            k.el.style.zIndex = Math.round(size);
+            k.el.style.opacity = ATM > 0 ? (1 - ATM * (1 - g)).toFixed(3) : "1";
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-proximity-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-proximity-1/registry-item.json
+++ b/registry/blocks/loop-proximity-1/registry-item.json
@@ -1,0 +1,403 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-proximity-1",
+  "type": "hyperframes:block",
+  "title": "Loop Proximity 1",
+  "description": "A field of image tiles swells as the camera passes over them. 8 image slots, 14s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "proximity"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 14,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "imageFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Image Fit",
+      "description": "Image Fit (engine parameter; see the block header comment).",
+      "default": "fit",
+      "options": [
+        {
+          "value": "fit",
+          "label": "Fit"
+        },
+        {
+          "value": "fill",
+          "label": "Fill"
+        }
+      ]
+    },
+    {
+      "id": "count",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Count",
+      "description": "Count (engine parameter; see the block header comment).",
+      "default": 500,
+      "min": 0,
+      "max": 1000,
+      "step": 10
+    },
+    {
+      "id": "tilt",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Tilt",
+      "description": "Tilt (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "sizeMix",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Size Mix",
+      "description": "Size Mix (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1
+    },
+    {
+      "id": "minScale",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Min Scale",
+      "description": "Min Scale (engine parameter; see the block header comment).",
+      "default": 5,
+      "min": 0,
+      "max": 86,
+      "step": 1
+    },
+    {
+      "id": "maxScale",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Max Scale",
+      "description": "Max Scale (engine parameter; see the block header comment).",
+      "default": 60,
+      "min": 0,
+      "max": 198,
+      "step": 1
+    },
+    {
+      "id": "maxDist",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Max Dist",
+      "description": "Max Dist (engine parameter; see the block header comment).",
+      "default": 35,
+      "min": 0,
+      "max": 86,
+      "step": 1
+    },
+    {
+      "id": "atmosphere",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Atmosphere",
+      "description": "Atmosphere (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "id": "panRange",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Pan Range",
+      "description": "Pan Range (engine parameter; see the block header comment).",
+      "default": 100,
+      "min": 0,
+      "max": 360,
+      "step": 10
+    },
+    {
+      "id": "buildInOut",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Build In Out",
+      "description": "Build In Out (engine parameter; see the block header comment).",
+      "default": "on",
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-proximity-1.html",
+      "target": "compositions/loop-proximity-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-ring/loop-ring.html
+++ b/registry/blocks/loop-ring/loop-ring.html
@@ -1,0 +1,262 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"scaleIntensity","type":"number","role":"style","label":"Appearance · Media scale","description":"Strength of the size change.","default":0.2,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":24,"min":0,"max":200,"step":1,"unit":"px"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"anticlockwise","options":[{"value":"anticlockwise","label":"Anticlockwise"},{"value":"clockwise","label":"Clockwise"}]},{"id":"radiusX","type":"number","role":"style","label":"Template options · Radius X","description":"Radius X (engine parameter; see the block header comment).","default":32,"min":0,"max":64,"step":1},{"id":"radiusY","type":"number","role":"style","label":"Template options · Radius Y","description":"Radius Y (engine parameter; see the block header comment).","default":32,"min":0,"max":64,"step":1},{"id":"repeat","type":"number","role":"style","label":"Template options · Repeat","description":"Repeat (engine parameter; see the block header comment).","default":1,"min":0,"max":10,"step":0.1},{"id":"tangent","type":"enum","role":"style","label":"Template options · Tangent","description":"Tangent (engine parameter; see the block header comment).","default":"true","options":[{"value":"true","label":"On"},{"value":"false","label":"Off"}]},{"id":"stack","type":"enum","role":"style","label":"Template options · Stack","description":"Stack (engine parameter; see the block header comment).","default":"lastOnTop","options":[{"value":"lastOnTop","label":"Last On Top"},{"value":"firstOnTop","label":"First On Top"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-ring</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-ring-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-ring-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-ring-root"
+      data-composition-id="loop-ring"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="16"
+    >
+      <div
+        id="loop-ring-loop"
+        class="clip"
+        data-start="0"
+        data-duration="16"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-ring-bg"></div>
+        <div id="loop-ring-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Ring loop family — N cards evenly spaced on an ellipse, each rotated to follow the
+        // curve (tangent), the whole ring spinning continuously.
+        // Measured on the 512 preview (2026-09-08, 8 cards): ring radius 163.8px = radiusX% * H (32% -> 163.8);
+        // card 102.5px square = scaleIntensity * H (0.2 -> 102.4; total card area 83086px^2 / 8 with r=11 corners);
+        // spin linear 4.5deg per 6 frames = 360deg per 16 s = `repeat` revolutions per loop, anticlockwise on screen;
+        // cards axis-aligned at 0/90/180/270deg and turned 45deg at 45deg (tangent=true); card sizes constant over the loop.
+        // Guesses: tangent card rotation = ring angle + 90 (top of the image faces outward; indistinguishable on the
+        // square placeholders); natural fit fixes card HEIGHT = scaleIntensity*H; stack = z-order only.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 16, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 16);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const SIZE = num("scaleIntensity", 0.2) * REF;
+        const RX = (num("radiusX", 32) / 100) * REF;
+        const RY = (num("radiusY", 32) / 100) * REF;
+        const REPEAT = Math.max(1, Math.round(num("repeat", 1)));
+        const TANGENT = /^(true|on|1)$/i.test(str("tangent", "true")); // spec boolean arrives as "true"/"false"
+        const DIR = str("direction", "anticlockwise") === "clockwise" ? 1 : -1; // CSS angles are clockwise-positive
+        const LAST_TOP = str("stack", "lastOnTop") === "lastOnTop";
+        const RADIUS = (num("borderRadius", 24) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+
+        document.getElementById("loop-ring-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-ring-bg"));
+        const stage = document.getElementById("loop-ring-stage");
+        const cards = [];
+        for (let i = 0; i < N; i++) {
+          const m = IMAGES[i],
+            a = aspect(m, FIT, CROP_AR);
+          const h = SIZE,
+            w = SIZE * a;
+          const c = card(m, w, h, RADIUS);
+          c.style.left = -w / 2 + "px";
+          c.style.top = -h / 2 + "px";
+          c.style.zIndex = LAST_TOP ? i + 1 : N - i;
+          stage.appendChild(c);
+          cards.push({ el: c, theta: (i * 360) / N });
+        }
+        function renderAt(t) {
+          const spin = DIR * REPEAT * 360 * frac(t);
+          for (const c of cards) {
+            const phi = c.theta + spin,
+              r = (phi * Math.PI) / 180;
+            const x = RX * Math.cos(r),
+              y = RY * Math.sin(r);
+            c.el.style.transform =
+              `translate(${x}px,${y}px)` + (TANGENT ? ` rotate(${phi + 90}deg)` : "");
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-ring"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-ring/registry-item.json
+++ b/registry/blocks/loop-ring/registry-item.json
@@ -1,0 +1,376 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-ring",
+  "type": "hyperframes:block",
+  "title": "Loop Ring",
+  "description": "Image cards evenly spaced on an ellipse, each rotated to follow the track, orbiting. 8 image slots, 16s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "ring"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 16,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "scaleIntensity",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Media scale",
+      "description": "Strength of the size change.",
+      "default": 0.2,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 24,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "anticlockwise",
+      "options": [
+        {
+          "value": "anticlockwise",
+          "label": "Anticlockwise"
+        },
+        {
+          "value": "clockwise",
+          "label": "Clockwise"
+        }
+      ]
+    },
+    {
+      "id": "radiusX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Radius X",
+      "description": "Radius X (engine parameter; see the block header comment).",
+      "default": 32,
+      "min": 0,
+      "max": 64,
+      "step": 1
+    },
+    {
+      "id": "radiusY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Radius Y",
+      "description": "Radius Y (engine parameter; see the block header comment).",
+      "default": 32,
+      "min": 0,
+      "max": 64,
+      "step": 1
+    },
+    {
+      "id": "repeat",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Repeat",
+      "description": "Repeat (engine parameter; see the block header comment).",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "tangent",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Tangent",
+      "description": "Tangent (engine parameter; see the block header comment).",
+      "default": "true",
+      "options": [
+        {
+          "value": "true",
+          "label": "On"
+        },
+        {
+          "value": "false",
+          "label": "Off"
+        }
+      ]
+    },
+    {
+      "id": "stack",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Stack",
+      "description": "Stack (engine parameter; see the block header comment).",
+      "default": "lastOnTop",
+      "options": [
+        {
+          "value": "lastOnTop",
+          "label": "Last On Top"
+        },
+        {
+          "value": "firstOnTop",
+          "label": "First On Top"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-ring.html",
+      "target": "compositions/loop-ring.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-scale-1/loop-scale-1.html
+++ b/registry/blocks/loop-scale-1/loop-scale-1.html
@@ -1,0 +1,317 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"stagger","type":"number","role":"style","label":"Animation · Stagger","description":"Stagger (engine parameter; see the block header comment).","default":0.4,"min":0,"max":2,"step":0.01},{"id":"spin","type":"number","role":"style","label":"Template options · Spin","description":"Spin (engine parameter; see the block header comment).","default":0,"min":-90,"max":90,"step":1},{"id":"imageFit","type":"enum","role":"style","label":"Template options · Image Fit","description":"Image Fit (engine parameter; see the block header comment).","default":"fit","options":[{"value":"fit","label":"Fit"},{"value":"fill","label":"Fill"}]},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":100,"min":0,"max":200,"step":1},{"id":"scaleStyle","type":"enum","role":"style","label":"Template options · Scale Style","description":"Scale Style (engine parameter; see the block header comment).","default":"bloom","options":[{"value":"bloom","label":"Bloom"},{"value":"recede","label":"Recede"}]},{"id":"growFrom","type":"enum","role":"style","label":"Template options · Grow From","description":"Grow From (engine parameter; see the block header comment).","default":"center","options":[{"value":"center","label":"Center"},{"value":"top","label":"Top"},{"value":"bottom","label":"Bottom"},{"value":"left","label":"Left"},{"value":"right","label":"Right"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-scale-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-scale-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-scale-1-stage {
+        position: absolute;
+        inset: 0;
+      }
+      .layer {
+        display: none;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-scale-1-root"
+      data-composition-id="loop-scale-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="4"
+    >
+      <div
+        id="loop-scale-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="4"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-scale-1-bg"></div>
+        <div id="loop-scale-1-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Scale loop family — "Images swell up out of nothing": a new image is
+        // born every DUR/N at scale 0 and grows to full plane size over a life T, newest on top, so the
+        // frame shows ~4-6 nested planes (a zoom tunnel). Measured on the 512 previews (2026-09-08):
+        //   spawn period = DUR/N exactly (Scale01 15f, Scale04 18.75f); `stagger` is NOT the period.
+        //   growth E(u) = 0.35*u + 0.65*expoInOut(k=10)(u), u = age/T  (fit rms 0.55% of H on Scale04
+        //     117 edge samples, 3.2% on Scale01; ~1px/frame linear tails, ~15px/frame peak).
+        //   T = 1.2 * stagger * DUR (Scale01: 58.5f = 0.4875 DUR @ stagger 0.4; Scale04: 106.5f = 0.71 DUR
+        //     @ stagger 0.6). Only N=8 available, so an N-dependence (e.g. stagger*(N+1.5)*period) cannot be excluded.
+        //   recede = bloom played backwards (Scale02 frame f == Scale01 frame 15-f, all edges).
+        //   spin: rotation = spin * (1 - E(u)) deg (Scale03 outer plane -2.3/-1.7/-1.1/-0.7/-0.4 deg vs predicted
+        //     2.3/1.6/1.1/0.7/0.3; the alternative spin*(1-u) predicts 6.3/4.5/3.1/1.9/0.9).
+        //   growFrom bottom: planes anchored at the frame's bottom edge, grow upward (Scale04 column profile).
+        // Guesses/knobs: planeSize = % of H for the plane box (100 = frame-high; previews square);
+        //   imageFit fit = contain the image in the plane box keeping aspect, fill = cover it (uniform placeholders
+        //   cannot show the difference); recede keeps the forward image order.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 4, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 4);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const SPIN = num("spin", 0);
+        const IMGFIT = str("imageFit", "fit");
+        const PLANE = num("planeSize", 100) / 100;
+        const STAGGER = num("stagger", 0.4);
+        const RECEDE = str("scaleStyle", "bloom") === "recede";
+        const FROM = str("growFrom", "center");
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const T = Math.min(0.999, 1.2 * STAGGER); // life as a fraction of the loop
+
+        document.getElementById("loop-scale-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-scale-1-bg"));
+        const stage = document.getElementById("loop-scale-1-stage");
+
+        // plane box: frame-shaped, scaled by planeSize; image contained (fit) or covering (fill) it
+        const BW = W * PLANE,
+          BH = H * PLANE;
+        const ORIGIN =
+          {
+            center: "50% 50%",
+            top: "50% 0%",
+            bottom: "50% 100%",
+            left: "0% 50%",
+            right: "100% 50%",
+          }[FROM] || "50% 50%";
+        const layers = IMAGES.map((m) => {
+          const a = aspect(m, FIT, CROP_AR);
+          let w, h;
+          if (IMGFIT === "fill") {
+            if (BW / BH > a) {
+              w = BW;
+              h = BW / a;
+            } else {
+              h = BH;
+              w = BH * a;
+            }
+          } else {
+            if (BW / BH > a) {
+              h = BH;
+              w = BH * a;
+            } else {
+              w = BW;
+              h = BW / a;
+            }
+          }
+          // wrapper = plane box, anchored to the frame edge named by growFrom; the image sits centred in it
+          const box = document.createElement("div");
+          box.className = "layer";
+          const left = FROM === "left" ? 0 : FROM === "right" ? W - BW : (W - BW) / 2;
+          const top = FROM === "top" ? 0 : FROM === "bottom" ? H - BH : (H - BH) / 2;
+          box.style.cssText = `position:absolute;left:${left}px;top:${top}px;width:${BW}px;height:${BH}px;overflow:hidden;transform-origin:${ORIGIN};border-radius:${RADIUS}px;`;
+          const c = card(m, w, h, 0);
+          c.style.left = (BW - w) / 2 + "px";
+          c.style.top = (BH - h) / 2 + "px";
+          box.appendChild(c);
+          stage.appendChild(box);
+          return box;
+        });
+
+        const expoK = (x, k) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, k * (2 * x - 1)) / 2
+                : 1 - Math.pow(2, -k * (2 * x - 1)) / 2;
+        const E = (u) => (u <= 0 ? 0 : u >= 1 ? 1 : 0.35 * u + 0.65 * expoK(u, 10));
+
+        function renderAt(t) {
+          const tau = RECEDE ? 1 - t : t; // recede = bloom in reverse
+          for (let i = 0; i < N; i++) {
+            const slot = RECEDE ? N - 1 - i : i; // keep the image order forward on screen
+            const age = frac(tau - (slot + 0.5) / N); // in loops; births sit half a period after the slot boundary (Scale01 phase 6.5f/15, Scale04 9.5f/18.75)
+            const el = layers[i];
+            if (age >= T) {
+              el.style.display = "none";
+              continue;
+            }
+            const s = E(age / T);
+            el.style.display = "block";
+            el.style.zIndex = String(1000 - Math.round(age * 999)); // younger on top
+            el.style.transform = `rotate(${SPIN * (1 - s)}deg) scale(${s})`;
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-scale-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-scale-1/registry-item.json
+++ b/registry/blocks/loop-scale-1/registry-item.json
@@ -1,0 +1,377 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-scale-1",
+  "type": "hyperframes:block",
+  "title": "Loop Scale 1",
+  "description": "A new image swells up out of nothing at the centre each beat, over the previous ones. 8 image slots, 4s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "scale"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 4,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "stagger",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Stagger",
+      "description": "Stagger (engine parameter; see the block header comment).",
+      "default": 0.4,
+      "min": 0,
+      "max": 2,
+      "step": 0.01
+    },
+    {
+      "id": "spin",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Spin",
+      "description": "Spin (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": -90,
+      "max": 90,
+      "step": 1
+    },
+    {
+      "id": "imageFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Image Fit",
+      "description": "Image Fit (engine parameter; see the block header comment).",
+      "default": "fit",
+      "options": [
+        {
+          "value": "fit",
+          "label": "Fit"
+        },
+        {
+          "value": "fill",
+          "label": "Fill"
+        }
+      ]
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 100,
+      "min": 0,
+      "max": 200,
+      "step": 1
+    },
+    {
+      "id": "scaleStyle",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Scale Style",
+      "description": "Scale Style (engine parameter; see the block header comment).",
+      "default": "bloom",
+      "options": [
+        {
+          "value": "bloom",
+          "label": "Bloom"
+        },
+        {
+          "value": "recede",
+          "label": "Recede"
+        }
+      ]
+    },
+    {
+      "id": "growFrom",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Grow From",
+      "description": "Grow From (engine parameter; see the block header comment).",
+      "default": "center",
+      "options": [
+        {
+          "value": "center",
+          "label": "Center"
+        },
+        {
+          "value": "top",
+          "label": "Top"
+        },
+        {
+          "value": "bottom",
+          "label": "Bottom"
+        },
+        {
+          "value": "left",
+          "label": "Left"
+        },
+        {
+          "value": "right",
+          "label": "Right"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-scale-1.html",
+      "target": "compositions/loop-scale-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-shelf/loop-shelf.html
+++ b/registry/blocks/loop-shelf/loop-shelf.html
@@ -1,0 +1,327 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"scaleIntensity","type":"number","role":"style","label":"Appearance · Media scale","description":"Strength of the size change.","default":0.645,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":18,"min":0,"max":200,"step":1,"unit":"px"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"rightToLeft","options":[{"value":"rightToLeft","label":"Right To Left"},{"value":"leftToRight","label":"Left To Right"}]},{"id":"easing","type":"enum","role":"style","label":"Animation · Easing","description":"Easing family for stepped motion.","default":"smooth","options":[{"value":"smooth","label":"Smooth"},{"value":"snappy","label":"Snappy"},{"value":"elastic","label":"Elastic"},{"value":"linear","label":"Linear"}]},{"id":"spacing","type":"number","role":"style","label":"Template options · Spacing","description":"Spacing (engine parameter; see the block header comment).","default":8,"min":0,"max":16,"step":0.1},{"id":"sideTilt","type":"number","role":"style","label":"Template options · Side Tilt","description":"Side Tilt (engine parameter; see the block header comment).","default":8,"min":0,"max":16,"step":0.1},{"id":"dim","type":"number","role":"style","label":"Template options · Dim","description":"Dim (engine parameter; see the block header comment).","default":40,"min":0,"max":80,"step":1},{"id":"visible","type":"number","role":"style","label":"Template options · Visible","description":"Visible (engine parameter; see the block header comment).","default":2,"min":0,"max":10,"step":0.1},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-shelf</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-shelf-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-shelf-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      #loop-shelf-row {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      .card img {
+        display: block;
+      }
+      .dim {
+        position: absolute;
+        inset: 0;
+        background: #000;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-shelf-root"
+      data-composition-id="loop-shelf"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="14"
+    >
+      <div
+        id="loop-shelf-loop"
+        class="clip"
+        data-start="0"
+        data-duration="14"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-shelf-bg"></div>
+        <div id="loop-shelf-stage"><div id="loop-shelf-row"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Shelf loop family — the focused card stands upright, neighbours fall back (translateZ) behind it,
+        // tilt outward in 2D (rotateZ, outer edge DOWN) and dim; the focused card sits on top (closer in z).
+        // Measured @512 (2026-09-08): focused card 330px = 0.645 H (= scaleIntensity·H, no padding); neighbours: column
+        // height constant 244 with the top edge sloping 11px over 80px -> pure rotateZ 8deg (= sideTilt), no rotateY
+        // foreshortening; size 241.6 = 0.732 S. Scale follows a perspective law k(d) = 1/(1 + 0.366·d): outgoing and
+        // incoming card scales at the same frame sum to d_in + d_out ~ 0.96-0.98 under it (linear lerp gives 1.08).
+        // Screen x = d·P·k(d) with world pitch P ~ 0.75·S (248px, from 5 mid-transition frames; noisy ±10%); the
+        // neighbour is 80% hidden behind the focused card (visible 0-91px at rest, matches). Dim: luma ×0.6 = 1-dim%.
+        // Timing: step = DUR/N; motion detected on frames 3-18 of a 52.5-frame step -> transition = 0.35·step
+        // (0.6s); `smooth` = easeInOutCubic (fitted on FocusSlider/Slats). Knobs: `tilt` (12) has no visible
+        // effect in the preview (no rotateY/rotateX foreshortening measurable) -> not consumed; `visible` hides
+        // cards beyond that many slots; elastic falls back to smooth; snappy = (0.4,0,0.2,1) guess.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 14, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 14);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const SI = num("scaleIntensity", 0.645);
+        const SPACING = num("spacing", 8); // unconsumed: no gap is visible (neighbours overlap behind)
+        const SIDE = num("sideTilt", 8);
+        const DIM = num("dim", 40) / 100;
+        const VISIBLE = Math.max(1, num("visible", 2));
+        const FWD = str("direction", "rightToLeft") === "rightToLeft" ? 1 : -1;
+        const RADIUS = (num("borderRadius", 18) * REF) / 1080;
+        const IMAGES = pick(Math.min(24, num("imageCount", 16)));
+        const N = IMAGES.length;
+        const TRANS = 0.35;
+
+        const bezier = (x1, y1, x2, y2) => (x) => {
+          if (x <= 0) return 0;
+          if (x >= 1) return 1;
+          let lo = 0,
+            hi = 1,
+            s = 0.5;
+          for (let i = 0; i < 24; i++) {
+            s = (lo + hi) / 2;
+            const bx = 3 * (1 - s) * (1 - s) * s * x1 + 3 * (1 - s) * s * s * x2 + s * s * s;
+            if (bx < x) lo = s;
+            else hi = s;
+          }
+          return 3 * (1 - s) * (1 - s) * s * y1 + 3 * (1 - s) * s * s * y2 + s * s * s;
+        };
+        const EASES = {
+          smooth: [0.65, 0, 0.35, 1],
+          linear: [0, 0, 1, 1],
+          snappy: [0.4, 0, 0.2, 1],
+        };
+        const ease = bezier(...(EASES[str("easing", "smooth")] || EASES.smooth));
+
+        document.getElementById("loop-shelf-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-shelf-bg"));
+        const S = SI * REF; // focused card height
+        const F = (1000 * REF) / 1080,
+          Z1 = 0.366 * F; // push-back per slot (only Z1/F matters)
+        document.getElementById("loop-shelf-stage").style.perspective = F + "px";
+        const row = document.getElementById("loop-shelf-row");
+
+        const cards = [],
+          dims = [],
+          widths = [];
+        for (let i = 0; i < N; i++) {
+          const m = IMAGES[i],
+            a = aspect(m, FIT, CROP_AR),
+            w = S * a;
+          const c = card(m, w, S, RADIUS);
+          c.style.left = -w / 2 + "px";
+          c.style.top = -S / 2 + "px";
+          const d = document.createElement("div");
+          d.className = "dim";
+          c.appendChild(d);
+          row.appendChild(c);
+          cards.push(c);
+          dims.push(d);
+          widths.push(w);
+        }
+        // world positions: pitch between neighbours = 0.75 × mean of their widths
+        const P = [0];
+        for (let i = 1; i <= N; i++)
+          P.push(P[i - 1] + (0.75 * (widths[i - 1] + widths[i % N])) / 2);
+        const TOTAL = P[N],
+          PITCH = TOTAL / N;
+
+        function renderAt(t) {
+          const u = frac(t) * N,
+            k = Math.floor(u),
+            g = u - k;
+          const e = ease(Math.min(1, g / TRANS));
+          const cam =
+            FWD > 0 ? P[k] + e * (P[k + 1] - P[k]) : TOTAL - (P[k] + e * (P[k + 1] - P[k]));
+          for (let i = 0; i < N; i++) {
+            let off = P[i] - cam;
+            off -= TOTAL * Math.round(off / TOTAL);
+            const d = off / PITCH,
+              ad = Math.abs(d),
+              c = cards[i];
+            if (ad > VISIBLE + 0.5) {
+              c.style.display = "none";
+              continue;
+            }
+            c.style.display = "";
+            const z = -ad * Z1; // screen scale = F/(F - z) = 1/(1+0.366·ad)
+            c.style.transform = `translate3d(${off}px,0,${z}px) rotateZ(${Math.sign(d) * Math.min(1, ad) * SIDE}deg)`;
+            dims[i].style.opacity = String(DIM * Math.min(1, ad));
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-shelf"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-shelf/registry-item.json
+++ b/registry/blocks/loop-shelf/registry-item.json
@@ -1,0 +1,378 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-shelf",
+  "type": "hyperframes:block",
+  "title": "Loop Shelf",
+  "description": "The focused image card stands upright while its neighbours fall back on a shelf. 8 image slots, 14s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "shelf",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 14,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "scaleIntensity",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Media scale",
+      "description": "Strength of the size change.",
+      "default": 0.645,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 18,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "rightToLeft",
+      "options": [
+        {
+          "value": "rightToLeft",
+          "label": "Right To Left"
+        },
+        {
+          "value": "leftToRight",
+          "label": "Left To Right"
+        }
+      ]
+    },
+    {
+      "id": "easing",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Easing",
+      "description": "Easing family for stepped motion.",
+      "default": "smooth",
+      "options": [
+        {
+          "value": "smooth",
+          "label": "Smooth"
+        },
+        {
+          "value": "snappy",
+          "label": "Snappy"
+        },
+        {
+          "value": "elastic",
+          "label": "Elastic"
+        },
+        {
+          "value": "linear",
+          "label": "Linear"
+        }
+      ]
+    },
+    {
+      "id": "spacing",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Spacing",
+      "description": "Spacing (engine parameter; see the block header comment).",
+      "default": 8,
+      "min": 0,
+      "max": 16,
+      "step": 0.1
+    },
+    {
+      "id": "sideTilt",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Side Tilt",
+      "description": "Side Tilt (engine parameter; see the block header comment).",
+      "default": 8,
+      "min": 0,
+      "max": 16,
+      "step": 0.1
+    },
+    {
+      "id": "dim",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Dim",
+      "description": "Dim (engine parameter; see the block header comment).",
+      "default": 40,
+      "min": 0,
+      "max": 80,
+      "step": 1
+    },
+    {
+      "id": "visible",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Visible",
+      "description": "Visible (engine parameter; see the block header comment).",
+      "default": 2,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-shelf.html",
+      "target": "compositions/loop-shelf.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-spin-1/loop-spin-1.html
+++ b/registry/blocks/loop-spin-1/loop-spin-1.html
@@ -1,0 +1,286 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"forward","options":[{"value":"forward","label":"Forward"},{"value":"reverse","label":"Reverse"}]},{"id":"imageScale","type":"number","role":"style","label":"Template options · Image Scale","description":"Image Scale (engine parameter; see the block header comment).","default":65,"min":0,"max":130,"step":1},{"id":"perspective","type":"number","role":"style","label":"Template options · Perspective","description":"Camera focal length: smaller = stronger perspective.","default":50,"min":0,"max":100,"step":1},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"axis","type":"enum","role":"style","label":"Template options · Axis","description":"Axis (engine parameter; see the block header comment).","default":"y","options":[{"value":"y","label":"Y"},{"value":"x","label":"X"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-spin-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-spin-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-spin-1-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      #loop-spin-1-pivot {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-spin-1-root"
+      data-composition-id="loop-spin-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="8"
+    >
+      <div
+        id="loop-spin-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="8"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-spin-1-bg"></div>
+        <div id="loop-spin-1-stage"><div id="loop-spin-1-pivot"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Spin loop family — ONE card at frame centre turns on the spot about the
+        // y (or x) axis; every half-turn (edge-on moment) the next image takes over, so the card always
+        // shows an un-mirrored front. Measured on Spin01/03 (2026-09-08, 512 previews):
+        //   size: face-on card = imageScale% of H (65 -> 335px, 60 -> 310px @512), centred.
+        //   period: one image per DUR/N (30 frames @ Spin01, 45 @ Spin03), edge-on exactly at the half period.
+        //   curve: angle = 180deg*(k + E(u)), E(u) = 0.2u + 0.8*expoInOut(u) (same ease as Marquee),
+        //          maxerr 4.5deg / 3.3deg over 26/39 measured frames (near/far edge-height fit).
+        //   perspective 50 -> f = 1.33*H (least-squares over 14 frames, rms 2.4px); NOT the 3D-family rule
+        //          (1000px*100/persp @1080 would give 1.85H). Scaling with other perspective values: assumed 1/persp (knob).
+        //   sign: forward = +rotateY (Spin01: right edge recedes) / +rotateX (Spin04: bottom edge nearer, 323 vs 296 @f8);
+        //         round 1 shipped the x axis mirrored (stale build hid the fix for one round; forced +/-1 renders settled it).
+        // Knobs (unmeasurable, all variants use defaults): cycles = passes through the image list per loop,
+        //   delay = phase shift in seconds, offsetX/Y = % of H, natural fit keeps the HEIGHT = imageScale% of H.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 8, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, expoInOut, frac } = RF;
+        const DUR = num("loopDuration", 8);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const SIZE = (num("imageScale", 65) / 100) * REF;
+        const PERSP = Math.max(1, num("perspective", 50));
+        const OX = (num("offsetX", 0) / 100) * REF,
+          OY = (num("offsetY", 0) / 100) * REF;
+        const AXIS = str("axis", "y");
+        const CYCLES = Math.max(1, num("cycles", 1) | 0);
+        const DELAY = num("delay", 0);
+        const FWD = str("direction", "forward") === "forward";
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(Math.min(12, num("imageCount", 16)));
+        const N = IMAGES.length;
+        const SEGS = N * CYCLES; // half-turns per loop
+        const SIGN = FWD ? 1 : -1; // forward = +rotateY (Spin01) / +rotateX (Spin04); verified on flat renders f8/f12
+        const ROT = AXIS === "y" ? "rotateY" : "rotateX";
+
+        document.getElementById("loop-spin-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-spin-1-bg"));
+        const f = 1.33 * REF * (50 / PERSP);
+        document.getElementById("loop-spin-1-stage").style.perspective = f + "px";
+        const pivot = document.getElementById("loop-spin-1-pivot");
+        pivot.style.transform = `translate3d(${OX}px,${OY}px,0)`;
+
+        // one card element per image, all stacked at the pivot; only the current one is shown
+        const cards = IMAGES.map((m) => {
+          const a = aspect(m, FIT, CROP_AR),
+            h = SIZE,
+            w = SIZE * a;
+          const c = card(m, w, h, RADIUS);
+          c.style.left = -w / 2 + "px";
+          c.style.top = -h / 2 + "px";
+          c.style.display = "none";
+          pivot.appendChild(c);
+          return c;
+        });
+        const E = (x) => 0.2 * x + 0.8 * expoInOut(x);
+        let shown = -1;
+        function renderAt(t) {
+          const p = frac(t + DELAY / DUR) * SEGS,
+            k = Math.floor(p),
+            u = p - k;
+          const theta = 180 * (k + E(u)); // cumulative turn, deg
+          const idx = Math.round(theta / 180),
+            rot = SIGN * (theta - 180 * idx); // face-on at each 180 boundary
+          const i = idx % N;
+          if (i !== shown) {
+            if (shown >= 0) cards[shown].style.display = "none";
+            cards[i].style.display = "block";
+            shown = i;
+          }
+          cards[i].style.transform = `${ROT}(${rot}deg)`;
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-spin-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-spin-1/registry-item.json
+++ b/registry/blocks/loop-spin-1/registry-item.json
@@ -1,0 +1,384 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-spin-1",
+  "type": "hyperframes:block",
+  "title": "Loop Spin 1",
+  "description": "One image card at the frame centre turns on the spot, showing the next image each half turn. 8 image slots, 8s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "spin",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 8,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "forward",
+      "options": [
+        {
+          "value": "forward",
+          "label": "Forward"
+        },
+        {
+          "value": "reverse",
+          "label": "Reverse"
+        }
+      ]
+    },
+    {
+      "id": "imageScale",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Image Scale",
+      "description": "Image Scale (engine parameter; see the block header comment).",
+      "default": 65,
+      "min": 0,
+      "max": 130,
+      "step": 1
+    },
+    {
+      "id": "perspective",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Perspective",
+      "description": "Camera focal length: smaller = stronger perspective.",
+      "default": 50,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "axis",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Axis",
+      "description": "Axis (engine parameter; see the block header comment).",
+      "default": "y",
+      "options": [
+        {
+          "value": "y",
+          "label": "Y"
+        },
+        {
+          "value": "x",
+          "label": "X"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-spin-1.html",
+      "target": "compositions/loop-spin-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-spiral-1/loop-spiral-1.html
+++ b/registry/blocks/loop-spiral-1/loop-spiral-1.html
@@ -1,0 +1,382 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"flipImage","type":"enum","role":"style","label":"Animation · Flip Image","description":"Flip Image (engine parameter; see the block header comment).","default":"off","options":[{"value":"off","label":"Off"},{"value":"on","label":"On"}]},{"id":"fade","type":"number","role":"style","label":"Animation · Fade","description":"Fade (engine parameter; see the block header comment).","default":0,"min":0,"max":100,"step":1},{"id":"autoFaceCamera","type":"enum","role":"style","label":"Animation · Auto Face Camera","description":"Auto Face Camera (engine parameter; see the block header comment).","default":"on","options":[{"value":"on","label":"On"},{"value":"off","label":"Off"}]},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":24,"step":1},{"id":"cycleDeg","type":"number","role":"style","label":"Animation · Cycle Deg","description":"Degrees turned per cycle.","default":360,"min":-180,"max":180,"step":1,"unit":"°"},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"forward","options":[{"value":"forward","label":"Forward"},{"value":"reverse","label":"Reverse"}]},{"id":"count","type":"number","role":"style","label":"Template options · Count","description":"Count (engine parameter; see the block header comment).","default":70,"min":0,"max":240,"step":10},{"id":"radius","type":"number","role":"style","label":"Template options · Radius","description":"Radius (engine parameter; see the block header comment).","default":1060,"min":0,"max":6000,"step":10},{"id":"turns","type":"number","role":"style","label":"Template options · Turns","description":"Turns (engine parameter; see the block header comment).","default":6,"min":0,"max":20,"step":0.1},{"id":"height","type":"number","role":"style","label":"Template options · Height","description":"Height (engine parameter; see the block header comment).","default":5000,"min":0,"max":10000,"step":10},{"id":"wobble","type":"number","role":"style","label":"Template options · Wobble","description":"Wobble (engine parameter; see the block header comment).","default":0,"min":0,"max":100,"step":1},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":250,"min":0,"max":1620,"step":10},{"id":"distance","type":"number","role":"style","label":"Template options · Distance","description":"Camera distance from the formation.","default":3050,"min":0,"max":9300,"step":10},{"id":"perspective","type":"number","role":"style","label":"Template options · Perspective","description":"Camera focal length: smaller = stronger perspective.","default":100,"min":0,"max":600,"step":10},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"cameraView","type":"enum","role":"style","label":"Template options · Camera View","description":"Camera View (engine parameter; see the block header comment).","default":"side","options":[{"value":"side","label":"Side"},{"value":"down","label":"Down"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-spiral-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-spiral-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-spiral-1-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      /* never put opacity/filter in will-change on preserve-3d elements: it flattens them silently */
+      #loop-spiral-1-world {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      /* origin 0 0: the transform is pos * rotate * translate(-50%,-50%), so the card centre lands exactly on pos */
+      .card {
+        position: absolute;
+        left: 0;
+        top: 0;
+        overflow: hidden;
+        transform-origin: 0 0;
+      }
+      .card img {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+      .card .shade {
+        position: absolute;
+        inset: 0;
+        background: #000;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-spiral-1-root"
+      data-composition-id="loop-spiral-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="10"
+    >
+      <div
+        id="loop-spiral-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="10"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-spiral-1-bg"></div>
+        <div id="loop-spiral-1-stage"><div id="loop-spiral-1-world"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Spiral loop family — `count` cards evenly spaced along a helix of
+        // `radius`, `turns`, total `height` (centred on the axis midpoint); the whole helix spins
+        // RIGIDLY about its axis (cards do not slide along it — the barber-pole illusion is the
+        // "climb"). Measured on the 512 previews (2026-09-08, /tmp/rf-spiral/*.py):
+        //   camera:  pinhole, f = 1000px*(100/perspective) at H=1080, `distance` = camera->axis
+        //            distance, world units cancel. side: camera on the axis normal, helix axis
+        //            vertical (S03 x-envelope 56..454 vs 58..454 predicted; far cards 37px vs 35;
+        //            per-card dy 17px vs 16.7; S06 envelope 102..409 vs 103..409). down: camera ON
+        //            the axis, `distance` above the helix centre (S08 far ring r=122px -> z=5960 =
+        //            D+height/2; r/size = R/planeSize constant 8.5 vs 9.0).
+        //   spin:    cycles x cycleDeg per loop, EACH cycle eased with 0.2*x + 0.8*expoInOut(x)
+        //            (far-band velocity fit rms 0.19 on S02/S03, peak 4.7x mean; the 12x60deg
+        //            variants show 12 eased bumps). forward: far side moves left (side view) /
+        //            counter-clockwise (down view); reverse measured the opposite on S02/S03/S09.
+        //   phase:   theta(u) = 90deg + (u-1)*turns*360 — anchored at the BOTTOM card (u=1). Fitted 88-93deg on
+        //            S01/03/05/06; S02 (3.5 turns) measures 272deg at the top = 92deg at the bottom.
+        //   handedness: descending the helix (screen down, side view) the cards swing right first
+        //            (S03 frame 0); in the down view nearer cards wind clockwise (S08).
+        //   facing:  autoFaceCamera on = screen-parallel billboards; off = card normal along the
+        //            helix radius, height along the axis (S09 cards read as annular sectors; S02
+        //            side cards edge-on at +-90deg).
+        //   fade:    colour x (1 - fade/100) reached ~30% into the depth range, ~1 at the near pole
+        //            (S02 far p90 78/136 = 0.57 vs 0.57; S05 96/136 = 0.71 vs 0.71) — Globe's ramp.
+        //   size:    planeSize is world units (height of the card; natural fit: width follows aspect).
+        //   wobble:  the helix AXIS is tilted: lateral offset of 2*(wobble/100)*R*(u-0.5) (S07: R_i/R = 1.0
+        //            at u=0.5, 0.5..1.3 at u=1 — linear, not sinusoidal), pointing screen-up (toward
+        //            theta=180deg) at t=0 and turning with the SAME eased angle but OPPOSITE to the cards
+        //            (-90deg at t=0, ~-50 at t=0.25, ~+100 at t=0.5 on S07; sign guessed from 3 samples).
+        // Knobs (guesses): delay = seconds of hold per cycle (all variants 0); offsetX/Y = % of H;
+        // image order i % N; flipImage mirrors each image horizontally.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 10, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, background, expoInOut, frac } = RF;
+        const DUR = num("loopDuration", 10);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const FLIP = on("flipImage", false);
+        const COUNT = Math.max(1, num("count", 70) | 0);
+        const R = Math.max(1, num("radius", 1060));
+        const TURNS = num("turns", 6);
+        const HEIGHT = num("height", 5000);
+        const WOBBLE = num("wobble", 0) / 100;
+        const PLANE = num("planeSize", 250);
+        const D = Math.max(0, num("distance", 3050));
+        const PERSP = Math.max(1, num("perspective", 100));
+        const FADE = Math.min(100, Math.max(0, num("fade", 0))) / 100;
+        const OX = num("offsetX", 0),
+          OY = num("offsetY", 0);
+        const DOWN = str("cameraView", "side") === "down";
+        const FACE = on("autoFaceCamera", true);
+        const CYCLES = Math.max(1, num("cycles", 1));
+        const CYCDEG = num("cycleDeg", 360);
+        const DELAY = Math.max(0, num("delay", 0));
+        const SIGN = str("direction", "forward") === "forward" ? 1 : -1;
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+
+        document.getElementById("loop-spiral-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-spiral-1-bg"));
+
+        const f = 1000 * (100 / PERSP) * (REF / 1080); // CSS focal length, px
+        const RMAX = R * (1 + Math.abs(WOBBLE));
+        const s = f / Math.max(D, RMAX, HEIGHT / 2, 1); // world -> stage px (only ratios matter)
+        const stage = document.getElementById("loop-spiral-1-stage");
+        stage.style.perspective = f + "px";
+        const world = document.getElementById("loop-spiral-1-world");
+        world.style.transform = `translate3d(${(OX / 100) * REF}px,${(OY / 100) * REF}px,0)`;
+        // depth range used for the fade ramp
+        const NEAR = DOWN ? D - HEIGHT / 2 : D - RMAX,
+          FAR = DOWN ? D + HEIGHT / 2 : D + RMAX;
+
+        const cards = [];
+        for (let i = 0; i < COUNT; i++) {
+          const u = i / COUNT;
+          const m = IMAGES[i % N],
+            a = aspect(m, FIT, CROP_AR);
+          const el = document.createElement("div");
+          el.className = "card";
+          const img = document.createElement("img");
+          img.src = m.src;
+          if (FLIP) img.style.transform = "scaleX(-1)";
+          const shade = document.createElement("div");
+          shade.className = "shade";
+          el.appendChild(img);
+          el.appendChild(shade);
+          world.appendChild(el);
+          const theta0 = Math.PI / 2 + (u - 1) * TURNS * 2 * Math.PI; // bottom card at +90deg: fitted 88-93deg on S01/03/05/06 (integer turns) and S02 (3.5 turns: top phase 272deg)
+          cards.push({
+            el,
+            shade,
+            a,
+            theta0,
+            tilt: 2 * WOBBLE * R * (u - 0.5),
+            y: (u - 0.5) * HEIGHT,
+          });
+        }
+
+        const easeC = (x) => 0.2 * x + 0.8 * expoInOut(x);
+        // per-cycle eased spin; delay = seconds of hold at the end of each cycle (unit unverified, all variants 0)
+        function angleAt(t) {
+          const cyc = DUR / CYCLES,
+            move = Math.max(0.01, cyc - DELAY);
+          const u = frac(t) * CYCLES,
+            k = Math.floor(u),
+            local = (u - k) * cyc;
+          return (SIGN * (k + easeC(Math.min(1, local / move))) * CYCDEG * Math.PI) / 180;
+        }
+        const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+        function renderAt(t) {
+          const ang = angleAt(t),
+            wsn = Math.sin(ang),
+            wcs = Math.cos(ang);
+          for (const c of cards) {
+            const th = c.theta0 + ang;
+            // helix coords: xh across, zh toward the side camera (theta=0 nearest); the tilt offset counter-rotates
+            const xh = R * Math.sin(th) + c.tilt * wsn,
+              zh = R * Math.cos(th) - c.tilt * wcs;
+            // camera space: x right, y down, depth = distance in front of the camera
+            let cx, cy, depth;
+            if (DOWN) {
+              cx = xh;
+              cy = zh;
+              depth = D + c.y;
+            } else {
+              cx = xh;
+              cy = c.y;
+              depth = D - zh;
+            }
+            if (depth < 0.02 * Math.max(R, 1)) {
+              c.el.style.visibility = "hidden";
+              continue;
+            }
+            c.el.style.visibility = "visible";
+            const h = PLANE * s,
+              w = h * c.a;
+            c.el.style.width = w + "px";
+            c.el.style.height = h + "px";
+            c.el.style.borderRadius = RADIUS * ((depth * s) / f) + "px";
+            const zr = 1 - 2 * clamp01((depth - NEAR) / (FAR - NEAR)); // +1 nearest
+            c.shade.style.opacity = FADE * clamp01((0.85 - zr) / 0.4);
+            const pos = `translate3d(${cx * s}px,${cy * s}px,${f - depth * s}px)`;
+            c.el.style.transform = FACE
+              ? `${pos} translate(-50%,-50%)`
+              : DOWN
+                ? `${pos} rotateZ(${-th}rad) rotateX(-90deg) translate(-50%,-50%)` // normal along the radius, height along the axis
+                : `${pos} rotateY(${th}rad) translate(-50%,-50%)`;
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-spiral-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-spiral-1/registry-item.json
+++ b/registry/blocks/loop-spiral-1/registry-item.json
@@ -1,0 +1,509 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-spiral-1",
+  "type": "hyperframes:block",
+  "title": "Loop Spiral 1",
+  "description": "Image cards evenly spaced along a helix that advances toward the camera. 8 image slots, 10s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "spiral",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 10,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "flipImage",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Flip Image",
+      "description": "Flip Image (engine parameter; see the block header comment).",
+      "default": "off",
+      "options": [
+        {
+          "value": "off",
+          "label": "Off"
+        },
+        {
+          "value": "on",
+          "label": "On"
+        }
+      ]
+    },
+    {
+      "id": "fade",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Fade",
+      "description": "Fade (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "id": "autoFaceCamera",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Auto Face Camera",
+      "description": "Auto Face Camera (engine parameter; see the block header comment).",
+      "default": "on",
+      "options": [
+        {
+          "value": "on",
+          "label": "On"
+        },
+        {
+          "value": "off",
+          "label": "Off"
+        }
+      ]
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 24,
+      "step": 1
+    },
+    {
+      "id": "cycleDeg",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycle Deg",
+      "description": "Degrees turned per cycle.",
+      "default": 360,
+      "min": -180,
+      "max": 180,
+      "step": 1,
+      "unit": "°"
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "forward",
+      "options": [
+        {
+          "value": "forward",
+          "label": "Forward"
+        },
+        {
+          "value": "reverse",
+          "label": "Reverse"
+        }
+      ]
+    },
+    {
+      "id": "count",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Count",
+      "description": "Count (engine parameter; see the block header comment).",
+      "default": 70,
+      "min": 0,
+      "max": 240,
+      "step": 10
+    },
+    {
+      "id": "radius",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Radius",
+      "description": "Radius (engine parameter; see the block header comment).",
+      "default": 1060,
+      "min": 0,
+      "max": 6000,
+      "step": 10
+    },
+    {
+      "id": "turns",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Turns",
+      "description": "Turns (engine parameter; see the block header comment).",
+      "default": 6,
+      "min": 0,
+      "max": 20,
+      "step": 0.1
+    },
+    {
+      "id": "height",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Height",
+      "description": "Height (engine parameter; see the block header comment).",
+      "default": 5000,
+      "min": 0,
+      "max": 10000,
+      "step": 10
+    },
+    {
+      "id": "wobble",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Wobble",
+      "description": "Wobble (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 250,
+      "min": 0,
+      "max": 1620,
+      "step": 10
+    },
+    {
+      "id": "distance",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Distance",
+      "description": "Camera distance from the formation.",
+      "default": 3050,
+      "min": 0,
+      "max": 9300,
+      "step": 10
+    },
+    {
+      "id": "perspective",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Perspective",
+      "description": "Camera focal length: smaller = stronger perspective.",
+      "default": 100,
+      "min": 0,
+      "max": 600,
+      "step": 10
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "cameraView",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Camera View",
+      "description": "Camera View (engine parameter; see the block header comment).",
+      "default": "side",
+      "options": [
+        {
+          "value": "side",
+          "label": "Side"
+        },
+        {
+          "value": "down",
+          "label": "Down"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-spiral-1.html",
+      "target": "compositions/loop-spiral-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-stack-1/loop-stack-1.html
+++ b/registry/blocks/loop-stack-1/loop-stack-1.html
@@ -1,0 +1,322 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"stagger","type":"number","role":"style","label":"Animation · Stagger","description":"Stagger (engine parameter; see the block header comment).","default":0.06666666666666667,"min":0,"max":2,"step":0.01},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"down","options":[{"value":"down","label":"Down"},{"value":"up","label":"Up"}]},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":38,"min":0,"max":76,"step":1},{"id":"visible","type":"number","role":"style","label":"Template options · Visible","description":"Visible (engine parameter; see the block header comment).","default":3,"min":0,"max":12,"step":0.1},{"id":"perspective","type":"number","role":"style","label":"Template options · Perspective","description":"Camera focal length: smaller = stronger perspective.","default":73,"min":0,"max":246,"step":10},{"id":"zoom","type":"number","role":"style","label":"Template options · Zoom","description":"Zoom (engine parameter; see the block header comment).","default":150,"min":0,"max":534,"step":10},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":-2.5,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-stack-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-stack-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-stack-1-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .card {
+        position: absolute;
+        overflow: hidden;
+      }
+      .card img {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-stack-1-root"
+      data-composition-id="loop-stack-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="11"
+    >
+      <div
+        id="loop-stack-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="11"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-stack-1-bg"></div>
+        <div id="loop-stack-1-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Stack loop family — "Cards deal onto a receding stack."
+        // Measured on the Stack01 preview (11s, 8 images -> 41.25f steps), 2026-09-08:
+        //   front card 292px square = planeSize*zoom/100 % of H (38*1.5 = 57% -> 292 @512), `visible` cards
+        //   recede behind it, peeking out above (direction down) with sizes 292/264/226 = S*(1 - .079L - .017L^2)
+        //   and top edges 134/108/80 (27px = 5.3% of H higher per level); the whole group's bbox is centred
+        //   (80..426; offsetY -2.5 -> -2.5px, Stack03 -7.5 -> -19px: used 0.4% of H per unit).
+        //   Stack03 (perspective 123, visible 6): front 328 = 64% H, tops every 20.7px, sizes
+        //   1/.957/.909/.854/.787/.689 -> quadratic a=.038 b=.0048 (max err 1.7%); Stack01 a=.079 b=.017.
+        //   Step: ONE smooth ease (bezier .5,0,.5,1) over the step moves every card one level toward the
+        //   camera (front 292 -> 304 at f20, card2 274 -> 284 -> 288 at f21/24/27, model within 2px); the
+        //   front card fades out around e = 0.5 over `stagger` of the step (0.0667*41.25 = 2.75f; luma
+        //   74 -> 93 -> 97 -> 101 at f20..23), the new back card fades in over tau 0.635..0.855 (luma
+        //   27,43,53,61,65,68,70 at f26..32, ease-out shape).
+        // Guesses/knobs: recession constants (a, b, rise) interpolated linearly in perspective between the two
+        //   measured variants; direction up mirrors the peek side (Stack02: peeks below, sheet agrees);
+        //   cycles = steps per loop multiplier; delay = seconds of phase.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 11, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, background, frac } = RF;
+        const DUR = num("loopDuration", 11);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const S = ((num("planeSize", 38) * num("zoom", 150)) / 100 / 100) * REF;
+        const VIS = Math.max(1, num("visible", 3) | 0);
+        const OX = num("offsetX", 0) * 0.004 * REF,
+          OY = num("offsetY", 0) * 0.004 * REF; // 0.4% of H per unit (S01 -2.5px, S03 -19px @512)
+        const PERSP = num("perspective", 73);
+        // recession constants: measured on Stack01 (perspective 73) and Stack03 (123), interpolated linearly in perspective (knob)
+        const lerpP = (a73, a123) => a73 + ((PERSP - 73) * (a123 - a73)) / 50;
+        const RA = Math.max(0.005, lerpP(0.079, 0.038)),
+          RB = Math.max(0, lerpP(0.017, 0.0048));
+        const CYCLES = Math.max(1, num("cycles", 1) | 0);
+        const STAG = num("stagger", 0.0667);
+        const DELAY = num("delay", 0);
+        const UP = str("direction", "down") === "up" ? -1 : 1; // +1: back cards peek out above
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const STEPS = N * CYCLES;
+        const RISE = lerpP(0.053, 0.0405) * REF; // top edge climb per level (S01 27px, S03 20.7px @512)
+        const bezier = (x1, y1, x2, y2) => (x) => {
+          if (x <= 0) return 0;
+          if (x >= 1) return 1;
+          let lo = 0,
+            hi = 1,
+            s = 0.5;
+          for (let i = 0; i < 24; i++) {
+            s = (lo + hi) / 2;
+            const bx = 3 * (1 - s) * (1 - s) * s * x1 + 3 * (1 - s) * s * s * x2 + s * s * s;
+            if (bx < x) lo = s;
+            else hi = s;
+          }
+          return 3 * (1 - s) * (1 - s) * s * y1 + 3 * (1 - s) * s * s * y2 + s * s * s;
+        };
+        const smooth = bezier(0.5, 0, 0.5, 1);
+        const sizeAt = (L) => S * Math.max(0.2, 1 - RA * L - RB * L * L);
+
+        document.getElementById("loop-stack-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-stack-1-bg"));
+        const stage = document.getElementById("loop-stack-1-stage");
+        // group bbox at rest: front bottom .. back top; centre it
+        const backTop = -S / 2 - RISE * (VIS - 1) + (S - sizeAt(VIS - 1)) * 0; // top of back card relative to front centre
+        const groupCentre = (backTop + S / 2) / 2; // front bottom = +S/2
+        const yShift = -groupCentre * UP + OY;
+        const cards = [];
+        for (let i = 0; i <= VIS; i++) {
+          // VIS + 1: the fading front plus the stack
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.borderRadius = RADIUS + "px";
+          const img = document.createElement("img");
+          el.appendChild(img);
+          stage.appendChild(el);
+          cards.push({ el, img, src: null });
+        }
+        function place(c, m, L, op) {
+          const size = sizeAt(L);
+          const a = aspect(m, FIT, CROP_AR);
+          const w = size * Math.min(1, a),
+            h = size * Math.min(1, 1 / a);
+          if (c.src !== m.src) {
+            c.img.src = m.src;
+            c.src = m.src;
+          }
+          c.el.style.display = op <= 0 ? "none" : "";
+          c.el.style.opacity = Math.min(1, op);
+          c.el.style.width = w + "px";
+          c.el.style.height = h + "px";
+          // level L: top edge RISE*L above the front's top edge (down) / below its bottom edge (up)
+          const top = UP > 0 ? -S / 2 - RISE * L : S / 2 + RISE * L - h;
+          c.el.style.transform = `translate(${OX - w / 2}px, ${top + yShift}px)`;
+        }
+        function renderAt(t) {
+          const g = frac(t + DELAY / DUR) * STEPS,
+            k = Math.floor(g),
+            tau = g - k;
+          const e = smooth(tau);
+          // draw back to front: level VIS (fading in), VIS-1 .. 1, then the leaving front (level -e)
+          const fin = Math.max(0, Math.min(1, (tau - 0.635) / 0.22));
+          const opIn = 1 - (1 - fin) * (1 - fin);
+          place(cards[0], IMAGES[(k + VIS) % N], VIS - e, opIn);
+          for (let m = VIS - 1; m >= 1; m--) place(cards[VIS - m], IMAGES[(k + m) % N], m - e, 1);
+          const opOut = 1 - Math.max(0, Math.min(1, (e - 0.5 + STAG / 2) / Math.max(STAG, 0.005)));
+          place(cards[VIS], IMAGES[k % N], -e, opOut);
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-stack-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-stack-1/registry-item.json
+++ b/registry/blocks/loop-stack-1/registry-item.json
@@ -1,0 +1,399 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-stack-1",
+  "type": "hyperframes:block",
+  "title": "Loop Stack 1",
+  "description": "Image cards deal onto a receding stack. 8 image slots, 11s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "stack",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 11,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "stagger",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Stagger",
+      "description": "Stagger (engine parameter; see the block header comment).",
+      "default": 0.06666666666666667,
+      "min": 0,
+      "max": 2,
+      "step": 0.01
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "down",
+      "options": [
+        {
+          "value": "down",
+          "label": "Down"
+        },
+        {
+          "value": "up",
+          "label": "Up"
+        }
+      ]
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 38,
+      "min": 0,
+      "max": 76,
+      "step": 1
+    },
+    {
+      "id": "visible",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Visible",
+      "description": "Visible (engine parameter; see the block header comment).",
+      "default": 3,
+      "min": 0,
+      "max": 12,
+      "step": 0.1
+    },
+    {
+      "id": "perspective",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Perspective",
+      "description": "Camera focal length: smaller = stronger perspective.",
+      "default": 73,
+      "min": 0,
+      "max": 246,
+      "step": 10
+    },
+    {
+      "id": "zoom",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Zoom",
+      "description": "Zoom (engine parameter; see the block header comment).",
+      "default": 150,
+      "min": 0,
+      "max": 534,
+      "step": 10
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": -2.5,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-stack-1.html",
+      "target": "compositions/loop-stack-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-stories-1/loop-stories-1.html
+++ b/registry/blocks/loop-stories-1/loop-stories-1.html
@@ -1,0 +1,388 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":6,"min":0,"max":200,"step":1,"unit":"px"},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0.33,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"right","options":[{"value":"right","label":"Right"},{"value":"left","label":"Left"},{"value":"down","label":"Down"},{"value":"up","label":"Up"}]},{"id":"thumbAspect","type":"enum","role":"style","label":"Template options · Thumb Aspect","description":"Thumb Aspect (engine parameter; see the block header comment).","default":"1:1","options":[{"value":"1:1","label":"1:1"},{"value":"3:4","label":"3:4"},{"value":"4:3","label":"4:3"}]},{"id":"bigScale","type":"number","role":"style","label":"Template options · Big Scale","description":"Big Scale (engine parameter; see the block header comment).","default":115,"min":0,"max":230,"step":10},{"id":"bigDrift","type":"number","role":"style","label":"Template options · Big Drift","description":"Big Drift (engine parameter; see the block header comment).","default":40,"min":0,"max":80,"step":1},{"id":"thumbSize","type":"number","role":"style","label":"Template options · Thumb Size","description":"Thumb Size (engine parameter; see the block header comment).","default":85,"min":0,"max":200,"step":1},{"id":"containerOpacity","type":"number","role":"style","label":"Template options · Container Opacity","description":"Container Opacity (engine parameter; see the block header comment).","default":40,"min":0,"max":80,"step":1},{"id":"containerBlur","type":"number","role":"style","label":"Template options · Container Blur","description":"Container Blur (engine parameter; see the block header comment).","default":60,"min":0,"max":120,"step":1},{"id":"selectorPad","type":"number","role":"style","label":"Template options · Selector Pad","description":"Selector Pad (engine parameter; see the block header comment).","default":5,"min":0,"max":11,"step":0.1},{"id":"selectorStroke","type":"number","role":"style","label":"Template options · Selector Stroke","description":"Selector Stroke (engine parameter; see the block header comment).","default":2,"min":0,"max":10,"step":0.1},{"id":"dimAmount","type":"number","role":"style","label":"Template options · Dim Amount","description":"Dim Amount (engine parameter; see the block header comment).","default":20,"min":0,"max":100,"step":1},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":30,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-stories-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-stories-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-stories-1-big {
+        position: absolute;
+        inset: 0;
+        overflow: hidden;
+      }
+      #loop-stories-1-big img {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: none;
+      }
+      #loop-stories-1-strip {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        overflow: hidden;
+      } /* clip box = panel bounds; the ring wraps through it */
+      #loop-stories-1-panel {
+        position: absolute;
+        inset: 0;
+      }
+      .thumb {
+        position: absolute;
+        overflow: hidden;
+      }
+      .thumb img {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+      .thumb .dim {
+        position: absolute;
+        inset: 0;
+        background: #000;
+      }
+      .ring {
+        position: absolute;
+        border: 0 solid #fff;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-stories-1-root"
+      data-composition-id="loop-stories-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="13"
+    >
+      <div
+        id="loop-stories-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="13"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-stories-1-bg"></div>
+        <div id="loop-stories-1-big"></div>
+        <div id="loop-stories-1-strip"><div id="loop-stories-1-panel"></div></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Stories loop family — the current image fills the frame (bigScale %, slow drift);
+        // a strip of thumbs with a selector ring that steps along; thumbs not under the ring are dimmed.
+        // Measured @512 (2026-09-08): thumb width = thumbSize·H/1080 (85 -> 40px, 100 -> 47px), height from thumbAspect
+        // (3:4 -> 53/63px measured); thumb gap 7-8px (~15.5px @1080, fixed; not selectorPad); strip centre at
+        // (offsetX% of W, offsetY% of H) from the frame centre (01: y = +153 = 30%; 02/03: x = -179 = -35%);
+        // ring = thumb + 2·(selectorPad+selectorStroke) px@1080 (46.7 vs 46 measured), white, stroke px@1080;
+        // panel (01/02) = strip bbox padded by the gap, black at 0.3·containerOpacity% (74 -> 65 luma = 12%),
+        // backdrop blur containerBlur px@1080 (unit guess); no panel when containerOpacity = 0 (03/04 confirmed).
+        // Timing: step = DUR/(N·cycles); the ring rests, then moves one thumb over [delay s, step] with easeInOutCubic
+        // (01: motion frames 10-48 of 48.75, 03 (delay 0): continuous); the big image HARD-CUTS at the midpoint of
+        // the ring's move (01: frame 29-30, 03: frame 24); dim crossfades with the ring (mid luma = midpoint).
+        // Knobs: drift = bigDrift% of the bigScale overscan travelled along the strip axis while an image is up (guess);
+        // panel/thumb corner radius = borderRadius px@1080.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 13, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, background, frac } = RF;
+        const DUR = num("loopDuration", 13);
+        const TASP = str("thumbAspect", "1:1").split(":").map(Number);
+        const TA = TASP[0] && TASP[1] ? TASP[0] / TASP[1] : 1;
+        const BIGSC = num("bigScale", 115) / 100;
+        const DRIFT = num("bigDrift", 40) / 100;
+        const TW = (num("thumbSize", 85) * REF) / 1080,
+          TH = TW / TA;
+        const COP = num("containerOpacity", 40) / 100;
+        const CBLUR = (num("containerBlur", 60) * REF) / 1080;
+        const SPAD = (num("selectorPad", 5) * REF) / 1080;
+        const SSTK = (num("selectorStroke", 2) * REF) / 1080;
+        const DIM = num("dimAmount", 20) / 100;
+        const OX = (num("offsetX", 0) / 100) * W,
+          OY = (num("offsetY", 30) / 100) * H;
+        const CYCLES = Math.max(1, num("cycles", 1) | 0);
+        const DELAY = Math.max(0, num("delay", 0.33));
+        const DIRN = str("direction", "right");
+        const RADIUS = (num("borderRadius", 6) * REF) / 1080;
+        const IMAGES = pick(Math.min(12, num("imageCount", 16)));
+        const N = IMAGES.length;
+        const VERT = DIRN === "down" || DIRN === "up";
+        const REV = DIRN === "left" || DIRN === "up"; // ring travels toward negative axis
+        const GAP = (15.5 * REF) / 1080;
+        const STEPS = N * CYCLES,
+          STEP = DUR / STEPS;
+
+        const cubic = (x) =>
+          x <= 0 ? 0 : x >= 1 ? 1 : x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2;
+
+        document.getElementById("loop-stories-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-stories-1-bg"));
+        // big image layer: one <img> per image, cover-fitted, scaled by bigScale
+        const big = document.getElementById("loop-stories-1-big");
+        const bigs = IMAGES.map((m) => {
+          const i = document.createElement("img");
+          i.src = m.src;
+          big.appendChild(i);
+          return i;
+        });
+        // strip geometry (axis coordinate of thumb j's centre; strip centred on OX/OY)
+        const PITCH = (VERT ? TH : TW) + GAP,
+          LEN = N * (VERT ? TH : TW) + (N - 1) * GAP;
+        const axisPos = (j) => (REV ? -1 : 1) * ((j + 0.5) * PITCH - GAP / 2 - LEN / 2);
+        const strip = document.getElementById("loop-stories-1-strip");
+        const PW = (VERT ? TW : LEN) + 2 * GAP,
+          PH = (VERT ? LEN : TH) + 2 * GAP; // clip box (= panel) size
+        strip.style.cssText = `width:${PW}px;height:${PH}px;transform:translate(${OX - PW / 2}px,${OY - PH / 2}px);`;
+        const CX = PW / 2,
+          CY = PH / 2;
+        const panel = document.getElementById("loop-stories-1-panel");
+        if (COP > 0)
+          panel.style.cssText =
+            `border-radius:${RADIUS + GAP}px;background:rgba(0,0,0,${0.3 * COP});` +
+            (CBLUR > 0
+              ? `backdrop-filter:blur(${CBLUR}px);-webkit-backdrop-filter:blur(${CBLUR}px);`
+              : "");
+        else panel.style.display = "none";
+        const thumbs = [],
+          dims = [];
+        for (let j = 0; j < N; j++) {
+          const t = document.createElement("div");
+          t.className = "thumb";
+          const p = axisPos(j),
+            x = CX + (VERT ? -TW / 2 : p - TW / 2),
+            y = CY + (VERT ? p - TH / 2 : -TH / 2);
+          t.style.cssText = `left:${x}px;top:${y}px;width:${TW}px;height:${TH}px;border-radius:${RADIUS}px;`;
+          const im = document.createElement("img");
+          im.src = IMAGES[j].src;
+          t.appendChild(im);
+          const d = document.createElement("div");
+          d.className = "dim";
+          t.appendChild(d);
+          strip.appendChild(t);
+          thumbs.push(t);
+          dims.push(d);
+        }
+        // two ring copies: the second trails one strip-length behind so the wrap slides off one end and in at the other
+        const RW = TW + 2 * (SPAD + SSTK),
+          RH = TH + 2 * (SPAD + SSTK);
+        const rings = [0, 1].map(() => {
+          const r = document.createElement("div");
+          r.className = "ring";
+          r.style.cssText =
+            `width:${RW}px;height:${RH}px;border-width:${SSTK}px;border-radius:${RADIUS + SPAD + SSTK}px;` +
+            (SSTK > 0 ? "" : "display:none;");
+          strip.appendChild(r);
+          return r;
+        });
+        const SGN = REV ? -1 : 1;
+
+        function renderAt(t) {
+          const u = frac(t) * STEPS,
+            k = Math.floor(u),
+            local = (u - k) * STEP; // seconds into the step
+          const e =
+            STEP > DELAY
+              ? cubic(Math.max(0, local - DELAY) / (STEP - DELAY))
+              : local >= STEP
+                ? 1
+                : 0;
+          const pos = (k % N) + e; // ring position in thumb units
+          const shown = (e < 0.5 ? k : k + 1) % N; // big image hard-cuts at mid-move
+          // drift: image travels DRIFT of its overscan along the strip axis while it is up (mid k-1 -> mid k)
+          const phase = e < 0.5 ? 0.5 + e : e - 0.5;
+          const over = ((BIGSC - 1) * (VERT ? H : W)) / 2,
+            dx = (2 * phase - 1) * DRIFT * over * (REV ? 1 : -1);
+          for (let j = 0; j < N; j++) {
+            const b = bigs[j];
+            if (j !== shown) {
+              b.style.display = "none";
+              continue;
+            }
+            b.style.display = "block";
+            b.style.transform = `scale(${BIGSC}) translate(${VERT ? 0 : dx}px,${VERT ? dx : 0}px)`;
+            b.style.transformOrigin = "50% 50%";
+          }
+          const rp = axisPos(k % N) + SGN * PITCH * e; // linear along the strip, may run off the end
+          rings.forEach((r, c) => {
+            const q = rp - c * SGN * N * PITCH;
+            r.style.left = CX + (VERT ? -RW / 2 : q - RW / 2) + "px";
+            r.style.top = CY + (VERT ? q - RH / 2 : -RH / 2) + "px";
+          });
+          for (let j = 0; j < N; j++) {
+            let sel = Math.max(0, 1 - Math.abs(j - pos));
+            if (j === 0 && k % N === N - 1) sel = Math.max(sel, e); // wrap: thumb 0 lights up as the ring returns
+            dims[j].style.opacity = String(DIM * (1 - sel));
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-stories-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-stories-1/registry-item.json
+++ b/registry/blocks/loop-stories-1/registry-item.json
@@ -1,0 +1,461 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-stories-1",
+  "type": "hyperframes:block",
+  "title": "Loop Stories 1",
+  "description": "The current image fills the frame with a slow drift; the next slides in like a story. 8 image slots, 13s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "stories"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 13,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 6,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0.33,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "right",
+      "options": [
+        {
+          "value": "right",
+          "label": "Right"
+        },
+        {
+          "value": "left",
+          "label": "Left"
+        },
+        {
+          "value": "down",
+          "label": "Down"
+        },
+        {
+          "value": "up",
+          "label": "Up"
+        }
+      ]
+    },
+    {
+      "id": "thumbAspect",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Thumb Aspect",
+      "description": "Thumb Aspect (engine parameter; see the block header comment).",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "4:3",
+          "label": "4:3"
+        }
+      ]
+    },
+    {
+      "id": "bigScale",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Big Scale",
+      "description": "Big Scale (engine parameter; see the block header comment).",
+      "default": 115,
+      "min": 0,
+      "max": 230,
+      "step": 10
+    },
+    {
+      "id": "bigDrift",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Big Drift",
+      "description": "Big Drift (engine parameter; see the block header comment).",
+      "default": 40,
+      "min": 0,
+      "max": 80,
+      "step": 1
+    },
+    {
+      "id": "thumbSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Thumb Size",
+      "description": "Thumb Size (engine parameter; see the block header comment).",
+      "default": 85,
+      "min": 0,
+      "max": 200,
+      "step": 1
+    },
+    {
+      "id": "containerOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Container Opacity",
+      "description": "Container Opacity (engine parameter; see the block header comment).",
+      "default": 40,
+      "min": 0,
+      "max": 80,
+      "step": 1
+    },
+    {
+      "id": "containerBlur",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Container Blur",
+      "description": "Container Blur (engine parameter; see the block header comment).",
+      "default": 60,
+      "min": 0,
+      "max": 120,
+      "step": 1
+    },
+    {
+      "id": "selectorPad",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Selector Pad",
+      "description": "Selector Pad (engine parameter; see the block header comment).",
+      "default": 5,
+      "min": 0,
+      "max": 11,
+      "step": 0.1
+    },
+    {
+      "id": "selectorStroke",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Selector Stroke",
+      "description": "Selector Stroke (engine parameter; see the block header comment).",
+      "default": 2,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "dimAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Dim Amount",
+      "description": "Dim Amount (engine parameter; see the block header comment).",
+      "default": 20,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 30,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-stories-1.html",
+      "target": "compositions/loop-stories-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-swirl/loop-swirl.html
+++ b/registry/blocks/loop-swirl/loop-swirl.html
@@ -1,0 +1,274 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"scaleIntensity","type":"number","role":"style","label":"Appearance · Media scale","description":"Strength of the size change.","default":0.23,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":26,"min":0,"max":200,"step":1,"unit":"px"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"inward","options":[{"value":"inward","label":"Inward"},{"value":"outward","label":"Outward"}]},{"id":"fadeIn","type":"number","role":"style","label":"Template options · Fade In","description":"Fade In (engine parameter; see the block header comment).","default":20,"min":0,"max":40,"step":1},{"id":"turns","type":"number","role":"style","label":"Template options · Turns","description":"Turns (engine parameter; see the block header comment).","default":3.5,"min":0,"max":7,"step":0.1},{"id":"spread","type":"number","role":"style","label":"Template options · Spread","description":"Spread (engine parameter; see the block header comment).","default":7,"min":0,"max":14,"step":0.1},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-swirl</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-swirl-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-swirl-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-swirl-root"
+      data-composition-id="loop-swirl"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="12"
+    >
+      <div
+        id="loop-swirl-loop"
+        class="clip"
+        data-start="0"
+        data-duration="12"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-swirl-bg"></div>
+        <div id="loop-swirl-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Swirl loop family — cards ride an Archimedean spiral (r = RMAX * phi/phiTotal,
+        // phiTotal = turns*360) from the frame edge to the centre, tangent to the curve, shrinking linearly with r;
+        // K = N*spread slots spaced uniformly in r^2 (constant arc step), every card advancing N slots per loop
+        // (so the image sequence loops seamlessly); cards fade out over the inner fadeIn% of RMAX.
+        // Measured on the 512 preview (2026-09-08): slot radii f0 59.4/89.4/112.4/131.1/148/163/176.6/189.5/201.5/
+        // 212.7/223/233.7/243.5 -> r^2 steps 4575 +- 100 (uniform in r^2; K = 512^2/4575 = 57.3 ~ 8*7 = 56);
+        // slot angles 33.3/319/263/216/175/139/104.5/73/43.6/15.8/349/324/300 deg -> dr/dphi = 0.4035 px/deg
+        // = 512/1260 (RMAX = H, 3.5 turns) with phi(y-up) = 180 - 1260*r/RMAX (fit err < 2 deg);
+        // card side = sqrt(area) = 0.233*r on 13 cards (0.232..0.24) -> scaleIntensity * r; motion: geometry repeats
+        // every 90 f with a 2-slot shift (card 112.4 -> 59.4 px, 131.1 -> 89.4) => 8 slots (= N) per 12 s, inward =
+        // angle increasing (ccw on screen), ~uniform in slot index; inner cards fade: opacity ~0.93 @ r89, 0.6 @ r71, 0.35 @ r46.
+        // Guesses: fade = min(1, r/(fadeIn% * RMAX)) (linear; measured points scatter +-0.15); depthFalloff unused
+        // (size already linear in r); z-order = inner on top; a 1-slot fade at the outer end hides the spawn.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 12, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 12);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const SCALE = num("scaleIntensity", 0.23);
+        const FADE = Math.max(0.001, num("fadeIn", 20) / 100);
+        const TURNS = num("turns", 3.5);
+        const SPREAD = Math.max(1, Math.round(num("spread", 7)));
+        const INWARD = str("direction", "inward") === "inward";
+        const RADIUS = (num("borderRadius", 26) * REF) / 1080; // px @1080 of a full-size card; scaled with the card below
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const RMAX = REF;
+        const K = N * SPREAD;
+        const PHI_TOT = TURNS * 360;
+
+        document.getElementById("loop-swirl-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-swirl-bg"));
+        const stage = document.getElementById("loop-swirl-stage");
+        const slots = [];
+        for (let k = 0; k < K; k++) {
+          const m = IMAGES[k % N],
+            a = aspect(m, FIT, CROP_AR);
+          const c = card(m, 100, 100, 0); // sized per frame
+          stage.appendChild(c);
+          slots.push({ el: c, img: c.firstChild, k, a });
+        }
+        const PHASE = 0.77; // slot fraction at t=0 (f0 innermost r=59.4)
+        function renderAt(t) {
+          const adv = frac(t) * N * (INWARD ? -1 : 1);
+          for (const s of slots) {
+            const kk = (((s.k + PHASE + adv) % K) + K) % K; // continuous slot position in [0,K)
+            const r = RMAX * Math.sqrt(kk / K);
+            const phi = 180 - (PHI_TOT * r) / RMAX; // y-up degrees
+            const rad = (phi * Math.PI) / 180;
+            const h = SCALE * r,
+              w = h * s.a;
+            s.el.style.width = w + "px";
+            s.el.style.height = h + "px";
+            s.img.style.width = w + "px";
+            s.img.style.height = h + "px";
+            s.el.style.borderRadius = RADIUS * (h / ((SCALE * RMAX) / 2)) + "px";
+            s.el.style.left = -w / 2 + "px";
+            s.el.style.top = -h / 2 + "px";
+            s.el.style.transform = `translate(${r * Math.cos(rad)}px,${-r * Math.sin(rad)}px) rotate(${-phi - 90}deg)`;
+            s.el.style.zIndex = Math.round(2000 - r);
+            s.el.style.opacity = Math.min(1, r / (FADE * RMAX), K - kk);
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-swirl"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-swirl/registry-item.json
+++ b/registry/blocks/loop-swirl/registry-item.json
@@ -1,0 +1,340 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-swirl",
+  "type": "hyperframes:block",
+  "title": "Loop Swirl",
+  "description": "Image cards ride an Archimedean spiral that swirls around the centre. 8 image slots, 12s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "swirl"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 12,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "scaleIntensity",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Media scale",
+      "description": "Strength of the size change.",
+      "default": 0.23,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 26,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "inward",
+      "options": [
+        {
+          "value": "inward",
+          "label": "Inward"
+        },
+        {
+          "value": "outward",
+          "label": "Outward"
+        }
+      ]
+    },
+    {
+      "id": "fadeIn",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Fade In",
+      "description": "Fade In (engine parameter; see the block header comment).",
+      "default": 20,
+      "min": 0,
+      "max": 40,
+      "step": 1
+    },
+    {
+      "id": "turns",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Turns",
+      "description": "Turns (engine parameter; see the block header comment).",
+      "default": 3.5,
+      "min": 0,
+      "max": 7,
+      "step": 0.1
+    },
+    {
+      "id": "spread",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Spread",
+      "description": "Spread (engine parameter; see the block header comment).",
+      "default": 7,
+      "min": 0,
+      "max": 14,
+      "step": 0.1
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-swirl.html",
+      "target": "compositions/loop-swirl.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-tunnel/loop-tunnel.html
+++ b/registry/blocks/loop-tunnel/loop-tunnel.html
@@ -1,0 +1,304 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"crop","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#08080b"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"scaleIntensity","type":"number","role":"style","label":"Appearance · Media scale","description":"Strength of the size change.","default":0.9,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"forward","options":[{"value":"forward","label":"Forward"},{"value":"backward","label":"Backward"}]},{"id":"depthFade","type":"number","role":"style","label":"Template options · Depth Fade","description":"Depth Fade (engine parameter; see the block header comment).","default":0.45,"min":0,"max":2,"step":0.01},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-tunnel</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-tunnel-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-tunnel-stage {
+        position: absolute;
+        inset: 0;
+        perspective-origin: 50% 50%;
+      }
+      #loop-tunnel-world,
+      #loop-tunnel-tunnel,
+      .ring {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+        transform-style: preserve-3d;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-tunnel-root"
+      data-composition-id="loop-tunnel"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="10"
+    >
+      <div
+        id="loop-tunnel-loop"
+        class="clip"
+        data-start="0"
+        data-duration="10"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-tunnel-bg"></div>
+        <div id="loop-tunnel-stage">
+          <div id="loop-tunnel-world"><div id="loop-tunnel-tunnel"></div></div>
+        </div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Tunnel loop family — square tube of side P (= pitch) built from rings of 4 media panels
+        // (one per wall), camera flying forward. Measured on the 512 preview (2026-09-08):
+        //   ring edges: 1/d linear, K = f·w/P = 255px @512 => with f = REF (CSS perspective = frame height) the tube
+        //   side 2w equals the pitch P; a ring's wall edge reaches the frame edge exactly at z = 1 pitch.
+        //   panels occupy 0.90 of the cell along z AND across (scaleIntensity 0.9 => panel = 0.9·cell; gap inert)
+        //   travel: 8.00 pitches per 10s loop, linear (resid 0.05); rings born at z = 5 pitches (opacity 0),
+        //   fade-in over 1 pitch, then depth fade ≈ 1 − 0.45·(z−1.5)/3.5 (depthFade 0.45) -> 1 at the near end.
+        //   4 distinct tones per ring in the preview => 4 different images per ring; order unknown (used T,R,B,L).
+        // Guesses: travel fixed at 8 pitches/loop (seamless when 32 % imageCount == 0, e.g. 8 or 16 images);
+        // `gap` unused (the 10% inset is already scaleIntensity); direction backward = negative travel.
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 10, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 10);
+        const FIT = str("mediaFit", "crop");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const SCALE = num("scaleIntensity", 0.9);
+        const DF = num("depthFade", 0.45);
+        const DIR = str("direction", "forward") === "forward" ? 1 : -1;
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const PITCHES = 8; // travel per loop, measured
+        const ZFAR = 5; // birth depth, pitches
+
+        document.getElementById("loop-tunnel-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-tunnel-bg"));
+
+        const f = REF,
+          P = REF,
+          w = P / 2,
+          cellS = SCALE * P;
+        document.getElementById("loop-tunnel-stage").style.perspective = f + "px";
+        document.getElementById("loop-tunnel-world").style.transform = `translateZ(${f}px)`;
+        const tunnel = document.getElementById("loop-tunnel-tunnel");
+
+        // wall transforms (div centred on the ring origin): plane offset + facing; ring origin = near edge of the cell
+        const WALLS = [
+          (s) => `translate3d(0,${-w}px,${-P / 2}px) rotateX(-90deg)`,
+          (s) => `translate3d(${w}px,0,${-P / 2}px) rotateY(-90deg)`,
+          (s) => `translate3d(0,${w}px,${-P / 2}px) rotateX(90deg)`,
+          (s) => `translate3d(${-w}px,0,${-P / 2}px) rotateY(90deg)`,
+        ];
+        // ring slots r = 0..ZFAR (slot r covers z in [r - p, r + 1 - p]); world ring index m = r + n
+        const slots = [];
+        for (let r = 0; r <= ZFAR; r++) {
+          const ring = document.createElement("div");
+          ring.className = "ring";
+          ring.style.transform = `translateZ(${-r * P}px)`;
+          const panels = WALLS.map((tf, wi) => {
+            const holder = document.createElement("div");
+            holder.style.cssText = `position:absolute;left:0;top:0;width:0;height:0;transform-style:preserve-3d;transform:${tf()};`;
+            ring.appendChild(holder);
+            return { holder, shown: -1 };
+          });
+          tunnel.appendChild(ring);
+          slots.push({ r, ring, panels });
+        }
+        function paint(pn, m, wi) {
+          if (pn.shown === m) return;
+          pn.shown = m;
+          const img = IMAGES[(((4 * m + wi) % N) + N) % N];
+          const a = aspect(img, FIT, CROP_AR);
+          const cw = cellS * Math.min(1, a),
+            ch = cellS * Math.min(1, 1 / a);
+          const c = card(img, cw, ch, RADIUS);
+          c.style.left = -cw / 2 + "px";
+          c.style.top = -ch / 2 + "px";
+          pn.holder.replaceChildren(c);
+        }
+        const clamp01 = (x) => Math.max(0, Math.min(1, x));
+        function renderAt(t) {
+          const T = DIR * t * PITCHES;
+          const n = Math.floor(T),
+            p = frac(T);
+          tunnel.style.transform = `translateZ(${p * P}px)`;
+          for (const s of slots) {
+            const m = s.r + n;
+            s.panels.forEach((pn, wi) => paint(pn, m, wi));
+            const zc = s.r - p + 0.5; // cell centre depth, pitches
+            const op = clamp01(ZFAR - zc + 0.5) * clamp01(1 - (DF * (zc - 1.5)) / (ZFAR - 1.5));
+            const o = zc > ZFAR + 0.5 ? "0" : op.toFixed(3);
+            for (const pn of s.panels) pn.holder.style.opacity = o; // on the leaf holders: opacity on the preserve-3d ring would flatten it
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-tunnel"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-tunnel/registry-item.json
+++ b/registry/blocks/loop-tunnel/registry-item.json
@@ -1,0 +1,319 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-tunnel",
+  "type": "hyperframes:block",
+  "title": "Loop Tunnel",
+  "description": "A square tunnel built from rings of image panels flies past the camera. 8 image slots, 10s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "tunnel",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 10,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "crop",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#08080b"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "scaleIntensity",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Media scale",
+      "description": "Strength of the size change.",
+      "default": 0.9,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "forward",
+      "options": [
+        {
+          "value": "forward",
+          "label": "Forward"
+        },
+        {
+          "value": "backward",
+          "label": "Backward"
+        }
+      ]
+    },
+    {
+      "id": "depthFade",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Depth Fade",
+      "description": "Depth Fade (engine parameter; see the block header comment).",
+      "default": 0.45,
+      "min": 0,
+      "max": 2,
+      "step": 0.01
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-tunnel.html",
+      "target": "compositions/loop-tunnel.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-vortexspin/loop-vortexspin.html
+++ b/registry/blocks/loop-vortexspin/loop-vortexspin.html
@@ -1,0 +1,294 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"crop","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"16:9","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"scaleIntensity","type":"number","role":"style","label":"Appearance · Media scale","description":"Strength of the size change.","default":0.15,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":11,"min":0,"max":200,"step":1,"unit":"px"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"alternate","options":[{"value":"cw","label":"Cw"},{"value":"ccw","label":"Ccw"},{"value":"alternate","label":"Alternate"}]},{"id":"rings","type":"number","role":"style","label":"Template options · Rings","description":"Rings (engine parameter; see the block header comment).","default":3,"min":0,"max":10,"step":0.1},{"id":"ringSize","type":"number","role":"style","label":"Template options · Ring Size","description":"Ring Size (engine parameter; see the block header comment).","default":34,"min":0,"max":68,"step":1},{"id":"cardStyle","type":"enum","role":"style","label":"Template options · Card Style","description":"Card Style (engine parameter; see the block header comment).","default":"curved","options":[{"value":"curved","label":"Curved"},{"value":"flat","label":"Flat"}]},{"id":"depthFade","type":"number","role":"style","label":"Template options · Depth Fade","description":"Depth Fade (engine parameter; see the block header comment).","default":50,"min":0,"max":100,"step":1},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-vortexspin</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-vortexspin-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-vortexspin-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-vortexspin-root"
+      data-composition-id="loop-vortexspin"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="20"
+    >
+      <div
+        id="loop-vortexspin-loop"
+        class="clip"
+        data-start="0"
+        data-duration="20"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-vortexspin-bg"></div>
+        <div id="loop-vortexspin-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Vortex loop family — `rings` concentric copies of the same N-card ring receding in
+        // depth: ring k is the outer ring scaled by 1/(1 + k/3) and faded by depthFade% * k/(rings-1); each card is an
+        // annular sector ("curved") tangent to its ring; rings spin linearly one revolution per loop, alternating
+        // direction (outer cw), odd rings phase-shifted half a slot.
+        // Measured on the 512 preview (2026-09-08, 8 images, crop 16:9): rings occupy r 150.5..197.5 / 115..146 / 89..114
+        // -> centreline radii 174 (= ringSize% * H, 34% -> 174.1), 130.5, 101.5 (ratios 0.75, 0.58 ~ 1/(1+k/3) = 0.75, 0.60);
+        // radial thickness 47 / 31 / 25 px (perspective law predicts 47 / 35 / 28 — 10% thinner inside, unexplained);
+        // every card spans 27.5 deg of arc in every ring (central scaling) -> outer arc 81 px x 45.5 px radial = 16:9 card
+        // 0.158 H wide (scaleIntensity 0.15 * H = 76.8; 5% off, kept as a fitted 1.055 factor); 8 cards per ring at 45 deg,
+        // outer/inner cards centred on 0/45/90..., middle ring on 22.5+45k; spin -9 deg per 15 frames (outer, inner) and
+        // +9 deg (middle) = 360 deg / 20 s; mean luma per ring 0.955 / 0.72 / 0.50 of the source grey -> opacity 1 - 0.5*k/2.
+        // Guesses: depth spacing 1/3 (fitted); backFade has no visible effect on the preview (no-op knob); rounded
+        // corners are dropped on curved cards; flat style = plain tangent-rotated cards.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 20, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 20);
+        const FIT = str("mediaFit", "crop");
+        const CROP_AR = str("cropAspectRatio", "16:9");
+        const RINGS = Math.max(1, Math.round(num("rings", 3)));
+        const R = (num("ringSize", 34) / 100) * REF;
+        const CARD_W = num("scaleIntensity", 0.15) * REF * 1.055;
+        const CURVED = str("cardStyle", "curved") === "curved";
+        const DFADE = num("depthFade", 50) / 100;
+        const DIRMODE = str("direction", "alternate");
+        const DEPTH = 1 / 3; // fitted ring-to-ring depth step
+        const RADIUS = (num("borderRadius", 11) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+
+        document.getElementById("loop-vortexspin-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-vortexspin-bg"));
+        const stage = document.getElementById("loop-vortexspin-stage");
+        const rings = [];
+        for (let k = RINGS - 1; k >= 0; k--) {
+          // inner rings first so outer ones paint on top
+          const s = 1 / (1 + k * DEPTH),
+            r = R * s;
+          const dir = DIRMODE === "ccw" ? -1 : DIRMODE === "alternate" && k % 2 ? -1 : 1;
+          const items = [];
+          for (let i = 0; i < N; i++) {
+            const m = IMAGES[i],
+              a = aspect(m, FIT, CROP_AR);
+            const w = CARD_W * s,
+              h = w / a;
+            let el,
+              ox = 0,
+              oy = 0; // (ox,oy): box centre offset from the card centre, radial = -y
+            if (CURVED) {
+              const rOut = r + h / 2,
+                rIn = r - h / 2,
+                alpha = w / 2 / r; // half angle, centreline arc = w
+              const bw = 2 * rOut * Math.sin(alpha),
+                bh = rOut - rIn * Math.cos(alpha);
+              el = card(m, bw, bh, 0);
+              const cx = bw / 2,
+                cy = rOut; // ring centre in box coords
+              const p = (rr, ang) =>
+                `${(cx + rr * Math.sin(ang)).toFixed(2)} ${(cy - rr * Math.cos(ang)).toFixed(2)}`;
+              el.style.clipPath = `path("M ${p(rOut, -alpha)} A ${rOut} ${rOut} 0 0 1 ${p(rOut, alpha)} L ${p(rIn, alpha)} A ${rIn} ${rIn} 0 0 0 ${p(rIn, -alpha)} Z")`;
+              oy = bh / 2 - (rOut - r); // box centre sits this far inward of the ring centreline
+              el.style.left = -bw / 2 + "px";
+              el.style.top = -bh / 2 + "px";
+            } else {
+              el = card(m, w, h, RADIUS * s);
+              el.style.left = -w / 2 + "px";
+              el.style.top = -h / 2 + "px";
+            }
+            el.style.opacity = RINGS > 1 ? 1 - (DFADE * k) / (RINGS - 1) : 1;
+            stage.appendChild(el);
+            items.push({ el, theta: ((i + 0.5 * (k % 2)) * 360) / N, oy });
+          }
+          rings.push({ r, dir, items });
+        }
+        function renderAt(t) {
+          const spin = 360 * frac(t);
+          for (const g of rings)
+            for (const c of g.items) {
+              const phi = c.theta + g.dir * spin,
+                rad = (phi * Math.PI) / 180;
+              const rc = g.r + c.oy; // box centre radius (curved boxes sit slightly inward)
+              c.el.style.transform = `translate(${rc * Math.cos(rad)}px,${rc * Math.sin(rad)}px) rotate(${phi + 90}deg)`;
+            }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-vortexspin"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-vortexspin/registry-item.json
+++ b/registry/blocks/loop-vortexspin/registry-item.json
@@ -1,0 +1,363 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-vortexspin",
+  "type": "hyperframes:block",
+  "title": "Loop Vortex Spin",
+  "description": "Concentric copies of one image ring recede into a vortex and spin. 8 image slots, 20s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "vortexspin",
+    "3d"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 20,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "crop",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "16:9",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "scaleIntensity",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Media scale",
+      "description": "Strength of the size change.",
+      "default": 0.15,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 11,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "alternate",
+      "options": [
+        {
+          "value": "cw",
+          "label": "Cw"
+        },
+        {
+          "value": "ccw",
+          "label": "Ccw"
+        },
+        {
+          "value": "alternate",
+          "label": "Alternate"
+        }
+      ]
+    },
+    {
+      "id": "rings",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Rings",
+      "description": "Rings (engine parameter; see the block header comment).",
+      "default": 3,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "ringSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Ring Size",
+      "description": "Ring Size (engine parameter; see the block header comment).",
+      "default": 34,
+      "min": 0,
+      "max": 68,
+      "step": 1
+    },
+    {
+      "id": "cardStyle",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Card Style",
+      "description": "Card Style (engine parameter; see the block header comment).",
+      "default": "curved",
+      "options": [
+        {
+          "value": "curved",
+          "label": "Curved"
+        },
+        {
+          "value": "flat",
+          "label": "Flat"
+        }
+      ]
+    },
+    {
+      "id": "depthFade",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Depth Fade",
+      "description": "Depth Fade (engine parameter; see the block header comment).",
+      "default": 50,
+      "min": 0,
+      "max": 100,
+      "step": 1
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-vortexspin.html",
+      "target": "compositions/loop-vortexspin.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-wheel-1/loop-wheel-1.html
+++ b/registry/blocks/loop-wheel-1/loop-wheel-1.html
@@ -1,0 +1,318 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"forward","options":[{"value":"forward","label":"Forward"},{"value":"reverse","label":"Reverse"}]},{"id":"ringRadius","type":"number","role":"style","label":"Template options · Ring Radius","description":"Ring Radius (engine parameter; see the block header comment).","default":990,"min":0,"max":1980,"step":10},{"id":"thumbSize","type":"number","role":"style","label":"Template options · Thumb Size","description":"Thumb Size (engine parameter; see the block header comment).","default":184,"min":0,"max":450,"step":10},{"id":"offsetX","type":"number","role":"style","label":"Template options · Offset X","description":"Horizontal offset of the formation, % of width.","default":0,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"offsetY","type":"number","role":"style","label":"Template options · Offset Y","description":"Vertical offset of the formation, % of height.","default":69,"min":-100,"max":100,"step":1,"unit":"%"},{"id":"bigImage","type":"enum","role":"style","label":"Template options · Big Image","description":"Big Image (engine parameter; see the block header comment).","default":"on","options":[{"value":"on","label":"On"},{"value":"off","label":"Off"}]},{"id":"repeatImages","type":"enum","role":"style","label":"Template options · Repeat Images","description":"Repeat Images (engine parameter; see the block header comment).","default":"on","options":[{"value":"on","label":"On"},{"value":"off","label":"Off"}]},{"id":"spinThumbs","type":"enum","role":"style","label":"Template options · Spin Thumbs","description":"Spin Thumbs (engine parameter; see the block header comment).","default":"on","options":[{"value":"on","label":"On"},{"value":"off","label":"Off"}]},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-wheel-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-wheel-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-wheel-1-big {
+        position: absolute;
+        inset: 0;
+        overflow: hidden;
+      }
+      #loop-wheel-1-big img {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        filter: brightness(0.9);
+        display: none;
+      }
+      #loop-wheel-1-big img.on {
+        display: block;
+      }
+      #loop-wheel-1-stage {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 0;
+        height: 0;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-wheel-1-root"
+      data-composition-id="loop-wheel-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="13"
+    >
+      <div
+        id="loop-wheel-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="13"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-wheel-1-bg"></div>
+        <div id="loop-wheel-1-big"></div>
+        <div id="loop-wheel-1-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Wheel loop family — a 2D ring of thumbnails around a centre that may sit far
+        // below the frame (only the top arc shows), turning one thumb pitch per step; optional full-frame
+        // "big image" backdrop = the thumb currently at the top of the ring.
+        // Measured on the 512 previews (2026-09-08):
+        //   ringRadius, thumbSize are 1080p px scaled by H: 421 -> 200 px, 467 -> 221.5, 990 -> 469.6 (radius);
+        //     225 -> 107 px, 71 -> 34, 184 -> 87 (thumb side). offsetY is % of H (69 -> centre y 609 = 256 + 353).
+        //   repeatImages on -> 2N slots (16 thumbs for 8 images, pitch 22.5deg); off -> N slots (45deg).
+        //   steps per loop = N * cycles, one pitch each, NO hold (delay 0): Wheel01 8 steps x 22.5 = 180deg/13 s,
+        //     Wheel04 8 x 45 = 360deg, Wheel05 16 x 45 = 720deg (cycles 2), Wheel06 8 x 22.5 = 180deg.
+        //   step ease: 0.2u + 0.8*expoInOut(u) (Wheel01 f0..49 trace, max err 0.01 at 7 samples) — same law as Marquee.
+        //   forward = clockwise on screen (top thumb moves right); spinThumbs on -> thumb rotated by its ring angle.
+        //   bigImage: hard cut at u = 0.5 of each step to the incoming top thumb's image, at brightness 0.9
+        //     (bg luma 66/91/115 vs thumb 74/101/128).
+        // Guesses/knobs: cycleDeg (180 everywhere) has no measurable effect and is ignored; delay is treated as a
+        //   hold % of each step (0 measured); natural fit fixes thumb HEIGHT = thumbSize.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 13, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, on, pick, aspect, card, background, expoInOut, frac } = RF;
+        const DUR = num("loopDuration", 13);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const R = (num("ringRadius", 990) * REF) / 1080;
+        const TH = (num("thumbSize", 184) * REF) / 1080;
+        const CX = W / 2 + (num("offsetX", 0) / 100) * REF;
+        const CY = H / 2 + (num("offsetY", 0) / 100) * REF;
+        const BIG = on("bigImage", true);
+        const REP = on("repeatImages", true);
+        const CYCLES = Math.max(1, Math.round(num("cycles", 1)));
+        const HOLD = Math.min(0.9, Math.max(0, num("delay", 0) / 100)); // knob: hold fraction per step
+        const DIR = str("direction", "forward") === "reverse" ? -1 : 1; // + = clockwise on screen
+        const SPIN = on("spinThumbs", true);
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const M = REP ? 2 * N : N; // slots on the ring
+        const PITCH = 360 / M;
+        const STEPS = N * CYCLES;
+
+        document.getElementById("loop-wheel-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-wheel-1-bg"));
+        const stage = document.getElementById("loop-wheel-1-stage");
+        const big = document.getElementById("loop-wheel-1-big");
+        const bigImgs = [];
+        if (BIG)
+          for (const m of IMAGES) {
+            const im = document.createElement("img");
+            im.src = m.src;
+            big.appendChild(im);
+            bigImgs.push(im);
+          }
+
+        const slots = [];
+        for (let j = 0; j < M; j++) {
+          const m = IMAGES[j % N],
+            a = aspect(m, FIT, CROP_AR);
+          const h = TH,
+            w = TH * a;
+          const c = card(m, w, h, RADIUS);
+          c.style.left = -w / 2 + "px";
+          c.style.top = -h / 2 + "px";
+          stage.appendChild(c);
+          slots.push({ el: c, theta: j * PITCH });
+        }
+        const easeC = (x) => 0.2 * x + 0.8 * expoInOut(x);
+        const LIM = Math.hypot(W, H) / 2 + TH; // cull thumbs far outside the frame
+        function renderAt(t) {
+          const s = frac(t) * STEPS,
+            k = Math.floor(s),
+            u = s - k;
+          const v = HOLD < 1 ? Math.min(1, u / (1 - HOLD)) : 1;
+          const spin = DIR * PITCH * (k + easeC(v));
+          for (const sl of slots) {
+            const phi = sl.theta + spin,
+              r = (phi * Math.PI) / 180;
+            const x = CX - W / 2 + R * Math.sin(r),
+              y = CY - H / 2 - R * Math.cos(r);
+            if (Math.abs(x) > LIM || Math.abs(y) > LIM) {
+              sl.el.style.display = "none";
+              continue;
+            }
+            sl.el.style.display = "";
+            sl.el.style.transform = `translate(${x}px,${y}px)` + (SPIN ? ` rotate(${phi}deg)` : "");
+          }
+          if (BIG) {
+            // slot at the top after step k is (-DIR*k) mod M; cut to the incoming one at mid-step
+            const kk = u < 0.5 ? k : k + 1;
+            const top = (((-DIR * kk) % M) + M) % M;
+            bigImgs.forEach((im, i) => im.classList.toggle("on", i === top % N));
+          }
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-wheel-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-wheel-1/registry-item.json
+++ b/registry/blocks/loop-wheel-1/registry-item.json
@@ -1,0 +1,419 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-wheel-1",
+  "type": "hyperframes:block",
+  "title": "Loop Wheel 1",
+  "description": "A 2D ring of image thumbnails turns around a centre that may sit off frame. 8 image slots, 13s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "wheel"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 13,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "forward",
+      "options": [
+        {
+          "value": "forward",
+          "label": "Forward"
+        },
+        {
+          "value": "reverse",
+          "label": "Reverse"
+        }
+      ]
+    },
+    {
+      "id": "ringRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Ring Radius",
+      "description": "Ring Radius (engine parameter; see the block header comment).",
+      "default": 990,
+      "min": 0,
+      "max": 1980,
+      "step": 10
+    },
+    {
+      "id": "thumbSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Thumb Size",
+      "description": "Thumb Size (engine parameter; see the block header comment).",
+      "default": 184,
+      "min": 0,
+      "max": 450,
+      "step": 10
+    },
+    {
+      "id": "offsetX",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset X",
+      "description": "Horizontal offset of the formation, % of width.",
+      "default": 0,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "offsetY",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Offset Y",
+      "description": "Vertical offset of the formation, % of height.",
+      "default": 69,
+      "min": -100,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "bigImage",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Big Image",
+      "description": "Big Image (engine parameter; see the block header comment).",
+      "default": "on",
+      "options": [
+        {
+          "value": "on",
+          "label": "On"
+        },
+        {
+          "value": "off",
+          "label": "Off"
+        }
+      ]
+    },
+    {
+      "id": "repeatImages",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Repeat Images",
+      "description": "Repeat Images (engine parameter; see the block header comment).",
+      "default": "on",
+      "options": [
+        {
+          "value": "on",
+          "label": "On"
+        },
+        {
+          "value": "off",
+          "label": "Off"
+        }
+      ]
+    },
+    {
+      "id": "spinThumbs",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Spin Thumbs",
+      "description": "Spin Thumbs (engine parameter; see the block header comment).",
+      "default": "on",
+      "options": [
+        {
+          "value": "on",
+          "label": "On"
+        },
+        {
+          "value": "off",
+          "label": "Off"
+        }
+      ]
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-wheel-1.html",
+      "target": "compositions/loop-wheel-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/blocks/loop-wipe-1/loop-wipe-1.html
+++ b/registry/blocks/loop-wipe-1/loop-wipe-1.html
@@ -1,0 +1,343 @@
+<!doctype html>
+<html
+  lang="en"
+  data-composition-variables='[{"id":"mediaFit","type":"enum","role":"style","label":"Media · Fit","description":"Natural keeps each image&#39;s own ratio; Crop fills the card box at the media aspect below.","default":"natural","options":[{"value":"natural","label":"Natural (original ratio)"},{"value":"crop","label":"Crop"}]},{"id":"cropAspectRatio","type":"enum","role":"style","label":"Media · Aspect","description":"Card aspect used when Fit is Crop.","default":"1:1","options":[{"value":"16:9","label":"16:9"},{"value":"9:16","label":"9:16"},{"value":"1:1","label":"1:1"},{"value":"4:5","label":"4:5"},{"value":"3:2","label":"3:2"},{"value":"3:4","label":"3:4"},{"value":"2:3","label":"2:3"}]},{"id":"backgroundType","type":"enum","role":"style","label":"Background · Type","description":"Gradient (start → end colours), flat Colour, or your own Image.","default":"gradient","options":[{"value":"gradient","label":"Gradient"},{"value":"color","label":"Color"},{"value":"image","label":"Image"}]},{"id":"backgroundGradientStart","type":"color","role":"style","label":"Background · Gradient start","description":"Top colour of the gradient.","default":"#111111"},{"id":"backgroundGradientEnd","type":"color","role":"style","label":"Background · Gradient end","description":"Bottom colour of the gradient.","default":"#444444"},{"id":"backgroundColor","type":"color","role":"style","label":"Background · Color","description":"Flat colour when Type is Color; also the ground under an Image.","default":"#0b0b0f"},{"id":"backgroundImage","type":"image","role":"style","label":"Background · Image","description":"Cover-fitted background when Type is Image.","portrays":["background_image"],"default":""},{"id":"blurAmount","type":"number","role":"style","label":"Background · Blur","description":"Blur on the background image, px.","default":0,"min":0,"max":60,"step":1,"unit":"px"},{"id":"backgroundGradientNoise","type":"number","role":"style","label":"Background · Grain","description":"Film-grain overlay strength.","default":0,"min":0,"max":100,"step":1,"unit":"%"},{"id":"backgroundOpacity","type":"number","role":"style","label":"Background · Opacity","description":"Opacity of the whole background layer (0 = transparent ground).","default":1,"min":0,"max":1,"step":0.05},{"id":"borderRadius","type":"number","role":"style","label":"Appearance · Border radius","description":"Card corner radius in px at 1080.","default":0,"min":0,"max":200,"step":1,"unit":"px"},{"id":"cycles","type":"number","role":"style","label":"Animation · Cycles","description":"Number of motion cycles per loop.","default":1,"min":0,"max":10,"step":0.1},{"id":"delay","type":"number","role":"style","label":"Animation · Delay","description":"Hold time between steps, seconds.","default":0,"min":0,"max":2,"step":0.01,"unit":"s"},{"id":"direction","type":"enum","role":"style","label":"Animation · Direction","description":"Direction of travel.","default":"up","options":[{"value":"up","label":"Up"},{"value":"down","label":"Down"},{"value":"left","label":"Left"},{"value":"right","label":"Right"}]},{"id":"imageFit","type":"enum","role":"style","label":"Template options · Image Fit","description":"Image Fit (engine parameter; see the block header comment).","default":"fill","options":[{"value":"fit","label":"Fit"},{"value":"fill","label":"Fill"}]},{"id":"planeSize","type":"number","role":"style","label":"Template options · Media size","description":"Card size in scene units.","default":100,"min":0,"max":200,"step":1},{"id":"scale","type":"number","role":"style","label":"Template options · Scale","description":"Scale (engine parameter; see the block header comment).","default":4,"min":0,"max":10,"step":0.1},{"id":"feather","type":"number","role":"style","label":"Template options · Feather","description":"Feather (engine parameter; see the block header comment).","default":0,"min":0,"max":2,"step":0.01},{"id":"image1","type":"image","role":"content","label":"Media · Image 1","description":"Image on card 1 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image2","type":"image","role":"content","label":"Media · Image 2","description":"Image on card 2 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image3","type":"image","role":"content","label":"Media · Image 3","description":"Image on card 3 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image4","type":"image","role":"content","label":"Media · Image 4","description":"Image on card 4 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image5","type":"image","role":"content","label":"Media · Image 5","description":"Image on card 5 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1050&#39; viewBox%3D&#39;0 0 1400 1050&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1050&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1046&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 778.05H621.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M286.65 778.05L379.05 662.55L471.45 778.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;552.3&#39; cy%3D&#39;674.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image6","type":"image","role":"content","label":"Media · Image 6","description":"Image on card 6 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;788&#39; viewBox%3D&#39;0 0 1400 788&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;788&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;784&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 583.908H529.376&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;12.382857142857144&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M278.004 583.908L347.348 497.228L416.692 583.908Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;477.36800000000005&#39; cy%3D&#39;505.896&#39; r%3D&#39;26.004&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image7","type":"image","role":"content","label":"Media · Image 7","description":"Image on card 7 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1050&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1050 1400&#39;%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1050&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1046&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M189 995.05H558.6&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;16.5&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M223.65 995.05L316.05 879.55L408.45 995.05Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;489.3&#39; cy%3D&#39;891.1&#39; r%3D&#39;34.65&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"},{"id":"image8","type":"image","role":"content","label":"Media · Image 8","description":"Image on card 8 of 8. Any aspect; fitted per mediaFit.","portrays":["subject_image"],"default":"data:image/svg+xml,%3Csvg xmlns%3D&#39;http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg&#39; width%3D&#39;1400&#39; height%3D&#39;1400&#39; viewBox%3D&#39;0 0 1400 1400&#39;%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;%230b0b0f&#39;%2F%3E%3Crect width%3D&#39;1400&#39; height%3D&#39;1400&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.18)&#39;%2F%3E%3Crect x%3D&#39;2&#39; y%3D&#39;2&#39; width%3D&#39;1396&#39; height%3D&#39;1396&#39; fill%3D&#39;none&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.14)&#39; stroke-width%3D&#39;4&#39;%2F%3E%3Cpath d%3D&#39;M252 1037.4H744.8&#39; stroke%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39; stroke-width%3D&#39;22&#39; stroke-linecap%3D&#39;round&#39;%2F%3E%3Cpath d%3D&#39;M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3Ccircle cx%3D&#39;652.4000000000001&#39; cy%3D&#39;898.8&#39; r%3D&#39;46.199999999999996&#39; fill%3D&#39;rgba(255%2C255%2C255%2C0.45)&#39;%2F%3E%3C%2Fsvg%3E"}]'
+>
+  <head>
+    <title>loop-wipe-1</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1080" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        width: 1080px;
+        height: 1080px;
+        overflow: hidden;
+        background: #0b0b0f;
+      }
+      #loop-wipe-1-bg {
+        position: absolute;
+        inset: 0;
+      }
+      #loop-wipe-1-stage {
+        position: absolute;
+        inset: 0;
+      }
+      .layer {
+        display: none;
+        position: absolute;
+        overflow: hidden;
+      }
+      .card img {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div
+      id="loop-wipe-1-root"
+      data-composition-id="loop-wipe-1"
+      data-start="0"
+      data-width="1080"
+      data-height="1080"
+      data-duration="13"
+    >
+      <div
+        id="loop-wipe-1-loop"
+        class="clip"
+        data-start="0"
+        data-duration="13"
+        data-track-index="1"
+        data-layout-allow-overflow
+      >
+        <div id="loop-wipe-1-bg"></div>
+        <div id="loop-wipe-1-stage"></div>
+      </div>
+    </div>
+    <script>
+      // Shared runtime for the the reference tool loop ports. Loaded by every family engine.
+      // Everything here is a pure function of the HyperFrames variables + t.
+      //
+      // Reference constants (measured on the 512x512 preview library, 2026-09-08):
+      //   Marquee planeSize -> 0.3% of frame height per unit (7 variants, all 1.54px/unit @512)
+      //   Marquee gap       -> 0.2% of frame height per unit
+      //   3D perspective    -> CSS focal length f = 1000px * (100/perspective) at H=1080
+      //                        (3D01/02/08/11: card widths & far-card spacing match to <3%)
+      // Both are calibrated on a SQUARE canvas; for 16:9 we scale by H. ponytail: if the
+      // dashboard 16:9 reference shows width-relative scaling, flip REF below to W.
+      window.RF = (() => {
+        // Variables are injected by the inline script via RF.use(): HyperFrames wraps INLINE scripts in a
+        // per-composition scope where getVariables() resolves; this external file only sees the host window.
+        const V = {},
+          MEDIA = [];
+        const use = (vars, media) => {
+          Object.assign(V, vars || {});
+          MEDIA.splice(0, MEDIA.length, ...(media || []));
+        };
+        const root = document.querySelector("[data-composition-id]");
+        const W = +root.dataset.width,
+          H = +root.dataset.height;
+        const REF = H;
+        const num = (k, d) => (V[k] !== undefined && V[k] !== "" && !isNaN(+V[k]) ? +V[k] : d);
+        const str = (k, d) => (V[k] !== undefined && V[k] !== "" ? String(V[k]) : d);
+        const on = (k, d) => /^(true|on|1)$/i.test(str(k, d ? "on" : "off")); // spec booleans arrive as "true"/"false", enums as on/off
+
+        function pick(n) {
+          n = Math.max(1, Math.min(MEDIA.length, n | 0));
+          return MEDIA.slice(0, n);
+        }
+        // aspect (w/h) a card takes for a media item under mediaFit + cropAspectRatio
+        function aspect(m, fit, cropAR) {
+          if (fit === "natural") return m.w / m.h;
+          const [a, b] = String(cropAR || "1:1")
+            .split(":")
+            .map(Number);
+          return a && b ? a / b : 1;
+        }
+        function card(m, w, h, radius) {
+          const el = document.createElement("div");
+          el.className = "card";
+          el.style.cssText = `position:absolute;width:${w}px;height:${h}px;overflow:hidden;border-radius:${radius}px;`;
+          const img = document.createElement("img");
+          img.src = m.src;
+          img.width = Math.round(w);
+          img.height = Math.round(h);
+          img.style.cssText = `display:block;width:${w}px;height:${h}px;object-fit:cover;`;
+          el.appendChild(img);
+          return el;
+        }
+        function background(el) {
+          // the editor's Background panel: type gradient | color | image, gradient start/end, grain (noise %), opacity, image blur
+          const type = str("backgroundType", "gradient");
+          const c = str("backgroundColor", "#0b0b0f");
+          el.style.background = c;
+          if (type === "gradient") {
+            const g1 = str("backgroundGradientStart", "#111111"),
+              g2 = str("backgroundGradientEnd", "#444444");
+            el.style.background = `linear-gradient(180deg, ${g1}, ${g2})`;
+          } else if (type === "image") {
+            const im = V.backgroundImage,
+              src = im && typeof im === "object" ? im.url || im.src || "" : im || "";
+            if (src) {
+              el.style.background = `${c} url("${src}") center / cover no-repeat`;
+              const b = num("blurAmount", 0);
+              if (b > 0) el.style.filter = `blur(${b}px)`;
+            }
+          }
+          el.style.opacity = String(Math.max(0, Math.min(1, num("backgroundOpacity", 1))));
+          const noise = num("backgroundGradientNoise", 0);
+          if (noise > 0) {
+            const g = document.createElement("div");
+            g.style.cssText = `position:absolute;inset:0;pointer-events:none;mix-blend-mode:overlay;opacity:${((noise / 100) * 0.7).toFixed(3)};background:url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'256'%20height%3D'256'%3E%3Cfilter%20id%3D'n'%3E%3CfeTurbulence%20type%3D'fractalNoise'%20baseFrequency%3D'0.9'%20numOctaves%3D'3'%20stitchTiles%3D'stitch'%20seed%3D'7'%2F%3E%3CfeColorMatrix%20values%3D'0%200%200%200%200.5%200%200%200%200%200.5%200%200%200%200%200.5%200%200%200%201%200'%2F%3E%3C%2Ffilter%3E%3Crect%20width%3D'256'%20height%3D'256'%20filter%3D'url(%23n)'%2F%3E%3C%2Fsvg%3E") 0 0 / 256px 256px repeat`;
+            el.appendChild(g);
+          }
+        }
+        const expoInOut = (x) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, 20 * x - 10) / 2
+                : (2 - Math.pow(2, -20 * x + 10)) / 2;
+        const frac = (x) => x - Math.floor(x);
+        return {
+          V,
+          use,
+          W,
+          H,
+          REF,
+          num,
+          str,
+          on,
+          MEDIA,
+          pick,
+          aspect,
+          card,
+          background,
+          expoInOut,
+          frac,
+        };
+      })();
+    </script>
+    <script>
+      (async () => {
+        // Wipe loop family — "Each image wipes over the last": the incoming image is
+        // revealed by a straight edge travelling across the plane; the outgoing image sits underneath.
+        // Measured on the 512 previews (2026-09-08):
+        //   period = DUR/(N*cycles) per image (Wipe01 48.75f, Wipe03 78.75f); the wipe lasts period - delay
+        //   (Wipe01/02 delay 0: the wipe fills the whole period, no hold; Wipe03/04 delay 1s: 48.75f wipe + 30f hold).
+        //   wipe progress p(u) = 0.22*u + 0.78*expoInOut(k=10)(u), u = time/(period-delay): joint fit over the
+        //   four variants, 514 samples, rms 2.5% of the travel (pure power inOut fits are 1.5-2x worse).
+        //   direction up: revealed from the bottom edge upward; right: from the left edge; down: from the top; left: from the right.
+        //   planeSize = % of H (Wipe03/04 68 -> 348px = 68% @512; Wipe01/02 100 = full frame).
+        // Guesses/knobs: plane box is frame-shaped (square previews cannot tell); imageFit fit = contain, fill = cover;
+        //   `scale` (4 on Wipe01/02) invisible on uniform placeholders -> used as a settle zoom of the incoming
+        //   image from 1+scale/100 to 1 across the wipe; `feather` (0 everywhere) -> soft edge width in % of H via a mask.
+        // media list [{src,w,h}] is inlined by build.mjs; HyperFrames scopes inline scripts, so hand both to the shared lib explicitly
+        const __V = Object.assign(
+          {},
+          (window.__hyperframes && window.__hyperframes.getVariables
+            ? window.__hyperframes.getVariables()
+            : null) || {},
+          { loopDuration: 13, loopRepeat: 2, imageCount: 8 },
+        );
+        const __PH = [
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+          "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E",
+        ];
+        const __MEDIA = await Promise.all(
+          ["image1", "image2", "image3", "image4", "image5", "image6", "image7", "image8"].map(
+            async (id, i) => {
+              const v = __V[id];
+              const src = (v && typeof v === "object" ? v.url || v.src : v) || __PH[i];
+              const img = new Image();
+              img.src = src;
+              try {
+                await img.decode();
+              } catch (e) {}
+              return { src, w: img.naturalWidth || 1400, h: img.naturalHeight || 1050 };
+            },
+          ),
+        );
+        RF.use(__V, __MEDIA);
+        const { W, H, REF, num, str, pick, aspect, card, background, frac } = RF;
+        const DUR = num("loopDuration", 13);
+        const FIT = str("mediaFit", "natural");
+        const CROP_AR = str("cropAspectRatio", "1:1");
+        const IMGFIT = str("imageFit", "fill");
+        const PLANE = num("planeSize", 100) / 100;
+        const DIR = str("direction", "up");
+        const SCALE = num("scale", 0) / 100;
+        const FEATHER = (num("feather", 0) / 100) * REF;
+        const CYCLES = Math.max(1, num("cycles", 1) | 0);
+        const DELAY = num("delay", 0);
+        const RADIUS = (num("borderRadius", 0) * REF) / 1080;
+        const IMAGES = pick(num("imageCount", 16));
+        const N = IMAGES.length;
+        const PERIOD = DUR / (N * CYCLES);
+        const WIPE = Math.max(0.05, PERIOD - DELAY); // seconds of travel per image
+
+        document.getElementById("loop-wipe-1-loop").dataset.duration = DUR;
+        background(document.getElementById("loop-wipe-1-bg"));
+        const stage = document.getElementById("loop-wipe-1-stage");
+
+        const BW = W * PLANE,
+          BH = H * PLANE,
+          L = (W - BW) / 2,
+          TP = (H - BH) / 2;
+        const layers = IMAGES.map((m) => {
+          const a = aspect(m, FIT, CROP_AR);
+          let w, h;
+          if (IMGFIT === "fill") {
+            if (BW / BH > a) {
+              w = BW;
+              h = BW / a;
+            } else {
+              h = BH;
+              w = BH * a;
+            }
+          } else {
+            if (BW / BH > a) {
+              h = BH;
+              w = BH * a;
+            } else {
+              w = BW;
+              h = BW / a;
+            }
+          }
+          const box = document.createElement("div");
+          box.className = "layer";
+          box.style.cssText += `left:${L}px;top:${TP}px;width:${BW}px;height:${BH}px;border-radius:${RADIUS}px;`;
+          const c = card(m, w, h, 0);
+          c.style.left = (BW - w) / 2 + "px";
+          c.style.top = (BH - h) / 2 + "px";
+          box.appendChild(c);
+          stage.appendChild(box);
+          return box;
+        });
+
+        const expoK = (x, k) =>
+          x <= 0
+            ? 0
+            : x >= 1
+              ? 1
+              : x < 0.5
+                ? Math.pow(2, k * (2 * x - 1)) / 2
+                : 1 - Math.pow(2, -k * (2 * x - 1)) / 2;
+        const P = (u) => (u <= 0 ? 0 : u >= 1 ? 1 : 0.22 * u + 0.78 * expoK(u, 10));
+        // clip the incoming plane so a fraction p is revealed from the leading edge; feather = soft band
+        function reveal(el, p) {
+          const fpx = FEATHER,
+            along = DIR === "up" || DIR === "down" ? BH : BW;
+          const cut = p * (along + fpx) - fpx; // hard-edge position from the start edge
+          if (fpx <= 0) {
+            const ins = along - cut;
+            el.style.clipPath =
+              DIR === "up"
+                ? `inset(${ins}px 0 0 0)`
+                : DIR === "down"
+                  ? `inset(0 0 ${ins}px 0)`
+                  : DIR === "left"
+                    ? `inset(0 0 0 ${ins}px)`
+                    : `inset(0 ${ins}px 0 0)`;
+            el.style.maskImage = "";
+          } else {
+            const toDir =
+              DIR === "up"
+                ? "to top"
+                : DIR === "down"
+                  ? "to bottom"
+                  : DIR === "left"
+                    ? "to left"
+                    : "to right";
+            el.style.clipPath = "";
+            el.style.maskImage =
+              el.style.webkitMaskImage = `linear-gradient(${toDir}, #000 ${cut}px, transparent ${cut + fpx}px)`;
+          }
+        }
+        let shown = [];
+        function renderAt(t) {
+          const s = frac(t) * N * CYCLES; // slot progress
+          const k = Math.floor(s) % N,
+            u = ((s - Math.floor(s)) * PERIOD) / WIPE;
+          const outI = k,
+            inI = (k + 1) % N,
+            p = P(u);
+          for (const i of shown) if (i !== outI && i !== inI) layers[i].style.display = "none";
+          shown = [outI, inI];
+          const out = layers[outI],
+            inn = layers[inI];
+          out.style.display = "block";
+          out.style.zIndex = "1";
+          out.style.clipPath = "";
+          out.style.maskImage = out.style.webkitMaskImage = "";
+          out.style.transform = "";
+          inn.style.display = "block";
+          inn.style.zIndex = "2";
+          reveal(inn, p);
+          inn.style.transform = SCALE ? `scale(${1 + SCALE * (1 - p)})` : "";
+        }
+        // one paused linear tween drives t; every frame is recomputed from t alone (seek-safe)
+        const state = { t: 0 };
+        const tl = gsap.timeline({ paused: true });
+        tl.to(state, { t: 1, duration: DUR, ease: "none", onUpdate: () => renderAt(state.t) }, 0);
+        renderAt(0);
+        window.__timelines = window.__timelines || {};
+        window.__timelines["loop-wipe-1"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/registry/blocks/loop-wipe-1/registry-item.json
+++ b/registry/blocks/loop-wipe-1/registry-item.json
@@ -1,0 +1,378 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "loop-wipe-1",
+  "type": "hyperframes:block",
+  "title": "Loop Wipe 1",
+  "description": "Each incoming image wipes over the last. 8 image slots, 13s seamless loop, 1:1.",
+  "tags": [
+    "loop",
+    "images",
+    "showcase",
+    "gallery",
+    "wipe"
+  ],
+  "author": "Miao Yang",
+  "license": "Apache-2.0",
+  "dimensions": {
+    "width": 1080,
+    "height": 1080
+  },
+  "duration": 13,
+  "variables": [
+    {
+      "id": "mediaFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Fit",
+      "description": "Natural keeps each image's own ratio; Crop fills the card box at the media aspect below.",
+      "default": "natural",
+      "options": [
+        {
+          "value": "natural",
+          "label": "Natural (original ratio)"
+        },
+        {
+          "value": "crop",
+          "label": "Crop"
+        }
+      ]
+    },
+    {
+      "id": "cropAspectRatio",
+      "type": "enum",
+      "role": "style",
+      "label": "Media · Aspect",
+      "description": "Card aspect used when Fit is Crop.",
+      "default": "1:1",
+      "options": [
+        {
+          "value": "16:9",
+          "label": "16:9"
+        },
+        {
+          "value": "9:16",
+          "label": "9:16"
+        },
+        {
+          "value": "1:1",
+          "label": "1:1"
+        },
+        {
+          "value": "4:5",
+          "label": "4:5"
+        },
+        {
+          "value": "3:2",
+          "label": "3:2"
+        },
+        {
+          "value": "3:4",
+          "label": "3:4"
+        },
+        {
+          "value": "2:3",
+          "label": "2:3"
+        }
+      ]
+    },
+    {
+      "id": "backgroundType",
+      "type": "enum",
+      "role": "style",
+      "label": "Background · Type",
+      "description": "Gradient (start → end colours), flat Colour, or your own Image.",
+      "default": "gradient",
+      "options": [
+        {
+          "value": "gradient",
+          "label": "Gradient"
+        },
+        {
+          "value": "color",
+          "label": "Color"
+        },
+        {
+          "value": "image",
+          "label": "Image"
+        }
+      ]
+    },
+    {
+      "id": "backgroundGradientStart",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient start",
+      "description": "Top colour of the gradient.",
+      "default": "#111111"
+    },
+    {
+      "id": "backgroundGradientEnd",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Gradient end",
+      "description": "Bottom colour of the gradient.",
+      "default": "#444444"
+    },
+    {
+      "id": "backgroundColor",
+      "type": "color",
+      "role": "style",
+      "label": "Background · Color",
+      "description": "Flat colour when Type is Color; also the ground under an Image.",
+      "default": "#0b0b0f"
+    },
+    {
+      "id": "backgroundImage",
+      "type": "image",
+      "role": "style",
+      "label": "Background · Image",
+      "description": "Cover-fitted background when Type is Image.",
+      "portrays": [
+        "background_image"
+      ],
+      "default": ""
+    },
+    {
+      "id": "blurAmount",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Blur",
+      "description": "Blur on the background image, px.",
+      "default": 0,
+      "min": 0,
+      "max": 60,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "backgroundGradientNoise",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Grain",
+      "description": "Film-grain overlay strength.",
+      "default": 0,
+      "min": 0,
+      "max": 100,
+      "step": 1,
+      "unit": "%"
+    },
+    {
+      "id": "backgroundOpacity",
+      "type": "number",
+      "role": "style",
+      "label": "Background · Opacity",
+      "description": "Opacity of the whole background layer (0 = transparent ground).",
+      "default": 1,
+      "min": 0,
+      "max": 1,
+      "step": 0.05
+    },
+    {
+      "id": "borderRadius",
+      "type": "number",
+      "role": "style",
+      "label": "Appearance · Border radius",
+      "description": "Card corner radius in px at 1080.",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 1,
+      "unit": "px"
+    },
+    {
+      "id": "cycles",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Cycles",
+      "description": "Number of motion cycles per loop.",
+      "default": 1,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "delay",
+      "type": "number",
+      "role": "style",
+      "label": "Animation · Delay",
+      "description": "Hold time between steps, seconds.",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01,
+      "unit": "s"
+    },
+    {
+      "id": "direction",
+      "type": "enum",
+      "role": "style",
+      "label": "Animation · Direction",
+      "description": "Direction of travel.",
+      "default": "up",
+      "options": [
+        {
+          "value": "up",
+          "label": "Up"
+        },
+        {
+          "value": "down",
+          "label": "Down"
+        },
+        {
+          "value": "left",
+          "label": "Left"
+        },
+        {
+          "value": "right",
+          "label": "Right"
+        }
+      ]
+    },
+    {
+      "id": "imageFit",
+      "type": "enum",
+      "role": "style",
+      "label": "Template options · Image Fit",
+      "description": "Image Fit (engine parameter; see the block header comment).",
+      "default": "fill",
+      "options": [
+        {
+          "value": "fit",
+          "label": "Fit"
+        },
+        {
+          "value": "fill",
+          "label": "Fill"
+        }
+      ]
+    },
+    {
+      "id": "planeSize",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Media size",
+      "description": "Card size in scene units.",
+      "default": 100,
+      "min": 0,
+      "max": 200,
+      "step": 1
+    },
+    {
+      "id": "scale",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Scale",
+      "description": "Scale (engine parameter; see the block header comment).",
+      "default": 4,
+      "min": 0,
+      "max": 10,
+      "step": 0.1
+    },
+    {
+      "id": "feather",
+      "type": "number",
+      "role": "style",
+      "label": "Template options · Feather",
+      "description": "Feather (engine parameter; see the block header comment).",
+      "default": 0,
+      "min": 0,
+      "max": 2,
+      "step": 0.01
+    },
+    {
+      "id": "image1",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 1",
+      "description": "Image on card 1 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image2",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 2",
+      "description": "Image on card 2 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image3",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 3",
+      "description": "Image on card 3 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image4",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 4",
+      "description": "Image on card 4 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image5",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 5",
+      "description": "Image on card 5 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1050' viewBox%3D'0 0 1400 1050'%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1050' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1046' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 778.05H621.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M286.65 778.05L379.05 662.55L471.45 778.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'552.3' cy%3D'674.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image6",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 6",
+      "description": "Image on card 6 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'788' viewBox%3D'0 0 1400 788'%3E%3Crect width%3D'1400' height%3D'788' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'788' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'784' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 583.908H529.376' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'12.382857142857144' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M278.004 583.908L347.348 497.228L416.692 583.908Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'477.36800000000005' cy%3D'505.896' r%3D'26.004' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image7",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 7",
+      "description": "Image on card 7 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1050' height%3D'1400' viewBox%3D'0 0 1050 1400'%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1050' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1046' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M189 995.05H558.6' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'16.5' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M223.65 995.05L316.05 879.55L408.45 995.05Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'489.3' cy%3D'891.1' r%3D'34.65' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    },
+    {
+      "id": "image8",
+      "type": "image",
+      "role": "content",
+      "label": "Media · Image 8",
+      "description": "Image on card 8 of 8. Any aspect; fitted per mediaFit.",
+      "portrays": [
+        "subject_image"
+      ],
+      "default": "data:image/svg+xml,%3Csvg xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg' width%3D'1400' height%3D'1400' viewBox%3D'0 0 1400 1400'%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'%230b0b0f'%2F%3E%3Crect width%3D'1400' height%3D'1400' fill%3D'rgba(255%2C255%2C255%2C0.18)'%2F%3E%3Crect x%3D'2' y%3D'2' width%3D'1396' height%3D'1396' fill%3D'none' stroke%3D'rgba(255%2C255%2C255%2C0.14)' stroke-width%3D'4'%2F%3E%3Cpath d%3D'M252 1037.4H744.8' stroke%3D'rgba(255%2C255%2C255%2C0.45)' stroke-width%3D'22' stroke-linecap%3D'round'%2F%3E%3Cpath d%3D'M298.2 1037.4L421.4 883.4L544.5999999999999 1037.4Z' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3Ccircle cx%3D'652.4000000000001' cy%3D'898.8' r%3D'46.199999999999996' fill%3D'rgba(255%2C255%2C255%2C0.45)'%2F%3E%3C%2Fsvg%3E"
+    }
+  ],
+  "files": [
+    {
+      "path": "loop-wipe-1.html",
+      "target": "compositions/loop-wipe-1.html",
+      "type": "hyperframes:composition"
+    }
+  ]
+}

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -436,6 +436,146 @@
       "type": "hyperframes:block"
     },
     {
+      "name": "loop-3d-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-bento-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-book-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-cardtoss",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-carousel-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-carousel3d-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-corridor",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-coverflow",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-deck-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-field-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-filmstrip",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-flicker-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-flip-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-fold",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-frames-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-globe-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-gravity-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-grid-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-marquee-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-orbit-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-pages-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-parallax-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-proximity-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-ring",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-scale-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-shelf",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-spin-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-spiral-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-stack-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-stories-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-swirl",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-tunnel",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-vortexspin",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-wheel-1",
+      "type": "hyperframes:block"
+    },
+    {
+      "name": "loop-wipe-1",
+      "type": "hyperframes:block"
+    },
+    {
       "name": "lower-third-bild",
       "type": "hyperframes:block"
     },


### PR DESCRIPTION
## Summary

Adds 35 curated loop template components to the registry — one variant per family, hand-picked from a 249-component loop-template collection (95 motion families) generated by Miao Yang. Each block is a self-contained HyperFrames composition: a single paused GSAP timeline that recomputes every card transform from `t`, with parameters exposed through `data-composition-variables` (Media / Background / Appearance / Animation / Template options groups) and `image1..N` content slots defaulting to monochrome SVG placeholders.

**Code-only** — each item ships `registry-item.json` + `<name>.html`. No preview thumbnails/videos are included; this repo shouldn't carry binary preview assets.

## Selected families

**3D / spatial effects**
- `loop-3d-1`, `loop-carousel3d-1`, `loop-globe-1`, `loop-orbit-1`, `loop-corridor`, `loop-tunnel`, `loop-vortexspin`

**Carousel / slider**
- `loop-carousel-1`, `loop-coverflow`, `loop-wheel-1`, `loop-ring`, `loop-filmstrip`

**Card / deck mechanics**
- `loop-deck-1`, `loop-stack-1`, `loop-cardtoss`, `loop-book-1`, `loop-flip-1`, `loop-fold`, `loop-shelf`

**Grid / layout**
- `loop-grid-1`, `loop-bento-1`, `loop-field-1`, `loop-frames-1`, `loop-pages-1`

**Motion / kinetic**
- `loop-marquee-1`, `loop-spiral-1`, `loop-spin-1`, `loop-swirl`, `loop-scale-1`, `loop-gravity-1`, `loop-parallax-1`, `loop-proximity-1`, `loop-flicker-1`, `loop-wipe-1`, `loop-stories-1`

35 total.

## Registry changes

- `registry/registry.json` — 35 new `hyperframes:block` entries, kept alphabetically sorted within the block group (215 blocks total, up from 180).

## Validation

- `node scripts/lint-registry-items.mjs` → passed, 434 items, 0 errors.

## Credit

Original 249-component collection authored by Miao Yang (`miao.yang@heygen.com`). This PR curates and imports a 35-item subset.

Note: there is a separate open draft PR (#3810) from the same source collection that imports all 249 blocks in one shot. This PR is an independent, smaller, code-only curated subset — flagging in case reviewers want to reconcile the two rather than merge both.