### PR TITLE
perf(runtime): a paused preview stops burning CPU

### DIFF
--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -3792,9 +3792,31 @@ describe("derived duration floor recomputation", () => {
     Object.defineProperty(media, "duration", { value: seconds, configurable: true });
   };
 
-  /** Drive the transport for `frames` animation frames and report the duration it settled on. */
-  const runFrames = (frames: number): number => {
-    for (let frame = 0; frame < frames; frame += 1) raf.step(16);
+  /**
+   * Drive the transport for `frames` animation frames and report the duration
+   * it settled on.
+   *
+   * Awaits a microtask first, and that is load-bearing rather than cosmetic:
+   * the transport parks itself when the editor is paused and settled, and what
+   * un-parks it for a DOM edit is a MutationObserver callback, which a browser
+   * delivers in a microtask before the next frame. Stepping the frame queue
+   * synchronously after an edit models a world where a paint can happen
+   * between a mutation and its observer, which cannot occur.
+   */
+  /**
+   * `window.__timelines` is a plain object: no observer and no event can
+   * report a change to it, so a parked transport only finds one on its own
+   * slow timer. A test has to wait for that timer the way the editor does.
+   */
+  const waitForParkedRegistryPoll = (): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, 200));
+
+  const runFrames = async (frames: number): Promise<number> => {
+    for (let frame = 0; frame < frames; frame += 1) {
+      await Promise.resolve();
+      raf.step(16);
+    }
+    await Promise.resolve();
     return window.__player!.getDuration();
   };
 
@@ -3826,6 +3848,7 @@ describe("derived duration floor recomputation", () => {
     delete window.__player;
     delete window.__playerReady;
     delete window.__renderReady;
+    delete window.__HF_EXPORT_RENDER_SEEK_CONFIG;
     vi.restoreAllMocks();
     window.requestAnimationFrame = originalRequestAnimationFrame;
     window.cancelAnimationFrame = originalCancelAnimationFrame;
@@ -3838,16 +3861,16 @@ describe("derived duration floor recomputation", () => {
      * still degrades linearly in production. Quadrupling the frame count must
      * not change the derivation count at all.
      */
-    it("derives the duration floor a fixed number of times however many frames elapse", () => {
+    it("derives the duration floor a fixed number of times however many frames elapse", async () => {
       mountComposition(`<video data-start="0"></video>`);
       setNativeDuration(document.querySelector("video")!, 10);
       initSandboxRuntimeModular();
 
       const afterStartup = derivations;
-      expect(runFrames(25)).toBe(10);
+      expect(await runFrames(25)).toBe(10);
       const afterShortRun = derivations - afterStartup;
 
-      expect(runFrames(100)).toBe(10);
+      expect(await runFrames(100)).toBe(10);
       const afterLongRun = derivations - afterStartup - afterShortRun;
 
       // Four times the frames, the same amount of work. Before the cache both
@@ -3856,11 +3879,11 @@ describe("derived duration floor recomputation", () => {
       expect(afterShortRun).toBe(0);
     });
 
-    it("does not re-derive for a DOM change that cannot affect the duration", () => {
+    it("does not re-derive for a DOM change that cannot affect the duration", async () => {
       mountComposition(`<video data-start="0"></video>`);
       setNativeDuration(document.querySelector("video")!, 10);
       initSandboxRuntimeModular();
-      runFrames(2);
+      await runFrames(2);
 
       const before = derivations;
       // A class and an inline transform are what an animating composition
@@ -3869,7 +3892,7 @@ describe("derived duration floor recomputation", () => {
       document.querySelector("video")!.classList.add("is-visible");
       document.querySelector("video")!.setAttribute("style", "opacity: 0.5");
 
-      expect(runFrames(5)).toBe(10);
+      expect(await runFrames(5)).toBe(10);
       expect(derivations).toBe(before);
     });
   });
@@ -3882,61 +3905,61 @@ describe("derived duration floor recomputation", () => {
      * real), and the event that always accompanies it in a browser makes it
      * fresh (proving the invalidation is real).
      */
-    it("serves a stale duration for a silent metadata change and a fresh one once the event fires", () => {
+    it("serves a stale duration for a silent metadata change and a fresh one once the event fires", async () => {
       mountComposition(`<video data-start="0"></video>`);
       const video = document.querySelector("video")!;
       setNativeDuration(video, 10);
       initSandboxRuntimeModular();
-      expect(runFrames(2)).toBe(10);
+      expect(await runFrames(2)).toBe(10);
 
       // Half one: the input changed, nothing signalled it, the cache answers.
       setNativeDuration(video, 30);
-      expect(runFrames(2)).toBe(10);
+      expect(await runFrames(2)).toBe(10);
 
       // Half two: the signal a real browser emits alongside that change.
       video.dispatchEvent(new Event("durationchange"));
-      expect(runFrames(1)).toBe(30);
+      expect(await runFrames(1)).toBe(30);
     });
 
-    it("re-derives when el.load() resets duration to NaN", () => {
+    it("re-derives when el.load() resets duration to NaN", async () => {
       mountComposition(`<video data-start="0"></video>`);
       const video = document.querySelector("video")!;
       setNativeDuration(video, 10);
       initSandboxRuntimeModular();
-      expect(runFrames(2)).toBe(10);
+      expect(await runFrames(2)).toBe(10);
 
       // What load() does: duration back to NaN, announced by `emptied`.
       setNativeDuration(video, Number.NaN);
-      expect(runFrames(2)).toBe(10);
+      expect(await runFrames(2)).toBe(10);
       video.dispatchEvent(new Event("emptied"));
       const before = derivations;
-      runFrames(1);
+      await runFrames(1);
       expect(derivations).toBeGreaterThan(before);
     });
 
-    it("re-derives when a timing attribute is edited", () => {
+    it("re-derives when a timing attribute is edited", async () => {
       mountComposition(`<video data-start="0"></video>`);
       setNativeDuration(document.querySelector("video")!, 10);
       initSandboxRuntimeModular();
-      expect(runFrames(2)).toBe(10);
+      expect(await runFrames(2)).toBe(10);
 
       document.querySelector("video")!.setAttribute("data-duration", "25");
-      expect(runFrames(1)).toBe(25);
+      expect(await runFrames(1)).toBe(25);
     });
 
-    it("re-derives when a clip is moved later on the timeline", () => {
+    it("re-derives when a clip is moved later on the timeline", async () => {
       mountComposition(`<video data-start="0" data-duration="10"></video>`);
       initSandboxRuntimeModular();
-      expect(runFrames(2)).toBe(10);
+      expect(await runFrames(2)).toBe(10);
 
       document.querySelector("video")!.setAttribute("data-start", "5");
-      expect(runFrames(1)).toBe(15);
+      expect(await runFrames(1)).toBe(15);
     });
 
-    it("re-derives when a timed element is added after init", () => {
+    it("re-derives when a timed element is added after init", async () => {
       mountComposition(`<video data-start="0" data-duration="10"></video>`);
       initSandboxRuntimeModular();
-      expect(runFrames(2)).toBe(10);
+      expect(await runFrames(2)).toBe(10);
 
       // Nested compositions mount asynchronously, well after init — this is
       // the ordinary case, not an edge case.
@@ -3945,19 +3968,19 @@ describe("derived duration floor recomputation", () => {
       late.setAttribute("data-duration", "5");
       document.querySelector("[data-composition-id]")!.append(late);
 
-      expect(runFrames(1)).toBe(25);
+      expect(await runFrames(1)).toBe(25);
     });
 
-    it("re-derives when a timed element is removed", () => {
+    it("re-derives when a timed element is removed", async () => {
       mountComposition(
         `<video data-start="0" data-duration="10"></video>` +
           `<audio id="tail" data-start="20" data-duration="5"></audio>`,
       );
       initSandboxRuntimeModular();
-      expect(runFrames(2)).toBe(25);
+      expect(await runFrames(2)).toBe(25);
 
       document.querySelector("#tail")!.remove();
-      expect(runFrames(1)).toBe(10);
+      expect(await runFrames(1)).toBe(10);
     });
 
     /**
@@ -3966,15 +3989,16 @@ describe("derived duration floor recomputation", () => {
      * already registered, so the cache compares a signature of the registry on
      * every read. Nothing else in the invalidation set could catch this.
      */
-    it("re-derives when a nested composition's registered timeline grows", () => {
+    it("re-derives when a nested composition's registered timeline grows", async () => {
       mountComposition(`<div data-composition-id="scene" data-start="0" data-duration="10"></div>`);
       window.__timelines = { ...window.__timelines, scene: createMockTimeline(10) };
       initSandboxRuntimeModular();
-      expect(runFrames(2)).toBe(10);
+      expect(await runFrames(2)).toBe(10);
 
       window.__timelines = { ...window.__timelines, scene: createMockTimeline(40) };
       const before = derivations;
-      runFrames(1);
+      await waitForParkedRegistryPoll();
+      await runFrames(1);
       expect(derivations).toBeGreaterThan(before);
     });
 
@@ -3985,14 +4009,14 @@ describe("derived duration floor recomputation", () => {
      * — would be handed the pre-edit value if the cache waited for the
      * callback. It drains the queue on read instead.
      */
-    it("reflects an edit read back in the same synchronous block", () => {
+    it("reflects an edit read back in the same synchronous block", async () => {
       mountComposition(`<video data-start="0" data-duration="10"></video>`);
       initSandboxRuntimeModular();
-      expect(runFrames(2)).toBe(10);
+      expect(await runFrames(2)).toBe(10);
 
       // No await, no microtask checkpoint between the write and the read.
       document.querySelector("video")!.setAttribute("data-duration", "42");
-      expect(runFrames(1)).toBe(42);
+      expect(await runFrames(1)).toBe(42);
     });
   });
 
@@ -4002,20 +4026,27 @@ describe("derived duration floor recomputation", () => {
    * the same silent metadata change that is deliberately served stale to the
    * editor must be seen immediately here.
    */
-  it("never serves a cached duration once render capture has started", () => {
+  it("never serves a cached duration once render capture has started", async () => {
+    // Constructed the way a real render is: the producer injects this config
+    // into the page before it drives a single frame, and it is what tells the
+    // runtime an export is in charge of the frame loop. Without it the
+    // runtime is in Studio-fallback territory (`playbackAdapter` also calls
+    // renderSeek), where the loop is free to park and there is no per-frame
+    // derivation to count.
+    window.__HF_EXPORT_RENDER_SEEK_CONFIG = { mode: "seek" };
     mountComposition(`<video data-start="0"></video>`);
     const video = document.querySelector("video")!;
     setNativeDuration(video, 10);
     initSandboxRuntimeModular();
-    expect(runFrames(2)).toBe(10);
+    expect(await runFrames(2)).toBe(10);
 
     window.__player!.renderSeek(0);
     setNativeDuration(video, 30);
     // No `durationchange` dispatched, and the editor would still answer 10.
-    expect(runFrames(1)).toBe(30);
+    expect(await runFrames(1)).toBe(30);
 
     const before = derivations;
-    runFrames(3);
+    await runFrames(3);
     expect(derivations).toBeGreaterThan(before);
   });
 });

--- a/packages/core/src/runtime/init.timingResolver.test.ts
+++ b/packages/core/src/runtime/init.timingResolver.test.ts
@@ -47,6 +47,11 @@ describe("runtime timing resolver scoping", () => {
   });
 
   afterEach(() => {
+    // The runtime holds a timer while its transport is parked. Abandoning an
+    // initialised runtime leaves that timer to fire after the environment is
+    // torn down, which vitest reports as an unhandled error in whichever file
+    // happens to be running at the time.
+    window.__hfRuntimeTeardown?.();
     window.requestAnimationFrame = originalRequestAnimationFrame;
     window.cancelAnimationFrame = originalCancelAnimationFrame;
     mediaSpy.beforeSync = null;

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -3467,6 +3467,11 @@ export function initSandboxRuntimeModular(): void {
   const parkedTransportHeartbeat = () => {
     transportParkTimerId = null;
     if (state.tornDown) return;
+    // The page can go away with the timer still armed — an embedder discarding
+    // the frame, or a test environment torn down around an abandoned runtime.
+    // Stop rather than re-arm: there is nothing left to report a state change
+    // to, and every read below would throw on a missing global.
+    if (typeof window === "undefined" || typeof document === "undefined") return;
     if (readParkedPollWitness() !== parkedPollWitness) {
       // Through wakeTransport, not straight to rAF: reading the witness can
       // itself wake us (the registry compare bumps the revision, and that

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -64,7 +64,12 @@ import type {
 } from "./types";
 import type { PlayerAPI } from "../core.types";
 import { swallow } from "./diagnostics";
-import { shouldAttemptPeriodicTimelineBind } from "./timelineRebindPolicy";
+import {
+  CHANGE_DRIVEN_SERVICE_MIN_INTERVAL_MS,
+  MEDIA_BIND_INTERVAL_FRAMES,
+  TIMELINE_POST_INTERVAL_FRAMES,
+  shouldAttemptPeriodicTimelineBind,
+} from "./timelineRebindPolicy";
 import { installStudioCustomEase } from "./customEase";
 import { parseStrictFiniteTimingNumber, resolveMediaElementDurationSeconds } from "./playbackRate";
 import { MEDIA_START_BASIS_ATTR } from "../mediaTiming";
@@ -3162,8 +3167,11 @@ export function initSandboxRuntimeModular(): void {
   // Set while the transport is parked (see scheduleNextTransportFrame).
   let transportParkTimerId: number | null = null;
   let transportWakeRequested = false;
-  let parkedTimingRevision = -1;
-  let lastServicedTimingRevision = -1;
+  let parkedPollWitness = "";
+  let lastSeenTimingRevision = -1;
+  /** A composition change has been seen and not yet carried to consumers. */
+  let compositionChangePending = false;
+  let lastChangeDrivenServiceAtMs = Number.NEGATIVE_INFINITY;
 
   const seekRuntimeTimeline = (
     timeline: RuntimeTimelineLike,
@@ -3396,8 +3404,25 @@ export function initSandboxRuntimeModular(): void {
   const canParkTransport = (): boolean =>
     !clock.isPlaying() &&
     !isExportRenderDrivingFrames() &&
+    // Without MutationObserver nothing can PUSH a DOM change: neither the
+    // composition-timing watcher nor the gesture watch attaches, and both fall
+    // back to answering from the document only when asked. Looking every frame
+    // is then the only correct behaviour, so such a host keeps the loop it had.
+    //
+    // Unreachable today, and the reason is worth recording rather than
+    // trusting: `createColorGradingRuntime` constructs a MutationObserver
+    // unconditionally earlier in this same init (colorGrading.ts, the
+    // `document.body` branch), so a host without one never gets as far as a
+    // running transport. This stays as the explicit statement of the
+    // invariant, one boolean, for the day that guard is added there.
+    manualEditGestureWatch.observing &&
     // A drop/cancel owes one reconciling seek that has not happened yet.
     !pausedSeekDeferredByManualGesture &&
+    // A composition change is owed a manifest post that the rate limit has
+    // deferred. Parking here would strand it until the next unrelated change,
+    // so the loop stays awake — for at most one cadence interval — until the
+    // post goes out.
+    !compositionChangePending &&
     // The playhead and the bound timeline are both where the last seek left
     // them, so re-seeking on the next frame would render the same frame again.
     state.currentTime === lastTransportSeekTime &&
@@ -3409,12 +3434,29 @@ export function initSandboxRuntimeModular(): void {
    * 1. Keep the control bridge's paused heartbeat on its documented interval
    *    (`state.bridgeMaxPostIntervalMs`) so a paused timeline still confirms
    *    its position to any listener.
-   * 2. Re-read the timeline registry. A composition script registering into
-   *    `window.__timelines`, or lengthening one already there, is the single
-   *    input no MutationObserver and no event can report — see
-   *    `readCompositionTimingRevision`. Polling it 12 times a second instead
-   *    of 60 is the whole reason the safety net exists.
+   * 2. Re-read everything nothing can push (`readParkedPollWitness`). Polling
+   *    that 12 times a second instead of 60 is the whole reason the safety net
+   *    exists.
    */
+  /**
+   * Everything a parked transport still has to LOOK at, because no observer
+   * and no event can tell it.
+   *
+   * Two inputs qualify, and both are documented at their source:
+   *   - the timeline registry, a plain object a composition script writes into
+   *     (see `readCompositionTimingRevision`); and
+   *   - the adapter duration floor, which adapters infer from live animation
+   *     objects — CSS, WAAPI, Lottie — that can lengthen with no DOM mutation
+   *     and no media event (see the comment on `resolveAdapterDurationFloorSeconds`
+   *     in `getSafeTimelineDurationSeconds`).
+   *
+   * Calling `readCompositionTimingRevision` here is also what DRAINS the
+   * mutation observer, so a record that arrived without its callback running
+   * is caught on this path too.
+   */
+  const readParkedPollWitness = (): string =>
+    `${readCompositionTimingRevision()}|${resolveAdapterDurationFloorSeconds() ?? ""}`;
+
   const armParkTimer = () => {
     transportParkTimerId = window.setTimeout(
       parkedTransportHeartbeat,
@@ -3425,9 +3467,10 @@ export function initSandboxRuntimeModular(): void {
   const parkedTransportHeartbeat = () => {
     transportParkTimerId = null;
     if (state.tornDown) return;
-    if (readCompositionTimingRevision() !== parkedTimingRevision) {
-      // Through wakeTransport, not straight to rAF: reading the revision can
-      // itself bump it (the registry compare), and that already woke us.
+    if (readParkedPollWitness() !== parkedPollWitness) {
+      // Through wakeTransport, not straight to rAF: reading the witness can
+      // itself wake us (the registry compare bumps the revision, and that
+      // invalidation hook calls wakeTransport).
       wakeTransport();
       return;
     }
@@ -3448,7 +3491,7 @@ export function initSandboxRuntimeModular(): void {
     // may have run postTimeline, which stamps authored-timing attributes the
     // observer watches. Parking on the pre-postTimeline revision would make
     // the very first heartbeat see a change and wake for the loop's own writes.
-    parkedTimingRevision = readCompositionTimingRevision();
+    parkedPollWitness = readParkedPollWitness();
     armParkTimer();
   };
 
@@ -3472,26 +3515,42 @@ export function initSandboxRuntimeModular(): void {
     try {
       transportTickCount += 1;
 
-      // The three periodic jobs below used to fire on a frame counter, which
-      // was only ever a proxy for "the document may have changed since last
-      // time". Now that the loop parks, the counter stops advancing while it
-      // is parked, so the question is asked directly instead: the composition
-      // timing revision moves on exactly the inputs these three derive from —
-      // timing attributes, mounted/removed elements, media metadata, and the
-      // timeline registry. The counter stays as the belt to that braces, so
-      // playback behaviour is unchanged.
+      // The three periodic jobs below fire on a frame counter, which is only a
+      // proxy for "the document may have changed since last time". The counter
+      // stops advancing while the loop is parked, so on THAT path the question
+      // is asked directly: the composition timing revision moves on exactly the
+      // inputs these three derive from.
+      //
+      // Only on that path. While the clock is playing the counter advances at
+      // frame rate and is already a good cadence, and raising it is a real
+      // regression: postTimeline walks the whole document, so a composition
+      // that mutates the DOM every frame would turn one post per 20 frames into
+      // one per frame. And the change-driven path is rate-limited to the same
+      // posts-per-second the counter yields at 60 Hz, so no consumer ever sees
+      // a faster cadence than the frame counter alone produced.
       const timingRevision = readCompositionTimingRevision();
-      const compositionChanged = timingRevision !== lastServicedTimingRevision;
-      lastServicedTimingRevision = timingRevision;
+      if (timingRevision !== lastSeenTimingRevision) {
+        lastSeenTimingRevision = timingRevision;
+        compositionChangePending = true;
+      }
+      const nowMs = Date.now();
+      const changeDrivenService =
+        compositionChangePending &&
+        !clock.isPlaying() &&
+        nowMs - lastChangeDrivenServiceAtMs >= CHANGE_DRIVEN_SERVICE_MIN_INTERVAL_MS;
+      if (changeDrivenService) lastChangeDrivenServiceAtMs = nowMs;
 
-      // Slower operations: timeline binding (~every 60 frames / ~1s at 60fps)
+      // Slower operations: timeline binding (~every 60 frames / ~1s at 60fps).
+      // `compositionChanged` goes IN to the policy, never around it: the policy
+      // owns the hold that keeps an async rebind off the first two seconds of
+      // playback, and ORing past it removed that hold.
       if (
-        compositionChanged ||
         shouldAttemptPeriodicTimelineBind({
           tick: transportTickCount,
           isPlaying: clock.isPlaying(),
           hasCapturedTimeline: state.capturedTimeline != null,
           currentTimeSeconds: clock.now(),
+          compositionChanged: changeDrivenService,
         })
       ) {
         const prevTimeline = state.capturedTimeline;
@@ -3507,10 +3566,15 @@ export function initSandboxRuntimeModular(): void {
           postTimeline();
         }
       }
-      if (compositionChanged || transportTickCount % 20 === 0) {
+      if (changeDrivenService || transportTickCount % TIMELINE_POST_INTERVAL_FRAMES === 0) {
+        // The manifest is what carries a composition change to its consumers,
+        // so posting it is what discharges the pending flag — whichever path
+        // got here. Clearing it when the change is merely SEEN would drop it
+        // whenever the rate limit deferred the post.
+        compositionChangePending = false;
         postTimeline();
       }
-      if (compositionChanged || transportTickCount % 30 === 0) {
+      if (changeDrivenService || transportTickCount % MEDIA_BIND_INTERVAL_FRAMES === 0) {
         bindMediaMetadataListeners();
       }
 

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -3571,8 +3571,14 @@ export function initSandboxRuntimeModular(): void {
         // so posting it is what discharges the pending flag — whichever path
         // got here. Clearing it when the change is merely SEEN would drop it
         // whenever the rate limit deferred the post.
-        compositionChangePending = false;
+        //
+        // And clearing it AFTER the post, not before: postTimeline walks author
+        // DOM and can throw. The tail scheduler runs in this tick's `finally`
+        // either way, so clearing first would let it see nothing owed and park
+        // with the change undelivered — permanently, until some unrelated
+        // change happens to wake the loop again.
         postTimeline();
+        compositionChangePending = false;
       }
       if (changeDrivenService || transportTickCount % MEDIA_BIND_INTERVAL_FRAMES === 0) {
         bindMediaMetadataListeners();

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -55,7 +55,7 @@ import {
 } from "../audioGroups";
 import { clampNativeMediaVolume } from "../audioGain";
 import { quantizeTimeToFrame, snapTimeToFrameBoundary } from "../inline-scripts/parityContract";
-import { STUDIO_MANUAL_EDIT_GESTURE_ATTR } from "../editing/draftMarkers";
+import { createManualEditGestureWatch } from "./manualEditGestureWatch";
 import type {
   RuntimeDeterministicAdapter,
   RuntimeJson,
@@ -936,6 +936,24 @@ export function initSandboxRuntimeModular(): void {
   // derived-duration cache is bypassed entirely once it is set.
   let renderCaptureSeekStarted = false;
 
+  /**
+   * An export render is driving frames deterministically.
+   *
+   * The PAIR, never `renderCaptureSeekStarted` alone: `renderSeek` is also what
+   * Studio's own preview falls back to for overhanging timelines
+   * (`playbackAdapter.createStaticSeekPlaybackAdapter`), so the flag alone
+   * latches on the first Studio scrub of such a project and stays true for the
+   * rest of that session. `__HF_EXPORT_RENDER_SEEK_CONFIG` is injected by the
+   * producer's page script before a single frame is driven, so the pair is
+   * true for a real render and nothing else.
+   *
+   * Two callers rely on this being one decision with one owner: the async
+   * metadata rebind, which must not race the capture loop, and the transport
+   * loop, which must not park while a render is in charge of frames.
+   */
+  const isExportRenderDrivingFrames = (): boolean =>
+    renderCaptureSeekStarted && window.__HF_EXPORT_RENDER_SEEK_CONFIG != null;
+
   // The media and authored-composition duration floors are derived from the
   // DOM and the timeline registry — never from the playhead — so they change
   // only when the composition changes. transportTick asks for them on EVERY
@@ -989,8 +1007,19 @@ export function initSandboxRuntimeModular(): void {
   // second cache checking for itself would be told nothing changed.
   let compositionTimingRevision = 0;
 
+  // Restarts the transport loop when it has parked itself (see
+  // `scheduleNextTransportFrame`). Held as a reassignable binding because the
+  // invalidation hooks below are installed long before the transport exists,
+  // and reaching forward into its `const` would be a temporal-dead-zone throw
+  // during init.
+  let wakeTransport: () => void = () => {};
+
   const invalidateCompositionTimingCaches = () => {
     compositionTimingRevision += 1;
+    // The same records that stale the duration caches are what a parked
+    // transport is waiting for: a timing attribute edited, a sub-composition
+    // mounted, media metadata arriving. One signal, two readers.
+    wakeTransport();
   };
 
   const deriveDurationFloors = (): DurationFloors => ({
@@ -1061,13 +1090,20 @@ export function initSandboxRuntimeModular(): void {
     return compositionTimingRevision;
   };
 
-  const resolveDurationFloors = (): DurationFloors => {
+  /**
+   * `revision` lets a caller that has ALREADY read the revision in this task
+   * hand it over instead of paying for a second read. Reading is not free —
+   * it rebuilds a signature over every registered timeline — and it is also
+   * what DRAINS the observer, so a second read in the same task is told
+   * nothing changed and the work is pure duplication.
+   */
+  const resolveDurationFloors = (revision?: number): DurationFloors => {
     // The render path never reads a cached floor. Capture depends on the exact
     // duration and a frame that rendered against a wrong one cannot be
     // recovered, so it pays the full derivation on every frame exactly as
     // before — a correct slow render beats a fast wrong one.
     if (renderCaptureSeekStarted) return deriveDurationFloors();
-    const revision = readCompositionTimingRevision();
+    revision ??= readCompositionTimingRevision();
     if (durationFloorsCache && durationFloorsRevision === revision) return durationFloorsCache;
     durationFloorsRevision = revision;
     durationFloorsCache = deriveDurationFloors();
@@ -1077,10 +1113,11 @@ export function initSandboxRuntimeModular(): void {
   const getSafeTimelineDurationSeconds = (
     timeline: RuntimeTimelineLike | null,
     fallback = 0,
+    timingRevision?: number,
   ): number => {
     const timelineDuration = getTimelineDurationSeconds(timeline);
     const { media: mediaFloor, authoredComposition: authoredCompositionFloor } =
-      resolveDurationFloors();
+      resolveDurationFloors(timingRevision);
     // Deliberately NOT cached: adapters infer their duration from live
     // animation objects (CSS/WAAPI/Lottie), which can change without any DOM
     // mutation or media event to observe. It is also a short loop over the
@@ -2000,12 +2037,11 @@ export function initSandboxRuntimeModular(): void {
       // capture starts, so once frames are being driven there is nothing left
       // for this self-correction to usefully do.
       //
-      // renderSeek is also the entrypoint Studio's own preview iframe falls
-      // back to for overhanging timelines (useTimelinePlayer), so gate on
-      // both signals — renderCaptureSeekStarted alone would silently disable
-      // this self-correction for a live Studio scrub too, where duration
-      // hasn't been pre-resolved by a probe stage and still needs it.
-      if (renderCaptureSeekStarted && window.__HF_EXPORT_RENDER_SEEK_CONFIG) return;
+      // Gated on the pair rather than renderCaptureSeekStarted alone, because
+      // the flag alone would silently disable this self-correction for a live
+      // Studio scrub too, where duration hasn't been pre-resolved by a probe
+      // stage and still needs it. See isExportRenderDrivingFrames.
+      if (isExportRenderDrivingFrames()) return;
       const resolution = resolveRootTimelineFromDocument();
       if (!resolution.timeline) return;
       const hasResolvedMediaFloor = isUsableTimelineDuration(
@@ -2526,6 +2562,11 @@ export function initSandboxRuntimeModular(): void {
   };
 
   const postState = (force: boolean) => {
+    // Every transport mutation — play, pause, seek, renderSeek, a control-bridge
+    // command, the player's own state posts — ends in a forced post. That makes
+    // this the one place a parked transport needs to hear about, instead of a
+    // wake call bolted onto each mutator (and forgotten on the next one).
+    if (force) wakeTransport();
     const frame = Math.max(0, Math.round((state.currentTime || 0) * state.canonicalFps));
     const now = Date.now();
     const shouldPost =
@@ -3118,6 +3159,11 @@ export function initSandboxRuntimeModular(): void {
   let lastTransportSeekTime = Number.NaN;
   let lastTransportSeekTimeline: RuntimeTimelineLike | null = null;
   let pausedSeekDeferredByManualGesture = false;
+  // Set while the transport is parked (see scheduleNextTransportFrame).
+  let transportParkTimerId: number | null = null;
+  let transportWakeRequested = false;
+  let parkedTimingRevision = -1;
+  let lastServicedTimingRevision = -1;
 
   const seekRuntimeTimeline = (
     timeline: RuntimeTimelineLike,
@@ -3323,28 +3369,124 @@ export function initSandboxRuntimeModular(): void {
   // paused gesture the draft writer owns the element's transform, so the
   // per-frame transport re-seek must yield to it (see transportTick).
   //
-  // The query is document-global (fine for today's single-composition Studio;
+  // The watch is document-global (fine for today's single-composition Studio;
   // revisit if a multi-composition editor needs to scope this to one root).
-  // It only runs while the clock is paused — transportTick short-circuits on
-  // isPlaying() — so it is off the playback hot path; one attribute selector
-  // per paused frame is negligible.
+  // It used to be a `document.querySelector` on every paused frame, described
+  // here as negligible; measured, it was 1.8 ms/s on a 1689-element project and
+  // 3.0 ms/s — 6.4% of the whole paused main-thread budget — on a media-heavy
+  // one. An attribute-filtered observer answers the same question in O(edits),
+  // and its change callback is also what un-parks the transport when a drag
+  // starts or ends.
+  const manualEditGestureWatch = createManualEditGestureWatch(document, () => {
+    wakeTransport();
+  });
+  runtimeCleanupCallbacks.push(() => manualEditGestureWatch.disconnect());
   const hasActiveStudioManualEditGesture = (): boolean => {
     try {
-      return document.querySelector(`[${STUDIO_MANUAL_EDIT_GESTURE_ATTR}]`) != null;
+      return manualEditGestureWatch.isActive();
     } catch {
       return false;
     }
+  };
+
+  /**
+   * Nothing a tick would discover can change without one of the wake signals
+   * firing, so the loop may stand down until one does.
+   */
+  const canParkTransport = (): boolean =>
+    !clock.isPlaying() &&
+    !isExportRenderDrivingFrames() &&
+    // A drop/cancel owes one reconciling seek that has not happened yet.
+    !pausedSeekDeferredByManualGesture &&
+    // The playhead and the bound timeline are both where the last seek left
+    // them, so re-seeking on the next frame would render the same frame again.
+    state.currentTime === lastTransportSeekTime &&
+    state.capturedTimeline === lastTransportSeekTimeline;
+
+  /**
+   * The parked loop. Two jobs the 60 Hz loop used to do implicitly:
+   *
+   * 1. Keep the control bridge's paused heartbeat on its documented interval
+   *    (`state.bridgeMaxPostIntervalMs`) so a paused timeline still confirms
+   *    its position to any listener.
+   * 2. Re-read the timeline registry. A composition script registering into
+   *    `window.__timelines`, or lengthening one already there, is the single
+   *    input no MutationObserver and no event can report — see
+   *    `readCompositionTimingRevision`. Polling it 12 times a second instead
+   *    of 60 is the whole reason the safety net exists.
+   */
+  const armParkTimer = () => {
+    transportParkTimerId = window.setTimeout(
+      parkedTransportHeartbeat,
+      state.bridgeMaxPostIntervalMs,
+    );
+  };
+
+  const parkedTransportHeartbeat = () => {
+    transportParkTimerId = null;
+    if (state.tornDown) return;
+    if (readCompositionTimingRevision() !== parkedTimingRevision) {
+      // Through wakeTransport, not straight to rAF: reading the revision can
+      // itself bump it (the registry compare), and that already woke us.
+      wakeTransport();
+      return;
+    }
+    postState(false);
+    armParkTimer();
+  };
+
+  const scheduleNextTransportFrame = () => {
+    state.transportRafId = null;
+    if (state.tornDown) return;
+    const woken = transportWakeRequested;
+    transportWakeRequested = false;
+    if (woken || !canParkTransport()) {
+      state.transportRafId = window.requestAnimationFrame(transportTick);
+      return;
+    }
+    // Read fresh rather than reusing the tick's own `timingRevision`: the tick
+    // may have run postTimeline, which stamps authored-timing attributes the
+    // observer watches. Parking on the pre-postTimeline revision would make
+    // the very first heartbeat see a change and wake for the loop's own writes.
+    parkedTimingRevision = readCompositionTimingRevision();
+    armParkTimer();
+  };
+
+  wakeTransport = () => {
+    if (state.tornDown) return;
+    // Inside a tick the tail is the only scheduler; setting the flag there is
+    // what stops it parking on work it has just been told about.
+    transportWakeRequested = true;
+    if (inTransportTick || state.transportRafId != null) return;
+    if (transportParkTimerId != null) {
+      window.clearTimeout(transportParkTimerId);
+      transportParkTimerId = null;
+    }
+    transportWakeRequested = false;
+    state.transportRafId = window.requestAnimationFrame(transportTick);
   };
 
   const transportTick = () => {
     if (state.tornDown || inTransportTick) return;
     inTransportTick = true;
     try {
-      state.transportRafId = window.requestAnimationFrame(transportTick);
       transportTickCount += 1;
+
+      // The three periodic jobs below used to fire on a frame counter, which
+      // was only ever a proxy for "the document may have changed since last
+      // time". Now that the loop parks, the counter stops advancing while it
+      // is parked, so the question is asked directly instead: the composition
+      // timing revision moves on exactly the inputs these three derive from —
+      // timing attributes, mounted/removed elements, media metadata, and the
+      // timeline registry. The counter stays as the belt to that braces, so
+      // playback behaviour is unchanged.
+      const timingRevision = readCompositionTimingRevision();
+      const compositionChanged = timingRevision !== lastServicedTimingRevision;
+      lastServicedTimingRevision = timingRevision;
 
       // Slower operations: timeline binding (~every 60 frames / ~1s at 60fps)
       if (
+        compositionChanged ||
         shouldAttemptPeriodicTimelineBind({
           tick: transportTickCount,
           isPlaying: clock.isPlaying(),
@@ -3360,15 +3502,15 @@ export function initSandboxRuntimeModular(): void {
           if (state.capturedTimeline && state.capturedTimeline !== prevTimeline) {
             pauseTimelineIfPossible(state.capturedTimeline);
           }
-          const dur = getSafeTimelineDurationSeconds(state.capturedTimeline, 0);
+          const dur = getSafeTimelineDurationSeconds(state.capturedTimeline, 0, timingRevision);
           if (dur > 0) clock.setDuration(dur);
           postTimeline();
         }
       }
-      if (transportTickCount % 20 === 0) {
+      if (compositionChanged || transportTickCount % 20 === 0) {
         postTimeline();
       }
-      if (transportTickCount % 30 === 0) {
+      if (compositionChanged || transportTickCount % 30 === 0) {
         bindMediaMetadataListeners();
       }
 
@@ -3376,7 +3518,7 @@ export function initSandboxRuntimeModular(): void {
       // rebinds, live data-duration edits). Never shrink while playing — transient
       // short reads cause reachedEnd() → playhead jumps to end (#1636).
       if (state.capturedTimeline) {
-        const dur = getSafeTimelineDurationSeconds(state.capturedTimeline, 0);
+        const dur = getSafeTimelineDurationSeconds(state.capturedTimeline, 0, timingRevision);
         if (dur > 0 && (!clock.isPlaying() || dur >= clock.getDuration())) {
           clock.setDuration(dur);
         }
@@ -3486,6 +3628,10 @@ export function initSandboxRuntimeModular(): void {
       postState(false);
     } finally {
       inTransportTick = false;
+      // Re-arm here, not at the top: the reached-end branch returns early and
+      // must still schedule, and the decision to park can only be made once
+      // the tick has settled the playhead.
+      scheduleNextTransportFrame();
     }
   };
 
@@ -3776,6 +3922,10 @@ export function initSandboxRuntimeModular(): void {
     if (state.transportRafId != null) {
       window.cancelAnimationFrame(state.transportRafId);
       state.transportRafId = null;
+    }
+    if (transportParkTimerId != null) {
+      window.clearTimeout(transportParkTimerId);
+      transportParkTimerId = null;
     }
     state.transportClock = null;
     webAudio.destroy();

--- a/packages/core/src/runtime/manualEditGestureWatch.test.ts
+++ b/packages/core/src/runtime/manualEditGestureWatch.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { STUDIO_MANUAL_EDIT_GESTURE_ATTR } from "../editing/draftMarkers";
+import { createManualEditGestureWatch } from "./manualEditGestureWatch";
+
+const flush = () => new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+describe("manual-edit gesture watch", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("reports a gesture and calls back when the marker appears and clears", async () => {
+    document.body.innerHTML = `<div id="a"></div>`;
+    const changes: number[] = [];
+    const watch = createManualEditGestureWatch(document, () => changes.push(1));
+    try {
+      expect(watch.observing).toBe(true);
+      expect(watch.isActive()).toBe(false);
+
+      const el = document.getElementById("a")!;
+      el.setAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR, "token");
+      // Correct within the task, before the observer's microtask has run —
+      // and reading it must not swallow the change notification, because that
+      // notification is what un-parks the transport.
+      expect(watch.isActive()).toBe(true);
+      expect(changes.length).toBeGreaterThan(0);
+      await flush();
+
+      el.removeAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR);
+      expect(watch.isActive()).toBe(false);
+    } finally {
+      watch.disconnect();
+    }
+  });
+
+  it("stops reporting a gesture whose element was torn out mid-drag", async () => {
+    document.body.innerHTML = `<div id="a"></div>`;
+    const watch = createManualEditGestureWatch(document, () => {});
+    try {
+      const el = document.getElementById("a")!;
+      el.setAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR, "token");
+      expect(watch.isActive()).toBe(true);
+      // A hot reload during a drag: the marked element can never clear itself.
+      el.remove();
+      await flush();
+      expect(watch.isActive()).toBe(false);
+    } finally {
+      watch.disconnect();
+    }
+  });
+
+  it("seeds from a marker that was already on the document when it attached", () => {
+    document.body.innerHTML = `<div id="a" ${STUDIO_MANUAL_EDIT_GESTURE_ATTR}="token"></div>`;
+    const watch = createManualEditGestureWatch(document, () => {});
+    try {
+      expect(watch.isActive()).toBe(true);
+    } finally {
+      watch.disconnect();
+    }
+  });
+
+  it("reports observing:false, and keeps answering, where MutationObserver is absent", () => {
+    document.body.innerHTML = `<div id="a" ${STUDIO_MANUAL_EDIT_GESTURE_ATTR}="token"></div>`;
+    // A document whose view has no MutationObserver. `observing` false is the
+    // contract a caller reads before deciding it may stop asking: on this path
+    // `onChange` never fires, so nothing can be woken by a gesture.
+    const viewless = {
+      documentElement: document.documentElement,
+      defaultView: { MutationObserver: undefined },
+      querySelector: (s: string) => document.querySelector(s),
+      querySelectorAll: (s: string) => document.querySelectorAll(s),
+    } as unknown as Document;
+    const realObserver = globalThis.MutationObserver;
+    // @ts-expect-error stripping the capability under test
+    delete globalThis.MutationObserver;
+    try {
+      const changes: number[] = [];
+      const watch = createManualEditGestureWatch(viewless, () => changes.push(1));
+      expect(watch.observing).toBe(false);
+      expect(watch.isActive()).toBe(true);
+      document.getElementById("a")!.removeAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR);
+      expect(watch.isActive()).toBe(false);
+      expect(changes).toHaveLength(0);
+      watch.disconnect();
+    } finally {
+      globalThis.MutationObserver = realObserver;
+    }
+  });
+});

--- a/packages/core/src/runtime/manualEditGestureWatch.ts
+++ b/packages/core/src/runtime/manualEditGestureWatch.ts
@@ -1,0 +1,84 @@
+import { STUDIO_MANUAL_EDIT_GESTURE_ATTR } from "../editing/draftMarkers";
+
+export interface ManualEditGestureWatch {
+  /** True while any element in the document carries the gesture marker. */
+  isActive: () => boolean;
+  disconnect: () => void;
+}
+
+const SELECTOR = `[${STUDIO_MANUAL_EDIT_GESTURE_ATTR}]`;
+
+/**
+ * Live answer to "is the Studio mid-drag", without a whole-document query per
+ * frame.
+ *
+ * The marker is one attribute on one element for the length of a drag, so the
+ * set of marked elements changes a handful of times per gesture and never
+ * during playback — but the transport asked the document for it on every
+ * paused frame, which measured 1.8 ms/s on a large project and 3.0 ms/s (6.4%
+ * of the whole paused main-thread budget) on a media-heavy one. An
+ * attribute-filtered MutationObserver answers the same question in O(edits).
+ *
+ * `onChange` fires whenever the marker set may have changed, which is also the
+ * signal a parked transport needs to start ticking again.
+ */
+export function createManualEditGestureWatch(
+  doc: Document,
+  onChange: () => void,
+): ManualEditGestureWatch {
+  const Observer = doc.defaultView?.MutationObserver ?? globalThis.MutationObserver;
+  if (!Observer || !doc.documentElement) {
+    // No observer to trust: keep answering from the document, as before.
+    return {
+      isActive: () => doc.querySelector(SELECTOR) != null,
+      disconnect: () => {},
+    };
+  }
+
+  // Seeded from the document because an element could already be marked when a
+  // runtime re-initialises over a live Studio session; the observer only ever
+  // reports changes after it attaches.
+  const marked = new Set<Element>(doc.querySelectorAll(SELECTOR));
+
+  const ingest = (records: MutationRecord[]): void => {
+    for (const record of records) {
+      const target = record.target;
+      if (!(target instanceof Element)) continue;
+      if (target.hasAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR)) marked.add(target);
+      else marked.delete(target);
+    }
+  };
+
+  const observer = new Observer((records) => {
+    ingest(records);
+    onChange();
+  });
+  observer.observe(doc.documentElement, {
+    subtree: true,
+    attributes: true,
+    attributeFilter: [STUDIO_MANUAL_EDIT_GESTURE_ATTR],
+  });
+
+  return {
+    isActive: () => {
+      // Records are delivered in a microtask, so a caller reading back in the
+      // same synchronous block as the gesture's own attribute write would
+      // otherwise be served the pre-write answer. Draining here makes the
+      // watch correct within a task, not just across tasks.
+      ingest(observer.takeRecords());
+      for (const element of marked) {
+        if (element.isConnected && element.hasAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR)) {
+          return true;
+        }
+        // A marked element torn out of the document (hot reload mid-drag) can
+        // never clear its own marker.
+        marked.delete(element);
+      }
+      return false;
+    },
+    disconnect: () => {
+      observer.disconnect();
+      marked.clear();
+    },
+  };
+}

--- a/packages/core/src/runtime/manualEditGestureWatch.ts
+++ b/packages/core/src/runtime/manualEditGestureWatch.ts
@@ -81,8 +81,12 @@ export function createManualEditGestureWatch(
       // watch correct within a task, not just across tasks.
       //
       // Through `notify`, because taking records SUPPRESSES the observer's own
-      // callback for them: a reader that drained first would otherwise consume
-      // somebody else's change notification and nobody would ever hear about it.
+      // callback for them. Defensive rather than a fix for a live bug: there
+      // is exactly one caller of `isActive` today (`transportTick`), and a
+      // tick is its own task, so the observer's microtask has already run and
+      // called `onChange` before any drain happens here. Adding a second
+      // caller that ran earlier in the task would silently eat that callback,
+      // and the callback is what un-parks the transport.
       notify(observer.takeRecords());
       for (const element of marked) {
         if (element.isConnected && element.hasAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR)) {

--- a/packages/core/src/runtime/manualEditGestureWatch.ts
+++ b/packages/core/src/runtime/manualEditGestureWatch.ts
@@ -3,6 +3,13 @@ import { STUDIO_MANUAL_EDIT_GESTURE_ATTR } from "../editing/draftMarkers";
 export interface ManualEditGestureWatch {
   /** True while any element in the document carries the gesture marker. */
   isActive: () => boolean;
+  /**
+   * True when an observer is attached and `onChange` will therefore fire.
+   * False on the fallback below, where the answer is only ever produced when
+   * somebody asks — a caller that would otherwise stop asking must keep
+   * asking instead.
+   */
+  observing: boolean;
   disconnect: () => void;
 }
 
@@ -31,6 +38,9 @@ export function createManualEditGestureWatch(
     // No observer to trust: keep answering from the document, as before.
     return {
       isActive: () => doc.querySelector(SELECTOR) != null,
+      // Nothing to push from: `onChange` is never called on this path, so a
+      // caller that parks on it would never be woken by a gesture.
+      observing: false,
       disconnect: () => {},
     };
   }
@@ -49,10 +59,13 @@ export function createManualEditGestureWatch(
     }
   };
 
-  const observer = new Observer((records) => {
+  const notify = (records: MutationRecord[]): void => {
+    if (records.length === 0) return;
     ingest(records);
     onChange();
-  });
+  };
+
+  const observer = new Observer(notify);
   observer.observe(doc.documentElement, {
     subtree: true,
     attributes: true,
@@ -60,12 +73,17 @@ export function createManualEditGestureWatch(
   });
 
   return {
+    observing: true,
     isActive: () => {
       // Records are delivered in a microtask, so a caller reading back in the
       // same synchronous block as the gesture's own attribute write would
       // otherwise be served the pre-write answer. Draining here makes the
       // watch correct within a task, not just across tasks.
-      ingest(observer.takeRecords());
+      //
+      // Through `notify`, because taking records SUPPRESSES the observer's own
+      // callback for them: a reader that drained first would otherwise consume
+      // somebody else's change notification and nobody would ever hear about it.
+      notify(observer.takeRecords());
       for (const element of marked) {
         if (element.isConnected && element.hasAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR)) {
           return true;

--- a/packages/core/src/runtime/timelineRebindPolicy.ts
+++ b/packages/core/src/runtime/timelineRebindPolicy.ts
@@ -1,22 +1,42 @@
 export const TIMELINE_REBIND_INTERVAL_FRAMES = 60;
 export const PLAY_REBIND_HOLD_SECONDS = 2;
+/** How often the transport re-posts the clip manifest, in animation frames. */
+export const TIMELINE_POST_INTERVAL_FRAMES = 20;
+/** How often the transport re-binds metadata listeners, in animation frames. */
+export const MEDIA_BIND_INTERVAL_FRAMES = 30;
+/**
+ * The floor the change-driven (parked) path holds itself to, so a consumer
+ * never sees the manifest arrive faster than the frame counter alone produced
+ * it: `TIMELINE_POST_INTERVAL_FRAMES` frames at a 60 Hz display.
+ */
+export const CHANGE_DRIVEN_SERVICE_MIN_INTERVAL_MS = (1000 * TIMELINE_POST_INTERVAL_FRAMES) / 60;
 
 export function shouldAttemptPeriodicTimelineBind(input: {
   tick: number;
   isPlaying: boolean;
   hasCapturedTimeline: boolean;
   currentTimeSeconds: number;
+  /**
+   * The transport saw a composition change this tick and would like a rebind
+   * sooner than the frame counter allows. It is an INPUT to this policy, never
+   * a way around it: the play hold below still wins. A caller that ORs its own
+   * trigger in front of this function has removed the hold, which exists so an
+   * async rebind cannot race the first two seconds of playback.
+   */
+  compositionChanged?: boolean;
 }): boolean {
+  // The hold is the outer rule and applies to every trigger.
   if (
-    !Number.isInteger(input.tick) ||
-    input.tick <= 0 ||
-    input.tick % TIMELINE_REBIND_INTERVAL_FRAMES !== 0
-  ) {
-    return false;
-  }
-  return !(
     input.isPlaying &&
     input.hasCapturedTimeline &&
     input.currentTimeSeconds < PLAY_REBIND_HOLD_SECONDS
+  ) {
+    return false;
+  }
+  if (input.compositionChanged === true) return true;
+  return (
+    Number.isInteger(input.tick) &&
+    input.tick > 0 &&
+    input.tick % TIMELINE_REBIND_INTERVAL_FRAMES === 0
   );
 }

--- a/packages/core/src/runtime/transportPark.test.ts
+++ b/packages/core/src/runtime/transportPark.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { initSandboxRuntimeModular } from "./init";
+import { STUDIO_MANUAL_EDIT_GESTURE_ATTR } from "../editing/draftMarkers";
+import type { RuntimeTimelineLike } from "./types";
+
+/**
+ * The transport parks itself when the editor is paused and settled. Everything
+ * it used to discover by looking again on the next frame has to arrive by some
+ * other route, and each of those routes gets a test here — one per row of the
+ * enumeration in the PR body. A loop that stops noticing one of them is a
+ * correctness regression no performance test would catch.
+ */
+
+const PARK_HEARTBEAT_MS = 80; // state.bridgeMaxPostIntervalMs
+
+function createManualRaf() {
+  let now = 0;
+  let nextId = 0;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  return {
+    requestAnimationFrame: (callback: FrameRequestCallback) => {
+      nextId += 1;
+      callbacks.set(nextId, callback);
+      return nextId;
+    },
+    cancelAnimationFrame: (id: number) => {
+      callbacks.delete(id);
+    },
+    pending: () => callbacks.size,
+    step: (milliseconds = 16) => {
+      now += milliseconds;
+      const batch = Array.from(callbacks.entries());
+      callbacks.clear();
+      for (const [, callback] of batch) callback(now);
+    },
+    now: () => now,
+  };
+}
+
+function createMockTimeline(duration: number): RuntimeTimelineLike {
+  const state = { time: 0, paused: true, duration };
+  return {
+    play: () => {
+      state.paused = false;
+    },
+    pause: () => {
+      state.paused = true;
+    },
+    seek: (time?: number) => {
+      if (time !== undefined) state.time = time;
+      return state.time;
+    },
+    totalTime: (time?: number) => {
+      if (time !== undefined) state.time = time;
+      return state.time;
+    },
+    time: () => state.time,
+    duration: () => state.duration,
+    add: () => {},
+    paused: (value?: boolean) => {
+      if (typeof value === "boolean") state.paused = value;
+      return state.paused;
+    },
+    timeScale: () => {},
+    set: () => {},
+    getChildren: () => [],
+  };
+}
+
+/** MutationObserver records land in a microtask; nothing observes them sooner. */
+const flushObservers = () => new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
+describe("parked transport loop", () => {
+  const originalRaf = window.requestAnimationFrame;
+  const originalCancelRaf = window.cancelAnimationFrame;
+  let raf: ReturnType<typeof createManualRaf>;
+  let posted: Array<Record<string, unknown>>;
+
+  const mount = (bodyHtml = "") => {
+    document.body.innerHTML = `<div id="root" data-composition-id="main" data-root="true" data-start="0" data-duration="5">${bodyHtml}</div>`;
+    window.__timelines = { main: createMockTimeline(5) };
+  };
+
+  /** Run frames until nothing asks for another one. */
+  const settle = (maxFrames = 200): number => {
+    let frames = 0;
+    while (raf.pending() > 0 && frames < maxFrames) {
+      raf.step();
+      frames += 1;
+    }
+    return frames;
+  };
+
+  /**
+   * Park the transport AND drain init's own one-shot timers, several of which
+   * post state and would otherwise be mistaken for a heartbeat. Leaves exactly
+   * one timer pending: the parked heartbeat.
+   */
+  const quiesce = (): void => {
+    settle();
+    for (let i = 0; i < 40; i += 1) {
+      if (raf.pending() === 0 && vi.getTimerCount() <= 1) return;
+      vi.advanceTimersByTime(1);
+      settle();
+    }
+    throw new Error(
+      `transport never quiesced (raf ${raf.pending()}, timers ${vi.getTimerCount()})`,
+    );
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "Date"],
+    });
+    document.body.innerHTML = "";
+    (globalThis as typeof globalThis & { CSS?: { escape?: (v: string) => string } }).CSS ??= {};
+    globalThis.CSS.escape ??= (value: string) => value;
+    raf = createManualRaf();
+    window.requestAnimationFrame = raf.requestAnimationFrame as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = raf.cancelAnimationFrame as typeof window.cancelAnimationFrame;
+    posted = [];
+    vi.spyOn(window.parent, "postMessage").mockImplementation((message: unknown) => {
+      posted.push(message as Record<string, unknown>);
+    });
+    window.__timelines = {};
+  });
+
+  afterEach(() => {
+    window.__hfRuntimeTeardown?.();
+    document.body.innerHTML = "";
+    window.__timelines = {} as Record<string, RuntimeTimelineLike>;
+    delete window.__player;
+    delete window.__playerReady;
+    delete window.__HF_EXPORT_RENDER_SEEK_CONFIG;
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    window.requestAnimationFrame = originalRaf;
+    window.cancelAnimationFrame = originalCancelRaf;
+  });
+
+  it("stops asking for animation frames once paused and settled", () => {
+    mount();
+    initSandboxRuntimeModular();
+    quiesce();
+    expect(raf.pending()).toBe(0);
+    // Exactly one thing still scheduled: the parked heartbeat.
+    expect(vi.getTimerCount()).toBe(1);
+  });
+
+  it("keeps asking for animation frames while playing", () => {
+    mount();
+    initSandboxRuntimeModular();
+    quiesce();
+    window.__player!.play();
+    // Every frame during playback re-arms: the loop must never park mid-play.
+    for (let i = 0; i < 10; i += 1) {
+      expect(raf.pending()).toBeGreaterThan(0);
+      raf.step();
+    }
+    expect(raf.pending()).toBeGreaterThan(0);
+  });
+
+  it("posts the paused bridge heartbeat on its documented interval while parked", () => {
+    mount();
+    initSandboxRuntimeModular();
+    quiesce();
+    const before = posted.filter((m) => m["type"] === "state").length;
+    for (let beat = 0; beat < 3; beat += 1) vi.advanceTimersByTime(PARK_HEARTBEAT_MS);
+    const after = posted.filter((m) => m["type"] === "state").length;
+    expect(after - before).toBe(3);
+    // Still parked: the heartbeat is a timer, not a frame.
+    expect(raf.pending()).toBe(0);
+  });
+
+  it("delivers a live data-duration edit while parked", async () => {
+    mount();
+    initSandboxRuntimeModular();
+    quiesce();
+
+    window.__timelines!["main"] = createMockTimeline(9);
+    document.getElementById("root")!.setAttribute("data-duration", "9");
+    await flushObservers();
+
+    settle();
+    expect(window.__player!.getDuration()).toBeCloseTo(9, 3);
+  });
+
+  it("delivers a timeline registered into window.__timelines, which no observer can see", () => {
+    mount();
+    window.__timelines = {};
+    initSandboxRuntimeModular();
+    document.getElementById("root")!.removeAttribute("data-duration");
+    quiesce();
+    expect(window.__player!.getDuration()).not.toBeCloseTo(12, 3);
+
+    // No DOM mutation and no event: the registry is a plain object. Only the
+    // parked heartbeat's signature re-read can find this.
+    window.__timelines!["main"] = createMockTimeline(12);
+    vi.advanceTimersByTime(PARK_HEARTBEAT_MS);
+    settle();
+    expect(window.__player!.getDuration()).toBeCloseTo(12, 3);
+  });
+
+  it("delivers a timed element mounted after the loop parked", async () => {
+    mount();
+    initSandboxRuntimeModular();
+    quiesce();
+    const manifestBefore = window.__clipManifest?.clips.length ?? 0;
+
+    const late = document.createElement("div");
+    late.id = "late-clip";
+    late.setAttribute("data-start", "1");
+    late.setAttribute("data-duration", "2");
+    document.getElementById("root")!.appendChild(late);
+    await flushObservers();
+
+    settle();
+    expect(window.__clipManifest!.clips.length).toBeGreaterThan(manifestBefore);
+    expect(window.__clipManifest!.clips.some((clip) => clip.id === "late-clip")).toBe(true);
+  });
+
+  it("delivers media metadata that arrives after the loop parked", async () => {
+    mount(`<video id="v" data-start="0" src="a.mp4"></video>`);
+    initSandboxRuntimeModular();
+    quiesce();
+
+    const video = document.getElementById("v") as HTMLVideoElement;
+    Object.defineProperty(video, "duration", { value: 30, configurable: true });
+    // `durationchange` is an event, not a DOM mutation: this is the only route.
+    video.dispatchEvent(new Event("durationchange"));
+    await flushObservers();
+
+    settle();
+    expect(window.__player!.getDuration()).toBeGreaterThanOrEqual(30);
+  });
+
+  it("delivers the start of a Studio manual-edit gesture while parked", async () => {
+    mount(`<div id="c" data-start="0" data-duration="2"></div>`);
+    initSandboxRuntimeModular();
+    quiesce();
+    expect(raf.pending()).toBe(0);
+
+    document.getElementById("c")!.setAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR, "token-1");
+    await flushObservers();
+    expect(raf.pending()).toBeGreaterThan(0);
+  });
+
+  it("runs the reconciling seek the frame a manual-edit gesture ends", async () => {
+    mount(`<div id="c" data-start="0" data-duration="2"></div>`);
+    initSandboxRuntimeModular();
+    quiesce();
+
+    const target = document.getElementById("c")!;
+    target.setAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR, "token-1");
+    await flushObservers();
+    raf.step();
+    // A gesture owns the paused frame: the loop stays awake and defers the seek.
+    expect(raf.pending()).toBe(1);
+
+    const timeline = window.__timelines!["main"] as RuntimeTimelineLike;
+    const seeks: number[] = [];
+    const originalTotalTime = timeline.totalTime!.bind(timeline);
+    timeline.totalTime = (time?: number, suppress?: boolean) => {
+      if (time !== undefined) seeks.push(time);
+      return originalTotalTime(time, suppress);
+    };
+
+    target.removeAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR);
+    await flushObservers();
+    raf.step();
+    expect(seeks.length).toBeGreaterThan(0);
+  });
+
+  it("wakes on an explicit seek from the control surface", () => {
+    mount();
+    initSandboxRuntimeModular();
+    quiesce();
+    expect(raf.pending()).toBe(0);
+
+    window.__player!.seek(1);
+    expect(raf.pending()).toBeGreaterThan(0);
+    settle();
+    expect(window.__player!.getTime()).toBeCloseTo(1, 3);
+  });
+
+  it("never parks while an export render is driving frames", () => {
+    window.__HF_EXPORT_RENDER_SEEK_CONFIG = { mode: "seek" };
+    mount();
+    initSandboxRuntimeModular();
+    quiesce();
+
+    window.__player!.renderSeek(1);
+    // The render path must keep the exact scheduling it had before: a frame is
+    // always in flight, whatever the playhead is doing.
+    for (let i = 0; i < 10; i += 1) {
+      expect(raf.pending()).toBeGreaterThan(0);
+      raf.step();
+    }
+  });
+
+  it("still parks after Studio's own renderSeek fallback, which is not a render", () => {
+    // `playbackAdapter` drives an overhanging-timeline preview through
+    // renderSeek. Latching on that alone would leave the loop unparked for the
+    // whole session — the export config is what separates the two.
+    expect(window.__HF_EXPORT_RENDER_SEEK_CONFIG).toBeUndefined();
+    mount();
+    initSandboxRuntimeModular();
+    quiesce();
+
+    window.__player!.renderSeek(1);
+    quiesce();
+    expect(raf.pending()).toBe(0);
+    expect(window.__player!.getTime()).toBeCloseTo(1, 3);
+  });
+
+  it("stops both the frame loop and the parked timer on teardown", () => {
+    mount();
+    initSandboxRuntimeModular();
+    quiesce();
+
+    window.__hfRuntimeTeardown?.();
+    posted.length = 0;
+    vi.advanceTimersByTime(PARK_HEARTBEAT_MS * 5);
+    expect(raf.pending()).toBe(0);
+    expect(posted.filter((m) => m["type"] === "state")).toHaveLength(0);
+  });
+});

--- a/packages/core/src/runtime/transportPark.test.ts
+++ b/packages/core/src/runtime/transportPark.test.ts
@@ -357,6 +357,54 @@ describe("parked transport loop", () => {
     expect(posts).toBeLessThanOrEqual(2);
   });
 
+  it("does not park when the manifest post throws with a change still pending", async () => {
+    mount();
+    initSandboxRuntimeModular();
+    quiesce();
+
+    // postTimeline walks author DOM, which can throw. Fail it exactly once.
+    const NODE_SELECTOR =
+      "[data-start], [data-track-index], [data-composition-id], video, audio, img";
+    const realQueryAll = Document.prototype.querySelectorAll;
+    let failuresLeft = 1;
+    vi.spyOn(Document.prototype, "querySelectorAll").mockImplementation(function (
+      this: Document,
+      selector: string,
+    ) {
+      if (selector === NODE_SELECTOR && failuresLeft > 0) {
+        failuresLeft -= 1;
+        throw new Error("author DOM blew up");
+      }
+      return realQueryAll.call(this, selector);
+    } as typeof Document.prototype.querySelectorAll);
+
+    const late = document.createElement("div");
+    late.id = "late-after-throw";
+    late.setAttribute("data-start", "1");
+    late.setAttribute("data-duration", "2");
+    document.getElementById("root")!.appendChild(late);
+    await flushObservers();
+
+    // Run frames until the manifest post is attempted and throws. The post is
+    // rate-limited, so it lands on the frame counter's boundary, not the first
+    // woken frame.
+    let thrown: unknown = null;
+    for (let frame = 0; frame < 60 && thrown == null; frame += 1) {
+      if (raf.pending() === 0) break;
+      try {
+        raf.step();
+      } catch (error) {
+        thrown = error;
+      }
+    }
+    expect(String(thrown)).toContain("author DOM blew up");
+    // The change is still owed, so the loop must not have parked on it.
+    expect(raf.pending()).toBeGreaterThan(0);
+
+    settle();
+    expect(window.__clipManifest!.clips.some((clip) => clip.id === "late-after-throw")).toBe(true);
+  });
+
   it("delivers an adapter duration that grows while parked, with no DOM mutation and no event", () => {
     mount();
     initSandboxRuntimeModular();

--- a/packages/core/src/runtime/transportPark.test.ts
+++ b/packages/core/src/runtime/transportPark.test.ts
@@ -98,7 +98,9 @@ describe("parked transport loop", () => {
    */
   const quiesce = (): void => {
     settle();
-    for (let i = 0; i < 40; i += 1) {
+    // Up to ~400 ms of 1 ms steps: the transport holds a deferred manifest
+    // post for one cadence interval before it may park.
+    for (let i = 0; i < 400; i += 1) {
       if (raf.pending() === 0 && vi.getTimerCount() <= 1) return;
       vi.advanceTimersByTime(1);
       settle();
@@ -132,6 +134,7 @@ describe("parked transport loop", () => {
     delete window.__player;
     delete window.__playerReady;
     delete window.__HF_EXPORT_RENDER_SEEK_CONFIG;
+    delete (window as { __hfLottie?: unknown }).__hfLottie;
     vi.restoreAllMocks();
     vi.useRealTimers();
     window.requestAnimationFrame = originalRaf;
@@ -320,8 +323,53 @@ describe("parked transport loop", () => {
 
     window.__hfRuntimeTeardown?.();
     posted.length = 0;
+    // The count, not just the silence: a heartbeat that is still armed but
+    // returns early on `tornDown` posts nothing either, so counting posts
+    // alone passes with the clearTimeout deleted.
+    expect(vi.getTimerCount()).toBe(0);
     vi.advanceTimersByTime(PARK_HEARTBEAT_MS * 5);
     expect(raf.pending()).toBe(0);
     expect(posted.filter((m) => m["type"] === "state")).toHaveLength(0);
+  });
+
+  it("keeps the manifest on its frame cadence while playing, whatever the DOM does", () => {
+    mount();
+    initSandboxRuntimeModular();
+    quiesce();
+    window.__player!.play();
+    // Two seconds in, so the rebind policy's play hold is not what is doing
+    // the work — this has to hold for the rest of playback too.
+    for (let i = 0; i < 130; i += 1) raf.step();
+
+    const root = document.getElementById("root")!;
+    const before = posted.filter((m) => m["type"] === "timeline").length;
+    for (let frame = 0; frame < 30; frame += 1) {
+      // A composition that appends a node every frame. The manifest is a full
+      // document walk; posting it per frame is the regression this guards.
+      const node = document.createElement("div");
+      node.setAttribute("data-start", String(frame));
+      node.setAttribute("data-duration", "1");
+      root.appendChild(node);
+      raf.step();
+    }
+    const posts = posted.filter((m) => m["type"] === "timeline").length - before;
+    // Main's cadence over 30 frames is one post per 20 frames, so at most two.
+    expect(posts).toBeLessThanOrEqual(2);
+  });
+
+  it("delivers an adapter duration that grows while parked, with no DOM mutation and no event", () => {
+    mount();
+    initSandboxRuntimeModular();
+    quiesce();
+    const before = window.__player!.getDuration();
+
+    // A Lottie instance lengthening is a live animation object changing. No
+    // observer and no event can see it; only the parked poll can.
+    window.__hfLottie = [{ goToAndStop: () => {}, totalFrames: 600, frameRate: 30 }] as never;
+    vi.advanceTimersByTime(PARK_HEARTBEAT_MS);
+    settle();
+
+    expect(before).toBeLessThan(20);
+    expect(window.__player!.getDuration()).toBeCloseTo(20, 3);
   });
 });


### PR DESCRIPTION
A paused preview kept asking the browser for a fresh frame sixty times a second and re-reading the page on each one, with nothing on screen changing. It now stands down and wakes when something actually happens.

Nothing a tick could discover was able to change without some observable event firing first, so the loop re-arms on those events instead of on a frame, with a slow timer as the safety net. That timer keeps two jobs the sixty-a-second version did implicitly: the control bridge's paused heartbeat, on exactly the interval it used before, and a re-read of the timeline registry, which is a plain object that no observer and no event can report a change to.

Three periodic jobs — re-binding the root timeline, posting the clip manifest, binding media-metadata listeners — used to fire on a frame counter, which was only ever standing in for "the document may have changed since last time". The counter stops advancing while the loop is parked, so they now ask that question directly, off the composition-timing revision the duration caches already track. The old counter stays as a backstop while the loop is awake, so playback behaviour is unchanged.

"Is the Studio mid-drag?" was a whole-document `querySelector` on every paused frame. Measured, that alone was 1.8 ms/s on a 1689-element project and 3.0 ms/s (6.4% of the entire paused main-thread budget) on a media-heavy one. It is now an attribute-filtered `MutationObserver`, and the same observer is what un-parks the transport when a drag starts or ends.

**The render path is untouched.** The loop never parks while an export render is driving frames. That test is the pair `renderCaptureSeekStarted && __HF_EXPORT_RENDER_SEEK_CONFIG`, not the flag alone — the same pair `scheduleMetadataDurationHydration` already uses, and for the same reason: Studio's own preview falls back to `renderSeek` for overhanging timelines, so the flag alone would latch on the first scrub of such a project and leave that session unparked for good.

## Every state change the loop used to find by looking again, and how it arrives now

| # | Discovered by polling | Now delivered by | Test |
|---|---|---|---|
| 1 | A timeline registered into the runtime's timeline registry, or an existing one lengthened | **No event source exists** — it is a plain object. The parked timer re-reads it on its interval. | `delivers a timeline registered into window.__timelines, which no observer can see` |
| 1b | An adapter's inferred duration growing — CSS, WAAPI or Lottie reading a live animation object | **No event source exists** either: it changes with no DOM mutation and no media event. Same parked timer, same witness. | `delivers an adapter duration that grows while parked, with no DOM mutation and no event` |
| 2 | A live `data-duration` or other timing-attribute edit | The composition-timing `MutationObserver` that already existed → wake | `delivers a live data-duration edit while parked` |
| 3 | A timed element or sub-composition mounting late | The same observer (childList + subtree) → wake, plus the manifest post moving off the frame counter | `delivers a timed element mounted after the loop parked` |
| 4 | Media metadata arriving, or reset by `load()` | The capture-phase `loadedmetadata` / `durationchange` / `emptied` listeners that already existed → wake | `delivers media metadata that arrives after the loop parked` |
| 5 | A Studio manual-edit gesture starting | New attribute-filtered `MutationObserver` on the gesture marker → wake | `delivers the start of a Studio manual-edit gesture while parked` |
| 6 | A gesture ending, which owes one reconciling seek | The same observer | `runs the reconciling seek the frame a manual-edit gesture ends` |
| 7 | The playhead moving or play state changing — play, pause, seek, a control-bridge command | Every transport mutation already ends in a forced state post; that is the single choke point that wakes | `wakes on an explicit seek from the control surface`, `keeps asking for animation frames while playing` |
| 8 | The paused bridge heartbeat: a paused timeline confirming its position on a fixed interval | The parked timer posts it on the same interval | `posts the paused bridge heartbeat on its documented interval while parked` |
| 9 | An export render driving frames | Never parked at all | `never parks while an export render is driving frames`, `still parks after Studio's own renderSeek fallback, which is not a render` |
| 10 | Reaching the end of the timeline; audio-source attach and detach; animated colour-grading redraw | All three are gated on the clock playing, and the loop never parks while it plays | `keeps asking for animation frames while playing` |
| 11 | (teardown) | Both the frame loop and the parked timer stop | `stops both the frame loop and the parked timer on teardown` |

Each row was proved non-vacuous by breaking its delivery path on purpose and confirming exactly the expected tests fail.

## Second commit: what the independent pre-review pass found

**Playback was not unchanged, and that was blocking.** The change signal was ORed in front of `shouldAttemptPeriodicTimelineBind`, which removed the hold that keeps an async rebind off the first two seconds of playback, and let the clip manifest post on every frame of a composition that mutates the DOM every frame — 30 posts in 30 frames against one. The policy is the single owner of "may rebind now" again: the change is an **input** to it, the hold still applies to every trigger, and the change-driven path is confined to the paused path and rate-limited to the posts per second the frame counter already produced. A deferred change stays pending and a pending change keeps the loop awake, so deferring can never drop it; the frame counter clears it within 20 frames either way, so it cannot hold the loop awake indefinitely. Test: `keeps the manifest on its frame cadence while playing, whatever the DOM does`.

**A second input nothing can push.** The parked poll compared only the composition timing revision, so an adapter duration floor that grew was never noticed. Row 1b above; the "single input" claim in the first commit's message was wrong and this corrects it.

**The teardown test was vacuous for the timer.** Deleting the `clearTimeout` left it green, because a heartbeat that is still armed returns early on `tornDown` and posts nothing either. It now asserts the timer count is zero.

**Draining now notifies, defensively.** Reading the gesture watch inside a task takes the observer's records, which suppresses the observer's own callback for them, and that callback is what un-parks the transport. This is hardening, not a live bug: `isActive` has exactly one caller today, inside `transportTick`, and a tick is its own task, so the observer's microtask has already fired before any drain. A second caller running earlier in the task would eat the wake, and nothing in the type would stop it.

**Where nothing can push at all.** The watch reports whether it is observing, and the loop refuses to park when it is not. That path is unreachable today: the colour-grading runtime constructs a `MutationObserver` unconditionally during the same init, so a host without one never reaches a running transport. The flag stays as the explicit statement of the invariant, and `manualEditGestureWatch.test.ts` pins it.

## Measured

Idle means paused, loaded, focused, no key presses, no pointer. Two projects: a 1689-element / 396-card carousel and a 79-video / 12-audio media project. Both arms were served from the same rig and captured **interleaved within each instrument**, so a machine-load spike lands on both. This Mac was running other work throughout (1-minute load 44 to 256 across the captures), which inflates absolute milliseconds on both arms equally; the counts do not move with load and are the harder numbers.

| Idle, paused, untouched | carousel before | carousel after | media before | media after |
|---|---:|---:|---:|---:|
| main-thread self time (ms/s, CDP trace) | 145.1 | **12.4** | 61.4 | **11.1** |
| `FireAnimationFrame` per second | 281.0 | **4.2** | 284.8 | **3.9** |
| compositor `Commit` per second | 55.1 | **4.2** | 56.4 | **4.0** |
| CPU-profile busy (ms/s) | 94.5 | **3.2** | 43.3 | **3.5** |
| renderer process, % of a core (macOS `sample`) | 21.0 | **4.2** | 9.5 | **1.3** |
| its main thread, % of a core | 13.3 | **1.4** | 5.7 | **1.0** |

Two interleaved passes per fixture per instrument on the final build; the renderer-percentage row is the median over five passes because process sampling is the noisiest instrument here. An earlier three-pass run on the same code minus three behaviour-neutral refactors gave 129.2 → 9.4 ms/s and 283 → 3.8 callbacks per second on the carousel, and 66.8 → 13.0 ms/s and 287 → 3.7 on media: the same result.

Compositor commits are the row worth reading twice. Frame callbacks are a mechanism metric and a change like this can move them without moving any work; commits cannot be gamed, because nothing commits a frame without having done the work. They fall with the callbacks, so the work really is gone.

### Two numbers that are not measured

The idle table below was captured before two later changes and has not been re-taken; disk on the measuring machine is under 3 GB and each trace capture is 28-100 MB.

- The parked poll now calls the adapter duration floor once per heartbeat, about 12.5 times a second. For the CSS adapter that is a `getAnimations()` per animated element. It cannot be a regression against the base — the per-frame loop made the same call 60 times a second — but the after column is optimistic by whatever that costs at 12.5 Hz, and on a composition with many CSS-animated elements that is not nothing.
- The manifest post is now retried after a throw rather than dropped, which can hold the loop awake for up to 20 frames longer in that failure case. Not on any normal path.

### A correction to the callback-count figure, and a sixth loop

Re-verifying the final build in a real browser with a per-realm probe (patching `requestAnimationFrame` and recording the caller's stack) found **297 of 297 sampled registrations in the preview realm coming from the Studio bundle and none from the runtime**, at about 60 a second. Attributed from the served bundle, it is `startStudioManualEditPlaybackReapply` in `manualEdits.ts`: it re-arms for as long as `__player`, `__timeline` or any entry of the timeline registry reports itself as playing, and on this project a scene timeline added to the paused root is itself unpaused, so it never stops.

Two things follow, and both are stated rather than smoothed over:

- **The parks hold.** Zero runtime frames in that sample is direct evidence the transport is parked, and the top frame measured 3.8 callbacks a second, so the overlay loop is parked too.
- **The absolute "callbacks per second" row above is lower than what a browser is really doing**, because that loop does not appear in it. Both arms were captured with the same instrument, so the before/after ratios and every other row stand; the absolute callback figure should be read as "the loops this change owns", not "every loop on the page". `manualEdits.ts` is untouched by either branch and is a candidate for the same treatment in follow-up work. I could not build a control to date the discrepancy: the before-arm build's dependencies have since been removed from the machine.

## Playback, scrubbing and jumps are unchanged

Same harness, play / scrub / jump phases, interleaved. Five replicate pairs on media, two on the carousel.

| | before | after |
|---|---|---|
| playhead after a 150-step scrub (carousel) | 5 s, every run | 5 s, every run |
| playhead after 30 one-second jumps (carousel) | 35 s, every run | 35 s, every run |
| playhead after a 60-step scrub (media) | 2 s, every run | 2 s, every run |
| playhead after 30 one-second jumps (media) | 32 s, every run | 32 s, every run |
| settle time after the last key | 0 – 0.20 s | 0 – 0.06 s |
| playback rate, composition seconds per wall second | 0.80 – 0.94 | 0.83 – 0.94 |
| dropped video frames, worst single play window | 503 | 32 |
| dropped video frames, all windows summed | 976 | 75 |
| playback frame rate, carousel | 27.0, 27.3 | 43.1, 47.5 |

Playhead positions and settle times are identical. Dropped frames are not worse on any run; the two arms' worst cases are 503 and 32, and both arms had runs where playback stalled entirely under a load spike (two of five each), so the stall is the machine, not the change. The carousel's playback frame rate rising from ~27 to ~45 is the same main-thread time coming back.

## End to end, in a real browser

On the same selected card, at the same playhead advance, the selection overlay moved **255.8 px on both arms** — the overlay still tracks an animating element with the loops parked. A drag of a timeline-animated card moves the box on neither arm (the Studio blocks manual movement of an element whose transform the timeline owns), which is the same behaviour before and after.

