### PR TITLE
test(engine): keep the probe cache bound test off the filesystem

### DIFF
--- a/packages/engine/src/utils/ffprobe.test.ts
+++ b/packages/engine/src/utils/ffprobe.test.ts
@@ -251,11 +251,10 @@ describe("probeMediaProfile", () => {
   });
 
   it("bounds the process-scoped probe cache", async () => {
-    const fixtureDir = mkdtempSync(resolve(tmpdir(), "hf-media-probe-lru-"));
-    const fixturePaths = Array.from({ length: 129 }, (_, index) =>
-      resolve(fixtureDir, `asset-${index}`),
-    );
-    for (const fixturePath of fixturePaths) writeFileSync(fixturePath, "probe identity");
+    // Cache identity is derived from stat, so synthesise it instead of writing
+    // 129 real files: the eviction rule is in-memory, and on a contended
+    // Windows runner the file churn alone pushed this past the test timeout.
+    const paths = Array.from({ length: 129 }, (_, index) => `/probe-lru/asset-${index}`);
     const outcome = {
       kind: "exit" as const,
       code: 0,
@@ -267,13 +266,31 @@ describe("probeMediaProfile", () => {
     const { spawn, calls } = createSpawnSpy([outcome]);
     vi.resetModules();
     vi.doMock("child_process", () => ({ spawn }));
-    const { probeMediaProfile } = await import("./ffprobe.js");
+    vi.doMock("fs", async () => {
+      const actual = await vi.importActual<typeof import("fs")>("fs");
+      const statSync = (filePath: string) => ({
+        dev: 1n,
+        ino: BigInt(paths.indexOf(filePath)),
+        size: 1n,
+        mtimeNs: 0n,
+        ctimeNs: 0n,
+      });
+      return { ...actual, statSync };
+    });
     try {
-      for (const fixturePath of fixturePaths) await probeMediaProfile(fixturePath);
-      await probeMediaProfile(fixturePaths[0]!);
+      const { probeMediaProfile } = await import("./ffprobe.js");
+      const [first, second, ...rest] = paths;
+      for (const filePath of paths.slice(0, 128)) await probeMediaProfile(filePath);
+      // A hit refreshes the entry, so the 129th insert evicts `second`, not `first`.
+      await probeMediaProfile(first!);
+      await probeMediaProfile(rest.at(-1)!);
+      expect(calls).toHaveLength(129);
+      await probeMediaProfile(first!);
+      expect(calls).toHaveLength(129);
+      await probeMediaProfile(second!);
       expect(calls).toHaveLength(130);
     } finally {
-      rmSync(fixtureDir, { recursive: true, force: true });
+      vi.doUnmock("fs");
     }
   });
 


### PR DESCRIPTION
## Why

`probeMediaProfile > bounds the process-scoped probe cache` is a recurring failure on the Windows test lane. It shows up on unrelated pull requests and on main, always as a 5s timeout. In a normal run the test takes ~300ms on Windows; on the failing runs it took over 5s while neighbouring tests in the same file only slowed about 2×.

The test created 129 real files in the temp dir, stat'ed each through the code under test, then deleted them, to check that the 129th insert evicts the oldest entry. That rule is in-memory. The file churn made the test's runtime a function of filesystem contention on the runner, not of the code.

## What changed

- The test synthesises `statSync` results (identity is `dev:ino:size:mtime:ctime`) instead of writing files, so it never touches disk. Locally it drops from ~115ms to ~35ms; on Windows it no longer scales with disk load.
- The test now also covers the LRU touch: a hit before the bound is reached keeps that entry resident and the next-oldest is evicted instead. The old shape never produced a cache hit during the fill, so removing the touch left it green.

## Verification

- `ffprobe.test.ts`: 115 passed.
- Raising the bound to 129 in `ffprobe.ts` fails the test (`expected 130, got 129`).
- Removing the LRU re-insert on hit fails the test (`expected 129, got 130`).
- oxfmt, oxlint and `tsc --noEmit` clean for the engine package.

No product code changes.
