### PR TITLE
fix(cli): hide detached Windows child consoles

### DIFF
--- a/packages/cli/src/commands/previewLifecycle.test.ts
+++ b/packages/cli/src/commands/previewLifecycle.test.ts
@@ -165,6 +165,8 @@ describe("background preview lifecycle", () => {
 
     expect(result).toMatchObject({ type: "started", port: 3211, pid: 5432 });
     expect(spawn).toHaveBeenCalledOnce();
+    const spawnOptions = (spawn.mock.calls[0] as unknown[] | undefined)?.[2];
+    expect(spawnOptions).toEqual(expect.objectContaining({ windowsHide: true }));
   });
 
   it.each([

--- a/packages/cli/src/commands/previewLifecycle.ts
+++ b/packages/cli/src/commands/previewLifecycle.ts
@@ -33,6 +33,7 @@ type SpawnPreview = (
     detached: boolean;
     stdio: ["ignore", number, number];
     env: NodeJS.ProcessEnv;
+    windowsHide: boolean;
   },
 ) => SpawnResult;
 
@@ -219,6 +220,7 @@ function spawnDetachedPreview(
         detached: true,
         stdio: ["ignore", logFd, logFd],
         env: process.env,
+        windowsHide: true,
       },
     );
   } finally {

--- a/packages/cli/src/telemetry/client.test.ts
+++ b/packages/cli/src/telemetry/client.test.ts
@@ -140,13 +140,14 @@ describe("telemetry queue delivery", () => {
     const [execPath, args, opts] = spawnMock.mock.calls[0] as unknown as [
       string,
       string[],
-      { detached: boolean },
+      { detached: boolean; windowsHide: boolean },
     ];
     expect(execPath).toBe(process.execPath);
     expect(args[0]).toBe("-e");
     expect(args[1]).toContain("render_complete");
     expect(args[1]).toMatch(/[0-9a-f-]{36}/); // event uuid rides along
     expect(opts.detached).toBe(true);
+    expect(opts.windowsHide).toBe(true);
 
     // Queue handed to the child — nothing left for a regular flush.
     const fetchMock = vi.fn(() => Promise.resolve(new Response("")));

--- a/packages/cli/src/telemetry/transport.ts
+++ b/packages/cli/src/telemetry/transport.ts
@@ -155,7 +155,7 @@ export function flushSync(): void {
         "-e",
         `fetch(${JSON.stringify(`${POSTHOG_HOST}/batch/`)},{method:"POST",headers:{"Content-Type":"application/json"},body:${JSON.stringify(payload)},signal:AbortSignal.timeout(${FLUSH_TIMEOUT_MS})}).catch(()=>{})`,
       ],
-      { detached: true, stdio: "ignore" },
+      { detached: true, stdio: "ignore", windowsHide: true },
     );
     // Let the parent exit without waiting for the child
     child.unref();

--- a/packages/cli/src/utils/openBrowser.test.ts
+++ b/packages/cli/src/utils/openBrowser.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import { openBrowser } from "./openBrowser.js";
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(() => ({ on: vi.fn(), unref: vi.fn() })),
+}));
+vi.mock("node:child_process", () => ({ spawn: spawnMock }));
 import {
   buildBrowserArgs,
   parseRemoteDebuggingPort,
@@ -66,6 +72,18 @@ describe("buildBrowserArgs", () => {
       "--remote-debugging-port=9222",
       "http://localhost:3002",
     ]);
+  });
+});
+
+describe("openBrowser", () => {
+  it("hides a detached browser process on Windows", () => {
+    openBrowser("http://localhost:3002", { browserPath: "/usr/bin/chromium" });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      "/usr/bin/chromium",
+      ["http://localhost:3002"],
+      expect.objectContaining({ detached: true, windowsHide: true }),
+    );
   });
 });
 

--- a/packages/cli/src/utils/openBrowser.ts
+++ b/packages/cli/src/utils/openBrowser.ts
@@ -81,6 +81,7 @@ export function openBrowser(url: string, options: OpenBrowserOptions = {}): void
     const child = spawn(options.browserPath, args, {
       detached: true,
       stdio: "ignore",
+      windowsHide: true,
     });
     child.on("error", () => {});
     child.unref();


### PR DESCRIPTION
## Summary

Detached CLI spawns could show console windows on Windows because `windowsHide` was omitted. Set `windowsHide: true` for telemetry flush, custom browser launch, and background preview.

Fixes #3476

## Reviewers

James Russo, Kevin Rajan, Ular Kimsanov