### PR TITLE
fix(cli): hide console window for detached child processes on Windows

### DIFF
--- a/packages/cli/src/commands/previewLifecycle.test.ts
+++ b/packages/cli/src/commands/previewLifecycle.test.ts
@@ -338,7 +338,7 @@ describe("background preview lifecycle", () => {
     let spawned = false;
     const scan = vi.fn(async () => (spawned ? [server] : []));
     const unref = vi.fn();
-    const spawn = vi.fn(() => {
+    const spawn = vi.fn((..._args: unknown[]) => {
       spawned = true;
       return { pid: 4321, unref };
     });
@@ -355,6 +355,10 @@ describe("background preview lifecycle", () => {
 
     expect(result).toMatchObject({ type: "started", port: 3210, pid: 4321 });
     expect(unref).toHaveBeenCalledOnce();
+    // A detached child gets its own console window on Windows unless hidden.
+    expect(spawn.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({ detached: true, windowsHide: true }),
+    );
     expect(existsSync(previewSessionPath(projectDir, stateHome))).toBe(true);
   });
 

--- a/packages/cli/src/commands/previewLifecycle.ts
+++ b/packages/cli/src/commands/previewLifecycle.ts
@@ -33,6 +33,7 @@ type SpawnPreview = (
     detached: boolean;
     stdio: ["ignore", number, number];
     env: NodeJS.ProcessEnv;
+    windowsHide: boolean;
   },
 ) => SpawnResult;
 
@@ -219,6 +220,7 @@ function spawnDetachedPreview(
         detached: true,
         stdio: ["ignore", logFd, logFd],
         env: process.env,
+        windowsHide: true,
       },
     );
   } finally {

--- a/packages/cli/src/telemetry/client.test.ts
+++ b/packages/cli/src/telemetry/client.test.ts
@@ -140,13 +140,15 @@ describe("telemetry queue delivery", () => {
     const [execPath, args, opts] = spawnMock.mock.calls[0] as unknown as [
       string,
       string[],
-      { detached: boolean },
+      { detached: boolean; windowsHide: boolean },
     ];
     expect(execPath).toBe(process.execPath);
     expect(args[0]).toBe("-e");
     expect(args[1]).toContain("render_complete");
     expect(args[1]).toMatch(/[0-9a-f-]{36}/); // event uuid rides along
     expect(opts.detached).toBe(true);
+    // A detached child gets its own console window on Windows unless hidden.
+    expect(opts.windowsHide).toBe(true);
 
     // Queue handed to the child — nothing left for a regular flush.
     const fetchMock = vi.fn(() => Promise.resolve(new Response("")));

--- a/packages/cli/src/telemetry/transport.ts
+++ b/packages/cli/src/telemetry/transport.ts
@@ -155,7 +155,7 @@ export function flushSync(): void {
         "-e",
         `fetch(${JSON.stringify(`${POSTHOG_HOST}/batch/`)},{method:"POST",headers:{"Content-Type":"application/json"},body:${JSON.stringify(payload)},signal:AbortSignal.timeout(${FLUSH_TIMEOUT_MS})}).catch(()=>{})`,
       ],
-      { detached: true, stdio: "ignore" },
+      { detached: true, stdio: "ignore", windowsHide: true },
     );
     // Let the parent exit without waiting for the child
     child.unref();

--- a/packages/cli/src/utils/openBrowser.ts
+++ b/packages/cli/src/utils/openBrowser.ts
@@ -81,6 +81,7 @@ export function openBrowser(url: string, options: OpenBrowserOptions = {}): void
     const child = spawn(options.browserPath, args, {
       detached: true,
       stdio: "ignore",
+      windowsHide: true,
     });
     child.on("error", () => {});
     child.unref();

--- a/packages/cli/src/utils/openBrowser.windowsHide.test.ts
+++ b/packages/cli/src/utils/openBrowser.windowsHide.test.ts
@@ -1,0 +1,24 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+
+vi.mock("node:child_process", () => ({ spawn: spawnMock }));
+
+import { openBrowser } from "./openBrowser.js";
+
+describe("openBrowser child-process options", () => {
+  it("hides the detached browser console window", () => {
+    const proc = new EventEmitter() as EventEmitter & { unref: ReturnType<typeof vi.fn> };
+    proc.unref = vi.fn();
+    spawnMock.mockReturnValue(proc);
+
+    openBrowser("http://localhost:3002", { browserPath: "/usr/bin/chromium" });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({ detached: true, windowsHide: true }),
+    );
+    expect(proc.unref).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What

Add `windowsHide: true` to the three `detached: true` spawns in `packages/cli` that were missing it, so they stop opening a console window on Windows.

| File | Spawn |
|---|---|
| `src/telemetry/transport.ts` (`flushSync`) | exit-time telemetry flush → PostHog |
| `src/utils/openBrowser.ts` (`openBrowser`) | `--browser-path` browser launch |
| `src/commands/previewLifecycle.ts` (`spawnDetachedPreview`) | background preview server |

## Why

Closes #3476. `child_process.spawn()` defaults `windowsHide` to `false`, and Node's docs state that on Windows a `detached: true` child **has its own console window**. So all three sites flash a console window at the user on every invocation.

`flushSync()` is the worst of the three: it is the process-exit flush path, so it fires on nearly every short-lived command (`check`, `lint`, `keyframes`, `capture`, `snapshot`, `preview`) that exits with queued events — not just renders.

`src/utils/autoUpdate.ts` already passes `windowsHide: true`, so the intent was clearly there and the other three were oversights rather than a deliberate difference.

## How

Three one-line option additions. `windowsHide` is a documented no-op on macOS and Linux, so this is inert off Windows — same rationale as the #3379 ffmpeg fix.

One supporting type change: `spawnDetachedPreview` builds its options object as an object literal and passes it to the `SpawnPreview`-typed `dependencies.spawn`. TypeScript's excess-property check rejects a key that is not on that type, so `SpawnPreview`'s `options` parameter gains `windowsHide: boolean`.

Not in scope, deliberately:
- #3430 (chrome-headless-shell) and the non-CLI spawns — different class of defect (console-subsystem binaries), tracked separately.
- The shared spawn helper + lint rule suggested at the end of #3476. That is an architecture change and belongs in its own PR.

Tests: the two existing spawn-asserting tests are extended (`telemetry/client.test.ts`, `commands/previewLifecycle.test.ts`), and `utils/openBrowser.windowsHide.test.ts` is added. That last one goes in its own file rather than into `openBrowser.test.ts` to follow the repo's existing `*.windowsHide.test.ts` convention (7 such files, incl. `orphanCleanup.windowsHide.test.ts` next door) — `openBrowser.test.ts` otherwise holds only pure-function tests and never mocks `spawn`.

## Test plan

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Documentation updated (if applicable)

The three touched test files pass in full (36/36):

```
bunx vitest run src/telemetry/client.test.ts \
  src/commands/previewLifecycle.test.ts \
  src/utils/openBrowser.windowsHide.test.ts
```

Reverting the three one-line changes makes exactly the three new assertions fail and nothing else, so the tests genuinely pin the fix rather than passing vacuously.

Also run on the changed files: `oxlint` (0 warnings, 0 errors), `oxfmt --check` (clean), `git diff --check` (clean), and the repo's own pre-commit suite (tracked-artifacts, largefiles, lint, format, fallow, typecheck) via `git commit`.

Two caveats, stated plainly:

- **No manual Windows verification.** I have no Windows desktop session to watch for the flashing window, so the fix rests on the documented `windowsHide`/`detached` semantics quoted in the issue — which is also how the issue itself was diagnosed. Someone on Windows confirming the window is gone would be worth more than my static reasoning.
- **`bun run --filter @hyperframes/cli test` is not green**, but not because of this change: 28 tests in 8 unrelated files (`commands/init*`, `commands/cloud/render`, `registry/publication`, `tts/synthesize.cache`, `utils/projectConfig.create`, `utils/skillsMirror`, `capture/scaffolding`) fail identically with and without this patch — I checked out the base commit and reproduced the same 28 failures. They look environment-related rather than code-related.

One note on the branch: it is based on `e5d89f77` rather than the current tip of `main`. The patch is byte-identical either way (none of these six files changed in between) and it merges cleanly, but I am happy to rebase if you would rather review it against the tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
