### PR TITLE
fix(player): authenticate slideshow navigation senders

### DIFF
--- a/packages/player/src/slideshow/hyperframes-slideshow.test.ts
+++ b/packages/player/src/slideshow/hyperframes-slideshow.test.ts
@@ -199,6 +199,30 @@ describe("<hyperframes-slideshow>", () => {
     el.remove();
   });
 
+  it("accepts embedding-parent and self navigation but rejects other senders", () => {
+    const onNext = vi.fn();
+    const el = makeEl({ onNext });
+    const embedding = document.createElement("iframe");
+    const foreign = document.createElement("iframe");
+    document.body.append(embedding, foreign);
+    vi.stubGlobal("parent", embedding.contentWindow);
+    try {
+      for (const source of [foreign.contentWindow, null]) {
+        window.dispatchEvent(new MessageEvent("message", { source, data: { type: "next" } }));
+      }
+      expect(onNext).not.toHaveBeenCalled();
+      for (const source of [window, embedding.contentWindow]) {
+        window.dispatchEvent(new MessageEvent("message", { source, data: { type: "next" } }));
+      }
+      expect(onNext).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.unstubAllGlobals();
+      embedding.remove();
+      foreign.remove();
+      el.remove();
+    }
+  });
+
   it("handles postMessage next", () => {
     const el = document.createElement("hyperframes-slideshow") as any;
     document.body.appendChild(el);
@@ -215,7 +239,7 @@ describe("<hyperframes-slideshow>", () => {
       currentSlide: { hotspots: [] },
       nextSlide: null,
     });
-    window.dispatchEvent(new MessageEvent("message", { data: { type: "next" } }));
+    window.dispatchEvent(new MessageEvent("message", { source: window, data: { type: "next" } }));
     expect(nextCalled).toBe(true);
     el.remove();
   });
@@ -1981,7 +2005,7 @@ describe("<hyperframes-slideshow> Fix 7 — audience mode ignores window postMes
       currentSlide: { hotspots: [] },
       nextSlide: null,
     });
-    window.dispatchEvent(new MessageEvent("message", { data: { type: "next" } }));
+    window.dispatchEvent(new MessageEvent("message", { source: window, data: { type: "next" } }));
     expect(nextCalled).toBe(false);
     el.remove();
   });
@@ -2003,7 +2027,7 @@ describe("<hyperframes-slideshow> Fix 7 — audience mode ignores window postMes
       currentSlide: { hotspots: [] },
       nextSlide: null,
     });
-    window.dispatchEvent(new MessageEvent("message", { data: { type: "next" } }));
+    window.dispatchEvent(new MessageEvent("message", { source: window, data: { type: "next" } }));
     expect(nextCalled).toBe(true);
     el.remove();
   });
@@ -2474,7 +2498,7 @@ describe("<hyperframes-slideshow> Fix 4 — back affordance (postMessage only; c
         backCalled = true;
       },
     });
-    window.dispatchEvent(new MessageEvent("message", { data: { type: "back" } }));
+    window.dispatchEvent(new MessageEvent("message", { source: window, data: { type: "back" } }));
     expect(backCalled).toBe(true);
     el.remove();
   });
@@ -2488,7 +2512,7 @@ describe("<hyperframes-slideshow> Fix 4 — back affordance (postMessage only; c
       },
     });
     el.setAttribute("mode", "audience");
-    window.dispatchEvent(new MessageEvent("message", { data: { type: "back" } }));
+    window.dispatchEvent(new MessageEvent("message", { source: window, data: { type: "back" } }));
     expect(backCalled).toBe(false);
     el.remove();
   });

--- a/packages/player/src/slideshow/hyperframes-slideshow.ts
+++ b/packages/player/src/slideshow/hyperframes-slideshow.ts
@@ -914,6 +914,7 @@ export class HyperframesSlideshow extends HTMLElement {
 
   // fallow-ignore-next-line complexity
   private onMessage = (e: MessageEvent): void => {
+    if (e.source !== window.parent && e.source !== window) return;
     // Audience mode is driven by BroadcastChannel; ignore embed postMessage nav.
     if (this.resolveMode() === "audience") return;
     const data = e.data as { type?: unknown; slideIndex?: unknown } | null;

--- a/packages/sdk-playground/src/main.test.ts
+++ b/packages/sdk-playground/src/main.test.ts
@@ -4,6 +4,11 @@ import { expect, it, vi } from "vitest";
 
 // Keep initialization at the asynchronous persistence boundary while exercising
 // the real static UI and its registered message listener.
+// The paused initializer never opens a composition. Keep unrelated SDK/parser
+// and raw animation-library transforms out of this message-boundary witness.
+vi.mock("@hyperframes/sdk", () => ({ openComposition: vi.fn() }));
+vi.mock("@hyperframes/core/gsap-parser-acorn", () => ({ parseGsapScriptAcorn: vi.fn() }));
+vi.mock("gsap/dist/gsap.min.js?raw", () => ({ default: "" }));
 vi.mock("./fileAdapter.js", () => ({
   createFileAdapter: () => new Promise(() => {}),
 }));


### PR DESCRIPTION
The slideshow accepts bare `next`, `prev`, `goto`, and `back` messages from any window. An unrelated child or sibling frame can therefore navigate the host slideshow.

Authenticate the sender before reading the payload: accept the embedding parent or the slideshow's own window (#634). Existing parent-driven embeds and same-window navigation remain available. Audience mode continues to ignore postMessage navigation and use its existing BroadcastChannel path. This is separate from the composition-to-host sound-effect contract fixed in #3819.

Verification: all 370 player tests, player typechecks, full workspace build, lint/format and signed hooks pass. The new sender regression fails the original implementation. Real Chromium verifies all four commands from a distinct embedding parent, same-window navigation, and rejection of sibling/null-source messages. Existing synthetic navigation tests now supply the actual self sender. Fallow has no changed-file findings.

Please independently verify the embed sender contract and #634's PR-ref result. No dismissal or query suppression is requested; verify main CodeQL closure after merge.

The playground message-boundary witness now mocks unused SDK/parser/GSAP initialization imports. Its initializer is already paused at persistence; the real UI listener remains exercised. This avoids transforming unrelated dependencies inside the test budget (two hosted 5s timeouts); all four local playground tests pass with the witness at127ms and unchanged timeout. Types and signed hooks pass.
