### PR TITLE
fix(cli): stop promising a universal per-time filmstrip for --layout strip

### DIFF
--- a/docs/packages/cli.mdx
+++ b/docs/packages/cli.mdx
@@ -775,7 +775,7 @@ npx hyperframes keyframes [dir] --selector "#card" --shot card-motion.png
 | `--json`             | Machine-readable results                                                                                                        |
 | `--shot`             | Write an onion-skin PNG of the real element sampled over the timeline. Pair with `--selector` to focus one element.             |
 | `--samples`          | Onion samples at equal time steps (default 9)                                                                                   |
-| `--layout`           | `path` — ghosts at real positions plus a path (default) — or `strip`, a filmstrip by time, for in-place or overlapping motion   |
+| `--layout`           | `path` — ghosts at real positions plus a path (default) — or `strip`, for in-place or overlapping motion. `strip` is a real per-time pixel filmstrip only when `--selector` targets an SVG element; any other selector (e.g. a DOM/sub-composition host) gets one live frame plus vector position markers instead |
 | `--from`, `--to`     | Sample only this time range, in seconds                                                                                         |
 | `--angle`            | Orbit camera: `front`, `iso`, `top`, `side`, `rear-iso`, or `yaw,pitch` in degrees                                             |
 | `--fit` / `--no-fit` | Zoom the motion to fill the diagnostic frame (default: on)                                                                      |

--- a/packages/cli/src/commands/keyframes.test.ts
+++ b/packages/cli/src/commands/keyframes.test.ts
@@ -2,9 +2,23 @@ import { existsSync, linkSync, mkdtempSync, mkdirSync, readFileSync, writeFileSy
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeAll, describe, expect, it } from "vitest";
+import type { ArgsDef } from "citty";
 import { ensureDOMParser } from "../utils/dom.js";
+import keyframesCommand from "./keyframes.js";
 import { collectShotSelectors, resolveScope, surfaceComposition } from "./keyframes.js";
 import { ensureShotOutputDir } from "./motionShot.js";
+
+// citty types `args` as Resolvable<ArgsDef> (object | promise | thunk); this
+// command always uses a static object, same narrowing as assertKnownFlags.
+function layoutArgDescription(): string {
+  const rawDef = keyframesCommand.args;
+  const args = rawDef && typeof rawDef === "object" ? (rawDef as ArgsDef) : undefined;
+  const layout = args?.["layout"];
+  if (!layout || typeof layout !== "object" || !("description" in layout)) {
+    throw new Error("expected keyframesCommand.args.layout.description to be defined");
+  }
+  return String(layout.description);
+}
 
 beforeAll(() => ensureDOMParser());
 
@@ -317,5 +331,26 @@ describe("keyframes template-wrapped sub-compositions", () => {
     </script></body></html>`;
     const { tweens } = surfaceComposition(topLevel, "index.html", "index.html");
     expect(tweens.length).toBeGreaterThan(0);
+  });
+});
+
+// PRINFRA-667: `--layout strip` only does a real per-time pixel capture when
+// the sampled selector is an SVG element (see motionShot.ts's stripTargetsSvg
+// gate); every other selector -- including every nested sub-composition host,
+// always a <div data-composition-src> -- silently falls back to one live
+// frame plus vector position markers. The old help text's unqualified
+// "filmstrip by time" promised the former for the latter case. This guards
+// against reintroducing that over-promise without a matching capability.
+describe("--layout strip help text", () => {
+  it("does not promise a universal per-time filmstrip", () => {
+    expect(layoutArgDescription()).not.toMatch(
+      /^--shot layout: 'path'.*or 'strip' \(filmstrip by time/,
+    );
+  });
+
+  it("discloses the SVG-only condition for a real per-time capture", () => {
+    const description = layoutArgDescription();
+    expect(description).toContain("SVG");
+    expect(description.toLowerCase()).toContain("only when");
   });
 });

--- a/packages/cli/src/commands/keyframes.ts
+++ b/packages/cli/src/commands/keyframes.ts
@@ -923,7 +923,7 @@ function createKeyframesCommand(options: Partial<KeyframesCommandOptions> = {}) 
       layout: {
         type: "string",
         description:
-          "--shot layout: 'path' (ghosts at real positions + path, default) or 'strip' (filmstrip by time — for in-place/overlapping motion).",
+          "--shot layout: 'path' (ghosts at real positions + path, default) or 'strip' (for in-place/overlapping motion). 'strip' captures a real per-time pixel filmstrip only when --selector targets an SVG element; any other selector (e.g. a DOM/sub-composition host) instead gets one live frame plus vector position markers.",
       },
       from: { type: "string", description: "--shot: sample only from this time (seconds)." },
       to: { type: "string", description: "--shot: sample only up to this time (seconds)." },

--- a/packages/cli/src/commands/motionShot.ts
+++ b/packages/cli/src/commands/motionShot.ts
@@ -73,7 +73,11 @@ export interface ShotOptions {
   entryFile?: string;
   /** Equal-time samples across the (windowed) timeline. Default 9. */
   samples?: number;
-  /** "path" = ghosts at real positions + path; "strip" = filmstrip by time. */
+  /** "path" = ghosts at real positions + path. "strip" = real per-time pixel
+   * filmstrip, but only when the selector targets an SVG element (see
+   * `stripTargetsSvg` below); for any other selector — including every
+   * nested sub-composition host, which is always a `<div data-composition-src>`
+   * — it falls back to one live frame plus vector position markers. */
   layout?: "path" | "strip";
   /** Zoom the motion to fill the frame. Default true. */
   fit?: boolean;


### PR DESCRIPTION
## What

`keyframes --shot --layout strip`'s help text, its type's inline doc comment, and the CLI reference docs all described `strip` as an unqualified "filmstrip by time." The tool doesn't actually do that for the overwhelmingly common case.

## Why

A real per-time pixel filmstrip is only produced when the sampled selector is an SVG element (gated by an internal shape check — `typeof element.getBBox === "function" && typeof element.getScreenCTM === "function"`). Any other selector — including every nested sub-composition host, which is always a `<div data-composition-src>` — silently falls back to one live screenshot plus vector position markers instead.

This isn't a capture bug: for a non-SVG selector, real per-time pixel compositing was never implemented, only 3D bbox/marker sampling. But the documented behavior over-promised what the tool does, so a user following the docs on the common case (a DOM/sub-composition selector) sees root captions and empty image boxes where they expected the nested composition's actual content to move across frames — the diagnostic strip is misleading, even though the real render is correct.

## How

Reworded all three descriptions (CLI help text, `ShotOptions.layout` TSDoc, and the reference docs table) to state the SVG-only condition and the DOM/sub-composition fallback explicitly. No behavior changed — this is a documentation-accuracy fix, per the ticket's own framing that a doc-only fix fully resolves the reported symptom (a silent, misleading omission) for a P3.

## Testing

Added a test asserting the CLI help text no longer makes the unqualified "filmstrip by time" claim and does disclose the SVG-only condition — guards against a future regression back to the misleading wording. Verified RED (fails against the pre-fix string) and GREEN (passes after the fix) via a local before/after comparison.

- `bunx vitest run src/commands/keyframes.test.ts src/commands/motionShotLayout.test.ts` — 46/46 passing
- `bunx tsc --noEmit` in `packages/cli` — clean
- `bunx oxlint` / `bunx oxfmt --write` on changed files — clean
- Full CLI suite (excluding known-broken-in-sandbox browser-launch tests, unrelated to this change): 217 test files / 3025 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)