### PR TITLE
perf(studio): a paused editor stops redrawing its overlays sixty times a second

### DIFF
--- a/packages/studio/src/components/editor/SnapGuideOverlay.tsx
+++ b/packages/studio/src/components/editor/SnapGuideOverlay.tsx
@@ -1,6 +1,7 @@
 import { memo, useRef, type RefObject } from "react";
 import { useMountEffect } from "../../hooks/useMountEffect";
 import { resolveGuideLineRect, type SnapGuide, type SpacingGuide } from "./snapEngine";
+import { subscribeOverlayFrame } from "./overlayFrameLoop";
 
 export interface SnapGuidesState {
   guides: SnapGuide[];
@@ -47,12 +48,8 @@ export const SnapGuideOverlay = memo(function SnapGuideOverlay({
   };
 
   useMountEffect(() => {
-    let frame = 0;
-
     // fallow-ignore-next-line complexity
     const update = () => {
-      frame = requestAnimationFrame(update);
-
       const state = snapGuidesRef.current;
       const guides = state?.guides ?? [];
       const spacingGuides = state?.spacingGuides ?? [];
@@ -116,8 +113,7 @@ export const SnapGuideOverlay = memo(function SnapGuideOverlay({
       }
     };
 
-    frame = requestAnimationFrame(update);
-    return () => cancelAnimationFrame(frame);
+    return subscribeOverlayFrame(update);
   });
 
   return (

--- a/packages/studio/src/components/editor/offCanvasIndicatorRefresh.ts
+++ b/packages/studio/src/components/editor/offCanvasIndicatorRefresh.ts
@@ -7,6 +7,7 @@ import {
   drainPendingLayerMutations,
 } from "./domEditLayerWalkCache";
 import { recomputeOffCanvasIndicators } from "./offCanvasIndicatorGeometry";
+import { requestOverlayFrames, subscribeOverlayFrame } from "./overlayFrameLoop";
 
 interface OffCanvasIndicatorRefreshOptions {
   iframeRef: React.RefObject<HTMLIFrameElement | null>;
@@ -78,12 +79,16 @@ export function rebuildDue(dirty: boolean, lastAt: number, now: number): boolean
 export function startOffCanvasIndicatorRefresh(
   options: OffCanvasIndicatorRefreshOptions,
 ): () => void {
-  let frame = 0;
   let lastCompSig = "";
   let lastRecomputeAt = Number.NEGATIVE_INFINITY;
   const walkCache = createDomEditLayerWalkCache();
   const markDirty = () => {
     options.dirtyRef.current = true;
+    // A rebuild is owed, so the shared loop has to be running to pay it. The
+    // preview's own MutationObserver is the wake source the top frame's
+    // pointer and message listeners cannot be: an edit inside the iframe
+    // reaches this callback and nothing else.
+    requestOverlayFrames();
   };
   const attachObserver = (doc: Document | null) => {
     options.observerRef.current?.disconnect();
@@ -97,7 +102,6 @@ export function startOffCanvasIndicatorRefresh(
     options.sigRef.current = "";
   };
   const update = () => {
-    frame = requestAnimationFrame(update);
     const iframe = options.iframeRef.current;
     const overlayEl = options.overlayRef.current;
     const doc = iframe?.contentDocument ?? null;
@@ -133,9 +137,9 @@ export function startOffCanvasIndicatorRefresh(
       walkCache,
     );
   };
-  frame = requestAnimationFrame(update);
+  const unsubscribe = subscribeOverlayFrame(update);
   return () => {
-    cancelAnimationFrame(frame);
+    unsubscribe();
     options.observerRef.current?.disconnect();
     options.observerRef.current = null;
     options.observedDocRef.current = null;

--- a/packages/studio/src/components/editor/overlayFrameLoop.test.ts
+++ b/packages/studio/src/components/editor/overlayFrameLoop.test.ts
@@ -94,6 +94,7 @@ describe("overlay frame loop", () => {
     window.dispatchEvent(
       new MessageEvent("message", {
         data: { source: "hf-preview", type: "state", frame, isPlaying },
+        origin: window.location.origin,
       }),
     );
   };
@@ -178,8 +179,35 @@ describe("overlay frame loop", () => {
     });
     framesOver(1000);
     runs = 0;
-    window.dispatchEvent(new MessageEvent("message", { data: { source: "some-extension" } }));
-    window.dispatchEvent(new MessageEvent("message", { data: "a string" }));
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { source: "some-extension" },
+        origin: window.location.origin,
+      }),
+    );
+    window.dispatchEvent(
+      new MessageEvent("message", { data: "a string", origin: window.location.origin }),
+    );
+    framesOver(200);
+    expect(runs).toBeLessThanOrEqual(2);
+  });
+
+  it("ignores a preview-shaped message from another origin", () => {
+    let runs = 0;
+    subscribeOverlayFrame(() => {
+      runs += 1;
+    });
+    framesOver(1000);
+    runs = 0;
+    // Same payload the preview sends, from somewhere that is not the preview.
+    // Anything embedded on the page can post this; only the origin tells them
+    // apart, and waking on it would hold the overlays at full rate for free.
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { source: "hf-preview", type: "state", frame: 42, isPlaying: false },
+        origin: "https://not-the-preview.example",
+      }),
+    );
     framesOver(200);
     expect(runs).toBeLessThanOrEqual(2);
   });
@@ -193,7 +221,10 @@ describe("overlay frame loop", () => {
     runs = 0;
     // A new clip manifest is news whatever the playhead is doing.
     window.dispatchEvent(
-      new MessageEvent("message", { data: { source: "hf-preview", type: "timeline", clips: [] } }),
+      new MessageEvent("message", {
+        data: { source: "hf-preview", type: "timeline", clips: [] },
+        origin: window.location.origin,
+      }),
     );
     framesOver(200);
     expect(runs).toBeGreaterThan(5);

--- a/packages/studio/src/components/editor/overlayFrameLoop.test.ts
+++ b/packages/studio/src/components/editor/overlayFrameLoop.test.ts
@@ -140,6 +140,65 @@ describe("overlay frame loop", () => {
     expect(runs).toBeGreaterThan(5);
   });
 
+  it("keeps every other subscriber running, and the loop alive, when one throws", () => {
+    const runs = { a: 0, c: 0 };
+    // The loop rethrows out of band so the error still reaches the page's
+    // error reporting. Capture those instead of letting them escape the test,
+    // and assert every one of them was surfaced rather than swallowed.
+    const rethrown: Array<() => void> = [];
+    vi.spyOn(globalThis, "queueMicrotask").mockImplementation((fn: () => void) => {
+      rethrown.push(fn);
+    });
+
+    subscribeOverlayFrame(() => {
+      runs.a += 1;
+    });
+    subscribeOverlayFrame(() => {
+      throw new Error("subscriber blew up");
+    });
+    subscribeOverlayFrame(() => {
+      runs.c += 1;
+    });
+
+    for (let i = 0; i < 5; i += 1) step();
+
+    // The survivors ran on every frame, every failure was reported, and the
+    // loop is still asking for more frames.
+    expect(runs.a).toBe(5);
+    expect(runs.c).toBe(5);
+    expect(rethrown).toHaveLength(5);
+    expect(() => rethrown[0]()).toThrow("subscriber blew up");
+    expect(queued.length).toBeGreaterThan(0);
+  });
+
+  it("does not wake for a message that is not the preview's", () => {
+    let runs = 0;
+    subscribeOverlayFrame(() => {
+      runs += 1;
+    });
+    framesOver(1000);
+    runs = 0;
+    window.dispatchEvent(new MessageEvent("message", { data: { source: "some-extension" } }));
+    window.dispatchEvent(new MessageEvent("message", { data: "a string" }));
+    framesOver(200);
+    expect(runs).toBeLessThanOrEqual(2);
+  });
+
+  it("wakes for a preview message that is not a state post", () => {
+    let runs = 0;
+    subscribeOverlayFrame(() => {
+      runs += 1;
+    });
+    framesOver(1000);
+    runs = 0;
+    // A new clip manifest is news whatever the playhead is doing.
+    window.dispatchEvent(
+      new MessageEvent("message", { data: { source: "hf-preview", type: "timeline", clips: [] } }),
+    );
+    framesOver(200);
+    expect(runs).toBeGreaterThan(5);
+  });
+
   it("stops entirely, and stops listening, once the last subscriber leaves", () => {
     let runs = 0;
     const unsubscribe = subscribeOverlayFrame(() => {

--- a/packages/studio/src/components/editor/overlayFrameLoop.test.ts
+++ b/packages/studio/src/components/editor/overlayFrameLoop.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  IDLE_POLL_MS,
+  requestOverlayFrames,
+  resetOverlayFrameLoopForTests,
+  subscribeOverlayFrame,
+} from "./overlayFrameLoop";
+
+/**
+ * The editor's overlay polls run on one shared, parkable frame loop. The two
+ * things that must hold: it stops asking for frames when nothing is happening,
+ * and every route by which something CAN happen starts it again.
+ */
+describe("overlay frame loop", () => {
+  const originalRaf = window.requestAnimationFrame;
+  const originalCancelRaf = window.cancelAnimationFrame;
+  let queued: Array<() => void>;
+
+  /** Run whatever frames are queued, once. */
+  const step = (): number => {
+    const batch = queued;
+    queued = [];
+    for (const callback of batch) callback();
+    return batch.length;
+  };
+
+  /** Frames requested over `ms` of wall time, stepping each one. */
+  const framesOver = (ms: number): number => {
+    let frames = 0;
+    for (let elapsed = 0; elapsed < ms; elapsed += 16) {
+      vi.advanceTimersByTime(16);
+      frames += step();
+    }
+    return frames;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance", "Date"] });
+    queued = [];
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      queued.push(() => callback(performance.now()));
+      return queued.length;
+    }) as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = (() => {
+      queued = [];
+    }) as typeof window.cancelAnimationFrame;
+  });
+
+  afterEach(() => {
+    resetOverlayFrameLoopForTests();
+    vi.useRealTimers();
+    window.requestAnimationFrame = originalRaf;
+    window.cancelAnimationFrame = originalCancelRaf;
+  });
+
+  it("runs every subscriber on one frame, not one frame each", () => {
+    const calls: string[] = [];
+    subscribeOverlayFrame(() => calls.push("a"));
+    subscribeOverlayFrame(() => calls.push("b"));
+    expect(step()).toBe(1);
+    expect(calls).toEqual(["a", "b"]);
+  });
+
+  it("drops to the idle poll rate once nothing has happened", () => {
+    let runs = 0;
+    subscribeOverlayFrame(() => {
+      runs += 1;
+    });
+    // Awake first: the subscriber has never read anything.
+    framesOver(500);
+    const runsWhileAwake = runs;
+    runs = 0;
+    framesOver(1000);
+    // A second of silence is four idle polls, not sixty frames.
+    expect(runsWhileAwake).toBeGreaterThan(10);
+    expect(runs).toBeLessThanOrEqual(Math.ceil(1000 / IDLE_POLL_MS) + 1);
+  });
+
+  it("wakes to full rate on a pointer event", () => {
+    let runs = 0;
+    subscribeOverlayFrame(() => {
+      runs += 1;
+    });
+    framesOver(1000);
+    runs = 0;
+    window.dispatchEvent(new Event("pointermove"));
+    expect(framesOver(200)).toBeGreaterThan(5);
+    expect(runs).toBeGreaterThan(5);
+  });
+
+  const previewState = (frame: number, isPlaying = false): void => {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { source: "hf-preview", type: "state", frame, isPlaying },
+      }),
+    );
+  };
+
+  it("wakes to full rate when the preview reports a new frame", () => {
+    let runs = 0;
+    subscribeOverlayFrame(() => {
+      runs += 1;
+    });
+    previewState(0);
+    framesOver(1000);
+    runs = 0;
+    previewState(1);
+    framesOver(200);
+    expect(runs).toBeGreaterThan(5);
+  });
+
+  it("ignores the paused heartbeat, which repeats a frame the overlays already drew", () => {
+    let runs = 0;
+    subscribeOverlayFrame(() => {
+      runs += 1;
+    });
+    previewState(7);
+    framesOver(1000);
+    runs = 0;
+    // The bridge posts an unchanged state every 80ms while paused. Treating
+    // that as news would hold the overlays at 60fps for the life of the tab.
+    for (let beat = 0; beat < 12; beat += 1) {
+      previewState(7);
+      framesOver(80);
+    }
+    expect(runs).toBeLessThanOrEqual(Math.ceil(960 / IDLE_POLL_MS) + 1);
+  });
+
+  it("wakes on an explicit request, which is how preview-document mutations arrive", () => {
+    let runs = 0;
+    subscribeOverlayFrame(() => {
+      runs += 1;
+    });
+    framesOver(1000);
+    runs = 0;
+    requestOverlayFrames();
+    framesOver(200);
+    expect(runs).toBeGreaterThan(5);
+  });
+
+  it("stops entirely, and stops listening, once the last subscriber leaves", () => {
+    let runs = 0;
+    const unsubscribe = subscribeOverlayFrame(() => {
+      runs += 1;
+    });
+    framesOver(100);
+    unsubscribe();
+    runs = 0;
+    window.dispatchEvent(new Event("pointermove"));
+    framesOver(1000);
+    expect(runs).toBe(0);
+    expect(queued).toHaveLength(0);
+  });
+});

--- a/packages/studio/src/components/editor/overlayFrameLoop.ts
+++ b/packages/studio/src/components/editor/overlayFrameLoop.ts
@@ -58,21 +58,48 @@ const WINDOW_EVENTS = [
 let lastPreviewFrame: number | null = null;
 let lastPreviewPlaying: boolean | null = null;
 
+/**
+ * The preview iframe is served by the editor's own origin (`useTimelinePlayer`
+ * builds its src against `window.location.origin`), so a message from anywhere
+ * else is not the preview whatever its payload claims. Answered before the
+ * payload is read, because a sender we do not trust controls every field in it.
+ */
+function isFromPreviewOrigin(event: MessageEvent): boolean {
+  if (typeof window === "undefined") return true;
+  return event.origin === window.location.origin;
+}
+
+/**
+ * `window` also receives postMessage traffic from extensions, devtools and any
+ * other embed on the page. Waking on those would hold the overlays awake for
+ * reasons that have nothing to do with the preview.
+ */
+function isPreviewPayload(data: unknown): data is { type?: unknown } {
+  if (data == null || typeof data !== "object") return false;
+  return (data as { source?: unknown }).source === "hf-preview";
+}
+
+/** The playhead position a `state` post carries, or null for any other post. */
+function previewStateOf(data: {
+  type?: unknown;
+}): { frame: number | null; playing: boolean } | null {
+  if (data.type !== "state") return null;
+  const frame = (data as { frame?: unknown }).frame;
+  return {
+    frame: typeof frame === "number" ? frame : null,
+    playing: (data as { isPlaying?: unknown }).isPlaying === true,
+  };
+}
+
 function onPreviewMessage(event: MessageEvent): void {
+  if (!isFromPreviewOrigin(event)) return;
   const data: unknown = event.data;
-  // Only the preview's own messages are news. `window` receives postMessage
-  // traffic from extensions, devtools and any other embed on the page, and
-  // waking on those would hold the overlays awake for reasons that have
-  // nothing to do with the preview.
-  if (data == null || typeof data !== "object") return;
-  if ((data as { source?: unknown }).source !== "hf-preview") return;
-  if ((data as { type?: unknown }).type === "state") {
-    const frame = (data as { frame?: unknown }).frame;
-    const playing = (data as { isPlaying?: unknown }).isPlaying === true;
-    const frameNumber = typeof frame === "number" ? frame : null;
-    if (frameNumber === lastPreviewFrame && playing === lastPreviewPlaying) return;
-    lastPreviewFrame = frameNumber;
-    lastPreviewPlaying = playing;
+  if (!isPreviewPayload(data)) return;
+  const state = previewStateOf(data);
+  if (state) {
+    if (state.frame === lastPreviewFrame && state.playing === lastPreviewPlaying) return;
+    lastPreviewFrame = state.frame;
+    lastPreviewPlaying = state.playing;
   }
   requestOverlayFrames();
 }

--- a/packages/studio/src/components/editor/overlayFrameLoop.ts
+++ b/packages/studio/src/components/editor/overlayFrameLoop.ts
@@ -1,0 +1,162 @@
+/**
+ * One animation frame for every editor overlay that tracks preview geometry by
+ * polling — and no frame at all while the editor is sitting still.
+ *
+ * Each overlay used to own an unconditional `requestAnimationFrame(update)`.
+ * Four of them never stopped, so a paused, untouched Studio ran ~240 callbacks
+ * a second, every one of them reading layout and one of them writing style,
+ * which kept the compositor committing 55 frames a second with nothing moving.
+ *
+ * Parking is safe because none of these overlays has a clock of its own. They
+ * change only in response to something observable: a pointer, a key, a scroll
+ * or resize, a message from the preview (the runtime posts one on every frame
+ * the playhead moves), or a mutation inside the preview document. Those are the
+ * wake sources below, and `requestOverlayFrames` is the door for anything else.
+ *
+ * `IDLE_POLL_MS` is the safety net, and the reason a missed wake source is a
+ * quarter second of staleness rather than a permanently frozen overlay.
+ */
+
+/**
+ * How long the loop keeps running frames after the last wake.
+ *
+ * Long enough to outlast the consequences of the event that woke it, not just
+ * the event: a click opens a panel whose CSS transition moves the preview for
+ * the next couple of hundred milliseconds, and no further event is dispatched
+ * while it does.
+ */
+const AWAKE_MS = 400;
+/** How often a parked loop runs one frame anyway, in case a wake was missed. */
+export const IDLE_POLL_MS = 250;
+
+const subscribers = new Set<() => void>();
+
+let frameId: number | null = null;
+let idleTimerId: ReturnType<typeof setTimeout> | null = null;
+let awakeUntil = 0;
+let listenersAttached = false;
+
+/** Wake sources. All passive reads; none of them can be cancelled by us. */
+const WINDOW_EVENTS = [
+  "pointerdown",
+  "pointermove",
+  "pointerup",
+  "wheel",
+  "keydown",
+  "keyup",
+  "scroll",
+  "resize",
+  "visibilitychange",
+] as const;
+
+// The preview posts a `state` message on a fixed interval even when the
+// playhead has not moved — the control bridge's paused heartbeat, which exists
+// so a listener can confirm a paused position. Waking on every message would
+// therefore hold the overlays at 60 fps for as long as the editor is open,
+// which is exactly the cost this loop exists to remove. Wake on the messages
+// that carry news instead.
+let lastPreviewFrame: number | null = null;
+let lastPreviewPlaying: boolean | null = null;
+
+function onPreviewMessage(event: MessageEvent): void {
+  const data: unknown = event.data;
+  if (
+    data != null &&
+    typeof data === "object" &&
+    (data as { source?: unknown }).source === "hf-preview" &&
+    (data as { type?: unknown }).type === "state"
+  ) {
+    const frame = (data as { frame?: unknown }).frame;
+    const playing = (data as { isPlaying?: unknown }).isPlaying === true;
+    const frameNumber = typeof frame === "number" ? frame : null;
+    if (frameNumber === lastPreviewFrame && playing === lastPreviewPlaying) return;
+    lastPreviewFrame = frameNumber;
+    lastPreviewPlaying = playing;
+  }
+  requestOverlayFrames();
+}
+
+function runFrame(): void {
+  frameId = null;
+  for (const subscriber of subscribers) subscriber();
+  schedule();
+}
+
+function schedule(): void {
+  if (subscribers.size === 0) return;
+  if (frameId != null || idleTimerId != null) return;
+  if (performance.now() < awakeUntil) {
+    frameId = requestAnimationFrame(runFrame);
+    return;
+  }
+  idleTimerId = setTimeout(() => {
+    idleTimerId = null;
+    frameId = requestAnimationFrame(runFrame);
+  }, IDLE_POLL_MS);
+}
+
+/** Something moved, or might have. Run frames at full rate for a moment. */
+export function requestOverlayFrames(): void {
+  awakeUntil = performance.now() + AWAKE_MS;
+  if (idleTimerId != null) {
+    clearTimeout(idleTimerId);
+    idleTimerId = null;
+  }
+  schedule();
+}
+
+function attachListeners(): void {
+  if (listenersAttached || typeof window === "undefined") return;
+  listenersAttached = true;
+  for (const type of WINDOW_EVENTS) {
+    window.addEventListener(type, requestOverlayFrames, { capture: true, passive: true });
+  }
+  window.addEventListener("message", onPreviewMessage, { capture: true, passive: true });
+}
+
+function detachListeners(): void {
+  if (!listenersAttached || typeof window === "undefined") return;
+  listenersAttached = false;
+  for (const type of WINDOW_EVENTS) {
+    window.removeEventListener(type, requestOverlayFrames, { capture: true });
+  }
+  window.removeEventListener("message", onPreviewMessage, { capture: true });
+}
+
+/**
+ * Run `update` on the shared loop. The subscriber must be a pure poll: it is
+ * called on an ordinary animation frame while the editor is active and roughly
+ * four times a second while it is not.
+ */
+export function subscribeOverlayFrame(update: () => void): () => void {
+  subscribers.add(update);
+  attachListeners();
+  // A fresh subscriber has never read anything, so it starts awake.
+  requestOverlayFrames();
+  return () => {
+    subscribers.delete(update);
+    if (subscribers.size > 0) return;
+    if (frameId != null) {
+      cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+    if (idleTimerId != null) {
+      clearTimeout(idleTimerId);
+      idleTimerId = null;
+    }
+    detachListeners();
+  };
+}
+
+/** Test seam: the loop is module state, and tests need it back at zero. */
+export function resetOverlayFrameLoopForTests(): void {
+  subscribers.clear();
+  if (frameId != null) cancelAnimationFrame(frameId);
+  if (idleTimerId != null) clearTimeout(idleTimerId);
+  frameId = null;
+  idleTimerId = null;
+  awakeUntil = 0;
+  lastPreviewFrame = null;
+  lastPreviewPlaying = null;
+  detachListeners();
+}

--- a/packages/studio/src/components/editor/overlayFrameLoop.ts
+++ b/packages/studio/src/components/editor/overlayFrameLoop.ts
@@ -60,12 +60,13 @@ let lastPreviewPlaying: boolean | null = null;
 
 function onPreviewMessage(event: MessageEvent): void {
   const data: unknown = event.data;
-  if (
-    data != null &&
-    typeof data === "object" &&
-    (data as { source?: unknown }).source === "hf-preview" &&
-    (data as { type?: unknown }).type === "state"
-  ) {
+  // Only the preview's own messages are news. `window` receives postMessage
+  // traffic from extensions, devtools and any other embed on the page, and
+  // waking on those would hold the overlays awake for reasons that have
+  // nothing to do with the preview.
+  if (data == null || typeof data !== "object") return;
+  if ((data as { source?: unknown }).source !== "hf-preview") return;
+  if ((data as { type?: unknown }).type === "state") {
     const frame = (data as { frame?: unknown }).frame;
     const playing = (data as { isPlaying?: unknown }).isPlaying === true;
     const frameNumber = typeof frame === "number" ? frame : null;
@@ -78,8 +79,22 @@ function onPreviewMessage(event: MessageEvent): void {
 
 function runFrame(): void {
   frameId = null;
-  for (const subscriber of subscribers) subscriber();
+  // Re-arm BEFORE running anything, exactly as the four separate loops this
+  // replaces did. A subscriber that throws must not take the loop down with
+  // it — and a shared loop makes that failure four overlays wide plus the
+  // idle-poll safety net, permanently, rather than one overlay's own problem.
   schedule();
+  for (const subscriber of subscribers) {
+    try {
+      subscriber();
+    } catch (error) {
+      // Rethrown out of band so it still reaches window.onerror and whatever
+      // reports errors, without any subscriber becoming the others' fate.
+      queueMicrotask(() => {
+        throw error;
+      });
+    }
+  }
 }
 
 function schedule(): void {

--- a/packages/studio/src/components/editor/useDomEditCompositionRect.ts
+++ b/packages/studio/src/components/editor/useDomEditCompositionRect.ts
@@ -1,5 +1,6 @@
 import { useState, type RefObject } from "react";
 import { useMountEffect } from "../../hooks/useMountEffect";
+import { subscribeOverlayFrame } from "./overlayFrameLoop";
 
 export interface DomEditCompositionRect {
   left: number;
@@ -39,10 +40,8 @@ export function useDomEditCompositionRect({
   });
 
   useMountEffect(() => {
-    let frame = 0;
     // fallow-ignore-next-line complexity
     const update = () => {
-      frame = requestAnimationFrame(update);
       const iframe = iframeRef.current;
       const overlayEl = overlayRef.current;
       if (!iframe || !overlayEl) return;
@@ -60,8 +59,7 @@ export function useDomEditCompositionRect({
       const next = { left, top, width: iRect.width, height: iRect.height, scaleX, scaleY };
       setCompRect((prev) => (sameRect(prev, next) ? prev : next));
     };
-    frame = requestAnimationFrame(update);
-    return () => cancelAnimationFrame(frame);
+    return subscribeOverlayFrame(update);
   });
 
   return compRect;

--- a/packages/studio/src/components/editor/useDomEditOverlayRects.ts
+++ b/packages/studio/src/components/editor/useDomEditOverlayRects.ts
@@ -20,6 +20,7 @@ import {
   orientedVisibleOverlayRect,
 } from "./domEditOverlayGeometry";
 import { computeOverlayRootScale } from "./domEditOverlayBasis";
+import { subscribeOverlayFrame } from "./overlayFrameLoop";
 
 function childRectsEqual(a: OverlayRect[], b: OverlayRect[]): boolean {
   if (a.length !== b.length) return false;
@@ -107,8 +108,6 @@ export function useDomEditOverlayRects({
   };
 
   useMountEffect(() => {
-    let frame = 0;
-
     const clearAll = () => {
       setOverlayRect(null);
       setHoverRect(null);
@@ -116,7 +115,6 @@ export function useDomEditOverlayRects({
     };
 
     const update = () => {
-      frame = requestAnimationFrame(update);
       if (rafPausedRef.current) {
         if (childRectsRef.current.length > 0) {
           childRectsRef.current = [];
@@ -263,8 +261,7 @@ export function useDomEditOverlayRects({
       setHoverRect(orientedGroupAwareOverlayRect(overlayEl, iframe, hoverEl, scale));
     };
 
-    frame = requestAnimationFrame(update);
-    return () => cancelAnimationFrame(frame);
+    return subscribeOverlayFrame(update);
   });
 
   return {

--- a/packages/studio/src/components/editor/useMotionPathData.ts
+++ b/packages/studio/src/components/editor/useMotionPathData.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type RefObject } from "react";
 import { readRuntimeKeyframes } from "../../hooks/gsapRuntimeKeyframes";
 import { isElementVisibleForOverlay } from "./domEditOverlayGeometry";
 import { buildMotionPathGeometry, type MotionPathGeometry } from "./motionPathGeometry";
+import { subscribeOverlayFrame } from "./overlayFrameLoop";
 
 type Rect = { left: number; top: number; width: number; height: number };
 
@@ -121,7 +122,6 @@ export function useMotionPathData(
       return;
     }
     setHome(null);
-    let raf = 0;
     const tick = () => {
       const el = iframeRef.current;
       if (el) {
@@ -153,10 +153,8 @@ export function useMotionPathData(
           setPScale((p) => (Math.abs(p - ps) < 0.001 ? p : ps));
         }
       }
-      raf = requestAnimationFrame(tick);
     };
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
+    return subscribeOverlayFrame(tick);
   }, [selector, iframeRef]);
 
   useEffect(() => {


### PR DESCRIPTION
Stacked on the runtime half. Review and merge that one first; this branch is targeted at it.

**CI does not run on this PR while its base is not `main`** — the workflow is `branches: [main]`. Retarget it to `main` once the base merges, and give `main` + this branch a full suite at that point; the suites quoted below were run locally in the stacked worktree.

Four overlays in the editing chrome — the composition rect, the selection and hover boxes, the off-canvas indicators and the snap guides — each owned an animation-frame loop that re-armed unconditionally. On a paused, untouched editor that is four callbacks per frame reading layout, and the snap-guide loop writes style on every one of them, which is why the compositor kept committing 55 frames a second with nothing moving.

None of the four has a clock of its own. Each only changes when something observable happens, so they now share one loop that runs at full rate for a moment after a pointer, key, wheel, scroll, resize or visibility change, after a preview message reporting a frame the overlays have not drawn, or after a mutation inside the preview document. Otherwise it polls four times a second, so a wake source nobody thought of costs a quarter second of staleness rather than a frozen overlay.

**The one subtlety, and it is the whole reason the first version of this did nothing.** The paused preview posts an unchanged status message every 80 ms so any listener can confirm its position. That message is indistinguishable, at the listener, from the message a moving playhead posts. Waking on every message therefore held the four overlays at 60 fps for the life of the tab: animation-frame callbacks fell five-fold while compositor commits did not move at all. The loop now compares the frame number in the message against the one the overlays last drew and treats a repeat as no news.

The awake window is 400 ms rather than one frame because the consequences of an event outlast the event: a click opens a panel whose CSS transition keeps moving the preview for the next couple of hundred milliseconds, and no further event is dispatched while it does.

## Tests

`overlayFrameLoop.test.ts`, seven tests:

| What it holds | Test |
|---|---|
| Every subscriber runs on one frame, not one frame each | `runs every subscriber on one frame, not one frame each` |
| The loop drops to the idle poll rate when nothing happens | `drops to the idle poll rate once nothing has happened` |
| A pointer event brings it back to full rate | `wakes to full rate on a pointer event` |
| A preview message reporting a new frame brings it back | `wakes to full rate when the preview reports a new frame` |
| The paused heartbeat does not | `ignores the paused heartbeat, which repeats a frame the overlays already drew` |
| Preview-document mutations arrive through the explicit request, which is how the off-canvas indicators mark themselves dirty | `wakes on an explicit request, which is how preview-document mutations arrive` |
| Unsubscribing stops the loop and removes its listeners | `stops entirely, and stops listening, once the last subscriber leaves` |

Each was proved non-vacuous by breaking its path on purpose (never parking, attaching no listeners, granting no awake window, dropping the frame comparison) and confirming exactly the expected tests fail.

## What the independent pre-review pass found

**One throw stopped all four overlays, and the safety net with them.** The shared loop re-armed *after* running its subscribers, so a subscriber that threw took down the frame loop and the idle poll permanently — a failure the four original loops kept to themselves, because each re-armed first. It now re-arms before running anything and isolates each subscriber, rethrowing out of band so the error still reaches the page's error reporting. Three of the subscribers read `contentDocument` with no cross-origin guard, which is pre-existing and unchanged; the isolation is what stops it being four overlays' problem instead of one's. Test: `keeps every other subscriber running, and the loop alive, when one throws`.

**Any window message woke the loop.** The wake sat outside the recognised-message check, so postMessage traffic from an extension, devtools or any other embed on the page held the overlays awake for 400 ms. Only the preview's own messages wake it now, and a repeated paused status post still does not. Tests: `does not wake for a message that is not the preview's`, `wakes for a preview message that is not a state post`.

**A fifth loop.** `useMotionPathData` had the same unconditional shape and is live whenever a keyframed element is selected. Converted; it fits inside this PR.

## Measured

Idle means paused, loaded, focused, no key presses, no pointer. Two projects: a 1689-element / 396-card carousel and a 79-video / 12-audio media project. Both arms were served from the same rig and captured **interleaved within each instrument**, so a machine-load spike lands on both. This Mac was running other work throughout (1-minute load 44 to 256 across the captures), which inflates absolute milliseconds on both arms equally; the counts do not move with load and are the harder numbers.

| Idle, paused, untouched | carousel before | carousel after | media before | media after |
|---|---:|---:|---:|---:|
| main-thread self time (ms/s, CDP trace) | 145.1 | **12.4** | 61.4 | **11.1** |
| `FireAnimationFrame` per second | 281.0 | **4.2** | 284.8 | **3.9** |
| compositor `Commit` per second | 55.1 | **4.2** | 56.4 | **4.0** |
| CPU-profile busy (ms/s) | 94.5 | **3.2** | 43.3 | **3.5** |
| renderer process, % of a core (macOS `sample`) | 21.0 | **4.2** | 9.5 | **1.3** |
| its main thread, % of a core | 13.3 | **1.4** | 5.7 | **1.0** |

Two interleaved passes per fixture per instrument on the final build; the renderer-percentage row is the median over five passes because process sampling is the noisiest instrument here. An earlier three-pass run on the same code minus three behaviour-neutral refactors gave 129.2 → 9.4 ms/s and 283 → 3.8 callbacks per second on the carousel, and 66.8 → 13.0 ms/s and 287 → 3.7 on media: the same result.

Compositor commits are the row worth reading twice. Frame callbacks are a mechanism metric and a change like this can move them without moving any work; commits cannot be gamed, because nothing commits a frame without having done the work. They fall with the callbacks, so the work really is gone.

### Two numbers that are not measured

The idle table below was captured before two later changes and has not been re-taken; disk on the measuring machine is under 3 GB and each trace capture is 28-100 MB.

- The parked poll now calls the adapter duration floor once per heartbeat, about 12.5 times a second. For the CSS adapter that is a `getAnimations()` per animated element. It cannot be a regression against the base — the per-frame loop made the same call 60 times a second — but the after column is optimistic by whatever that costs at 12.5 Hz, and on a composition with many CSS-animated elements that is not nothing.
- The manifest post is now retried after a throw rather than dropped, which can hold the loop awake for up to 20 frames longer in that failure case. Not on any normal path.

### A correction to the callback-count figure, and a sixth loop

Re-verifying the final build in a real browser with a per-realm probe (patching `requestAnimationFrame` and recording the caller's stack) found **297 of 297 sampled registrations in the preview realm coming from the Studio bundle and none from the runtime**, at about 60 a second. Attributed from the served bundle, it is `startStudioManualEditPlaybackReapply` in `manualEdits.ts`: it re-arms for as long as `__player`, `__timeline` or any entry of the timeline registry reports itself as playing, and on this project a scene timeline added to the paused root is itself unpaused, so it never stops.

Two things follow, and both are stated rather than smoothed over:

- **The parks hold.** Zero runtime frames in that sample is direct evidence the transport is parked, and the top frame measured 3.8 callbacks a second, so the overlay loop is parked too.
- **The absolute "callbacks per second" row above is lower than what a browser is really doing**, because that loop does not appear in it. Both arms were captured with the same instrument, so the before/after ratios and every other row stand; the absolute callback figure should be read as "the loops this change owns", not "every loop on the page". `manualEdits.ts` is untouched by either branch and is a candidate for the same treatment in follow-up work. I could not build a control to date the discrepancy: the before-arm build's dependencies have since been removed from the machine.

## Playback, scrubbing and jumps are unchanged

Same harness, play / scrub / jump phases, interleaved. Five replicate pairs on media, two on the carousel.

| | before | after |
|---|---|---|
| playhead after a 150-step scrub (carousel) | 5 s, every run | 5 s, every run |
| playhead after 30 one-second jumps (carousel) | 35 s, every run | 35 s, every run |
| playhead after a 60-step scrub (media) | 2 s, every run | 2 s, every run |
| playhead after 30 one-second jumps (media) | 32 s, every run | 32 s, every run |
| settle time after the last key | 0 – 0.20 s | 0 – 0.06 s |
| playback rate, composition seconds per wall second | 0.80 – 0.94 | 0.83 – 0.94 |
| dropped video frames, worst single play window | 503 | 32 |
| dropped video frames, all windows summed | 976 | 75 |
| playback frame rate, carousel | 27.0, 27.3 | 43.1, 47.5 |

Playhead positions and settle times are identical. Dropped frames are not worse on any run; the two arms' worst cases are 503 and 32, and both arms had runs where playback stalled entirely under a load spike (two of five each), so the stall is the machine, not the change. The carousel's playback frame rate rising from ~27 to ~45 is the same main-thread time coming back.

## End to end, in a real browser

On the same selected card, at the same playhead advance, the selection overlay moved **255.8 px on both arms** — the overlay still tracks an animating element with the loops parked. A drag of a timeline-animated card moves the box on neither arm (the Studio blocks manual movement of an element whose transform the timeline owns), which is the same behaviour before and after.

