### PR TITLE
fix: unbreak the regression suite on Windows (PSNR filtergraph escaping + console window popups)

### DIFF
--- a/packages/core/src/mediaGradeAnalyzer.ts
+++ b/packages/core/src/mediaGradeAnalyzer.ts
@@ -124,7 +124,7 @@ function probeMedia(mediaPath: string, ffprobePath: string): GradeMediaProbe {
         "--",
         mediaPath,
       ],
-      { encoding: "utf8", timeout: 5_000, stdio: ["ignore", "pipe", "pipe"] },
+      { encoding: "utf8", timeout: 5_000, stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
     );
     const parsed = asRecord(JSON.parse(raw));
     const streams = Array.isArray(parsed.streams) ? parsed.streams : [];
@@ -341,6 +341,7 @@ export function analyzeMediaGrade(
         encoding: "utf8",
         timeout: Number(process.env.HYPERFRAMES_ANALYZE_TIMEOUT_MS) || DEFAULT_TIMEOUT_MS,
         stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
       },
     );
     return summarizeMediaTreatmentAnalysis(probe, parseMediaTreatmentSignalStats(raw));

--- a/packages/engine/src/services/browserManager.ts
+++ b/packages/engine/src/services/browserManager.ts
@@ -809,6 +809,10 @@ function probeNvidiaVramMb(): number | null {
       timeout: 3000,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      // execSync goes through a shell, so without this every probe flashes a
+      // cmd.exe window on the user's desktop — including on the machines with
+      // no NVIDIA GPU, where the command only exists to fail.
+      windowsHide: true,
     }).trim();
     const mb = parseInt(out.split("\n")[0] ?? "", 10);
     if (Number.isFinite(mb) && mb > 0) {

--- a/packages/producer/src/parity-harness.ts
+++ b/packages/producer/src/parity-harness.ts
@@ -116,7 +116,7 @@ function writeImageDiff(basePath: string, comparePath: string, outputPath: strin
       "[0:v][1:v]blend=all_mode=difference",
       outputPath,
     ],
-    { stdio: "pipe" },
+    { stdio: "pipe", windowsHide: true },
   );
   if (ffmpeg.status !== 0) {
     const stderr = (ffmpeg.stderr || Buffer.from("")).toString("utf-8");

--- a/packages/producer/src/plan-parity-analysis.ts
+++ b/packages/producer/src/plan-parity-analysis.ts
@@ -40,6 +40,7 @@ function requireCommandSuccess(
     encoding: "buffer",
     maxBuffer,
     stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
   });
   if (result.error) throw result.error;
   if (result.status !== 0) {
@@ -218,7 +219,7 @@ async function canonicalPcmAudio(
         "s16le",
         "-",
       ],
-      { stdio: ["ignore", "pipe", "pipe"] },
+      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
     );
     const hash = createHash("sha256");
     const stderr: Buffer[] = [];

--- a/packages/producer/src/regression-harness.ts
+++ b/packages/producer/src/regression-harness.ts
@@ -544,6 +544,7 @@ function runFfmpeg(args: string[], label: string): { stdout: Buffer; stderr: str
     stdio: ["ignore", "pipe", "pipe"],
     maxBuffer: 256 * 1024 * 1024,
     encoding: "buffer",
+    windowsHide: true,
   });
   const stderr = result.stderr.toString("utf-8");
   if (result.status !== 0) {

--- a/packages/producer/src/regression-harness.ts
+++ b/packages/producer/src/regression-harness.ts
@@ -631,10 +631,15 @@ export function psnrAtFrames(
   const statsDir = mkdtempSync(join(tmpdir(), "hf-psnr-"));
   const statsFile = join(statsDir, "psnr.log");
   try {
-    // ffmpeg treats `:` and `\` in filter option values as syntax, so a temp
-    // path containing either would break the filtergraph. mkdtemp under
-    // tmpdir() does not produce those on POSIX, but escape defensively.
-    const escaped = statsFile.replace(/\\/g, "\\\\").replace(/:/g, "\\:");
+    // ffmpeg treats `:` and `\` in filter option values as syntax, and a
+    // filtergraph argument is unescaped TWICE: once when the graph is split
+    // into filters and their options, then again when the option value itself
+    // is read. One round of escaping only survives the first pass, so on
+    // Windows `C:\Users\...` reaches the option parser as `C:\Users\...`,
+    // whose bare `:` starts a new option and fails the whole graph with
+    // "No option name near '\Users\...'". Escaping for both passes is a no-op
+    // on POSIX, where mkdtemp under tmpdir() produces neither character.
+    const escaped = statsFile.replace(/\\/g, "\\\\\\\\").replace(/:/g, "\\\\:");
     const selectExpr = wanted.map((frame) => `eq(n\\,${frame})`).join("+");
     const stream = (index: number, label: string) =>
       `[${index}:v]select='${selectExpr}',settb=1/1,setpts=N[${label}]`;

--- a/packages/producer/src/services/mediaTypeTestFixtures.ts
+++ b/packages/producer/src/services/mediaTypeTestFixtures.ts
@@ -1,7 +1,9 @@
 import { spawnSync } from "node:child_process";
 
 export function synthesizeMediaFixture(args: string[]): void {
-  const result = spawnSync("ffmpeg", ["-y", "-hide_banner", "-loglevel", "error", ...args]);
+  const result = spawnSync("ffmpeg", ["-y", "-hide_banner", "-loglevel", "error", ...args], {
+    windowsHide: true,
+  });
   if (result.status !== 0) {
     throw new Error(`ffmpeg fixture synthesis failed: ${result.stderr.toString().slice(-400)}`);
   }

--- a/packages/producer/src/services/render/audioPadTrim.ts
+++ b/packages/producer/src/services/render/audioPadTrim.ts
@@ -634,7 +634,10 @@ async function runFfprobeJson<T>(args: string[], signal?: AbortSignal): Promise<
   if (!args.includes("--")) {
     throw new Error('[audioPadTrim] ffprobe args must terminate options with "--".');
   }
-  const proc = spawn(getFfprobeBinary(), args, { stdio: ["ignore", "pipe", "pipe"] });
+  const proc = spawn(getFfprobeBinary(), args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
   trackChildProcess(proc);
   let stdout = "";
   proc.stdout.on("data", (data: Buffer) => {

--- a/packages/producer/src/utils/audioRegression.ts
+++ b/packages/producer/src/utils/audioRegression.ts
@@ -200,7 +200,7 @@ export function computeAudioResidualRmsDb(
       "null",
       "-",
     ],
-    { encoding: "utf-8" },
+    { encoding: "utf-8", windowsHide: true },
   );
 
   // `spawnSync` swallows `ENOENT`, signal kills, and non-zero exits
@@ -318,7 +318,7 @@ function probeAudioDuration(file: string): { seconds: number; error?: string } {
       "--",
       file,
     ],
-    { encoding: "utf-8" },
+    { encoding: "utf-8", windowsHide: true },
   );
   if (proc.error) {
     return {


### PR DESCRIPTION
## What

Two independent Windows fixes found while setting the repo up on Windows 11:

1. **PSNR `stats_file` escaping** (`packages/producer/src/regression-harness.ts`) — the regression suite's visual comparison could not run at all on Windows.
2. **`windowsHide: true`** on the 11 remaining `child_process` call sites that lacked it, across `core`, `engine` and `producer`.

## Why

**PSNR escaping.** An ffmpeg filtergraph argument is unescaped *twice*: once when the graph is split into filters and their options, then again when the option value itself is read. `psnrAtFrames` escaped `\` and `:` a single time, which only survives the first pass.

On POSIX this is invisible, because `mkdtemp` under `tmpdir()` produces neither character. On Windows the stats path is always `C:\Users\...`, so it reaches the option parser with a bare `:`, which starts a new option and fails the whole graph:

```
[AVFilterGraph] No option name near '\Users\btay\AppData\Local\Temp\hf-psnr-CeMZ8F\psnr.log'
[AVFilterGraph] Error parsing filterchain '[rv][gv]psnr=shortest=1:repeatlast=0:stats_file=C\:\\Users\\btay\\...\\psnr.log'
Error : Invalid argument
```

Every suite that got as far as quality validation died there. A full Windows run reported **73 total / 0 passed / 73 failed**, but only 2 of those failed at compilation and 1 at visual comparison — the other ~70 never got to compare anything.

**`windowsHide`.** Node's `windowsHide` defaults to `false`, so every child process that is a console application pops a window on the user's desktop. Over a render — let alone a regression run — that is a steady stream of black windows stealing focus. The repo already sets the flag across `cli`, `studio-server` and most of `engine`; these were the remaining gaps, all on paths that run during a normal render.

Worth calling out one of them: `probeNvidiaVramMb` in `engine/browserManager` uses `execSync`, which goes through a shell, so it flashes a `cmd.exe` window **even on machines with no NVIDIA GPU** — where the command exists only to fail.

## How

**PSNR escaping** — escape for both passes. Verified against ffmpeg 9.0.1 on Windows with an identical fixture:

| stats_file argument | result |
| --- | --- |
| `C\:\\Users\\...` (single escape, previous) | fails — reproduces the error above |
| `C\\:\\\\Users\\\\...` (double escape, **this PR**) | works |
| `C\:/Users/...` (forward slashes, single-escaped colon) | fails |
| `C\\:/Users/...` (forward slashes, double-escaped colon) | works |
| relative filename + `cwd` | works |

Double-escaping was chosen over the `cwd` approach because it is a one-line change that keeps `runFfmpeg`'s signature and does not require the other path arguments to be absolute. It is a no-op on POSIX.

**`windowsHide`** — added to the call sites that lacked it:

- `core/mediaGradeAnalyzer` — ffprobe + ffmpeg, once per analyzed media file
- `engine/browserManager` — the `nvidia-smi` VRAM probe described above
- `producer` — the regression harness ffmpeg runner, the PSNR/audio comparison helpers, fixture synthesis, and the ffprobe call in `audioPadTrim`

The two concerns are separate commits, so either can be dropped independently.

## Test plan

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Documentation updated (if applicable)

Environment: Windows 11 Pro 26200, Node v24.19.0, bun 1.4.2, ffmpeg 9.0.1.

- `bun run --filter '*' typecheck` — all 14 packages exit 0
- `bunx oxlint` / `bunx oxfmt --check` on the changed files — 0 warnings, 0 errors
- lefthook pre-commit (format, fallow, typecheck, commitlint) green on both commits
- **PSNR fix, before:** every suite reaching quality validation failed with `No option name near '\Users\...'`
- **PSNR fix, after:** `bunx tsx src/regression-harness.ts sub-comp-t0` completes all 100 checkpoints and passes — `Total: 1 | Passed: 1 | Failed: 0`, visual PASSED (3 failed frames, threshold 5), audio PASSED (correlation 1.000, lag 0)

No POSIX behavior change in either commit, so this needs a look from someone on macOS/Linux only insofar as CI covers it.

Two notes for maintainers, both out of scope here and neither touched by this PR:

- The regression fixtures fetch source media from `gen-os-static.s3.us-east-2.amazonaws.com`. That host is sinkholed to `0.0.0.0` by Cloudflare's malware-filtering resolver (1.1.1.2), which silently strips `data-end` / `data-duration` and shows up as a golden-snapshot mismatch rather than a network error. Took a while to identify; may be worth a clearer diagnostic.
- `mediaTypeTestFixtures` and a couple of extractor tests still pass `-vsync`, which ffmpeg 9 removed in favour of `-fps_mode`. Test-only — the production paths already use `-fps_mode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
