### PR TITLE
perf(runtime): reuse one timing resolver per pass and derive duration only when the composition changes

### DIFF
--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -3674,3 +3674,270 @@ describe("initSandboxRuntimeModular", () => {
     });
   });
 });
+
+/**
+ * The derived duration floor is a function of the composition, not of the
+ * playhead — yet transportTick asked for it on every animation frame, which
+ * made a paused, untouched editor scan every media element ~60 times a second.
+ *
+ * These tests pin the two halves of that change: the derivation must happen a
+ * FIXED number of times regardless of how many frames elapse, and every input
+ * that can change the answer must still force a fresh one.
+ *
+ * The probe is `[data-composition-id][data-start]`, which `init.ts` queries in
+ * exactly one place: `resolveAuthoredCompositionDurationFloorSeconds`, reached
+ * only from a real derivation. Counting it needs no production test hook, and
+ * it cannot be satisfied by a derivation that was skipped.
+ */
+describe("derived duration floor recomputation", () => {
+  const DERIVATION_PROBE_SELECTOR = "[data-composition-id][data-start]";
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+  const originalCancelAnimationFrame = window.cancelAnimationFrame;
+
+  let raf: ReturnType<typeof createManualRaf>;
+  let derivations: number;
+
+  /**
+   * Registers a short root timeline as well as the markup. transportTick only
+   * syncs the clock duration when a timeline is BOUND, so a fixture without
+   * one never reaches the per-frame call these tests are about — it would make
+   * the invariance assertion pass for the wrong reason. The timeline is
+   * deliberately shorter than every media window here so the derived floor,
+   * not the timeline, is what the assertions read.
+   */
+  const mountComposition = (bodyHtml: string) => {
+    document.body.innerHTML = `<div data-composition-id="main" data-root="true" data-start="0">${bodyHtml}</div>`;
+    window.__timelines = { main: createMockTimeline(1) };
+  };
+
+  const setNativeDuration = (media: HTMLMediaElement, seconds: number) => {
+    Object.defineProperty(media, "duration", { value: seconds, configurable: true });
+  };
+
+  /** Drive the transport for `frames` animation frames and report the duration it settled on. */
+  const runFrames = (frames: number): number => {
+    for (let frame = 0; frame < frames; frame += 1) raf.step(16);
+    return window.__player!.getDuration();
+  };
+
+  beforeEach(() => {
+    resetRuntimeDataForTests();
+    document.body.innerHTML = "";
+    (globalThis as typeof globalThis & { CSS?: { escape?: (value: string) => string } }).CSS ??= {};
+    globalThis.CSS.escape ??= (value: string) => value;
+    raf = createManualRaf();
+    window.requestAnimationFrame = raf.requestAnimationFrame as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = raf.cancelAnimationFrame as typeof window.cancelAnimationFrame;
+    derivations = 0;
+    const originalQuerySelectorAll = Element.prototype.querySelectorAll;
+    vi.spyOn(Element.prototype, "querySelectorAll").mockImplementation(function (
+      this: Element,
+      selector: string,
+    ) {
+      if (selector === DERIVATION_PROBE_SELECTOR) derivations += 1;
+      return originalQuerySelectorAll.call(this, selector);
+    } as typeof Element.prototype.querySelectorAll);
+    window.__timelines = {};
+  });
+
+  afterEach(() => {
+    window.__hfRuntimeTeardown?.();
+    resetRuntimeDataForTests();
+    document.body.innerHTML = "";
+    window.__timelines = {} as Record<string, RuntimeTimelineLike>;
+    delete window.__player;
+    delete window.__playerReady;
+    delete window.__renderReady;
+    vi.restoreAllMocks();
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  describe("invariance across frames", () => {
+    /**
+     * The load-bearing assertion, and it is INVARIANCE, not a threshold: a
+     * threshold ("fewer than 10 derivations") passes on a small fixture and
+     * still degrades linearly in production. Quadrupling the frame count must
+     * not change the derivation count at all.
+     */
+    it("derives the duration floor a fixed number of times however many frames elapse", () => {
+      mountComposition(`<video data-start="0"></video>`);
+      setNativeDuration(document.querySelector("video")!, 10);
+      initSandboxRuntimeModular();
+
+      const afterStartup = derivations;
+      expect(runFrames(25)).toBe(10);
+      const afterShortRun = derivations - afterStartup;
+
+      expect(runFrames(100)).toBe(10);
+      const afterLongRun = derivations - afterStartup - afterShortRun;
+
+      // Four times the frames, the same amount of work. Before the cache both
+      // numbers tracked the frame count (25 and 100).
+      expect(afterShortRun).toBe(afterLongRun);
+      expect(afterShortRun).toBe(0);
+    });
+
+    it("does not re-derive for a DOM change that cannot affect the duration", () => {
+      mountComposition(`<video data-start="0"></video>`);
+      setNativeDuration(document.querySelector("video")!, 10);
+      initSandboxRuntimeModular();
+      runFrames(2);
+
+      const before = derivations;
+      // A class and an inline transform are what an animating composition
+      // writes on every frame. Treating those as duration inputs would make
+      // the cache useless during playback.
+      document.querySelector("video")!.classList.add("is-visible");
+      document.querySelector("video")!.setAttribute("style", "opacity: 0.5");
+
+      expect(runFrames(5)).toBe(10);
+      expect(derivations).toBe(before);
+    });
+  });
+
+  describe("invalidation, one test per input that can change the answer", () => {
+    /**
+     * Media metadata is the input with no DOM footprint at all: `duration`
+     * goes from NaN to a number on the element itself. Both halves are visible
+     * here — the silent property change is served STALE (proving the cache is
+     * real), and the event that always accompanies it in a browser makes it
+     * fresh (proving the invalidation is real).
+     */
+    it("serves a stale duration for a silent metadata change and a fresh one once the event fires", () => {
+      mountComposition(`<video data-start="0"></video>`);
+      const video = document.querySelector("video")!;
+      setNativeDuration(video, 10);
+      initSandboxRuntimeModular();
+      expect(runFrames(2)).toBe(10);
+
+      // Half one: the input changed, nothing signalled it, the cache answers.
+      setNativeDuration(video, 30);
+      expect(runFrames(2)).toBe(10);
+
+      // Half two: the signal a real browser emits alongside that change.
+      video.dispatchEvent(new Event("durationchange"));
+      expect(runFrames(1)).toBe(30);
+    });
+
+    it("re-derives when el.load() resets duration to NaN", () => {
+      mountComposition(`<video data-start="0"></video>`);
+      const video = document.querySelector("video")!;
+      setNativeDuration(video, 10);
+      initSandboxRuntimeModular();
+      expect(runFrames(2)).toBe(10);
+
+      // What load() does: duration back to NaN, announced by `emptied`.
+      setNativeDuration(video, Number.NaN);
+      expect(runFrames(2)).toBe(10);
+      video.dispatchEvent(new Event("emptied"));
+      const before = derivations;
+      runFrames(1);
+      expect(derivations).toBeGreaterThan(before);
+    });
+
+    it("re-derives when a timing attribute is edited", () => {
+      mountComposition(`<video data-start="0"></video>`);
+      setNativeDuration(document.querySelector("video")!, 10);
+      initSandboxRuntimeModular();
+      expect(runFrames(2)).toBe(10);
+
+      document.querySelector("video")!.setAttribute("data-duration", "25");
+      expect(runFrames(1)).toBe(25);
+    });
+
+    it("re-derives when a clip is moved later on the timeline", () => {
+      mountComposition(`<video data-start="0" data-duration="10"></video>`);
+      initSandboxRuntimeModular();
+      expect(runFrames(2)).toBe(10);
+
+      document.querySelector("video")!.setAttribute("data-start", "5");
+      expect(runFrames(1)).toBe(15);
+    });
+
+    it("re-derives when a timed element is added after init", () => {
+      mountComposition(`<video data-start="0" data-duration="10"></video>`);
+      initSandboxRuntimeModular();
+      expect(runFrames(2)).toBe(10);
+
+      // Nested compositions mount asynchronously, well after init — this is
+      // the ordinary case, not an edge case.
+      const late = document.createElement("audio");
+      late.setAttribute("data-start", "20");
+      late.setAttribute("data-duration", "5");
+      document.querySelector("[data-composition-id]")!.append(late);
+
+      expect(runFrames(1)).toBe(25);
+    });
+
+    it("re-derives when a timed element is removed", () => {
+      mountComposition(
+        `<video data-start="0" data-duration="10"></video>` +
+          `<audio id="tail" data-start="20" data-duration="5"></audio>`,
+      );
+      initSandboxRuntimeModular();
+      expect(runFrames(2)).toBe(25);
+
+      document.querySelector("#tail")!.remove();
+      expect(runFrames(1)).toBe(10);
+    });
+
+    /**
+     * `window.__timelines` is a plain object. No MutationObserver and no event
+     * can see a composition script registering into it or lengthening what it
+     * already registered, so the cache compares a signature of the registry on
+     * every read. Nothing else in the invalidation set could catch this.
+     */
+    it("re-derives when a nested composition's registered timeline grows", () => {
+      mountComposition(`<div data-composition-id="scene" data-start="0" data-duration="10"></div>`);
+      window.__timelines = { ...window.__timelines, scene: createMockTimeline(10) };
+      initSandboxRuntimeModular();
+      expect(runFrames(2)).toBe(10);
+
+      window.__timelines = { ...window.__timelines, scene: createMockTimeline(40) };
+      const before = derivations;
+      runFrames(1);
+      expect(derivations).toBeGreaterThan(before);
+    });
+
+    /**
+     * MutationObserver records are delivered in a microtask. A caller that
+     * edits a timing attribute and reads the duration back in the same
+     * synchronous block — which is exactly what the Studio's live editing does
+     * — would be handed the pre-edit value if the cache waited for the
+     * callback. It drains the queue on read instead.
+     */
+    it("reflects an edit read back in the same synchronous block", () => {
+      mountComposition(`<video data-start="0" data-duration="10"></video>`);
+      initSandboxRuntimeModular();
+      expect(runFrames(2)).toBe(10);
+
+      // No await, no microtask checkpoint between the write and the read.
+      document.querySelector("video")!.setAttribute("data-duration", "42");
+      expect(runFrames(1)).toBe(42);
+    });
+  });
+
+  /**
+   * The render path depends on the exact duration and a frame captured against
+   * a wrong one cannot be recovered, so it does not read the cache at all —
+   * the same silent metadata change that is deliberately served stale to the
+   * editor must be seen immediately here.
+   */
+  it("never serves a cached duration once render capture has started", () => {
+    mountComposition(`<video data-start="0"></video>`);
+    const video = document.querySelector("video")!;
+    setNativeDuration(video, 10);
+    initSandboxRuntimeModular();
+    expect(runFrames(2)).toBe(10);
+
+    window.__player!.renderSeek(0);
+    setNativeDuration(video, 30);
+    // No `durationchange` dispatched, and the editor would still answer 10.
+    expect(runFrames(1)).toBe(30);
+
+    const before = derivations;
+    runFrames(3);
+    expect(derivations).toBeGreaterThan(before);
+  });
+});

--- a/packages/core/src/runtime/init.timingResolver.test.ts
+++ b/packages/core/src/runtime/init.timingResolver.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeTimelineLike } from "./types";
+
+const resolverSpy = vi.hoisted(() => ({ constructions: 0 }));
+const mediaSpy = vi.hoisted(() => ({ beforeSync: null as null | (() => void) }));
+
+vi.mock("./startResolver", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./startResolver")>();
+  return {
+    ...actual,
+    createRuntimeStartTimeResolver: (
+      params: Parameters<typeof actual.createRuntimeStartTimeResolver>[0],
+    ) => {
+      resolverSpy.constructions += 1;
+      return actual.createRuntimeStartTimeResolver(params);
+    },
+  };
+});
+
+vi.mock("./media", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./media")>();
+  return {
+    ...actual,
+    syncRuntimeMedia: (params: Parameters<typeof actual.syncRuntimeMedia>[0]) => {
+      mediaSpy.beforeSync?.();
+      return actual.syncRuntimeMedia(params);
+    },
+  };
+});
+
+const { initSandboxRuntimeModular } = await import("./init");
+
+function createMockTimeline(duration: number): RuntimeTimelineLike {
+  const state = { time: 0, paused: true };
+  return {
+    play: () => {
+      state.paused = false;
+    },
+    pause: () => {
+      state.paused = true;
+    },
+    seek: (time?: number) => (time === undefined ? state.time : (state.time = time)),
+    totalTime: (time?: number) => (time === undefined ? state.time : (state.time = time)),
+    time: () => state.time,
+    duration: () => duration,
+    add: () => {},
+    paused: (value?: boolean) =>
+      typeof value === "boolean" ? (state.paused = value) : state.paused,
+    timeScale: () => {},
+    set: () => {},
+    getChildren: () => [],
+  };
+}
+
+/** jsdom leaves `duration` as NaN; a writable getter also lets a test mimic the
+ *  `el.load()` reset `syncRuntimeMedia` performs on the seek-retry path. */
+function stubDuration(el: HTMLMediaElement, initial: number): { set: (next: number) => void } {
+  let value = initial;
+  Object.defineProperty(el, "duration", { get: () => value, configurable: true });
+  return { set: (next: number) => (value = next) };
+}
+
+describe("runtime timing resolver scoping", () => {
+  const originalRequestAnimationFrame = window.requestAnimationFrame;
+  const originalCancelAnimationFrame = window.cancelAnimationFrame;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    (globalThis as typeof globalThis & { CSS?: { escape?: (value: string) => string } }).CSS ??= {};
+    globalThis.CSS.escape ??= (value: string) => value;
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = (() => {}) as typeof window.cancelAnimationFrame;
+    resolverSpy.constructions = 0;
+    mediaSpy.beforeSync = null;
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+    mediaSpy.beforeSync = null;
+    delete window.__player;
+    delete window.__playerReady;
+  });
+
+  /** One seek plus one transport tick: between them they drive all three
+   *  scopes (media cache, visibility pass, media-window duration scan). */
+  const passWithMediaCount = (count: number): number => {
+    const frames: FrameRequestCallback[] = [];
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    }) as typeof window.requestAnimationFrame;
+    const flushFrame = () => frames.splice(0, frames.length).forEach((callback) => callback(0));
+
+    const clips = Array.from(
+      { length: count },
+      (_, i) => `<video id="clip${i}" data-start="${i}" data-duration="1"></video>`,
+    ).join("");
+    document.body.innerHTML = `<div data-composition-id="main" data-root="true">${clips}</div>`;
+    for (const video of document.querySelectorAll("video")) {
+      stubDuration(video as HTMLVideoElement, 1);
+    }
+    window.__timelines = { main: createMockTimeline(count) };
+    initSandboxRuntimeModular();
+    // Let the runtime bind its timeline, so the tick below takes the
+    // duration-resolution branch rather than short-circuiting.
+    flushFrame();
+
+    resolverSpy.constructions = 0;
+    window.__player?.renderSeek(0.5);
+    flushFrame();
+    return resolverSpy.constructions;
+  };
+
+  // Non-vacuity: this is the whole point of the change. Every resolver carries
+  // WeakMap caches, so building one per call means a seek re-walks the ancestor
+  // chain of every element. Before the fix this count grew with media count
+  // (~7 constructions per media element); after it, it is flat.
+  it("builds a constant number of timing resolvers per seek, not one per element", () => {
+    const few = passWithMediaCount(2);
+    const many = passWithMediaCount(12);
+
+    expect(many).toBe(few);
+    // A ceiling, so a future caller that reintroduces per-element construction
+    // inside a scope fails here even if it happens to be element-count-flat.
+    expect(many).toBeLessThanOrEqual(6);
+  });
+
+  // The two scopes exist because `syncRuntimeMedia` can call `el.load()` on its
+  // seek-past-buffered-range retry, which synchronously resets `el.duration`.
+  // One scope spanning the media pass would serve the pre-`load()` duration to
+  // the visibility pass that runs after it.
+  it("resolves a post-load() duration in the visibility pass, not the cached pre-load() one", () => {
+    document.body.innerHTML =
+      `<div data-composition-id="main" data-root="true">` +
+      // `lead`'s duration is read (and cached) while the media cache is built,
+      // because `follower`'s start is expressed relative to it.
+      `<video id="lead" data-start="0"></video>` +
+      `<audio id="follower" data-start="lead + 0" data-duration="1"></audio>` +
+      `</div>`;
+    const lead = document.querySelector<HTMLVideoElement>("#lead")!;
+    const follower = document.querySelector<HTMLAudioElement>("#follower")!;
+    const leadDuration = stubDuration(lead, 10);
+    stubDuration(follower, 1);
+    window.__timelines = {};
+    initSandboxRuntimeModular();
+
+    // Stands in for the `el.load()` the seek-retry performs: the source turns
+    // out to be shorter than the metadata first reported.
+    mediaSpy.beforeSync = () => leadDuration.set(2);
+
+    window.__player?.renderSeek(2.5);
+
+    // Fresh read => follower starts at 2 and is on screen at 2.5.
+    // Stale cache => follower starts at 10 and is hidden.
+    expect(follower.style.visibility).toBe("visible");
+  });
+});

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -955,13 +955,140 @@ export function initSandboxRuntimeModular(): void {
     return maxSeconds > MIN_VALID_TIMELINE_DURATION_SECONDS ? maxSeconds : null;
   };
 
+  // Flips true on the first renderSeek call — the render/producer capture
+  // protocol's signal that it has started deterministically driving frames.
+  // One-way for this page lifetime; every producer render gets a fresh runtime.
+  // See scheduleMetadataDurationHydration for why this gates the async
+  // metadata rebind off once set, and resolveDurationFloors for why the
+  // derived-duration cache is bypassed entirely once it is set.
+  let renderCaptureSeekStarted = false;
+
+  // The media and authored-composition duration floors are derived from the
+  // DOM and the timeline registry — never from the playhead — so they change
+  // only when the composition changes. transportTick asks for them on EVERY
+  // animation frame, and deriving them scans every media element and walks
+  // each one's composition ancestry, which is the largest single cost of a
+  // paused, untouched editor. Derive once and reuse until an input changes.
+  //
+  // Every input that can change the answer, and the signal that catches it:
+  //   - timing attributes edited (Studio live editing, variables re-applied,
+  //     the runtime's own autostamping)      -> MutationObserver, attribute filter below
+  //   - media or timed elements added/removed (nested compositions mount
+  //     asynchronously, well after init)     -> MutationObserver, childList + subtree
+  //   - media metadata arriving or being reset (`el.load()` puts `duration`
+  //     back to NaN) — no DOM mutation at all -> capture-phase media events below
+  //   - a timeline registered, or an existing one's duration changing, in
+  //     `window.__timelines` (a plain object, not observable) -> registry
+  //     signature compared on read
+  // The bias is deliberate: a redundant derivation is a missed optimisation,
+  // a missed one is a wrong duration.
+  type DurationFloors = { media: number | null; authoredComposition: number | null };
+  const DURATION_FLOOR_INPUT_ATTRIBUTES = [
+    "data-start",
+    "data-duration",
+    "data-end",
+    "data-composition-id",
+    "data-composition-src",
+    "data-composition-file",
+    "data-root",
+    "data-hf-authored-duration",
+    "data-hf-authored-end",
+    "data-hf-auto-start",
+    MEDIA_START_BASIS_ATTR,
+    "data-playback-rate",
+    "data-playback-start",
+    "data-media-start",
+    // `data-start` may be an expression referencing another element by id, and
+    // a media element's `duration` follows its source.
+    "id",
+    "src",
+  ];
+  const DURATION_FLOOR_MEDIA_EVENTS = ["loadedmetadata", "durationchange", "emptied"] as const;
+  let durationFloorsCache: DurationFloors | null = null;
+  let durationFloorsRegistrySignature: string | null = null;
+  let durationFloorsObserver: MutationObserver | null = null;
+
+  const invalidateDurationFloors = () => {
+    durationFloorsCache = null;
+  };
+
+  const deriveDurationFloors = (): DurationFloors => ({
+    media: resolveMediaDurationFloorSeconds(),
+    authoredComposition: resolveAuthoredCompositionDurationFloorSeconds(),
+  });
+
+  const readTimelineRegistrySignature = (): string => {
+    const timelines = (window.__timelines ?? {}) as Record<string, RuntimeTimelineLike | undefined>;
+    let signature = "";
+    for (const timelineId of Object.keys(timelines)) {
+      const timeline = timelines[timelineId];
+      if (!timeline) continue;
+      signature += `${timelineId}=${getTimelineDurationSeconds(timeline) ?? "?"};`;
+    }
+    return signature;
+  };
+
+  const watchDurationFloorInputs = () => {
+    if (durationFloorsObserver || typeof MutationObserver === "undefined") return;
+    durationFloorsObserver = new MutationObserver(invalidateDurationFloors);
+    durationFloorsObserver.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: DURATION_FLOOR_INPUT_ATTRIBUTES,
+    });
+    // Media duration changes are published as events, not DOM mutations, and
+    // they do not bubble — so listen in the capture phase, which reaches every
+    // media element including ones added long after this binds.
+    for (const eventType of DURATION_FLOOR_MEDIA_EVENTS) {
+      document.addEventListener(eventType, invalidateDurationFloors, true);
+    }
+    runtimeCleanupCallbacks.push(() => {
+      durationFloorsObserver?.disconnect();
+      durationFloorsObserver = null;
+      invalidateDurationFloors();
+      for (const eventType of DURATION_FLOOR_MEDIA_EVENTS) {
+        document.removeEventListener(eventType, invalidateDurationFloors, true);
+      }
+    });
+  };
+
+  const resolveDurationFloors = (): DurationFloors => {
+    // The render path never reads a cached floor. Capture depends on the exact
+    // duration and a frame that rendered against a wrong one cannot be
+    // recovered, so it pays the full derivation on every frame exactly as
+    // before — a correct slow render beats a fast wrong one.
+    if (renderCaptureSeekStarted) return deriveDurationFloors();
+    watchDurationFloorInputs();
+    // MutationObserver records are delivered in a microtask, so a caller that
+    // edits a timing attribute and reads the duration back in the SAME
+    // synchronous block would otherwise be served the pre-edit value. Draining
+    // the queue here makes the cache correct within a task, not just across
+    // tasks. Taking the records suppresses the callback for them, which is
+    // exactly equivalent since the callback only marks the cache stale.
+    if (durationFloorsObserver && durationFloorsObserver.takeRecords().length > 0) {
+      invalidateDurationFloors();
+    }
+    const registrySignature = readTimelineRegistrySignature();
+    if (durationFloorsCache && registrySignature === durationFloorsRegistrySignature) {
+      return durationFloorsCache;
+    }
+    durationFloorsRegistrySignature = registrySignature;
+    durationFloorsCache = deriveDurationFloors();
+    return durationFloorsCache;
+  };
+
   const getSafeTimelineDurationSeconds = (
     timeline: RuntimeTimelineLike | null,
     fallback = 0,
   ): number => {
     const timelineDuration = getTimelineDurationSeconds(timeline);
-    const mediaFloor = resolveMediaDurationFloorSeconds();
-    const authoredCompositionFloor = resolveAuthoredCompositionDurationFloorSeconds();
+    const { media: mediaFloor, authoredComposition: authoredCompositionFloor } =
+      resolveDurationFloors();
+    // Deliberately NOT cached: adapters infer their duration from live
+    // animation objects (CSS/WAAPI/Lottie), which can change without any DOM
+    // mutation or media event to observe. It is also a short loop over the
+    // registered adapters, not a document scan.
     const adapterFloor = resolveAdapterDurationFloorSeconds();
     const durationFloor = Math.max(
       mediaFloor ?? 0,
@@ -1013,9 +1140,10 @@ export function initSandboxRuntimeModular(): void {
       timelineRegistry: timelines,
       includeAuthoredTimingAttrs: true,
     });
-    const mediaDurationFloorSeconds = resolveMediaDurationFloorSeconds();
-    const authoredCompositionDurationFloorSeconds =
-      resolveAuthoredCompositionDurationFloorSeconds();
+    const {
+      media: mediaDurationFloorSeconds,
+      authoredComposition: authoredCompositionDurationFloorSeconds,
+    } = resolveDurationFloors();
     const durationFloorSeconds =
       Math.max(mediaDurationFloorSeconds ?? 0, authoredCompositionDurationFloorSeconds ?? 0) ||
       null;
@@ -1854,12 +1982,6 @@ export function initSandboxRuntimeModular(): void {
 
   let metadataRebindDebounceTimerId: number | null = null;
   let metadataRebindApplied = false;
-  // Flips true on the first renderSeek call — the render/producer capture
-  // protocol's signal that it has started deterministically driving frames.
-  // One-way for this page lifetime; every producer render gets a fresh runtime.
-  // See scheduleMetadataDurationHydration for why this gates the async
-  // metadata rebind off once set.
-  let renderCaptureSeekStarted = false;
   const metadataBoundMedia = new Set<HTMLMediaElement>();
   const volumeKeyframeCache = new WeakMap<HTMLMediaElement, VolumeKeyframe[]>();
 

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -645,34 +645,63 @@ export function initSandboxRuntimeModular(): void {
     }
   };
 
+  const createTimingResolver = (includeAuthoredTimingAttrs: boolean) =>
+    createRuntimeStartTimeResolver({
+      timelineRegistry: (window.__timelines ?? {}) as Record<
+        string,
+        RuntimeTimelineLike | undefined
+      >,
+      includeAuthoredTimingAttrs,
+    });
+
+  // `createRuntimeStartTimeResolver` memoizes starts and durations in WeakMaps,
+  // but a resolver built per call throws those caches away before the second
+  // lookup ever happens, so one pass re-walks every ancestor chain once per
+  // element. `withTimingResolver` installs ONE resolver for the duration of a
+  // synchronous callback; every resolve inside shares its caches.
+  //
+  // NEVER widen these into a single scope spanning a whole media pass.
+  // `syncRuntimeMedia` calls `el.load()` on the seek-past-buffered-range retry
+  // (media.ts), which synchronously resets `el.duration` to NaN, and
+  // `resolveDurationForElement` reads `element.duration` (startResolver.ts). A
+  // cache living across `refreshRuntimeMediaCache` -> `syncRuntimeMedia` ->
+  // `syncTimedElementVisibility` would serve the pre-`load()` duration to a
+  // post-`load()` read. Two scopes with the write in between is what makes that
+  // impossible. Do not merge them.
+  let activeTimingResolver: ReturnType<typeof createTimingResolver> | null = null;
+
+  const withTimingResolver = <T>(fn: () => T): T => {
+    const previous = activeTimingResolver;
+    activeTimingResolver = createTimingResolver(true);
+    try {
+      return fn();
+    } finally {
+      activeTimingResolver = previous;
+    }
+  };
+
+  // The installed resolver carries authored timing attrs; a caller that opts
+  // out gets its own, exactly as before.
+  const timingResolverFor = (includeAuthoredTimingAttrs: boolean) =>
+    includeAuthoredTimingAttrs && activeTimingResolver
+      ? activeTimingResolver
+      : createTimingResolver(includeAuthoredTimingAttrs);
+
   const resolveStartForElement = (
     element: Element,
     fallback = 0,
     opts?: { includeAuthoredTimingAttrs?: boolean },
-  ): number => {
-    const resolver = createRuntimeStartTimeResolver({
-      timelineRegistry: (window.__timelines ?? {}) as Record<
-        string,
-        RuntimeTimelineLike | undefined
-      >,
-      includeAuthoredTimingAttrs: opts?.includeAuthoredTimingAttrs ?? true,
-    });
-    return resolver.resolveStartForElement(element, fallback);
-  };
+  ): number =>
+    timingResolverFor(opts?.includeAuthoredTimingAttrs ?? true).resolveStartForElement(
+      element,
+      fallback,
+    );
 
   const resolveDurationForElement = (
     element: Element,
     opts?: { includeAuthoredTimingAttrs?: boolean },
-  ): number | null => {
-    const resolver = createRuntimeStartTimeResolver({
-      timelineRegistry: (window.__timelines ?? {}) as Record<
-        string,
-        RuntimeTimelineLike | undefined
-      >,
-      includeAuthoredTimingAttrs: opts?.includeAuthoredTimingAttrs ?? true,
-    });
-    return resolver.resolveDurationForElement(element);
-  };
+  ): number | null =>
+    timingResolverFor(opts?.includeAuthoredTimingAttrs ?? true).resolveDurationForElement(element);
 
   const resolveMediaCompositionContext = (element: Element) => {
     const compositionRoot = element.closest("[data-composition-id]");
@@ -814,20 +843,35 @@ export function initSandboxRuntimeModular(): void {
     return null;
   };
 
+  // Scope 3 of 3 (see `withTimingResolver`). Every media element resolves its
+  // composition ancestry here, and this runs on every transport tick via
+  // `getSafeTimelineDurationSeconds`, so it is the heaviest consumer of the
+  // per-call resolvers.
+  //
+  // The scope sits HERE and not on `getSafeTimelineDurationSeconds`, which
+  // would look like the tidier boundary: that function also calls
+  // `timeline.duration()` (author-supplied GSAP) and every adapter's
+  // `getInferredDurationSeconds()` (third-party runtimes). Foreign code inside
+  // a cache scope can touch the DOM between two resolves. This loop is DOM
+  // reads only, so nothing can change under it.
   const resolveMediaWindowDurationSeconds = (): number | null => {
     const mediaNodes = Array.from(
       document.querySelectorAll("video[data-start], audio[data-start]"),
     ) as HTMLMediaElement[];
+    // Checked before the scope opens: a composition with no timed media runs
+    // this every tick, and it should not pay for a resolver it never uses.
     if (mediaNodes.length === 0) return null;
-    let maxWindowEndSeconds = 0;
-    for (const node of mediaNodes) {
-      const start = resolveAbsoluteMediaStartSeconds(node);
-      if (!Number.isFinite(start)) continue;
-      const duration = resolveMediaElementDurationSeconds(node);
-      if (duration == null || duration <= MIN_VALID_TIMELINE_DURATION_SECONDS) continue;
-      maxWindowEndSeconds = Math.max(maxWindowEndSeconds, Math.max(0, start) + duration);
-    }
-    return maxWindowEndSeconds > MIN_VALID_TIMELINE_DURATION_SECONDS ? maxWindowEndSeconds : null;
+    return withTimingResolver(() => {
+      let maxWindowEndSeconds = 0;
+      for (const node of mediaNodes) {
+        const start = resolveAbsoluteMediaStartSeconds(node);
+        if (!Number.isFinite(start)) continue;
+        const duration = resolveMediaElementDurationSeconds(node);
+        if (duration == null || duration <= MIN_VALID_TIMELINE_DURATION_SECONDS) continue;
+        maxWindowEndSeconds = Math.max(maxWindowEndSeconds, Math.max(0, start) + duration);
+      }
+      return maxWindowEndSeconds > MIN_VALID_TIMELINE_DURATION_SECONDS ? maxWindowEndSeconds : null;
+    });
   };
 
   const resolveAuthoredCompositionDurationFloorSeconds = (): number | null => {
@@ -2086,10 +2130,7 @@ export function initSandboxRuntimeModular(): void {
     }
   };
 
-  const syncTimedElementVisibility = (
-    currentTime: number,
-    visibilityNodes: Element[] = Array.from(document.querySelectorAll("[data-start]")),
-  ) => {
+  const applyTimedElementVisibility = (currentTime: number, visibilityNodes: Element[]) => {
     const rootComp = resolveRootCompositionElement();
     for (const rawNode of visibilityNodes) {
       if (!(rawNode instanceof HTMLElement)) continue;
@@ -2160,41 +2201,54 @@ export function initSandboxRuntimeModular(): void {
     syncAudioGroupMute();
   };
 
+  // Scope 2 of 3 (see `withTimingResolver`). One resolver for the whole
+  // visibility pass: every node costs 2 x (1 + ancestor depth) resolves, and
+  // ancestor chains are shared between siblings. Nothing in this body calls
+  // `el.load()` or awaits, so no duration can change under the cache.
+  const syncTimedElementVisibility = (
+    currentTime: number,
+    visibilityNodes: Element[] = Array.from(document.querySelectorAll("[data-start]")),
+  ) => withTimingResolver(() => applyTimedElementVisibility(currentTime, visibilityNodes));
+
   const syncMediaForCurrentState = () => {
-    const cache = refreshRuntimeMediaCache({
-      shouldIncludeElement: (element) =>
-        element.hasAttribute("data-start") ||
-        Boolean(resolveMediaCompositionContext(element).compositionRoot),
-      resolveStartSeconds: (element) => {
-        return resolveAbsoluteMediaStartSeconds(element);
-      },
-      resolveDurationSeconds: (element) => {
-        const context = resolveMediaCompositionContext(element);
-        const start = resolveAbsoluteMediaStartSeconds(element);
-        const hostRemaining =
-          context.inheritedStart != null &&
-          context.inheritedDuration != null &&
-          context.inheritedDuration > 0
-            ? Math.max(0, context.inheritedStart + context.inheritedDuration - start)
+    // Scope 1 of 3 (see `withTimingResolver`). Closes before `syncRuntimeMedia`,
+    // which may call `el.load()` and invalidate every cached duration.
+    const cache = withTimingResolver(() =>
+      refreshRuntimeMediaCache({
+        shouldIncludeElement: (element) =>
+          element.hasAttribute("data-start") ||
+          Boolean(resolveMediaCompositionContext(element).compositionRoot),
+        resolveStartSeconds: (element) => {
+          return resolveAbsoluteMediaStartSeconds(element);
+        },
+        resolveDurationSeconds: (element) => {
+          const context = resolveMediaCompositionContext(element);
+          const start = resolveAbsoluteMediaStartSeconds(element);
+          const hostRemaining =
+            context.inheritedStart != null &&
+            context.inheritedDuration != null &&
+            context.inheritedDuration > 0
+              ? Math.max(0, context.inheritedStart + context.inheritedDuration - start)
+              : null;
+          const sourceDuration = Number.isFinite(element.duration)
+            ? resolveNaturalMediaTimelineDuration(element, element.duration)
             : null;
-        const sourceDuration = Number.isFinite(element.duration)
-          ? resolveNaturalMediaTimelineDuration(element, element.duration)
-          : null;
-        // The element's own data-duration is an explicit clip-length trim
-        // (the studio writes it when you drag the clip edge). It must bound
-        // playback so a trimmed track stops at its edge instead of running on
-        // to the source-file or host-composition end. Absent → no cap (an
-        // untrimmed clip plays its natural source length).
-        const ownDuration = parseStrictFiniteTimingNumber(element.dataset.duration);
-        const explicitDuration = ownDuration != null && ownDuration > 0 ? ownDuration : null;
-        return resolveRuntimeMediaClipDuration({
-          isVideo: element.tagName === "VIDEO",
-          sourceDuration,
-          hostRemaining,
-          explicitDuration,
-        });
-      },
-    });
+          // The element's own data-duration is an explicit clip-length trim
+          // (the studio writes it when you drag the clip edge). It must bound
+          // playback so a trimmed track stops at its edge instead of running on
+          // to the source-file or host-composition end. Absent → no cap (an
+          // untrimmed clip plays its natural source length).
+          const ownDuration = parseStrictFiniteTimingNumber(element.dataset.duration);
+          const explicitDuration = ownDuration != null && ownDuration > 0 ? ownDuration : null;
+          return resolveRuntimeMediaClipDuration({
+            isVideo: element.tagName === "VIDEO",
+            sourceDuration,
+            hostRemaining,
+            explicitDuration,
+          });
+        },
+      }),
+    );
     // Attach probed volume keyframes to clips so syncRuntimeMedia can use the
     // same envelope the renderer uses instead of tracking GSAP-change diffs.
     for (const clip of cache.mediaClips) {


### PR DESCRIPTION
## The defect

`createRuntimeStartTimeResolver` (`packages/core/src/runtime/startResolver.ts`) is a real memoizer: it allocates a `startCache` WeakMap, a `durationCache` WeakMap and a `visiting` Set, and resolving one element's start walks — and caches — its whole composition ancestry.

`resolveStartForElement` and `resolveDurationForElement` in `runtime/init.ts` each built a **brand-new resolver on every call** and threw it away. The caches never served a second lookup.

The consequence is not a constant factor. It means per-seek work scales with **total timeline content** rather than with what actually changed, because every element re-walks ancestry that a sibling just resolved:

- `resolveMediaCompositionContext` calls both wrappers, so two resolvers per call.
- `refreshRuntimeMediaCache`'s two callbacks recompute the identical context and the identical absolute start.
- `syncTimedElementVisibility` costs `2 x (1 + ancestor depth)` resolves per timed element.
- `resolveMediaWindowDurationSeconds` scans every media element, and it runs on **every rAF** via `getSafeTimelineDurationSeconds`, so most of that cost is paid while the editor sits paused and idle.

The correct pattern already existed one file over: `runtime/timeline.ts` hoists one resolver for a whole payload build.

## The fix

`withTimingResolver(fn)` installs one resolver in a closure variable for the duration of a synchronous callback and restores the previous value in a `finally`, so a throw cannot leak the scope. Both wrappers use the installed resolver when one is present and otherwise fall back to today's construct-per-call, so every caller outside a scope is unchanged.

Three scopes are opened:

1. the media-cache build in `syncMediaForCurrentState`
2. the body of `syncTimedElementVisibility`
3. the media scan in `resolveMediaWindowDurationSeconds`

## Why three scopes and not one

**This is the load-bearing design decision, and merging them would reintroduce a stale read.**

`syncRuntimeMedia` calls `el.load()` on the seek-past-buffered-range retry (`runtime/media.ts`), which synchronously resets `el.duration` to `NaN`. `resolveDurationForElement` reads `element.duration`. A single cache spanning `refreshRuntimeMediaCache` -> `syncRuntimeMedia` -> `syncTimedElementVisibility` would hand the pre-`load()` duration to a post-`load()` read.

Splitting at the write makes that staleness *unrepresentable* rather than merely handled — no invalidation hook, no observer, no dirty flag. A scope lives for exactly one synchronous call with no `await` and no event dispatch inside, so nothing can mutate the DOM underneath it. There is a comment at the helper saying this, so the scopes do not get "simplified" back together later.

The same rule decided scope 3's placement. It sits on `resolveMediaWindowDurationSeconds` and **not** on its caller `getSafeTimelineDurationSeconds`, which looks like the tidier boundary: that caller also invokes author-supplied `timeline.duration()` and every adapter's `getInferredDurationSeconds()`. Foreign code inside a cache scope can touch the DOM between two resolves.

For the same reason `seekStandaloneRegisteredTimelines` is deliberately **left unwrapped**, even though it resolves once per registered sub-composition timeline on every seek. Its loop calls `timeline.totalTime()` and `timeline.duration()` — author GSAP code whose `onUpdate` handlers run synchronously. It is a genuine remaining win, but it needs its own argument, not this PR's.

## Measurements

A/B against a 79-video / 12-audio / 20-nested-composition composition, 200 single-frame seeks per run, Chrome CPU sampler at 100 microseconds, attribution restricted to the runtime bundle. Both arms are the **same** Studio preview with only the runtime bundle swapped by request interception; arms were run interleaved so both saw the same machine conditions.

Self time in `resolveStartForElementInternal`, the function that does the ancestry walk, ms per seek:

| pass | before | after | load avg (1m) |
|---|---|---|---|
| 1 | 0.277 | 0.119 | 32 |
| 2 | 0.228 | 0.068 | 28 / 71 |
| 3 | 0.231 | 0.075 | 61 / 50 |
| 4 | 0.236 | 0.062 | 28 / 24 |

Median **0.232 -> 0.072 ms/seek, about -69%**, and the separation is clean: the worst "after" run still beat the best "before" run. Inclusive time for the same function moved 0.58 -> 0.175 ms/seek. `createRuntimeStartTimeResolver` self time dropped roughly 80%.

Idle (paused editor, no input, same harness, 13.2 s window), which is where most of the `getSafeTimelineDurationSeconds` cost is paid:

| metric | before | after |
|---|---|---|
| runtime bundle, main-thread self time | 9.63 ms/s | 8.77 ms/s |
| `resolveStartForElementInternal` inclusive | 3.80 ms/s | 1.21 ms/s |
| `getSafeTimelineDurationSeconds` inclusive | 11.2 ms/s | 9.6 ms/s |

**Honest caveats, because they matter for how much to read into the above:**

- **Whole-runtime cost did not halve.** Total runtime-bundle self time went from a median of about 1.46 to about 1.18 ms/seek, roughly -19%, with a wide spread. The resolver path is only part of a seek; the adapters, seek dispatch and media sync are untouched. The clean, repeatable result is the ~70% cut on the path this change actually targets. Anyone expecting the seek to halve will be disappointed.
- **The machine was loaded.** Every run above was taken at a 1-minute load average between 20 and 71 on a shared machine. Absolute ms figures are inflated. The A/B delta is still meaningful because arms were interleaved and the separation is monotone across all four pairs, but do not quote the absolute numbers as a spec.
- **No caching or dirty-flagging of `getSafeTimelineDurationSeconds` here.** That it runs unconditionally on every rAF while paused is a real and separate problem, with its own invalidation argument. Out of scope for this PR.

## Tests

`packages/core/src/runtime/init.timingResolver.test.ts`, both driven through the public `initSandboxRuntimeModular()` -> `window.__player.renderSeek()` boundary.

1. **Constant resolver count.** Wraps `createRuntimeStartTimeResolver` and asserts the construction count for one seek plus one transport tick is identical for 2 and for 12 media elements, plus a small ceiling. Proven non-vacuous by neutering `withTimingResolver` into a pass-through: the count becomes **33 for 2 elements and 183 for 12** (15 per media element) and the test fails. With the fix it is a flat **4**.
2. **The two scopes are separate.** A `<video>` whose duration is cached while the media cache is built, with a follower clip whose start is expressed relative to it; the video's duration is then changed between the scopes, standing in for the `el.load()` reset. Asserts the visibility pass sees the fresh duration. Proven non-vacuous by merging the scopes into one spanning scope: the follower resolves to the stale start and the assertion flips from `visible` to `hidden`.

## Gates

- `bun run test:hyperframe-runtime-ci` in `packages/core`: typecheck, preview-guard lint, runtime build, contract / behaviour / seek / duration-guard / parity / security suites, coverage, linter tests. **51 files, 1082 tests, all passing.**
- Root `bun run lint` and `bun run format:check`: clean.
- `bunx fallow audit --base origin/main --fail-on-issues`: no issues in the 2 changed files.
- `packages/player` `tests/perf` scrub scenario **fails its gate on this machine, and it fails the same way on unmodified `origin/main`** — worse, in fact (aggregate `inline_p95` 223.9 ms on a pristine baseline checkout vs 57.2 ms on this branch), because the first of three runs is a cold-start outlier that dominates the aggregate under load. Pre-existing and environmental, not introduced here. Note also that its `10-video-grid` fixture has ~14 videos, so even when green it can only show **no regression** — the win here is a multiplier on element count and that fixture is too small to show it.

---

## Part 2: derive composition duration only when the composition changes

## The problem

A paused editor with nothing happening burns CPU continuously, and a large share of it is the runtime recomputing a number that has not changed.

`transportTick` calls `getSafeTimelineDurationSeconds` on every animation frame, unconditionally. Deriving that value scans every `video[data-start], audio[data-start]` in the document and, per element, resolves an absolute start by walking its composition ancestry, then does the same for nested composition windows. The result is a function of the composition, not of the playhead — so on a paused, untouched composition it produces the same answer ~60 times a second, forever.

Measured on a 91-media-element composition, paused and untouched: the media scan ran **1.05 times per animation frame**. That is what a user feels as a warm laptop with an editor open and nothing happening.

## The change

Derive the two DOM-derived duration floors once and reuse them until an input could have changed. Nothing about the returned value changes; only how often it is computed.

The honest part of this is the invalidation set, so here it is in full. Each input, and the signal that catches it:

| Input that can change the answer | Signal |
|---|---|
| Timing attributes edited (live editing, variables re-applied, the runtime's own autostamping) | `MutationObserver`, `attributeFilter` over the timing attributes the resolvers actually read |
| Timed elements added or removed, including nested compositions that mount asynchronously after init | The same observer, `childList` + `subtree` |
| Media metadata arriving, or `el.load()` resetting `duration` to `NaN` — neither mutates the DOM | Capture-phase `loadedmetadata` / `durationchange` / `emptied` listeners on `document` |
| A timeline registered, or an existing one lengthened, in `window.__timelines` — a plain object nothing can observe | A registry signature compared on read |

The bias is deliberate and stated in the code: a redundant derivation is a missed optimisation, a missed one is a wrong duration.

**Observer records are delivered in a microtask**, so the pending queue is drained on read as well (`takeRecords()`). Without that, a caller that edits a timing attribute and reads the duration back in the same synchronous block — the ordinary live-editing case — would be served the pre-edit value. Taking the records suppresses the callback for them, which is exactly equivalent, since the callback only marks the cache stale.

**The render path does not read the cache at all.** Capture depends on the exact duration and a frame rendered against a wrong one cannot be recovered, so once `renderSeek` has been called the derivation runs in full on every frame, exactly as before. The producer drives frames through `window.__player.renderSeek(...)`, so the flag is set before any captured frame.

`resolveAdapterDurationFloorSeconds()` is deliberately left uncached: adapters infer duration from live animation objects (CSS/WAAPI/Lottie) that can change with no DOM mutation or media event to observe, and it is a short loop over registered adapters rather than a document scan.

## Results

Two studio previews, arms differing only by the runtime bundle (the harness request-intercepts the runtime and fails the run if interception never fires), interleaved.

The headline number is a **count**, not a duration. The machine was heavily loaded while measuring (1-minute load average 40–98), which makes every millisecond figure unreliable — but a count of work done is invariant to contention, and it is a stronger claim anyway.

**Idle, paused and untouched:**

| Composition | Media scans per frame, before | after |
|---|---|---|
| 91 media elements | 1.05 | 0.05 |
| 25-block carousel | 1.05 | 0.05 |

Repeated across two passes each; identical to two decimal places. On the carousel the authored-composition scan likewise went from 1.00 per frame to 0.00. The residual 0.05 per frame is a separate per-20-tick caller in `timeline.ts` that this change does not touch.

**Across 100 single-frame seeks**, confirming the cache does not thrash while scrubbing:

| Composition | Media scans per seek, before | after |
|---|---|---|
| 91 media elements | 2.28 | 0.11 |
| 25-block carousel | 1.45 | 0.10 |

**Does the invalidation cost as much as the recompute?** No, and it is worth showing rather than asserting. Timed in-page, same realm, interleaved so contention hits both equally:

| Composition | Derivation | Cache-hit read path | Ratio |
|---|---|---|---|
| 91 media elements, 22 registered timelines | 0.0933 ms | 0.0010 ms | 93x |
| 25-block carousel, 27 registered timelines | 0.0243 ms | 0.0007 ms | 35x |

The read path is the registry signature plus a `takeRecords()` drain. The derivation figure understates the real cost, since the in-page probe does not reconstruct a timing resolver the way the real derivation does, so treat the ratio as a lower bound.

Wall-clock CPU was measured too and is not reported as fact: at load 40–98 the before/after renderer CPU figures moved in both directions and are pure noise.

## Tests

`packages/core`: `bun run test:hyperframe-runtime-ci` passes end to end (typecheck, preview guards, build, contract, behaviour, seek, duration, parity, security, coverage, linter). The two arms that pin the invariants at stake here:

```
$ bun run test:hyperframe-runtime-duration-guards
{"event":"hyperframe_runtime_duration_guards_verified", ...}

$ bun run test:hyperframe-runtime-parity
{"event":"hyperframe_runtime_parity_verified","bytes":400875,"sha256":"d588ab2c..."}
```

Root `bun run lint` and `bun run format:check` are clean. 1091 runtime tests pass.

11 new tests, and the two things they are built to prove:

**Invariance, not a threshold.** A threshold ("fewer than N derivations") passes on a small fixture and still degrades linearly in production. The test asserts that quadrupling the frame count does not change the derivation count at all. Reverting the cache in place turns that assertion into `expected 25 to be 100` — 25 frames produced 25 derivations, 100 produced 100, exactly one per frame.

**Every invalidation signal is load-bearing.** Each was disabled in turn to confirm a specific test notices:

| Signal removed | Tests that fail |
|---|---|
| `childList` + `subtree` | 5 |
| `attributeFilter` | 3 |
| Registry signature | 1 |
| `takeRecords()` drain | 5 |
| Media event listeners | 2 |

The `takeRecords()` row is the one worth pausing on: it looks like defensive polish, and removing it breaks nearly every DOM-driven invalidation, because they all read back inside the same task.

The counter is non-invasive — no production test hook. It counts calls to `[data-composition-id][data-start]`, which the runtime queries in exactly one place, reachable only from a real derivation.

## Noted, not fixed

`timeline.ts` carries near-copies of two functions this change touches. `resolveMediaElementDurationSeconds` is a true clone. `resolveMediaWindowEndSeconds` is *not* a safe merge: it resolves a clip's start from the raw `data-start` attribute, while the runtime's version routes through the media-start-basis resolution. Those two can disagree. That needs a decision about which is correct rather than a silent consolidation, so it is called out here rather than folded into a performance change.