### PR TITLE
fix(playground): render initialization errors as text

### DIFF
--- a/packages/sdk-playground/src/main.error.test.ts
+++ b/packages/sdk-playground/src/main.error.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import pageHtml from "../index.html?raw";
+import { expect, it, vi } from "vitest";
+
+vi.mock("@hyperframes/sdk", () => ({ openComposition: vi.fn() }));
+vi.mock("@hyperframes/core/gsap-parser-acorn", () => ({ parseGsapScriptAcorn: vi.fn() }));
+vi.mock("gsap/dist/gsap.min.js?raw", () => ({ default: "" }));
+vi.mock("./fileAdapter.js", () => ({
+  createFileAdapter: () => Promise.reject(new Error('<img src=x onerror="alert(1)"> & failed')),
+}));
+
+it("shows initialization errors as literal text without creating attacker markup", async () => {
+  document.documentElement.innerHTML = pageHtml;
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+    },
+  );
+  const listeners = vi.spyOn(window, "addEventListener");
+  try {
+    await import("./main.js");
+    await vi.waitFor(() => expect(document.querySelector("pre")).not.toBeNull());
+    expect(document.body.textContent).toBe('Error: <img src=x onerror="alert(1)"> & failed');
+    expect(document.body.querySelector("img")).toBeNull();
+    expect(document.body.children).toHaveLength(1);
+    expect(document.querySelector("pre")?.style.padding).toBe("20px");
+  } finally {
+    for (const [type, listener] of listeners.mock.calls) window.removeEventListener(type, listener);
+    listeners.mockRestore();
+    vi.unstubAllGlobals();
+    document.documentElement.innerHTML = "";
+  }
+});

--- a/packages/sdk-playground/src/main.ts
+++ b/packages/sdk-playground/src/main.ts
@@ -1466,5 +1466,9 @@ async function init() {
 }
 
 init().catch((err) => {
-  document.body.innerHTML = `<pre style="color:#f87171;padding:20px">${String(err)}</pre>`;
+  const message = document.createElement("pre");
+  message.style.color = "#f87171";
+  message.style.padding = "20px";
+  message.textContent = String(err);
+  document.body.replaceChildren(message);
 });


### PR DESCRIPTION
Playground initialization errors were interpolated into `innerHTML`, allowing error text containing markup to create active DOM elements. Build the same styled `<pre>` with `textContent` and replace the body with that element, preserving the error text, color, and padding.

Targets code-scanning alert #618. The regression exercises the real initialization failure handler with an HTML-bearing error and verifies literal text, no injected image, and the existing presentation. It fails the previous implementation.

Validation: five playground tests, playground typecheck, full workspace build, Fallow, and signed commit hooks pass.
