### PR TITLE
fix(producer): pass stub formatter path as an argument

### DIFF
--- a/packages/producer/scripts/build-hf-early-stub.ts
+++ b/packages/producer/scripts/build-hf-early-stub.ts
@@ -14,7 +14,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildSync } from "esbuild";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 const thisDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(thisDir, "..");
@@ -67,7 +67,7 @@ writeFileSync(
 // Format the generated file so `oxfmt --check` passes in CI.
 // Errors are intentionally swallowed — oxfmt unavailable in some envs.
 try {
-  execSync(`bunx oxfmt ${outPath}`, { stdio: "ignore" });
+  execFileSync("bun", ["x", "oxfmt", outPath], { stdio: "ignore" });
 } catch {
   // not fatal
 }


### PR DESCRIPTION
A checkout path containing shell metacharacters could execute commands when the producer formats its generated early stub (CodeQL #447). Invoke `bun x oxfmt` with an argument array so the full output path stays data. `bunx` is the documented alias for `bun x`: https://bun.sh/docs/pm/bunx.

Generated stub contents, formatter selection, and the existing nonfatal formatter-failure behavior are preserved.

Validation:
- Executed the actual build script in a temporary checkout path containing spaces, semicolons, and a shell comment. The original code executed a controlled marker command; the fix passed the entire path as one argument and did not execute it.
- Compared generated bytes across baseline, fixed, and failing-formatter runs: identical. Formatter failure still exits successfully.
- Normal generator invocation, changed-file oxlint/oxfmt, and full workspace build pass.

Native CI and independent review are required before merge.
