### PR TITLE
fix(runtime): the editor keeps waking during a drag on a preview it did not build

### DIFF
--- a/packages/core/src/runtime/manualEditGestureWatch.test.ts
+++ b/packages/core/src/runtime/manualEditGestureWatch.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { JSDOM } from "jsdom";
 import { STUDIO_MANUAL_EDIT_GESTURE_ATTR } from "../editing/draftMarkers";
 import { createManualEditGestureWatch } from "./manualEditGestureWatch";
 
@@ -28,6 +29,28 @@ describe("manual-edit gesture watch", () => {
       await flush();
 
       el.removeAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR);
+      expect(watch.isActive()).toBe(false);
+    } finally {
+      watch.disconnect();
+    }
+  });
+
+  it("sees a gesture on an element adopted from another realm", async () => {
+    // The composition body is built in the editor window and moved into the
+    // preview document, so its nodes carry another realm's prototypes and
+    // `target instanceof Element` answers false for every one of them. A
+    // gesture on such an element must still be seen, or a parked transport
+    // never wakes while the user drags.
+    const foreign = new JSDOM("<!doctype html><html><body></body></html>");
+    const el = foreign.window.document.createElement("div");
+    document.body.appendChild(document.adoptNode(el as unknown as Node));
+    const watch = createManualEditGestureWatch(document, () => {});
+    try {
+      expect(el instanceof Element).toBe(false);
+      (el as unknown as Element).setAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR, "token");
+      expect(watch.isActive()).toBe(true);
+      await flush();
+      (el as unknown as Element).removeAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR);
       expect(watch.isActive()).toBe(false);
     } finally {
       watch.disconnect();

--- a/packages/core/src/runtime/manualEditGestureWatch.ts
+++ b/packages/core/src/runtime/manualEditGestureWatch.ts
@@ -1,4 +1,5 @@
 import { STUDIO_MANUAL_EDIT_GESTURE_ATTR } from "../editing/draftMarkers";
+import { isElementNode } from "./domRealm";
 
 export interface ManualEditGestureWatch {
   /** True while any element in the document carries the gesture marker. */
@@ -53,7 +54,10 @@ export function createManualEditGestureWatch(
   const ingest = (records: MutationRecord[]): void => {
     for (const record of records) {
       const target = record.target;
-      if (!(target instanceof Element)) continue;
+      // Structural, not `instanceof`: the composition body is adopted into the
+      // preview frame, so its nodes answer to another realm's Element and an
+      // identity check silently skips every gesture. See domRealm.ts.
+      if (!isElementNode(target)) continue;
       if (target.hasAttribute(STUDIO_MANUAL_EDIT_GESTURE_ATTR)) marked.add(target);
       else marked.delete(target);
     }


### PR DESCRIPTION
`main` is red. The preview-guard lint added in #3848 bans realm-bound DOM `instanceof` under `src/runtime`, and the gesture watch merged in #3845 has one at `manualEditGestureWatch.ts:56`. Each PR was green alone; they collide only once both are on main.

It is not only a lint failure. The composition body is adopted into the preview frame, so its nodes carry another realm's prototypes and `target instanceof Element` is false for every mutation record. The watch therefore never reports a gesture, and the transport it gates does not wake while the user drags a layer.

## Change

The record target goes through `isElementNode` from `domRealm.ts`, with a comment naming why an identity check cannot work here.

## Verification

| Check | Result |
|---|---|
| `manualEditGestureWatch.test.ts` | 5 passed, exit 0 |
| same file with `instanceof Element` restored | 1 failed, exit 1, the new test |
| `test:hyperframe-runtime-ci` typecheck plus preview-guard lint plus runtime tests | pass, 569 tests |
| oxlint, oxfmt on both files | 0 errors |

The new test adopts an element from a second realm, asserts `el instanceof Element` is false, then asserts the watch sees the marker appear and clear.

`test:runtime-coverage` fails on this machine for thirty-odd untouched files with a module-mocking error, identically with and without this change, so it is not from this diff.