### PR TITLE
fix(skills): exclude repo-native skills from public installs

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -48,3 +48,8 @@ The parallel set at `.claude/skills/` is a byte-identical copy so
 Claude Code users get the same auto-discover behaviour — keep the two
 in sync when editing. A `scripts/check-skill-mirror.mjs` check enforces
 this at CI time.
+
+Each repo-native skill declares `metadata.internal: true`, so `npx skills add`
+skips it during normal installs (including `--all`). This does not change local
+agent discovery. To explicitly install these skills elsewhere, set
+`INSTALL_INTERNAL_SKILLS=1` when running the installer.

--- a/.agents/skills/captions-overlay/SKILL.md
+++ b/.agents/skills/captions-overlay/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: captions-overlay
 description: Overlay doctrine for the embedded-captions workflow — the caption MODEL (drop / rail / embed) and the rule that captions are an OVERLAY composited on top of the film, never a reserved bottom band you shift content up to avoid. Load when adding captions/subtitles to a talking-head or launch video, when deciding whether a phrase should be dropped, ride the verbatim rail, or be promoted to a scarce embedded climax, when laying out a composition that will carry captions (do NOT reserve a keep-out band), or when centering a composition on the true frame center under captions. Quotes the rail+embed model from embedded-captions and constraint #13 (captions overlay, keep-out band retired) from the product-launch-video scene agent. Applies ON TOP of embedded-captions.
+metadata:
+  internal: true
 ---
 
 # Captions Overlay Doctrine

--- a/.agents/skills/changelog-video/SKILL.md
+++ b/.agents/skills/changelog-video/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: changelog-video
 description: Turn a weekly changelog .md into a finished branded changelog video (square 1080, ~45-60s, Annie VO, animated brand background, mock-UI visualizations, lowkey captions). Use when the user provides a changelog/digest markdown and wants the weekly video, or says "changelog video". Self-contained — fonts, background, lexicon, and scripts ship in this skill.
+metadata:
+  internal: true
 ---
 
 # Changelog → Branded Video

--- a/.agents/skills/cut-the-curve/SKILL.md
+++ b/.agents/skills/cut-the-curve/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: cut-the-curve
 description: "The technique catalog: five velocity-matched SEAMS (zoom-through, INVERSE zoom-through, cut-the-curve, waterfall cut, rack-focus blur-cut) plus the two in-scene techniques — waterfall ENTRY (staggered arrival cascades for title cards / segment openers) and the nudge curve (slow-fast-slow three-phase group slides). Covers partial-travel (~12% of frame) velocity matching via mirrored power4 eases, the Z scale-sign rule, size-scaled blur (10px text / 18-20px full-frame), word-by-word staggered cuts, cascade pacing by element weight, and the 10/65/25 slide ratio. Read before authoring any transition, text-beat handoff, kinetic text entry, or group reposition. [depth, zoom, inverse-zoom, scale-sign, mirrored-zoom, rack-focus, pacing, velocity, cut-the-curve, waterfall, stagger, cascade, kinetic-text, title-card, segment-opener, nudge, slide, easing, group-motion, z-depth, motion-graphics, cinematic, transition, blur, directional-continuity]"
+metadata:
+  internal: true
 ---
 
 # Cut the Curve — the technique catalog

--- a/.agents/skills/motion-doctrine/SKILL.md
+++ b/.agents/skills/motion-doctrine/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: motion-doctrine
 description: "GATEWAY — load FIRST before composing any HyperFrames animation or video. The high-level motion law that makes a multi-scene video feel like ONE continuous camera move instead of a stack of independently-animated slides. Covers the vector law (how you exit determines how you enter, incl. the Z scale-sign rule), the film's current, carrier elements, causal motion, the Seam Gate (build-gate enforcement), the ban on idle wobble (motion must PERFORM, not breathe), stillness-before-climax, and the sustained-motion routes. Routes to the low-level technique skills (cut-the-curve — the full catalog incl. waterfall entry + nudge curve, oversized-cursor, seam-craft). These rules SUPERSEDE generic / upstream motion guidance. [continuity, direction, vector, momentum, seam, transition, ease, performance, idle-motion, narrative-motion, film-grammar]"
+metadata:
+  internal: true
 ---
 
 # Motion Doctrine (Gateway)

--- a/.agents/skills/oversized-cursor/SKILL.md
+++ b/.agents/skills/oversized-cursor/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: oversized-cursor
 description: House-style oversized macOS cursor technique for HyperFrames launch videos. Load whenever a scene involves cursors or a pointer-led action, when kicking off a UI scene, when igniting a morph/transition/typing run with a click, or when a scene reads as static, dead, or stale and needs a cheap high-yield source of motion to carry the viewer's eye and segment them out of the stale state. Covers cursor size/look (incl. brand-motif cursors), the off-screen entry law, tip-targeting and the click tap, click-ignites-the-next-beat, and exit / cross-scene handoff.
+metadata:
+  internal: true
 ---
 
 # Oversized Cursor — the eye-carrier

--- a/.agents/skills/seam-craft/SKILL.md
+++ b/.agents/skills/seam-craft/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: seam-craft
 description: Render-correctness doctrine for scene-to-scene seams in HyperFrames launch videos — the prerequisites that make transitions composite correctly on the master timeline. Load when assembling the master timeline / index.html, when a white flash appears at a cut or crossfade seam (especially on dark films), when reasoning about why a transition opacity dip shows through, or when verifying the render-side mechanics of how overlapping scene wrappers blend. Covers the opaque stage-ground (#root background) white-flash guard and how the injector overlaps wrappers, holds final frames, ping-pongs tracks, and stamps lint-clean template code onto the master timeline. Does NOT contain the per-transition catalog — see the transition registry for individual transition entries.
+metadata:
+  internal: true
 ---
 
 # Seam Craft — render prerequisites for scene-to-scene transitions

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -46,3 +46,8 @@ The parallel set at `.agents/skills/` is a byte-identical copy so Codex
 CLI users get the same auto-discover behaviour — keep the two in sync
 when editing. A `scripts/check-skill-mirror.mjs` check enforces this at
 CI time.
+
+Each repo-native skill declares `metadata.internal: true`, so `npx skills add`
+skips it during normal installs (including `--all`). This does not change local
+agent discovery. To explicitly install these skills elsewhere, set
+`INSTALL_INTERNAL_SKILLS=1` when running the installer.

--- a/.claude/skills/captions-overlay/SKILL.md
+++ b/.claude/skills/captions-overlay/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: captions-overlay
 description: Overlay doctrine for the embedded-captions workflow — the caption MODEL (drop / rail / embed) and the rule that captions are an OVERLAY composited on top of the film, never a reserved bottom band you shift content up to avoid. Load when adding captions/subtitles to a talking-head or launch video, when deciding whether a phrase should be dropped, ride the verbatim rail, or be promoted to a scarce embedded climax, when laying out a composition that will carry captions (do NOT reserve a keep-out band), or when centering a composition on the true frame center under captions. Quotes the rail+embed model from embedded-captions and constraint #13 (captions overlay, keep-out band retired) from the product-launch-video scene agent. Applies ON TOP of embedded-captions.
+metadata:
+  internal: true
 ---
 
 # Captions Overlay Doctrine

--- a/.claude/skills/changelog-video/SKILL.md
+++ b/.claude/skills/changelog-video/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: changelog-video
 description: Turn a weekly changelog .md into a finished branded changelog video (square 1080, ~45-60s, Annie VO, animated brand background, mock-UI visualizations, lowkey captions). Use when the user provides a changelog/digest markdown and wants the weekly video, or says "changelog video". Self-contained — fonts, background, lexicon, and scripts ship in this skill.
+metadata:
+  internal: true
 ---
 
 # Changelog → Branded Video

--- a/.claude/skills/cut-the-curve/SKILL.md
+++ b/.claude/skills/cut-the-curve/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: cut-the-curve
 description: "The technique catalog: five velocity-matched SEAMS (zoom-through, INVERSE zoom-through, cut-the-curve, waterfall cut, rack-focus blur-cut) plus the two in-scene techniques — waterfall ENTRY (staggered arrival cascades for title cards / segment openers) and the nudge curve (slow-fast-slow three-phase group slides). Covers partial-travel (~12% of frame) velocity matching via mirrored power4 eases, the Z scale-sign rule, size-scaled blur (10px text / 18-20px full-frame), word-by-word staggered cuts, cascade pacing by element weight, and the 10/65/25 slide ratio. Read before authoring any transition, text-beat handoff, kinetic text entry, or group reposition. [depth, zoom, inverse-zoom, scale-sign, mirrored-zoom, rack-focus, pacing, velocity, cut-the-curve, waterfall, stagger, cascade, kinetic-text, title-card, segment-opener, nudge, slide, easing, group-motion, z-depth, motion-graphics, cinematic, transition, blur, directional-continuity]"
+metadata:
+  internal: true
 ---
 
 # Cut the Curve — the technique catalog

--- a/.claude/skills/motion-doctrine/SKILL.md
+++ b/.claude/skills/motion-doctrine/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: motion-doctrine
 description: "GATEWAY — load FIRST before composing any HyperFrames animation or video. The high-level motion law that makes a multi-scene video feel like ONE continuous camera move instead of a stack of independently-animated slides. Covers the vector law (how you exit determines how you enter, incl. the Z scale-sign rule), the film's current, carrier elements, causal motion, the Seam Gate (build-gate enforcement), the ban on idle wobble (motion must PERFORM, not breathe), stillness-before-climax, and the sustained-motion routes. Routes to the low-level technique skills (cut-the-curve — the full catalog incl. waterfall entry + nudge curve, oversized-cursor, seam-craft). These rules SUPERSEDE generic / upstream motion guidance. [continuity, direction, vector, momentum, seam, transition, ease, performance, idle-motion, narrative-motion, film-grammar]"
+metadata:
+  internal: true
 ---
 
 # Motion Doctrine (Gateway)

--- a/.claude/skills/oversized-cursor/SKILL.md
+++ b/.claude/skills/oversized-cursor/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: oversized-cursor
 description: House-style oversized macOS cursor technique for HyperFrames launch videos. Load whenever a scene involves cursors or a pointer-led action, when kicking off a UI scene, when igniting a morph/transition/typing run with a click, or when a scene reads as static, dead, or stale and needs a cheap high-yield source of motion to carry the viewer's eye and segment them out of the stale state. Covers cursor size/look (incl. brand-motif cursors), the off-screen entry law, tip-targeting and the click tap, click-ignites-the-next-beat, and exit / cross-scene handoff.
+metadata:
+  internal: true
 ---
 
 # Oversized Cursor — the eye-carrier

--- a/.claude/skills/seam-craft/SKILL.md
+++ b/.claude/skills/seam-craft/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: seam-craft
 description: Render-correctness doctrine for scene-to-scene seams in HyperFrames launch videos — the prerequisites that make transitions composite correctly on the master timeline. Load when assembling the master timeline / index.html, when a white flash appears at a cut or crossfade seam (especially on dark films), when reasoning about why a transition opacity dip shows through, or when verifying the render-side mechanics of how overlapping scene wrappers blend. Covers the opaque stage-ground (#root background) white-flash guard and how the injector overlaps wrappers, holds final frames, ping-pongs tracks, and stamps lint-clean template code onto the master timeline. Does NOT contain the per-transition catalog — see the transition registry for individual transition entries.
+metadata:
+  internal: true
 ---
 
 # Seam Craft — render prerequisites for scene-to-scene transitions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This repo ships AI agent skills via [vercel-labs/skills](https://github.com/verc
 ```bash
 npx hyperframes skills update           # default: installs/refreshes the core set — workflows install on demand
 npx hyperframes skills                  # all 20 published skills at once
-npx skills add heygen-com/hyperframes   # interactive picker (terminal only; --all also pulls the repo-internal skills under .claude/skills)
+npx skills add heygen-com/hyperframes   # interactive picker (terminal only; repo-internal skills are excluded by default)
 ```
 
 **Creation workflows** route through one entry skill — read `/hyperframes` first: it orients you to the whole surface, confirms the brief up front (the intent layer), and maps "make me a…" intent — usually a video, but also a navigable deck (`/slideshow`) or a composition port (`/remotion-to-hyperframes`) — to a concrete workflow. Consult it before invoking a specific workflow:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Install the HyperFrames skills, then describe the video you want:
 npx skills add heygen-com/hyperframes
 ```
 
-> The picker opens with nothing pre-selected — the **Core Skills** group is all you need: the `/hyperframes` router installs each creation workflow on demand. Agents and non-interactive runs should use `npx hyperframes skills update` instead — it installs exactly the core set, whereas `skills add --all` installs every `SKILL.md` in the repo — the 20 published skills plus six repo-internal ones under `.claude/skills` / `.agents/skills`. For the full published set use `npx hyperframes skills`.
+> The picker opens with nothing pre-selected — the **Core Skills** group is all you need: the `/hyperframes` router installs each creation workflow on demand. Agents and non-interactive runs should use `npx hyperframes skills update` instead — it installs exactly the core set, whereas `skills add --all` installs all 20 published skills. The six repo-internal skills under `.claude/skills` / `.agents/skills` are excluded by default. For the full published set use `npx hyperframes skills`.
 >
 > `skills add` resolves the skills.sh registry blob, which can lag `main` by hours. `npx hyperframes skills update` installs from the current `main`, so reach for it when you need the newest copy of a skill.
 

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -116,7 +116,7 @@ Install the complete published set deliberately with:
 npx hyperframes skills
 ```
 
-(`npx skills add heygen-com/hyperframes --all` also works, but it installs every `SKILL.md` in the repository, including repo-internal skills that are not part of the published set.)
+`npx skills add heygen-com/hyperframes --all` also installs the complete published set. Repo-internal skills are excluded by default.
 
 Or install one named skill:
 


### PR DESCRIPTION
## What

Exclude the six repo-native skills from normal `npx skills add heygen-com/hyperframes` discovery and installation, including `--all`. Normal discovery now returns the 20 published skills instead of 26.

## Why

The six internal skills are intentionally mirrored under `.agents/skills` and `.claude/skills` for agents working in this repository. The installer scans both locations. Although skills 1.5.25 deduplicates names, it still exposes these six repo-only skills alongside the public catalog.

## How

Add `metadata.internal: true` to all six skills in both mirrors and update the installation documentation. Preserve both repo-local trees. `INSTALL_INTERNAL_SKILLS=1` remains an explicit opt-in to discover/install the internal skills. Existing user installations are not deleted or migrated.

## Test plan

- [x] Tested with skills CLI 1.5.25: unmodified source lists 26 skills; patched source lists 20 with both `--list` and `--all --list`.
- [x] Fresh isolated Codex project install contains exactly the 20 public skills and none of the six internal skills.
- [x] `INSTALL_INTERNAL_SKILLS=1` lists all 26 skills.
- [x] `bun scripts/lint-skills.ts`: 32 definitions pass.
- [x] `node scripts/check-skill-mirror.mjs`: all 24 mirrored files remain byte-identical.
- [x] Formatting, tracked-artifact, large-file, and commit-message hooks pass.
- [x] Mintlify build validation and broken-link checks pass.
- [x] Documentation updated.

This is a metadata/documentation-only change; no runtime TypeScript changes or new unit tests.
