### PR TITLE
fix(studio): keep file-change subscription stable across redraws

### DIFF
--- a/packages/studio/src/hooks/useEditorSave.test.tsx
+++ b/packages/studio/src/hooks/useEditorSave.test.tsx
@@ -41,6 +41,11 @@ async function mountEditorSave(writeProjectFile: WriteProjectFile) {
   return {
     handle: captured.handle,
     showToast,
+    rerender: async () => {
+      await act(async () => root.render(<Probe />));
+      if (!captured.handle) throw new Error("Editor save handle was not mounted");
+      return captured.handle;
+    },
     unmount: () => act(async () => root.unmount()),
   };
 }
@@ -58,6 +63,28 @@ describe("useEditorSave pending work", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  it("keeps the pending getter stable across redraws while reading current edits", async () => {
+    const mounted = await mountEditorSave(vi.fn(async () => undefined));
+    const getPendingCandidate = mounted.handle.getPendingCandidate;
+    try {
+      expect(getPendingCandidate()).toBeNull();
+      for (let redraw = 0; redraw < 30; redraw++) {
+        const current = await mounted.rerender();
+        expect(current.getPendingCandidate).toBe(getPendingCandidate);
+      }
+      act(() => mounted.handle.handleContentChange("latest pending source"));
+      expect(getPendingCandidate()).toEqual({
+        projectId: "project-a",
+        path: "index.html",
+        content: "latest pending source",
+      });
+      act(() => mounted.handle.discardPendingSave());
+      expect(getPendingCandidate()).toBeNull();
+    } finally {
+      await mounted.unmount();
+    }
   });
 
   it("exposes and flushes the latest rAF-buffered source candidate", async () => {

--- a/packages/studio/src/hooks/useEditorSave.ts
+++ b/packages/studio/src/hooks/useEditorSave.ts
@@ -185,10 +185,12 @@ export function useEditorSave({
     pendingCandidateRef.current = null;
   }, []);
 
+  const getPendingCandidate = useCallback(() => pendingCandidateRef.current, []);
+
   return {
     saveRafRef,
     handleContentChange,
-    getPendingCandidate: () => pendingCandidateRef.current,
+    getPendingCandidate,
     flushPendingSave,
     discardPendingSave,
   };


### PR DESCRIPTION
## What

Keep Studio's file-change subscription stable across unrelated screen updates.

## Why

Studio currently reconnects its file-change subscription whenever its parent redraws. `useEditorSave` returns a fresh `getPendingCandidate` closure; this propagates through `useFileManager` into `useExternalFileChangeCoordinator` and changes the callback that owns the subscription effect. Playback and render-progress updates therefore close and recreate `/api/events` even when the project and file have not changed.

## How

Keep the getter stable with `useCallback`, reading the existing ref at call time. This preserves current pending-edit behavior while avoiding unnecessary subscription replacement.

## Test plan

- [x] Regression test verifies a stable getter across 30 redraws, the latest pending source, and discard behavior.
- [x] Both save and external-file-change suites pass: 18 tests.
- [x] Related workspace builds, including Studio's production build and declarations, pass.
- [x] Changed files pass oxlint and oxfmt.
- [x] Manual browser retest of the production Studio build: a real 20-second, six-scene composition played to completion; Export advanced through 600 frames and completed in 49 seconds; Download emitted its browser event; a text edit saved through Studio and remained after a full page reload. The output probes as 20 seconds, 1080 x 1920, H.264 with AAC audio. This was a local Node server, not a deployed proxy test.

A separate local integration probe using both original hooks and the existing subscription test adapter reproduces 31 subscriptions and 30 cleanups across 30 redraws before the fix, and one retained subscription with the fix. This establishes the React subscription regression; it does not claim to fix an independent proxy's connection cleanup or every export-progress failure. No documentation change is required for this internal bug fix.
