### PR TITLE
fix(fonts): preserve quoted family names in rendering

### DIFF
--- a/packages/producer/src/services/deterministicFonts-failClosed.test.ts
+++ b/packages/producer/src/services/deterministicFonts-failClosed.test.ts
@@ -63,7 +63,7 @@ function makeGoogleFontFetch(cssRequests: string[]): typeof fetch {
     if (requestUrl.startsWith("https://fonts.googleapis.com/")) {
       cssRequests.push(requestUrl);
       const family = new URL(requestUrl).searchParams.get("family")?.split(":", 1)[0] ?? "test";
-      const fontUrl = `https://fonts.gstatic.com/s/test/v1/${family.toLowerCase().replace(/\s+/g, "-")}.woff2`;
+      const fontUrl = `https://fonts.gstatic.com/s/test/v1/${encodeURIComponent(family.toLowerCase().replace(/\s+/g, "-")).replace(/[()]/g, "_")}.woff2`;
       return new Response(
         `@font-face {
           font-style: normal;
@@ -335,5 +335,26 @@ describe("FontFetchError", () => {
     expect(err.familyName).toBe("Foo");
     expect(err.url).toBe("https://example.com");
     expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe("quoted font fetch candidates", () => {
+  it("fetches literal generic and function-shaped names, including root aliases", async () => {
+    const cssRequests: string[] = [];
+    await injectDeterministicFontFaces(
+      `<html><head><style>
+      :root { --display: "system-ui"; }
+      h1 { font-family: var(--display), sans-serif; }
+      h2 { font-family: "serif", "var(--Display)", var(--runtime); }
+    </style></head><body>Hello</body></html>`,
+      {
+        failClosedFontFetch: true,
+        allowSystemFontCapture: false,
+        fetchImpl: makeGoogleFontFetch(cssRequests),
+      },
+    );
+    expect(
+      cssRequests.map((url) => new URL(url).searchParams.get("family")?.split(":", 1)[0]),
+    ).toEqual(["system-ui", "serif", "var(--Display)"]);
   });
 });

--- a/packages/producer/src/services/deterministicFonts.test.ts
+++ b/packages/producer/src/services/deterministicFonts.test.ts
@@ -3,6 +3,7 @@ import {
   FONT_ALIASES,
   FONT_ALIAS_KEYS,
   injectDeterministicFontFaces,
+  normalizeSystemFontPrimaryFamilies,
 } from "./deterministicFonts.js";
 
 describe("existing font-face recognition", () => {
@@ -115,5 +116,17 @@ describe("FONT_ALIASES cross-platform coverage", () => {
     expect(FONT_ALIAS_KEYS.has("consolas")).toBe(true);
     expect(FONT_ALIAS_KEYS.has("inter")).toBe(true);
     expect(FONT_ALIAS_KEYS.size).toBe(Object.keys(FONT_ALIASES).length);
+  });
+});
+
+describe("quoted font family names", () => {
+  it("preserves literal generic names on CSS, inline, attribute, and variable surfaces", () => {
+    const html = `<html><head><style>
+      :root { --display: "serif"; }
+      h1 { font-family: "system-ui", sans-serif; }
+    </style></head><body>
+      <p style='font-family: "serif"' data-font-family='"system-ui"'>Hello</p>
+    </body></html>`;
+    expect(normalizeSystemFontPrimaryFamilies(html)).toBe(html);
   });
 });

--- a/packages/producer/src/services/deterministicFonts.ts
+++ b/packages/producer/src/services/deterministicFonts.ts
@@ -59,6 +59,15 @@ export const GENERIC_FAMILIES: ReadonlySet<string> = new Set([
  * token, as does a comma inside a quoted family name.
  */
 export function parseFontFamilyValue(value: string): string[] {
+  return parseFontFamilyValueTokens(value).map((token) => token.value);
+}
+
+type FontFamilyToken = { value: string; quoted: boolean };
+
+// The existing delimiter scanner keeps quote/escape/depth states together;
+// this change retains its control flow and adds quote metadata to the output.
+// fallow-ignore-next-line complexity
+function parseFontFamilyValueTokens(value: string): FontFamilyToken[] {
   const pieces: string[] = [];
   let start = 0;
   let depth = 0;
@@ -91,15 +100,19 @@ export function parseFontFamilyValue(value: string): string[] {
   }
   pieces.push(value.slice(start));
 
-  return pieces
-    .map((piece) => piece.trim().replace(/^['"]/, "").replace(/['"]$/, "").trim())
-    .filter((piece) => piece.length > 0);
+  return pieces.map(fontFamilyToken).filter((token) => token.value.length > 0);
+}
+
+function fontFamilyToken(piece: string): FontFamilyToken {
+  const raw = piece.trim();
+  const quoted = (raw[0] === '"' || raw[0] === "'") && raw.at(-1) === raw[0];
+  return { value: quoted ? raw.slice(1, -1).trim() : raw, quoted };
 }
 
 function systemPrimaryReplacement(value: string, deterministicPrimary: string): string | null {
-  const families = parseFontFamilyValue(value);
-  if (families.length === 0) return null;
-  if (!GENERIC_FAMILIES.has(normalizeFamilyName(families[0]!))) return null;
+  const primary = parseFontFamilyValueTokens(value)[0];
+  if (!primary || primary.quoted) return null;
+  if (!GENERIC_FAMILIES.has(normalizeFamilyName(primary.value))) return null;
   return `${deterministicPrimary}, ${value.trim()}`;
 }
 
@@ -294,17 +307,17 @@ function primaryCssVariableName(value: string): string | null {
   return null;
 }
 
-export function resolveFontFamilyDeclarationFamilies(
+export function resolveFontFamilyDeclarationCandidates(
   declaration: string,
   customProperties: ReadonlyMap<string, string>,
-): string[] {
-  const families = parseFontFamilyValue(declaration);
+): FontFamilyToken[] {
+  const families = parseFontFamilyValueTokens(declaration);
   const variableName = primaryCssVariableName(declaration);
   if (!variableName) return families;
 
   const resolved = customProperties.get(variableName);
   if (!resolved) return families;
-  return [...parseFontFamilyValue(resolved), ...families.slice(1)];
+  return [...parseFontFamilyValueTokens(resolved), ...families.slice(1)];
 }
 
 /**
@@ -466,13 +479,11 @@ function extractRequestedFontFamilies(html: string): Map<string, string> {
   const requested = new Map<string, string>();
   const customProperties = collectFontFamilyCustomProperties(html);
   for (const { declaration } of iterateFontFamilyDeclarations(html)) {
-    for (const originalCase of resolveFontFamilyDeclarationFamilies(
-      declaration,
-      customProperties,
-    )) {
+    for (const candidate of resolveFontFamilyDeclarationCandidates(declaration, customProperties)) {
+      const originalCase = candidate.value;
       const normalized = originalCase.toLowerCase();
-      if (!normalized || GENERIC_FAMILIES.has(normalized)) continue;
-      if (normalized.startsWith("var(")) continue;
+      if (!normalized || (!candidate.quoted && GENERIC_FAMILIES.has(normalized))) continue;
+      if (!candidate.quoted && normalized.startsWith("var(")) continue;
       if (!requested.has(normalized)) requested.set(normalized, originalCase);
     }
   }

--- a/packages/producer/src/services/render/planValidation.test.ts
+++ b/packages/producer/src/services/render/planValidation.test.ts
@@ -318,3 +318,18 @@ describe("validateNoSystemFonts", () => {
     expect(() => validateNoSystemFonts(ok)).not.toThrow();
   });
 });
+
+describe("quoted primary family validation", () => {
+  it.each(['"serif"', "'system-ui'", "var(--display)"])(
+    "allows literal %s while retaining the unquoted generic guard",
+    (family) => {
+      expect(() =>
+        validateNoSystemFonts(`<style>:root { --display: "serif"; }
+        h1 { font-family: ${family}, sans-serif; }</style>`),
+      ).not.toThrow();
+      expect(() => validateNoSystemFonts(`<style>h1 { font-family: serif; }</style>`)).toThrow(
+        PlanValidationError,
+      );
+    },
+  );
+});

--- a/packages/producer/src/services/render/planValidation.ts
+++ b/packages/producer/src/services/render/planValidation.ts
@@ -10,7 +10,7 @@ import {
   collectFontFamilyCustomProperties,
   GENERIC_FAMILIES,
   iterateFontFamilyDeclarations,
-  resolveFontFamilyDeclarationFamilies,
+  resolveFontFamilyDeclarationCandidates,
 } from "../deterministicFonts.js";
 
 /**
@@ -123,12 +123,13 @@ export function validateNoGpuEncode(config: ValidateNoGpuEncodeInput): void {
 export function validateNoSystemFonts(compiledHtml: string): void {
   const customProperties = collectFontFamilyCustomProperties(compiledHtml);
   for (const { surface, declaration } of iterateFontFamilyDeclarations(compiledHtml)) {
-    const families = resolveFontFamilyDeclarationFamilies(declaration, customProperties);
+    const families = resolveFontFamilyDeclarationCandidates(declaration, customProperties);
     if (families.length === 0) continue;
-    const primaryRaw = families[0]!;
+    const primary = families[0]!;
+    const primaryRaw = primary.value;
     // Unresolved var() primaries are left to the browser; resolved custom
     // properties are checked above so common `--font: system-ui` aliases fail.
-    if (!GENERIC_FAMILIES.has(primaryRaw.toLowerCase())) continue;
+    if (primary.quoted || !GENERIC_FAMILIES.has(primaryRaw.toLowerCase())) continue;
     throw new PlanValidationError(
       SYSTEM_FONT_USED,
       `[planValidation] Composition declares a host-OS / generic primary ${surface}: ` +


### PR DESCRIPTION
Quoted CSS family names are literals: `"serif"` names a font, while `serif` is a generic keyword. Current rendering loses that distinction, inserts Inter ahead of authored literal names, rejects them in distributed plan validation, and skips fetching literal generic or `"var(...)"` names.

Preserve quote information through the existing font-family splitter and custom-property resolution, then use it in normalization, deterministic injection, and plan validation. The existing unquoted generic guard remains covered. This follows the [CSS Fonts specification](https://www.w3.org/TR/css-fonts-4/#font-family-prop).

Carries forward the quote-provenance portion of #2778 on current main. That PR stays open for its separate scoped custom-property, fallback, and lint parsing work; this change does not claim to replace those parts.

Validation: 74 focused producer tests pass, including regressions for CSS, inline styles, data attributes, root aliases, literal generic names, and function-shaped names. Producer typecheck, repository commit hooks, and independent adversarial review pass.
