### PR TITLE
fix(cli): apply the canvas/video pixel-hash carve-out to img

### DIFF
--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -1689,7 +1689,13 @@
         axes && axes !== "normal" ? axes : ""
       }`;
     });
-    for (const media of root.querySelectorAll("canvas, video")) {
+    // img shares the same pixel-only-motion blind spot as canvas/video: an
+    // equal-size, equal-position opaque src/visibility swap moves no
+    // geometry and no opacity. mediaPixelHash already handles it generically
+    // (drawImage accepts any CanvasImageSource; width/height fall back to
+    // rect.width/height same as canvas/video), so only the element selector
+    // needed widening.
+    for (const media of root.querySelectorAll("canvas, video, img")) {
       if (!isVisibleElement(media)) continue;
       parts.push(`p:${mediaPixelHash(media)}`);
     }

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -63,6 +63,44 @@ describe("layout-audit.browser", () => {
     expect(after).not.toBe(before);
   });
 
+  // PRINFRA-666: an equal-size, equal-position opaque <img> src/visibility
+  // swap (the authoring pattern for a paused-GSAP-cursor-driven "reveal
+  // frame N of a still sequence" composition) moves no geometry and no
+  // opacity, so it was invisible to the fingerprint and false-positived
+  // sweep_static — mediaPixelHash already existed for exactly this pixel-only
+  // motion class, it just wasn't applied to img.
+  it("changes the sweep fingerprint when a same-size opaque img is swapped", () => {
+    document.body.innerHTML = `
+      <div id="root" data-composition-id="main" data-width="640" data-height="360">
+        <img id="frame" />
+      </div>
+    `;
+    installGeometry({
+      root: rect({ left: 0, top: 0, width: 640, height: 360 }),
+      frame: rect({ left: 0, top: 0, width: 640, height: 360 }),
+    });
+
+    let pixelValue = 20;
+    const getContextSpy = vi.spyOn(HTMLCanvasElement.prototype, "getContext") as unknown as {
+      mockReturnValue(value: CanvasRenderingContext2D): void;
+    };
+    getContextSpy.mockReturnValue({
+      drawImage() {},
+      getImageData() {
+        return { data: new Uint8ClampedArray(8 * 8 * 4).fill(pixelValue) };
+      },
+    } as unknown as CanvasRenderingContext2D);
+
+    installAuditScript();
+    const collect = (window as unknown as { __hyperframesLayoutGeometry: () => string })
+      .__hyperframesLayoutGeometry;
+    const before = collect();
+    pixelValue = 220;
+    const after = collect();
+
+    expect(after).not.toBe(before);
+  });
+
   // Opacity-reveal fixture (CLI feedback digest 2026-07-14): code-typing style
   // scenes reveal pre-laid-out characters via opacity only — no geometry ever
   // moves. The sweep fingerprint must treat that as motion, both while a glyph


### PR DESCRIPTION
## What

`check`'s sweep_static guard false-positives on a composition that swaps between equal-size, equal-position opaque `<img>` elements — a common authoring pattern for revealing frame N of a still sequence from a paused GSAP cursor. The render itself is correct; only `check`'s verdict is wrong.

## Why

The sweep guard fingerprints every visible element's box + opacity + font-variation-settings per seeked sample. That's deliberately blind to pixel-only motion (a canvas repainting, a video playing) with no element moving, so an existing carve-out downsamples each visible `canvas`/`video` to 8x8 and folds its pixels into the fingerprint specifically to catch that class of motion.

That carve-out's element selector (`root.querySelectorAll("canvas, video")`) never included `img`. An img src/visibility swap between equal-size opaque images moves zero geometry and zero opacity, so it stays outside both the base fingerprint and the pixel-hash carve-out — the whole-run fingerprint reads byte-identical across every sample and `sweep_static` fires on an animating composition.

## How

Widened the selector to `canvas, video, img`. No other change was needed: `mediaPixelHash` already handles `img` correctly — `drawImage` accepts any `CanvasImageSource`, and its width/height detection already falls back to the element's bounding rect the same way it does for `canvas`/`video`.

**Scope note:** this repo has an open PR (#3707) touching the same function (`collectLayoutGeometry` in this same file) for a different, unrelated bug (text/counter fingerprinting). This change is deliberately isolated to the `canvas, video` → `canvas, video, img` selector line and a new comment above it — verified against #3707's current diff that neither touches this exact loop, so the two PRs shouldn't conflict regardless of merge order.

## Testing

Added a test mirroring the existing "changes the sweep fingerprint when visible video pixels advance" test, using an `<img>` element instead of `<video>` with the same pixel-mock approach.

- `bunx tsc --noEmit` in `packages/cli` — clean
- `bunx oxlint` / `bunx oxfmt --write` on changed files — clean, no changes needed
- Full CLI suite (excluding known-broken browser-launch tests unrelated to this change): 217 test files / 3023 tests passing

One local-environment caveat, disclosed for transparency: `layout-audit.browser.test.ts` (the file the new test lives in) can't execute in my local sandbox — it fails identically with or without this change (`No such built-in module: node:`, a happy-dom + Vite externalization issue affecting every test file in this repo that imports Node builtins at the top under `@vitest-environment happy-dom`, not specific to this change). I verified the new test's logic and mocking approach are structurally identical to the existing, CI-passing video test it's modeled on, and will confirm via this PR's CI run rather than a local one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)