### PR TITLE
fix(cli): keep check --json stdout pure by sending proxy pre-resolve diagnostics to stderr

### DIFF
--- a/packages/cli/src/utils/checkBrowser.test.ts
+++ b/packages/cli/src/utils/checkBrowser.test.ts
@@ -605,14 +605,66 @@ describe("preResolveHostileMediaProxies", () => {
       },
     });
     mocks.resolveProxy.mockRejectedValue(new Error("ffmpeg exited with code 1"));
-    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
     await expect(
       preResolveHostileMediaProxies(projectDir, "<html></html>"),
     ).resolves.toBeUndefined();
-    expect(infoSpy).toHaveBeenCalledWith(
+    expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("media proxy pre-resolve: 0/1 ready, 1 failed"),
     );
+  });
+
+  // PRINFRA-648: `check --json` promises a pure JSON envelope on stdout. The
+  // pre-resolve summary used to go through `console.info` (stdout), so any
+  // project with HEVC/ProRes/AV1 media broke `JSON.parse(stdout)` downstream.
+  // Every diagnostic this helper emits must land on stderr and never stdout.
+  it("writes the pre-resolve summary to stderr and leaves stdout untouched", async () => {
+    const projectDir = mkProjectDir();
+    mocks.scanProjectMediaCodecMap.mockResolvedValue({
+      "/clip.mp4": {
+        codecName: "hevc",
+        browserHostile: true,
+        representativeMime: null,
+        hasAlpha: false,
+      },
+    });
+    mocks.resolveProxy.mockResolvedValue("/cache/clip.mp4");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await preResolveHostileMediaProxies(projectDir, "<html></html>");
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^\[hyperframes\] media proxy pre-resolve: 1\/1 ready, 0 failed \(\d+ms\)$/,
+      ),
+    );
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("writes a scan failure to stderr and leaves stdout untouched", async () => {
+    const projectDir = mkProjectDir();
+    mocks.scanProjectMediaCodecMap.mockRejectedValue(new Error("ffprobe not found"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await expect(
+      preResolveHostileMediaProxies(projectDir, "<html></html>"),
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[hyperframes] media proxy pre-resolve: scan failed (ffprobe not found)",
+    );
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(mocks.resolveProxy).not.toHaveBeenCalled();
   });
 
   it("pre-resolves an alpha VP9 asset through the Chromium-compatible VP8 proxy", async () => {

--- a/packages/cli/src/utils/checkBrowser.ts
+++ b/packages/cli/src/utils/checkBrowser.ts
@@ -110,6 +110,11 @@ interface FinishedContrast {
  * (docs/plans/2026-07-14-002-feat-transparent-media-proxies-plan.md, unit U4).
  * Best-effort: a probe or transcode failure does not fail `check`; one summary
  * line records the pre-resolve outcome before the runtime attempts playback.
+ *
+ * Both diagnostic lines go to stderr, never stdout: `check --json` promises a
+ * pure JSON envelope on stdout, and `console.info` writes to stdout, so a
+ * project with HEVC/ProRes/AV1 media used to break `JSON.parse(stdout)` in
+ * every automation consumer (PRINFRA-648).
  */
 export async function preResolveHostileMediaProxies(
   projectDir: string,
@@ -121,7 +126,7 @@ export async function preResolveHostileMediaProxies(
   try {
     codecMap = await scanProjectMediaCodecMap(projectDir, [{ html }]);
   } catch (err) {
-    console.info(
+    console.error(
       `[hyperframes] media proxy pre-resolve: scan failed (${normalizeErrorMessage(err)})`,
     );
     return;
@@ -142,7 +147,7 @@ export async function preResolveHostileMediaProxies(
     ),
   );
   const failed = results.filter((result) => result.status === "rejected").length;
-  console.info(
+  console.error(
     `[hyperframes] media proxy pre-resolve: ${results.length - failed}/${results.length} ready, ${failed} failed (${Date.now() - startedAt}ms)`,
   );
 }


### PR DESCRIPTION
## Summary

`hyperframes check --json` did not always emit pure JSON on stdout. `preResolveHostileMediaProxies()` in `packages/cli/src/utils/checkBrowser.ts` logged its summary line (`[hyperframes] media proxy pre-resolve: N/M ready, F failed (Xms)`) and its scan-failure line via `console.info`, which writes to **stdout**. With `autoProxy` on (the default), any project containing HEVC/ProRes/AV1 media emitted that line *before* the JSON envelope, so `JSON.parse(stdout)` failed for any consumer of the machine-readable output.

## Fix

Route both diagnostics through `console.error` (stderr). This matches how `check` already reports its own failures, fixes every caller in one place, and avoids threading a second copy of the `--json` decision into `CheckOptions`. Human-mode output is unchanged — the line still appears in the terminal.

## Tests

- Existing "swallows a resolveProxy rejection" test updated to spy on `console.error`.
- New: the summary line lands on stderr with the exact `N/M ready, F failed (Xms)` shape, and `console.info` / `console.log` / `process.stdout.write` are never called.
- New: a scan failure lands on stderr, stdout stays untouched, and no proxy resolution is attempted.

`tsc --noEmit` and `oxfmt --check` are clean for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
