### PR TITLE
fix(cli): let .hyperframesignore negation re-include hidden directories

### DIFF
--- a/packages/cli/src/utils/publishProject.test.ts
+++ b/packages/cli/src/utils/publishProject.test.ts
@@ -283,6 +283,35 @@ describe("createPublishArchive", () => {
     }
   });
 
+  it("allows .hyperframesignore to re-include a hidden directory", () => {
+    const dir = makeProjectDir();
+    try {
+      writeFileSync(join(dir, "index.html"), "<html></html>", "utf-8");
+      mkdirSync(join(dir, ".media"));
+      writeFileSync(join(dir, ".media", "logo.png"), "logo", "utf-8");
+      writeFileSync(join(dir, ".hyperframesignore"), "!/.media/\n!/.media/**\n", "utf-8");
+
+      const zip = new AdmZip(createPublishArchive(dir).buffer);
+      expect(zip.getEntries().map((entry) => entry.entryName)).toContain(".media/logo.png");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("still excludes an unmatched hidden directory by default", () => {
+    const dir = makeProjectDir();
+    try {
+      writeFileSync(join(dir, "index.html"), "<html></html>", "utf-8");
+      mkdirSync(join(dir, ".cache"));
+      writeFileSync(join(dir, ".cache", "entry.bin"), "cache", "utf-8");
+
+      const zip = new AdmZip(createPublishArchive(dir).buffer);
+      expect(zip.getEntries().map((entry) => entry.entryName)).not.toContain(".cache/entry.bin");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("fails clearly when .hyperframesignore excludes index.html", () => {
     const dir = makeProjectDir();
     try {

--- a/packages/cli/src/utils/publishProject.ts
+++ b/packages/cli/src/utils/publishProject.ts
@@ -11,7 +11,11 @@ import { writeProjectLink } from "./projectLink.js";
 const IGNORED_DIRS = new Set([".git", "node_modules", "dist", ".next", "coverage"]);
 const IGNORED_FILES = new Set([".DS_Store", "Thumbs.db"]);
 const HYPERFRAMES_IGNORE_FILE = ".hyperframesignore";
-const DEFAULT_PROJECT_IGNORE = ["/renders/", "/snapshots/"];
+// Unanchored (no leading/mid slash) so it matches a dot-prefixed name at any
+// depth, same as the segments it replaces below — but as a matcher pattern
+// instead of a hard skip, a project's own `.hyperframesignore` negation can
+// still override it.
+const DEFAULT_PROJECT_IGNORE = ["/renders/", "/snapshots/", ".*"];
 const PUBLISH_CONTENT_TYPE = "application/zip";
 const PUBLISH_METADATA_TIMEOUT_MS = 30_000;
 const PUBLISH_UPLOAD_MIN_TIMEOUT_MS = 120_000;
@@ -252,8 +256,12 @@ export function uploadTimeoutMs(byteLength: number): number {
   );
 }
 
+// Absolute, non-negotiable exclusions only — anything a `.hyperframesignore`
+// negation rule should be able to override (including dot-prefixed paths;
+// see DEFAULT_PROJECT_IGNORE) must go through the ignore matcher instead of
+// short-circuiting here.
 function shouldIgnoreSegment(segment: string): boolean {
-  return segment.startsWith(".") || IGNORED_DIRS.has(segment) || IGNORED_FILES.has(segment);
+  return IGNORED_DIRS.has(segment) || IGNORED_FILES.has(segment);
 }
 
 function createProjectIgnore(rootDir: string): Ignore {


### PR DESCRIPTION
## What

`.hyperframesignore` negation rules (e.g. `!/.media/`) could never re-include a hidden (dot-prefixed) directory in the publish or cloud-render project archive, even though negation works correctly for every other kind of path.

## Why

`collectProjectFiles`'s walker called `shouldIgnoreSegment` first for every directory entry, and that check unconditionally excluded any name starting with `.` — before the project's ignore matcher (built from `DEFAULT_PROJECT_IGNORE` + `.hyperframesignore`, where negation is evaluated) ever ran on that path. A hidden directory was discarded at the walk step, so no negation rule downstream could ever reach it.

## How

- Moved the dot-prefix exclusion out of the hard `shouldIgnoreSegment` short-circuit and into the same ignore matcher that already parses `.hyperframesignore`, as a new default pattern (`.*`) in `DEFAULT_PROJECT_IGNORE`. Dot-prefixed paths are still excluded by default, but now via the same gitignore-style negation path as everything else, so a project's `.hyperframesignore` can override it.
- `shouldIgnoreSegment` is now reserved for the fixed, non-negotiable exclusions only (`.git`, `node_modules`, `dist`, `.next`, `coverage`, `.DS_Store`, `Thumbs.db`) — the set no `.hyperframesignore` rule should ever be able to reach.
- Added regression coverage for both directions: a `.hyperframesignore` negation re-including a hidden directory, and an unmatched hidden directory still being excluded by default (no behavior change for existing projects without an explicit negation rule).

## Testing

- `bunx vitest run packages/cli/src/utils/publishProject.test.ts` — 40/40 passing (2 new)
- `bunx vitest run packages/cli/src/commands/cloud/render.test.ts` — 10/10 passing (cloud render reuses the same archive builder)
- `bunx tsc --noEmit` in `packages/cli` — clean
- `bunx oxlint` / `bunx oxfmt --write` on changed files — clean, no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)