### PR TITLE
fix(registry): authenticate deck sound effect messages

### DIFF
--- a/packages/core/src/runtime/deckAudio.test.ts
+++ b/packages/core/src/runtime/deckAudio.test.ts
@@ -1,0 +1,74 @@
+import { JSDOM } from "jsdom";
+import { expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+const demoHtml = readFileSync(
+  resolve(__dirname, "../../../../registry/examples/airbnb-deck/demo.html"),
+  "utf8",
+);
+
+it("accepts only current-player sound names while preserving unlock and mute behavior", async () => {
+  const clips: Array<{
+    play: ReturnType<typeof vi.fn>;
+    pause: ReturnType<typeof vi.fn>;
+    volume: number;
+    currentTime: number;
+  }> = [];
+  const dom = new JSDOM(demoHtml, {
+    runScripts: "dangerously",
+    beforeParse(window) {
+      Object.defineProperty(window, "Audio", {
+        value: function () {
+          const clip = {
+            play: vi.fn(() => Promise.resolve()),
+            pause: vi.fn(),
+            volume: 1,
+            currentTime: 0,
+          };
+          clips.push(clip);
+          return clip;
+        },
+      });
+    },
+  });
+  try {
+    const w = dom.window;
+    const player = w.document.querySelector("hyperframes-player")!;
+    const frame = w.document.createElement("iframe");
+    player.append(frame);
+    Object.defineProperty(player, "iframeElement", { get: () => player.querySelector("iframe") });
+    const original = frame.contentWindow;
+    const send = (source: MessageEventSource | null, name: unknown) =>
+      w.dispatchEvent(new w.MessageEvent("message", { source, data: { type: "hf-sfx", name } }));
+    send(original, "advance");
+    expect(clips.every((clip) => clip.play.mock.calls.length === 0)).toBe(true);
+    w.dispatchEvent(new w.Event("pointerdown"));
+    await Promise.resolve();
+    clips.forEach((clip) => clip.play.mockClear());
+    for (const name of ["advance", "fragment", "branch-enter", "back"]) send(original, name);
+    expect(clips.map((clip) => clip.play.mock.calls.length)).toEqual([1, 1, 1, 1]);
+    for (const name of ["__proto__", "constructor", "unknown", ["advance"]]) send(original, name);
+    expect(Object.hasOwn(w.Object.prototype, "currentTime")).toBe(false);
+    send(null, "advance");
+    const foreign = w.document.createElement("iframe");
+    w.document.body.append(foreign);
+    send(foreign.contentWindow, "advance");
+    expect(clips.map((clip) => clip.play.mock.calls.length)).toEqual([1, 1, 1, 1]);
+    const replacement = w.document.createElement("iframe");
+    frame.replaceWith(replacement);
+    send(original, "advance");
+    expect(clips[0]!.play).toHaveBeenCalledTimes(1);
+    send(replacement.contentWindow, "advance");
+    expect(clips[0]!.play).toHaveBeenCalledTimes(2);
+    const slideshow = w.document.querySelector("hyperframes-slideshow")!;
+    slideshow.dispatchEvent(new w.CustomEvent("hf-sound", { detail: { muted: true } }));
+    send(replacement.contentWindow, "advance");
+    expect(clips[0]!.play).toHaveBeenCalledTimes(2);
+    slideshow.dispatchEvent(new w.CustomEvent("hf-sound", { detail: { muted: false } }));
+    send(replacement.contentWindow, "advance");
+    expect(clips[0]!.play).toHaveBeenCalledTimes(3);
+    expect(clips.map((clip) => clip.volume)).toEqual([0.45, 0.4, 0.4, 0.4]);
+  } finally {
+    dom.window.close();
+  }
+});

--- a/registry/examples/airbnb-deck/demo.html
+++ b/registry/examples/airbnb-deck/demo.html
@@ -168,8 +168,12 @@
         window.addEventListener("click", unlock, true);
 
         window.addEventListener("message", function (e) {
+          var player = slideshow && slideshow.querySelector("hyperframes-player");
+          var frame = player && player.iframeElement;
+          if (!frame || !frame.contentWindow || e.source !== frame.contentWindow) return;
           var d = e.data;
           if (!d || d.type !== "hf-sfx") return;
+          if (typeof d.name !== "string" || !Object.hasOwn(clips, d.name)) return;
           // Skip playback when muted — the component owns mute state.
           if (muted) return;
           var el = clips[d.name];


### PR DESCRIPTION
The Airbnb deck's sound-effect handler accepts messages from unrelated windows and indexes an ordinary object using the supplied clip name. A message naming `__proto__` can therefore assign `currentTime` to `Object.prototype`.

Require the sender to be the current deck player's non-null iframe window (#637), and require an own string clip name before lookup (#636). The four sound effects, gesture unlock, volume and slideshow mute behavior remain unchanged. The player is resolved for each message so a replaced iframe cannot keep controlling sound.

Verification: a regression executes the actual demo scripts in JSDOM with mocked Audio and covers all four clip names, unlock/mute/unmute, null/foreign/replaced senders, inherited names, coerced names and prototype integrity. It passes the fix and fails the original demo. A real Chromium check with the actual player iframe confirms valid sound messages work while self messages and prototype names are rejected. Full workspace build, core typechecks, lint/format and signed hooks pass; Fallow is clear.

Validation limitation: the repository CLI lint/check commands target the unchanged `index.html` composition, not the `demo.html` host page. They stop on its existing requestAnimationFrame lint finding (plus a file-size warning); no browser/layout pass is claimed from that command. The host-page behavior is covered by the separate real-browser check above.

Please verify both alert flows and compatibility. No dismissals; verify main CodeQL closure after merge. Test lives with the core JSDOM fixtures to use its existing dependency, with no new dependencies or production core changes.
