### PR TITLE
feat(producer): add opt-in OpenMAIC static capture reuse

### DIFF
--- a/packages/producer/src/services/render/__test_utils__/sourceStaticPlanFixture.ts
+++ b/packages/producer/src/services/render/__test_utils__/sourceStaticPlanFixture.ts
@@ -1,0 +1,112 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SOURCE_STATIC_PLAN_PRODUCER_VERSION, type StaticPlanInput } from "../sourceStaticPlan.js";
+const hash = (bytes: Uint8Array) => createHash("sha256").update(bytes).digest("hex");
+export async function fixture(scratch: string[]) {
+  const root = await mkdtemp(join(tmpdir(), "openmaic-static-plan-"));
+  scratch.push(root);
+  await mkdir(join(root, "assets", "slides"), { recursive: true });
+  await mkdir(join(root, "assets", "vendor"), { recursive: true });
+  const manifest = {
+    schema: "openmaic.videoTimeline",
+    version: 4,
+    compiler: "openmaic-video-timeline",
+    stage: { id: "stage" },
+    totalDurationMs: 10_000,
+    scenes: [
+      {
+        id: "scene",
+        index: 0,
+        type: "slide",
+        startMs: 0,
+        durationMs: 10_000,
+        base: { kind: "slide-snapshot", assetRef: "slides/页.png" },
+      },
+    ],
+    assets: { entries: [{ path: "slides/页.png", present: true }] },
+  };
+  const files = new Map([
+    ["openmaic-video-manifest.json", Buffer.from(JSON.stringify(manifest))],
+    ["index.html", Buffer.from('<script src="assets/vendor/gsap.min.js"></script>')],
+    ["assets/vendor/gsap.min.js", Buffer.from("gsap")],
+    ["assets/slides/页.png", Buffer.from("image")],
+  ]);
+  for (const [relative, bytes] of files) await writeFile(join(root, relative), bytes);
+  const identity = (path: string) => ({
+    path,
+    size: files.get(path)!.length,
+    sha256: hash(files.get(path)!),
+  });
+  const carrier = {
+    schema: "openmaic.sourceStaticPlan",
+    version: 1,
+    planner: "openmaic-slide-snapshot-v1",
+    producer: { package: "@hyperframes/producer", version: SOURCE_STATIC_PLAN_PRODUCER_VERSION },
+    burnInSubtitles: false,
+    fps: { num: 30, den: 1 },
+    timeline: {
+      schema: manifest.schema,
+      version: manifest.version,
+      compiler: manifest.compiler,
+      stageId: "stage",
+      durationMs: 10_000,
+      totalFrames: 300,
+    },
+    intervals: [
+      {
+        startMs: 1000,
+        endMs: 2000,
+        startFrame: 30,
+        endExclusiveFrame: 60,
+        sceneId: "scene",
+        sceneIndex: 0,
+        sceneType: "slide",
+        baseKind: "slide-snapshot",
+        assetRef: "slides/页.png",
+      },
+    ],
+    rejectedSceneReasons: {},
+    excludedFrameReasons: {},
+    identity: {
+      manifest: identity("openmaic-video-manifest.json"),
+      indexHtml: identity("index.html"),
+      gsapVendorPath: "assets/vendor/gsap.min.js",
+      runtimeDependencies: [identity("assets/vendor/gsap.min.js")],
+      sourceAssets: [
+        {
+          assetRef: "slides/页.png",
+          zipEntry: "assets/slides/页.png",
+          size: files.get("assets/slides/页.png")!.length,
+          sha256: hash(files.get("assets/slides/页.png")!),
+        },
+      ],
+    },
+  };
+  await writeFile(join(root, "openmaic-source-static-plan.json"), `${JSON.stringify(carrier)}\n`);
+  return { root, carrier };
+}
+
+export function eligibility(
+  root: string,
+  overrides: Partial<StaticPlanInput> = {},
+): StaticPlanInput {
+  return {
+    enabled: true,
+    projectDir: root,
+    producerVersion: SOURCE_STATIC_PLAN_PRODUCER_VERSION,
+    fps: { num: 30, den: 1 },
+    totalFrames: 300,
+    initialDirectSdrDiskEligible: true,
+    capturePlanKind: "sdr_disk",
+    workerCount: 1,
+    chunked: false,
+    captureMode: "beginframe",
+    forceScreenshot: false,
+    workerEncodeEnabled: false,
+    staticDedupEnabled: false,
+    staticDedupArmed: false,
+    ...overrides,
+  };
+}

--- a/packages/producer/src/services/render/__test_utils__/sourceStaticPlanFixture.ts
+++ b/packages/producer/src/services/render/__test_utils__/sourceStaticPlanFixture.ts
@@ -95,6 +95,7 @@ export function eligibility(
   return {
     enabled: true,
     projectDir: root,
+    entryFile: "index.html",
     producerVersion: SOURCE_STATIC_PLAN_PRODUCER_VERSION,
     fps: { num: 30, den: 1 },
     totalFrames: 300,

--- a/packages/producer/src/services/render/sourceStaticPlan.test.ts
+++ b/packages/producer/src/services/render/sourceStaticPlan.test.ts
@@ -1,0 +1,350 @@
+import { fixture, eligibility } from "./__test_utils__/sourceStaticPlanFixture.js";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  executeOpenMaicDiskSchedule,
+  resolveOpenMaicStaticPlan,
+  verifyDenseFrameDirectory,
+} from "./sourceStaticPlan.js";
+
+const scratch: string[] = [];
+const hash = (bytes: Uint8Array) => createHash("sha256").update(bytes).digest("hex");
+
+afterEach(async () => {
+  await Promise.all(scratch.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("producer sdr_disk static-plan owner", () => {
+  it.each(["", "[]", "[{}]", "{}", "null"])(
+    "rejects malformed carrier %s before optimization",
+    async (bytes) => {
+      const { root } = await fixture(scratch);
+      await writeFile(join(root, "openmaic-source-static-plan.json"), bytes);
+      expect((await resolveOpenMaicStaticPlan(eligibility(root))).mode).toBe("baseline");
+    },
+  );
+  it("rejects copied frame corruption instead of settling an incomplete optimization", async () => {
+    const root = await mkdtemp(join(tmpdir(), "native-corrupt-copy-"));
+    scratch.push(root);
+    await expect(
+      executeOpenMaicDiskSchedule({
+        schedule: { items: [{ startFrame: 0, durationFrames: 2 }] },
+        framesDir: root,
+        extension: "jpg",
+        assertNotAborted() {},
+        reportFrame() {},
+        async capture() {
+          await writeFile(join(root, "frame_000000.jpg"), "anchor");
+        },
+        operations: {
+          async link() {
+            throw Object.assign(new Error("cross device"), { code: "EXDEV" });
+          },
+          async copyFile(_source, destination) {
+            await writeFile(destination, "corrupt");
+          },
+        },
+      }),
+    ).rejects.toThrow("copied frame identity mismatch");
+  });
+
+  it("keeps default-off on the complete duration-one schedule without reading a carrier", async () => {
+    const result = await resolveOpenMaicStaticPlan(
+      eligibility("/missing", { enabled: false, totalFrames: 4 }),
+    );
+    expect(result).toMatchObject({ mode: "baseline", reason: "disabled" });
+    expect(result.items).toEqual(
+      Array.from({ length: 4 }, (_, startFrame) => ({ startFrame, durationFrames: 1 })),
+    );
+  });
+
+  it("accepts a valid carrier and creates a complete schedule", async () => {
+    const { root } = await fixture(scratch);
+    const result = await resolveOpenMaicStaticPlan(eligibility(root));
+    expect(result.mode).toBe("optimized");
+    expect(result.items.reduce((sum, item) => sum + item.durationFrames, 0)).toBe(300);
+    expect(result.items).toContainEqual({ startFrame: 30, durationFrames: 30 });
+  });
+
+  it("reads identities from the extracted project root, not the browser compiled directory", async () => {
+    const { root } = await fixture(scratch);
+    const compiledDir = await mkdtemp(join(tmpdir(), "openmaic-static-compiled-"));
+    scratch.push(compiledDir);
+    await writeFile(join(compiledDir, "index.html"), "<p>compiled browser document only</p>");
+
+    await expect(resolveOpenMaicStaticPlan(eligibility(root))).resolves.toMatchObject({
+      mode: "optimized",
+    });
+    await expect(resolveOpenMaicStaticPlan(eligibility(compiledDir))).resolves.toMatchObject({
+      mode: "baseline",
+      reason: "carrier_unreadable",
+    });
+  });
+
+  it("falls back for a validly shaped carrier with zero coverage", async () => {
+    const { root, carrier } = await fixture(scratch);
+    carrier.intervals = [];
+    carrier.identity.sourceAssets = [];
+    await writeFile(join(root, "openmaic-source-static-plan.json"), `${JSON.stringify(carrier)}\n`);
+    await expect(resolveOpenMaicStaticPlan(eligibility(root))).resolves.toMatchObject({
+      mode: "baseline",
+      reason: "zero_coverage",
+    });
+  });
+
+  it.each([
+    ["wrong backend", { capturePlanKind: "sdr_streaming" }],
+    ["initial streaming provenance", { initialDirectSdrDiskEligible: false }],
+    ["wrong fps", { fps: { num: 60, den: 1 } }],
+    ["screenshot", { captureMode: "screenshot" }],
+    ["force screenshot", { forceScreenshot: true }],
+    ["pipelined", { workerEncodeEnabled: true }],
+    ["multi-worker", { workerCount: 2 }],
+    ["chunk frame range", { frameRange: { startFrame: 0, endFrame: 300 } }],
+    ["HF static dedup enabled", { staticDedupEnabled: true }],
+    ["HF static dedup", { staticDedupArmed: true }],
+  ])("falls back before capture for %s", async (_label, patch) => {
+    const { root } = await fixture(scratch);
+    const result = await resolveOpenMaicStaticPlan(eligibility(root, patch));
+    expect(result.mode).toBe("baseline");
+    expect(result.items).toHaveLength(300);
+  });
+
+  it("rejects the whole carrier on identity drift instead of accepting a subset", async () => {
+    const { root } = await fixture(scratch);
+    await writeFile(join(root, "assets/vendor/gsap.min.js"), "altered");
+    const result = await resolveOpenMaicStaticPlan(eligibility(root));
+    expect(result).toMatchObject({ mode: "baseline", reason: "file_identity_mismatch" });
+    expect(result.items.every((item) => item.durationFrames === 1)).toBe(true);
+  });
+
+  it("rejects external executable/font closure exactly like the packaging owner", async () => {
+    const { root, carrier } = await fixture(scratch);
+    const index = Buffer.from(
+      '<script src="assets/vendor/gsap.min.js"></script><script src="https://example.com/runtime.js"></script>',
+    );
+    await writeFile(join(root, "index.html"), index);
+    carrier.identity.indexHtml = {
+      path: "index.html",
+      size: index.length,
+      sha256: hash(index),
+    };
+    await writeFile(join(root, "openmaic-source-static-plan.json"), `${JSON.stringify(carrier)}\n`);
+
+    await expect(resolveOpenMaicStaticPlan(eligibility(root))).resolves.toMatchObject({
+      mode: "baseline",
+      reason: "external_runtime_dependency",
+    });
+  });
+
+  it.each([
+    ["manifest", "openmaic-video-manifest.json"],
+    ["index", "index.html"],
+    ["source asset", "assets/slides/页.png"],
+  ])("rejects the whole carrier when %s bytes drift", async (_label, path) => {
+    const { root } = await fixture(scratch);
+    await writeFile(join(root, path), "altered");
+    const result = await resolveOpenMaicStaticPlan(eligibility(root));
+    expect(result.mode).toBe("baseline");
+    expect(result.items).toHaveLength(300);
+    expect(result.items.every((item) => item.durationFrames === 1)).toBe(true);
+  });
+
+  it("rejects non-exact time-to-frame identity and overlapping intervals as whole plans", async () => {
+    const first = await fixture(scratch);
+    first.carrier.intervals[0]!.startFrame = 31;
+    await writeFile(
+      join(first.root, "openmaic-source-static-plan.json"),
+      `${JSON.stringify(first.carrier)}\n`,
+    );
+    await expect(resolveOpenMaicStaticPlan(eligibility(first.root))).resolves.toMatchObject({
+      mode: "baseline",
+      reason: "scene_asset_binding",
+    });
+
+    const second = await fixture(scratch);
+    second.carrier.intervals.push({
+      ...second.carrier.intervals[0]!,
+      startMs: 1500,
+      endMs: 2500,
+      startFrame: 45,
+      endExclusiveFrame: 75,
+    });
+    await writeFile(
+      join(second.root, "openmaic-source-static-plan.json"),
+      `${JSON.stringify(second.carrier)}\n`,
+    );
+    await expect(resolveOpenMaicStaticPlan(eligibility(second.root))).resolves.toMatchObject({
+      mode: "baseline",
+      reason: "interval_structure",
+    });
+  });
+
+  it("materializes dense frames and advances logical progress", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openmaic-static-frames-"));
+    scratch.push(root);
+    const progress: number[] = [];
+    const result = await executeOpenMaicDiskSchedule({
+      schedule: {
+        items: [
+          { startFrame: 0, durationFrames: 3 },
+          { startFrame: 3, durationFrames: 1 },
+        ],
+      },
+      framesDir: root,
+      extension: "jpg",
+      assertNotAborted() {},
+      async capture(index) {
+        await writeFile(
+          join(root, `frame_${String(index).padStart(6, "0")}.jpg`),
+          `frame-${index}`,
+        );
+      },
+      async reportFrame(index) {
+        progress.push(index + 1);
+      },
+    });
+    expect(result).toEqual({ physicalCaptures: 2, linkedFrames: 2, copiedFrames: 0 });
+    expect(progress).toEqual([1, 2, 3, 4]);
+    await expect(verifyDenseFrameDirectory(root, 4, "jpg")).resolves.toBeUndefined();
+    expect(await readFile(join(root, "frame_000002.jpg"), "utf8")).toBe("frame-0");
+  });
+
+  it.each([
+    {
+      label: "static -> video",
+      totalFrames: 9,
+      activeStart: 3,
+      activeEnd: 6,
+      items: [
+        { startFrame: 0, durationFrames: 3 },
+        ...Array.from({ length: 6 }, (_, offset) => ({
+          startFrame: offset + 3,
+          durationFrames: 1,
+        })),
+      ],
+      expectedCaptures: [0, 3, 4, 5, 6, 7, 8],
+    },
+    {
+      label: "video -> static",
+      totalFrames: 9,
+      activeStart: 0,
+      activeEnd: 3,
+      items: [
+        { startFrame: 0, durationFrames: 1 },
+        { startFrame: 1, durationFrames: 1 },
+        { startFrame: 2, durationFrames: 1 },
+        { startFrame: 3, durationFrames: 3 },
+        { startFrame: 6, durationFrames: 1 },
+        { startFrame: 7, durationFrames: 1 },
+        { startFrame: 8, durationFrames: 1 },
+      ],
+      expectedCaptures: [0, 1, 2, 3, 6, 7, 8],
+    },
+    {
+      label: "static -> video -> static",
+      totalFrames: 12,
+      activeStart: 3,
+      activeEnd: 6,
+      items: [
+        { startFrame: 0, durationFrames: 3 },
+        { startFrame: 3, durationFrames: 1 },
+        { startFrame: 4, durationFrames: 1 },
+        { startFrame: 5, durationFrames: 1 },
+        { startFrame: 6, durationFrames: 3 },
+        { startFrame: 9, durationFrames: 1 },
+        { startFrame: 10, durationFrames: 1 },
+        { startFrame: 11, durationFrames: 1 },
+      ],
+      expectedCaptures: [0, 3, 4, 5, 6, 9, 10, 11],
+    },
+  ])(
+    "preserves absolute-time video injector update/clear semantics for $label",
+    async ({ totalFrames, activeStart, activeEnd, items, expectedCaptures }) => {
+      const root = await mkdtemp(join(tmpdir(), "openmaic-static-video-boundaries-"));
+      scratch.push(root);
+      const captures: number[] = [];
+      const activeVideoFrames: { index: number; timeSeconds: number; active: boolean }[] = [];
+      const progress: number[] = [];
+      await executeOpenMaicDiskSchedule({
+        schedule: { items },
+        framesDir: root,
+        extension: "jpg",
+        assertNotAborted() {},
+        async capture(index) {
+          captures.push(index);
+          // captureFrame receives absolute timeline time in the generated owner;
+          // model the unchanged producer injector's update/clear decision at that time.
+          activeVideoFrames.push({
+            index,
+            timeSeconds: index / 30,
+            active: index >= activeStart && index < activeEnd,
+          });
+          await writeFile(join(root, `frame_${String(index).padStart(6, "0")}.jpg`), `f-${index}`);
+        },
+        reportFrame(index) {
+          progress.push(index + 1);
+        },
+      });
+
+      expect(captures).toEqual(expectedCaptures);
+      expect(activeVideoFrames).toEqual(
+        expectedCaptures.map((index) => ({
+          index,
+          timeSeconds: index / 30,
+          active: index >= activeStart && index < activeEnd,
+        })),
+      );
+      expect(progress).toEqual(Array.from({ length: totalFrames }, (_, index) => index + 1));
+      await expect(verifyDenseFrameDirectory(root, totalFrames, "jpg")).resolves.toBeUndefined();
+    },
+  );
+
+  it("uses only an allowed copy fallback and rejects unexpected link failure", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openmaic-static-copy-"));
+    scratch.push(root);
+    const exdev = Object.assign(new Error("cross-device"), { code: "EXDEV" });
+    const copied = await executeOpenMaicDiskSchedule({
+      schedule: { items: [{ startFrame: 0, durationFrames: 2 }] },
+      framesDir: root,
+      extension: "jpg",
+      assertNotAborted() {},
+      async capture() {
+        await writeFile(join(root, "frame_000000.jpg"), "anchor");
+      },
+      async reportFrame() {},
+      operations: {
+        async link() {
+          throw exdev;
+        },
+      },
+    });
+    expect(copied.copiedFrames).toBe(1);
+
+    const second = await mkdtemp(join(tmpdir(), "openmaic-static-failure-"));
+    scratch.push(second);
+    const eio = Object.assign(new Error("io"), { code: "EIO" });
+    await expect(
+      executeOpenMaicDiskSchedule({
+        schedule: { items: [{ startFrame: 0, durationFrames: 2 }] },
+        framesDir: second,
+        extension: "jpg",
+        assertNotAborted() {},
+        async capture() {
+          await writeFile(join(second, "frame_000000.jpg"), "anchor");
+        },
+        async reportFrame() {},
+        operations: {
+          async link() {
+            throw eio;
+          },
+        },
+      }),
+    ).rejects.toMatchObject({ code: "EIO" });
+    await rm(second, { recursive: true, force: true });
+    await expect(stat(second)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/packages/producer/src/services/render/sourceStaticPlan.test.ts
+++ b/packages/producer/src/services/render/sourceStaticPlan.test.ts
@@ -84,6 +84,18 @@ describe("producer sdr_disk static-plan owner", () => {
     });
   });
 
+  it.each([undefined, "alternate.html", "./index.html"])(
+    "rejects an unbound or unsupported render entry %s despite valid index identities",
+    async (entryFile) => {
+      const { root } = await fixture(scratch);
+      const result = await resolveOpenMaicStaticPlan(eligibility(root, { entryFile }));
+      expect(result).toMatchObject({ mode: "baseline", reason: "unsupported_entry_file" });
+      expect(result.items).toEqual(
+        Array.from({ length: 300 }, (_, startFrame) => ({ startFrame, durationFrames: 1 })),
+      );
+    },
+  );
+
   it("falls back for a validly shaped carrier with zero coverage", async () => {
     const { root, carrier } = await fixture(scratch);
     carrier.intervals = [];

--- a/packages/producer/src/services/render/sourceStaticPlan.ts
+++ b/packages/producer/src/services/render/sourceStaticPlan.ts
@@ -76,6 +76,8 @@ interface Manifest {
 export interface StaticPlanInput {
   enabled?: boolean;
   projectDir?: string;
+  /** Resolved source entry selected by the pipeline, before compilation. */
+  entryFile?: string;
   producerVersion: string;
   fps: Fps;
   totalFrames: number;
@@ -313,6 +315,8 @@ export async function resolveOpenMaicStaticPlan(
 ): Promise<StaticPlanSchedule> {
   const fallback = (reason: string) => baseline(input.totalFrames, reason);
   if (input.enabled !== true) return fallback("disabled");
+  // This carrier binds the root index.html, not arbitrary alternate entries.
+  if (input.entryFile !== "index.html") return fallback("unsupported_entry_file");
   if (input.initialDirectSdrDiskEligible !== true) return fallback("not_initial_direct_sdr_disk");
   if (input.capturePlanKind !== "sdr_disk") return fallback("wrong_backend");
   if (input.workerCount !== 1 || input.chunked === true || input.frameRange !== undefined) {

--- a/packages/producer/src/services/render/sourceStaticPlan.ts
+++ b/packages/producer/src/services/render/sourceStaticPlan.ts
@@ -1,0 +1,542 @@
+import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import { access, copyFile, link, lstat, readFile, readdir } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+
+import { version as producerVersion } from "../../../package.json";
+
+/** Match the carrier against this build's package version, not a version range. */
+export const SOURCE_STATIC_PLAN_PRODUCER_VERSION = producerVersion;
+interface Fps {
+  num: number;
+  den: number;
+}
+interface Identity {
+  path?: string;
+  zipEntry?: string;
+  size: number;
+  sha256: string;
+}
+interface AssetIdentity extends Identity {
+  assetRef: string;
+  zipEntry: string;
+}
+interface Interval {
+  startMs: number;
+  endMs: number;
+  startFrame: number;
+  endExclusiveFrame: number;
+  sceneId: string;
+  sceneIndex: number;
+  sceneType: string;
+  baseKind: string;
+  assetRef: string;
+}
+interface Carrier {
+  schema: string;
+  version: number;
+  planner: string;
+  producer: { package: string; version: string };
+  burnInSubtitles: boolean;
+  fps: Fps;
+  timeline: {
+    schema: string;
+    version: number;
+    compiler: string;
+    stageId: string;
+    durationMs: number;
+    totalFrames: number;
+  };
+  identity: {
+    manifest: Identity;
+    indexHtml: Identity;
+    runtimeDependencies: Identity[];
+    gsapVendorPath: string;
+    sourceAssets: AssetIdentity[];
+  };
+  intervals: Interval[];
+}
+interface Scene {
+  id: string;
+  index: number;
+  type: string;
+  startMs: number;
+  durationMs: number;
+  base: { kind: string; assetRef?: string };
+}
+interface Manifest {
+  schema: string;
+  version: number;
+  compiler: string;
+  stage: { id: string };
+  totalDurationMs: number;
+  scenes: Scene[];
+  assets: { entries: { present: boolean; path: string }[] };
+}
+export interface StaticPlanInput {
+  enabled?: boolean;
+  projectDir?: string;
+  producerVersion: string;
+  fps: Fps;
+  totalFrames: number;
+  initialDirectSdrDiskEligible?: boolean;
+  capturePlanKind: string;
+  workerCount: number;
+  chunked?: boolean;
+  frameRange?: { startFrame: number; endFrame: number };
+  captureMode?: string;
+  forceScreenshot?: boolean;
+  workerEncodeEnabled?: boolean;
+  staticDedupEnabled?: boolean;
+  staticDedupArmed?: boolean;
+}
+export interface ScheduleItem {
+  startFrame: number;
+  durationFrames: number;
+}
+export interface StaticPlanSchedule {
+  mode: "baseline" | "optimized";
+  reason: string;
+  items: ScheduleItem[];
+  carrierSha256?: string;
+}
+interface FileOperations {
+  link: typeof link;
+  copyFile: typeof copyFile;
+}
+export interface DiskScheduleInput {
+  schedule: Pick<StaticPlanSchedule, "items">;
+  framesDir: string;
+  extension: "jpg" | "png";
+  assertNotAborted: () => void;
+  capture: (index: number) => Promise<unknown>;
+  reportFrame: (index: number) => void;
+  operations?: Partial<FileOperations>;
+}
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function identity(value: unknown): value is Identity {
+  return (
+    record(value) &&
+    typeof value.size === "number" &&
+    typeof value.sha256 === "string" &&
+    (value.path === undefined || typeof value.path === "string") &&
+    (value.zipEntry === undefined || typeof value.zipEntry === "string")
+  );
+}
+function assetIdentity(value: unknown): value is AssetIdentity {
+  return (
+    identity(value) &&
+    "assetRef" in value &&
+    typeof value.assetRef === "string" &&
+    typeof value.zipEntry === "string"
+  );
+}
+function interval(value: unknown): value is Interval {
+  return (
+    record(value) &&
+    ["startMs", "endMs", "startFrame", "endExclusiveFrame", "sceneIndex"].every(
+      (k) => typeof value[k] === "number",
+    ) &&
+    ["sceneId", "sceneType", "baseKind", "assetRef"].every((k) => typeof value[k] === "string")
+  );
+}
+function carrierShape(value: unknown): value is Carrier {
+  if (
+    !record(value) ||
+    !record(value.producer) ||
+    !record(value.fps) ||
+    !record(value.timeline) ||
+    !record(value.identity)
+  )
+    return false;
+  const { producer, fps, timeline, identity: ids } = value;
+  return (
+    typeof value.schema === "string" &&
+    typeof value.version === "number" &&
+    typeof value.planner === "string" &&
+    typeof value.burnInSubtitles === "boolean" &&
+    typeof producer.package === "string" &&
+    typeof producer.version === "string" &&
+    typeof fps.num === "number" &&
+    typeof fps.den === "number" &&
+    ["schema", "compiler", "stageId"].every((k) => typeof timeline[k] === "string") &&
+    ["version", "durationMs", "totalFrames"].every((k) => typeof timeline[k] === "number") &&
+    identity(ids.manifest) &&
+    identity(ids.indexHtml) &&
+    typeof ids.gsapVendorPath === "string" &&
+    Array.isArray(ids.runtimeDependencies) &&
+    ids.runtimeDependencies.every(identity) &&
+    Array.isArray(ids.sourceAssets) &&
+    ids.sourceAssets.every(assetIdentity) &&
+    Array.isArray(value.intervals) &&
+    value.intervals.every(interval)
+  );
+}
+function scene(value: unknown): value is Scene {
+  return (
+    record(value) &&
+    typeof value.id === "string" &&
+    typeof value.type === "string" &&
+    ["index", "startMs", "durationMs"].every((k) => typeof value[k] === "number") &&
+    record(value.base) &&
+    typeof value.base.kind === "string" &&
+    (value.base.assetRef === undefined || typeof value.base.assetRef === "string")
+  );
+}
+function manifestShape(value: unknown): value is Manifest {
+  return (
+    record(value) &&
+    typeof value.schema === "string" &&
+    typeof value.version === "number" &&
+    typeof value.compiler === "string" &&
+    typeof value.totalDurationMs === "number" &&
+    record(value.stage) &&
+    typeof value.stage.id === "string" &&
+    Array.isArray(value.scenes) &&
+    value.scenes.every(scene) &&
+    record(value.assets) &&
+    Array.isArray(value.assets.entries) &&
+    value.assets.entries.every(
+      (a) => record(a) && typeof a.present === "boolean" && typeof a.path === "string",
+    )
+  );
+}
+class InvalidStaticPlan extends Error {}
+
+export const CARRIER_PATH = "openmaic-source-static-plan.json";
+const ALLOWED_COPY_CODES = new Set(["EXDEV", "EPERM", "EACCES", "ENOTSUP"]);
+const SUPPORTED_FPS = new Set(["24/1", "30/1", "60/1"]);
+const HASH = /^[a-f0-9]{64}$/;
+
+function sha256(bytes: Uint8Array) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function baseline(totalFrames: number, reason: string): StaticPlanSchedule {
+  return {
+    mode: "baseline",
+    reason,
+    items: Array.from({ length: totalFrames }, (_, startFrame) => ({
+      startFrame,
+      durationFrames: 1,
+    })),
+  };
+}
+
+function fail(reason: string): never {
+  throw new InvalidStaticPlan(reason);
+}
+
+function safeEntry(root: string, entry: string | undefined) {
+  if (
+    typeof entry !== "string" ||
+    entry.length === 0 ||
+    entry.includes("\\") ||
+    entry.startsWith("/")
+  ) {
+    fail("unsafe_path");
+  }
+  const target = resolve(root, entry);
+  const rel = relative(resolve(root), target);
+  if (rel.startsWith("..") || (rel === "" && entry !== ".")) fail("unsafe_path");
+  return target;
+}
+
+async function verifyFile(root: string, identity: Identity) {
+  if (
+    !identity ||
+    !Number.isSafeInteger(identity.size) ||
+    identity.size < 0 ||
+    !HASH.test(identity.sha256)
+  ) {
+    fail("malformed_identity");
+  }
+  const path = safeEntry(root, identity.path ?? identity.zipEntry);
+  const info = await lstat(path).catch(() => null);
+  if (!info?.isFile() || info.isSymbolicLink() || info.size !== identity.size)
+    fail("file_identity_mismatch");
+  const bytes = await readFile(path);
+  if (sha256(bytes) !== identity.sha256) fail("file_identity_mismatch");
+  return bytes;
+}
+
+function totalFramesForDurationMs(durationMs: number, fps: Fps) {
+  const r = BigInt(durationMs) * BigInt(fps.num);
+  const q = 1000n * BigInt(fps.den);
+  const nearest = (2n * r + q) / (2n * q);
+  const delta = r >= nearest * q ? r - nearest * q : nearest * q - r;
+  return Number(delta * 1000n <= q ? nearest : (r + q - 1n) / q);
+}
+
+function frameAtOrAfter(ms: number, fps: Fps) {
+  const r = BigInt(ms) * BigInt(fps.num);
+  const q = 1000n * BigInt(fps.den);
+  return Number((r + q - 1n) / q);
+}
+
+function referencedRuntimePaths(indexBytes: Buffer) {
+  const html = indexBytes.toString("utf8");
+  const paths = new Set<string>();
+  for (const match of html.matchAll(/(?:(?:src|href)=|url\()["']?([^"')]+)["']?\)?/g)) {
+    const path = match[1];
+    if (path === undefined) continue;
+    if (!/\.(?:js|css|woff2?|ttf|otf)(?:\?|$)/i.test(path)) continue;
+    if (/^(?:https?:|\/\/)/i.test(path)) fail("external_runtime_dependency");
+    if (path.startsWith("data:")) continue;
+    paths.add(path.replace(/^\.\//, ""));
+  }
+  return [...paths].sort();
+}
+
+function buildSchedule(intervals: Interval[], totalFrames: number) {
+  const items: ScheduleItem[] = [];
+  let cursor = 0;
+  for (const interval of intervals) {
+    while (cursor < interval.startFrame) items.push({ startFrame: cursor++, durationFrames: 1 });
+    items.push({
+      startFrame: interval.startFrame,
+      durationFrames: interval.endExclusiveFrame - interval.startFrame,
+    });
+    cursor = interval.endExclusiveFrame;
+  }
+  while (cursor < totalFrames) items.push({ startFrame: cursor++, durationFrames: 1 });
+  if (items.reduce((sum, item) => sum + item.durationFrames, 0) !== totalFrames)
+    fail("schedule_coverage");
+  return items;
+}
+
+/** Complete pre-capture validation. A rejection always returns the dense baseline schedule. */
+export async function resolveOpenMaicStaticPlan(
+  input: StaticPlanInput,
+): Promise<StaticPlanSchedule> {
+  const fallback = (reason: string) => baseline(input.totalFrames, reason);
+  if (input.enabled !== true) return fallback("disabled");
+  if (input.initialDirectSdrDiskEligible !== true) return fallback("not_initial_direct_sdr_disk");
+  if (input.capturePlanKind !== "sdr_disk") return fallback("wrong_backend");
+  if (input.workerCount !== 1 || input.chunked === true || input.frameRange !== undefined) {
+    return fallback("unsupported_parallel_or_chunk_path");
+  }
+  if (
+    input.captureMode !== "beginframe" ||
+    input.forceScreenshot === true ||
+    input.workerEncodeEnabled === true
+  ) {
+    return fallback("unsupported_capture_mode");
+  }
+  if (input.staticDedupEnabled === true || input.staticDedupArmed === true)
+    return fallback("hf_static_dedup_armed");
+
+  try {
+    if (!input.projectDir) return fallback("carrier_unreadable");
+    const carrierPath = safeEntry(input.projectDir, CARRIER_PATH);
+    const carrierBytes = await readFile(carrierPath);
+    const carrier: unknown = JSON.parse(carrierBytes.toString("utf8"));
+    if (!carrierShape(carrier)) fail("malformed_carrier");
+    if (
+      carrier.schema !== "openmaic.sourceStaticPlan" ||
+      carrier.version !== 1 ||
+      carrier.planner !== "openmaic-slide-snapshot-v1"
+    )
+      fail("schema");
+    if (
+      carrier.producer?.package !== "@hyperframes/producer" ||
+      carrier.producer?.version !== input.producerVersion
+    )
+      fail("producer_identity");
+    if (carrier.burnInSubtitles !== false) fail("burn_in_subtitles");
+    if (!SUPPORTED_FPS.has(`${input.fps.num}/${input.fps.den}`)) fail("fps");
+    if (carrier.fps?.num !== input.fps.num || carrier.fps?.den !== input.fps.den)
+      fail("fps_identity");
+    if (!Number.isSafeInteger(carrier.timeline?.durationMs) || carrier.timeline.durationMs < 0)
+      fail("timeline_duration");
+    if (
+      carrier.timeline.totalFrames !== input.totalFrames ||
+      totalFramesForDurationMs(carrier.timeline.durationMs, input.fps) !== input.totalFrames
+    )
+      fail("total_frames");
+
+    const manifestBytes = await verifyFile(input.projectDir, carrier.identity?.manifest);
+    const indexBytes = await verifyFile(input.projectDir, carrier.identity?.indexHtml);
+    if (
+      carrier.identity?.manifest?.path !== "openmaic-video-manifest.json" ||
+      carrier.identity?.indexHtml?.path !== "index.html"
+    )
+      fail("runtime_closure");
+    if (
+      !Array.isArray(carrier.identity?.runtimeDependencies) ||
+      carrier.identity.runtimeDependencies.length === 0
+    )
+      fail("runtime_closure");
+    const runtimePaths = carrier.identity.runtimeDependencies.map((identity) => identity.path);
+    if (
+      typeof carrier.identity.gsapVendorPath !== "string" ||
+      !runtimePaths.includes(carrier.identity.gsapVendorPath)
+    )
+      fail("runtime_closure");
+    if (JSON.stringify(runtimePaths) !== JSON.stringify([...new Set(runtimePaths)].sort()))
+      fail("runtime_closure");
+    for (const identity of carrier.identity.runtimeDependencies)
+      await verifyFile(input.projectDir, identity);
+    if (JSON.stringify(runtimePaths) !== JSON.stringify(referencedRuntimePaths(indexBytes)))
+      fail("runtime_closure");
+    if (!Array.isArray(carrier.identity?.sourceAssets)) fail("asset_closure");
+    const assets = new Map<string, AssetIdentity>();
+    for (const identity of carrier.identity.sourceAssets) {
+      if (
+        assets.has(identity.assetRef) ||
+        identity.zipEntry !== `assets/${identity.assetRef}` ||
+        identity.assetRef?.includes("\\") ||
+        identity.assetRef?.startsWith("/") ||
+        identity.assetRef?.split("/").includes("..")
+      )
+        fail("asset_closure");
+      await verifyFile(input.projectDir, identity);
+      assets.set(identity.assetRef, identity);
+    }
+    if (JSON.stringify([...assets.keys()]) !== JSON.stringify([...assets.keys()].sort()))
+      fail("asset_closure");
+    const manifest: unknown = JSON.parse(manifestBytes.toString("utf8"));
+    if (!manifestShape(manifest)) fail("malformed_manifest");
+    if (
+      manifest.schema !== carrier.timeline.schema ||
+      manifest.version !== carrier.timeline.version ||
+      manifest.compiler !== carrier.timeline.compiler ||
+      manifest.stage?.id !== carrier.timeline.stageId ||
+      manifest.totalDurationMs !== carrier.timeline.durationMs
+    )
+      fail("timeline_identity");
+    const scenes = new Map((manifest.scenes ?? []).map((scene) => [scene.id, scene]));
+    const presentManifestAssets = new Set(
+      (manifest.assets?.entries ?? [])
+        .filter((asset) => asset.present === true)
+        .map((asset) => asset.path),
+    );
+    const intervals = carrier.intervals;
+    if (!Array.isArray(intervals) || intervals.length === 0) fail("zero_coverage");
+    let previousEnd = 0;
+    for (const interval of intervals) {
+      if (
+        !Number.isSafeInteger(interval.startMs) ||
+        !Number.isSafeInteger(interval.endMs) ||
+        !Number.isSafeInteger(interval.startFrame) ||
+        !Number.isSafeInteger(interval.endExclusiveFrame) ||
+        interval.startMs < 0 ||
+        interval.endMs <= interval.startMs ||
+        interval.endMs > carrier.timeline.durationMs ||
+        interval.startFrame < previousEnd ||
+        interval.endExclusiveFrame <= interval.startFrame ||
+        interval.endExclusiveFrame > input.totalFrames
+      )
+        fail("interval_structure");
+      const scene = scenes.get(interval.sceneId);
+      if (
+        !scene ||
+        scene.index !== interval.sceneIndex ||
+        scene.type !== "slide" ||
+        scene.base?.kind !== "slide-snapshot" ||
+        scene.base.assetRef !== interval.assetRef ||
+        interval.sceneType !== "slide" ||
+        interval.baseKind !== "slide-snapshot" ||
+        interval.startMs < scene.startMs ||
+        interval.endMs > scene.startMs + scene.durationMs ||
+        interval.startFrame !== frameAtOrAfter(interval.startMs, input.fps) ||
+        interval.endExclusiveFrame !== frameAtOrAfter(interval.endMs, input.fps) ||
+        !assets.has(interval.assetRef) ||
+        !presentManifestAssets.has(interval.assetRef)
+      )
+        fail("scene_asset_binding");
+      previousEnd = interval.endExclusiveFrame;
+    }
+    const referenced = [...new Set(intervals.map((interval) => interval.assetRef))].sort();
+    if (JSON.stringify(referenced) !== JSON.stringify([...assets.keys()].sort()))
+      fail("asset_closure");
+    return {
+      mode: "optimized",
+      reason: "valid",
+      carrierSha256: sha256(carrierBytes),
+      items: buildSchedule(intervals, input.totalFrames),
+    };
+  } catch (error) {
+    return fallback(error instanceof InvalidStaticPlan ? error.message : "carrier_unreadable");
+  }
+}
+
+function frameName(index: number, extension: string) {
+  return `frame_${String(index).padStart(6, "0")}.${extension}`;
+}
+
+async function regularNonEmpty(path: string) {
+  const info = await lstat(path).catch(() => null);
+  return Boolean(info?.isFile() && !info.isSymbolicLink() && info.size > 0);
+}
+
+async function materializeOne(anchor: string, destination: string, operations: FileOperations) {
+  if (!(await regularNonEmpty(anchor)))
+    throw new Error("static-plan anchor is missing, empty, or non-regular");
+  if (await lstat(destination).catch(() => null))
+    throw new Error("static-plan destination already exists");
+  try {
+    await operations.link(anchor, destination);
+    return "link";
+  } catch (error) {
+    if (!record(error) || typeof error.code !== "string" || !ALLOWED_COPY_CODES.has(error.code))
+      throw error;
+    await operations.copyFile(anchor, destination, fsConstants.COPYFILE_EXCL);
+    const [anchorBytes, destinationBytes] = await Promise.all([
+      readFile(anchor),
+      readFile(destination),
+    ]);
+    if (
+      anchorBytes.byteLength !== destinationBytes.byteLength ||
+      sha256(anchorBytes) !== sha256(destinationBytes)
+    ) {
+      throw new Error("static-plan copied frame identity mismatch");
+    }
+    return "copy";
+  }
+}
+
+/** Optimized schedule consumer. Default-off and rejected plans stay on producer's original loop. */
+export async function executeOpenMaicDiskSchedule(input: DiskScheduleInput) {
+  const operations = { link, copyFile, ...(input.operations ?? {}) };
+  let physicalCaptures = 0;
+  let linkedFrames = 0;
+  let copiedFrames = 0;
+  for (const item of input.schedule.items) {
+    input.assertNotAborted();
+    await input.capture(item.startFrame);
+    physicalCaptures += 1;
+    input.reportFrame(item.startFrame);
+    const anchor = join(input.framesDir, frameName(item.startFrame, input.extension));
+    for (let offset = 1; offset < item.durationFrames; offset += 1) {
+      input.assertNotAborted();
+      const logicalFrame = item.startFrame + offset;
+      const destination = join(input.framesDir, frameName(logicalFrame, input.extension));
+      const method = await materializeOne(anchor, destination, operations);
+      if (method === "link") linkedFrames += 1;
+      else copiedFrames += 1;
+      input.reportFrame(logicalFrame);
+      input.assertNotAborted();
+    }
+  }
+  return { physicalCaptures, linkedFrames, copiedFrames };
+}
+
+export async function verifyDenseFrameDirectory(
+  framesDir: string,
+  totalFrames: number,
+  extension: string,
+) {
+  const names = (await readdir(framesDir)).sort();
+  const expected = Array.from({ length: totalFrames }, (_, index) => frameName(index, extension));
+  if (JSON.stringify(names) !== JSON.stringify(expected))
+    throw new Error("static-plan dense frame inventory mismatch");
+  for (const name of names) {
+    const path = join(framesDir, name);
+    if (!(await regularNonEmpty(path))) throw new Error(`invalid dense frame: ${name}`);
+    await access(path, fsConstants.R_OK);
+    if (dirname(path) !== resolve(framesDir)) throw new Error("dense frame path escaped framesDir");
+  }
+}

--- a/packages/producer/src/services/render/stages/captureStage.sourceStaticPlan.test.ts
+++ b/packages/producer/src/services/render/stages/captureStage.sourceStaticPlan.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { CaptureSession } from "@hyperframes/engine";
+import {
+  captureFrame,
+  closeCaptureSession,
+  initializeSession,
+  createCaptureSession,
+  resolveConfig,
+} from "@hyperframes/engine";
+import { createRenderJob } from "../../renderOrchestrator.js";
+import { createCapturePlan } from "../capturePlan.js";
+import { fixture } from "../__test_utils__/sourceStaticPlanFixture.js";
+import { runCaptureStage, type CaptureStageInput } from "./captureStage.js";
+
+vi.mock("@hyperframes/engine", async (original) => ({
+  ...(await original<typeof import("@hyperframes/engine")>()),
+  captureFrame: vi.fn(),
+  closeCaptureSession: vi.fn(),
+  initializeSession: vi.fn(),
+  createCaptureSession: vi.fn(() => {
+    throw new Error("unexpected browser creation");
+  }),
+  prepareCaptureSessionForReuse: vi.fn(),
+  verifyDiskDrawElementSamples: vi.fn(),
+  getCapturePerfSummary: vi.fn(() => ({})),
+}));
+const scratch: string[] = [];
+afterEach(async () => {
+  await Promise.all(scratch.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+async function input(enabled?: boolean) {
+  const { root } = await fixture(scratch);
+  const framesDir = join(root, "frames");
+  await mkdir(framesDir);
+  // The engine's browser-bearing session is replaced at its IO boundary only.
+  const session = {
+    options: { captureBeyondViewport: false },
+    browserConsoleBuffer: ["browser diagnostic"],
+    isInitialized: false,
+    captureMode: "beginframe",
+    staticDedupEnabled: false,
+    staticFrames: new Set<number>(),
+    workerEncodeEnabled: false,
+  } as unknown as CaptureSession;
+  vi.mocked(initializeSession).mockImplementation(async () => {
+    session.isInitialized = true;
+  });
+  vi.mocked(captureFrame).mockImplementation(async (_session, index, time) => {
+    const path = join(framesDir, `frame_${String(index).padStart(6, "0")}.jpg`);
+    await writeFile(path, `frame-${index}`);
+    return { path, frameIndex: index, time, captureTimeMs: 0 };
+  });
+  const plan = createCapturePlan({
+    workerCount: 1,
+    forceScreenshot: false,
+    forceParallelStream: false,
+    useStreamingEncode: false,
+    useLayeredComposite: false,
+    usePageSideCompositing: false,
+    hasHdrContent: false,
+    needsAlpha: false,
+    routing: { kind: "default" },
+  });
+  if (plan.kind !== "sdr_disk") throw new Error("fixture route");
+  const value: CaptureStageInput = {
+    sourceProjectDir: root,
+    initialDirectSdrDiskEligible: true,
+    sourceStaticPlanEnabled: enabled,
+    fileServer: { url: "http://unused.invalid" } as CaptureStageInput["fileServer"],
+    workDir: root,
+    framesDir,
+    job: createRenderJob({ fps: 30, quality: "standard" }),
+    totalFrames: 300,
+    cfg: resolveConfig(),
+    plan,
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    probeSession: session,
+    captureAttempts: [],
+    dedupPerfs: [],
+    // Current upstream checks disk headroom even when reusing a probe session.
+    buildCaptureOptions: () => ({ width: 64, height: 36, fps: { num: 30, den: 1 } }),
+    createRenderVideoFrameInjector: () => null,
+    abortSignal: undefined,
+    assertNotAborted() {},
+  };
+  return { value, session, root, framesDir };
+}
+describe("native capture stage source-static-plan integration", () => {
+  it.each([undefined, false])(
+    "default/OFF %s does not read carrier or scan the directory",
+    async (enabled) => {
+      const { value, framesDir } = await input(enabled);
+      value.sourceProjectDir = "/missing";
+      await writeFile(join(framesDir, "sentinel"), "OFF must not run optimized dense scan");
+      await runCaptureStage(value);
+      expect(captureFrame).toHaveBeenCalledTimes(300);
+      expect(value.log.info).not.toHaveBeenCalled();
+      expect(closeCaptureSession).toHaveBeenCalledTimes(1);
+      expect(createCaptureSession).not.toHaveBeenCalled();
+    },
+  );
+  it("captures anchors at absolute times, materializes exact dense files, and reports every logical frame", async () => {
+    const { value, session, framesDir } = await input(true);
+    const progress: number[] = [];
+    value.onProgress = (job) => {
+      progress.push(job.framesRendered ?? 0);
+    };
+    await runCaptureStage(value);
+    expect(initializeSession).toHaveBeenCalledBefore(vi.mocked(captureFrame));
+    expect(captureFrame).toHaveBeenCalledTimes(271);
+    expect(captureFrame).toHaveBeenCalledWith(session, 30, 1);
+    expect(captureFrame).toHaveBeenCalledWith(session, 60, 2);
+    expect(vi.mocked(captureFrame).mock.calls.some(([, i]) => i > 30 && i < 60)).toBe(false);
+    expect(progress).toEqual(Array.from({ length: 300 }, (_, i) => i + 1));
+    expect(await readFile(join(framesDir, "frame_000059.jpg"), "utf8")).toBe("frame-30");
+    expect(await readdir(framesDir)).toHaveLength(300);
+    expect(closeCaptureSession).toHaveBeenCalledTimes(1);
+  });
+  it.each(["provenance", "dedup-enabled", "dedup-armed", "carrier", "screenshot", "frame-range"])(
+    "%s rejects before writes and uses original loop without extra scan",
+    async (reason) => {
+      const { value, session, framesDir, root } = await input(true);
+      if (reason === "provenance") value.initialDirectSdrDiskEligible = false;
+      if (reason === "dedup-enabled") session.staticDedupEnabled = true;
+      if (reason === "dedup-armed") session.staticFrames = new Set([0]);
+      if (reason === "carrier")
+        await writeFile(join(root, "openmaic-source-static-plan.json"), "{}");
+      if (reason === "screenshot") session.captureMode = "screenshot";
+      if (reason === "frame-range") value.frameRange = { startFrame: 100, endFrame: 400 };
+      await writeFile(join(framesDir, "sentinel"), "no new dense scan on fallback");
+      await runCaptureStage(value);
+      expect(captureFrame).toHaveBeenCalledTimes(300);
+      if (reason === "frame-range")
+        expect(captureFrame).toHaveBeenNthCalledWith(1, session, 0, 100 / 30);
+      expect(closeCaptureSession).toHaveBeenCalledTimes(1);
+    },
+  );
+  it.each(["capture-error", "mode-drift", "destination-exists", "cancel", "dense-inventory"])(
+    "%s after optimized writes fails and closes, without baseline replay",
+    async (reason) => {
+      const { value, session, framesDir } = await input(true);
+      if (reason === "destination-exists")
+        await writeFile(join(framesDir, "frame_000031.jpg"), "existing");
+      if (reason === "dense-inventory") await writeFile(join(framesDir, "extra"), "extra");
+      const actual = vi.mocked(captureFrame).getMockImplementation()!;
+      vi.mocked(captureFrame).mockImplementation(async (...args) => {
+        const path = await actual(...args);
+        if (args[1] === 30) {
+          if (reason === "capture-error") throw new Error("injected capture IO failure");
+          if (reason === "mode-drift") session.captureMode = "screenshot";
+          if (reason === "cancel")
+            value.assertNotAborted = () => {
+              throw new Error("cancelled");
+            };
+        }
+        return path;
+      });
+      // Capture stage destructures assertNotAborted at entry, so read a shared flag at that real seam.
+      let cancelled = false;
+      if (reason === "cancel") {
+        value.onProgress = (job) => {
+          if (job.framesRendered === 31) cancelled = true;
+        };
+        value.assertNotAborted = () => {
+          if (cancelled) throw new Error("cancelled");
+        };
+      }
+      await expect(runCaptureStage(value)).rejects.toThrow();
+      expect(captureFrame).toHaveBeenCalledTimes(reason === "dense-inventory" ? 271 : 31);
+      expect(closeCaptureSession).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/packages/producer/src/services/render/stages/captureStage.sourceStaticPlan.test.ts
+++ b/packages/producer/src/services/render/stages/captureStage.sourceStaticPlan.test.ts
@@ -69,6 +69,7 @@ async function input(enabled?: boolean) {
   if (plan.kind !== "sdr_disk") throw new Error("fixture route");
   const value: CaptureStageInput = {
     sourceProjectDir: root,
+    sourceEntryFile: "index.html",
     initialDirectSdrDiskEligible: true,
     sourceStaticPlanEnabled: enabled,
     fileServer: { url: "http://unused.invalid" } as CaptureStageInput["fileServer"],
@@ -119,6 +120,29 @@ describe("native capture stage source-static-plan integration", () => {
     expect(progress).toEqual(Array.from({ length: 300 }, (_, i) => i + 1));
     expect(await readFile(join(framesDir, "frame_000059.jpg"), "utf8")).toBe("frame-30");
     expect(await readdir(framesDir)).toHaveLength(300);
+    expect(closeCaptureSession).toHaveBeenCalledTimes(1);
+  });
+  it("captures every frame of an alternate entry with the same fps and frame count", async () => {
+    const { value, session, framesDir, root } = await input(true);
+    await writeFile(
+      join(root, "alternate.html"),
+      '<div data-duration="10" style="animation: move 1s infinite"></div>',
+    );
+    value.job.config.entryFile = "alternate.html";
+    value.sourceEntryFile = "alternate.html";
+    const carrierBefore = await readFile(join(root, "openmaic-source-static-plan.json"));
+    // The browser IO fixture writes distinct bytes for each frame, including
+    // [30,60), where the unrelated index.html carrier would reuse frame 30.
+    await runCaptureStage(value);
+
+    expect(captureFrame).toHaveBeenCalledTimes(300);
+    expect(captureFrame).toHaveBeenCalledWith(session, 59, 59 / 30);
+    expect(await readFile(join(framesDir, "frame_000059.jpg"), "utf8")).toBe("frame-59");
+    expect(value.log.info).toHaveBeenCalledWith(
+      "[Render] OpenMAIC source static plan",
+      expect.objectContaining({ mode: "baseline", reason: "unsupported_entry_file" }),
+    );
+    expect(await readFile(join(root, "openmaic-source-static-plan.json"))).toEqual(carrierBefore);
     expect(closeCaptureSession).toHaveBeenCalledTimes(1);
   });
   it.each(["provenance", "dedup-enabled", "dedup-armed", "carrier", "screenshot", "frame-range"])(

--- a/packages/producer/src/services/render/stages/captureStage.ts
+++ b/packages/producer/src/services/render/stages/captureStage.ts
@@ -38,6 +38,12 @@
 
 import { statfsSync } from "node:fs";
 import {
+  executeOpenMaicDiskSchedule,
+  resolveOpenMaicStaticPlan,
+  verifyDenseFrameDirectory,
+  SOURCE_STATIC_PLAN_PRODUCER_VERSION,
+} from "../sourceStaticPlan.js";
+import {
   type BeforeCaptureHook,
   type CaptureOptions,
   type CapturePerfSummary,
@@ -67,6 +73,9 @@ import { updateJobStatus } from "../shared.js";
 import type { SdrDiskCapturePlan } from "../capturePlan.js";
 
 export interface CaptureStageInput {
+  sourceProjectDir?: string;
+  initialDirectSdrDiskEligible?: boolean;
+  sourceStaticPlanEnabled?: boolean;
   fileServer: FileServerHandle;
   workDir: string;
   framesDir: string;
@@ -368,12 +377,58 @@ export async function runCaptureStage(input: CaptureStageInput): Promise<Capture
         }
         await drainPrev();
       } else {
-        for (let i = 0; i < rangeFrames; i++) {
-          assertNotAborted();
-          const absoluteIdx = rangeStart + i;
-          const time = (absoluteIdx * job.config.fps.den) / job.config.fps.num;
-          await captureFrame(session, i, time);
-          reportFrame(i);
+        let openMaicSchedule = null;
+        if (input.sourceStaticPlanEnabled === true) {
+          openMaicSchedule = await resolveOpenMaicStaticPlan({
+            enabled: true,
+            projectDir: input.sourceProjectDir,
+            producerVersion: SOURCE_STATIC_PLAN_PRODUCER_VERSION,
+            fps: job.config.fps,
+            totalFrames: rangeFrames,
+            initialDirectSdrDiskEligible: input.initialDirectSdrDiskEligible,
+            capturePlanKind: plan.kind,
+            workerCount,
+            chunked: false,
+            frameRange,
+            captureMode: session.captureMode,
+            forceScreenshot,
+            workerEncodeEnabled: session.workerEncodeEnabled,
+            staticDedupEnabled: session.staticDedupEnabled === true,
+            staticDedupArmed: (session.staticFrames?.size ?? 0) > 0,
+          });
+          log.info("[Render] OpenMAIC source static plan", {
+            mode: openMaicSchedule.mode,
+            reason: openMaicSchedule.reason,
+            physicalItems: openMaicSchedule.items.length,
+            logicalFrames: rangeFrames,
+          });
+        }
+        if (openMaicSchedule?.mode === "optimized") {
+          const openMaicMaterialization = await executeOpenMaicDiskSchedule({
+            schedule: openMaicSchedule,
+            framesDir,
+            extension: needsAlpha ? "png" : "jpg",
+            assertNotAborted,
+            capture: async (fileIndex) => {
+              const absoluteIdx = rangeStart + fileIndex;
+              const time = (absoluteIdx * job.config.fps.den) / job.config.fps.num;
+              await captureFrame(session, fileIndex, time);
+              if (session.captureMode !== "beginframe") {
+                throw new Error("OpenMAIC static-plan capture mode drifted after optimized writes");
+              }
+            },
+            reportFrame,
+          });
+          log.info("[Render] OpenMAIC source static materialization", openMaicMaterialization);
+          await verifyDenseFrameDirectory(framesDir, rangeFrames, needsAlpha ? "png" : "jpg");
+        } else {
+          for (let i = 0; i < rangeFrames; i++) {
+            assertNotAborted();
+            const absoluteIdx = rangeStart + i;
+            const time = (absoluteIdx * job.config.fps.den) / job.config.fps.num;
+            await captureFrame(session, i, time);
+            reportFrame(i);
+          }
         }
       }
       // Sequential disk drawElement self-verification (PRINFRA-352 follow-up):

--- a/packages/producer/src/services/render/stages/captureStage.ts
+++ b/packages/producer/src/services/render/stages/captureStage.ts
@@ -74,6 +74,7 @@ import type { SdrDiskCapturePlan } from "../capturePlan.js";
 
 export interface CaptureStageInput {
   sourceProjectDir?: string;
+  sourceEntryFile?: string;
   initialDirectSdrDiskEligible?: boolean;
   sourceStaticPlanEnabled?: boolean;
   fileServer: FileServerHandle;
@@ -382,6 +383,7 @@ export async function runCaptureStage(input: CaptureStageInput): Promise<Capture
           openMaicSchedule = await resolveOpenMaicStaticPlan({
             enabled: true,
             projectDir: input.sourceProjectDir,
+            entryFile: input.sourceEntryFile,
             producerVersion: SOURCE_STATIC_PLAN_PRODUCER_VERSION,
             fps: job.config.fps,
             totalFrames: rangeFrames,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -3860,6 +3860,7 @@ async function executeRenderPipeline(input: {
             () =>
               runCaptureStage({
                 sourceProjectDir: projectDir,
+                sourceEntryFile: entryFile,
                 initialDirectSdrDiskEligible,
                 sourceStaticPlanEnabled: job.config.sourceStaticPlan?.enabled === true,
                 fileServer: activeFileServer,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -31,6 +31,7 @@
  * diagnostics).
  */
 
+import { rm } from "node:fs/promises";
 import {
   existsSync,
   mkdirSync,
@@ -320,6 +321,8 @@ export interface RenderConfig {
   debug?: boolean;
   /** Strict rejects correctness warnings; best-effort returns a qualified outcome. */
   strictness?: RenderStrictness;
+  /** Opt-in OpenMAIC slide-snapshot reuse; invalid/ineligible plans use dense capture. */
+  sourceStaticPlan?: { enabled: boolean };
   /** Entry HTML file relative to projectDir. Defaults to "index.html". */
   entryFile?: string;
   /** Full producer config. When provided, env vars are not read. */
@@ -2132,7 +2135,7 @@ export async function executeRenderJob(
       log.info("KEEP_TEMP=1 — leaving workDir on disk for inspection", { workDir });
       return;
     }
-    rmSync(workDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    return rm(workDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   try {
@@ -3477,6 +3480,8 @@ async function executeRenderPipeline(input: {
       needsAlpha,
       routing: captureRouting,
     });
+    // Preserve initial route provenance across streaming/HDR retry fallbacks.
+    const initialDirectSdrDiskEligible = capturePlan.kind === "sdr_disk";
     const syncCapturePlan = (): void => {
       workerCount = capturePlan.workerCount;
       captureForceScreenshot = capturePlan.forceScreenshot;
@@ -3854,6 +3859,9 @@ async function executeRenderPipeline(input: {
             captureStageObservationData({ needsAlpha: diskPlan.needsAlpha }),
             () =>
               runCaptureStage({
+                sourceProjectDir: projectDir,
+                initialDirectSdrDiskEligible,
+                sourceStaticPlanEnabled: job.config.sourceStaticPlan?.enabled === true,
                 fileServer: activeFileServer,
                 workDir,
                 framesDir,

--- a/packages/producer/src/services/renderOrchestrator.workDir.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.workDir.test.ts
@@ -145,6 +145,23 @@ function deferred() {
   return { promise, resolve };
 }
 describe("executeRenderJob workDir ownership", () => {
+  it.each([undefined, "index.html", "alternate.html"])(
+    "passes the selected render entry %s to the static-plan boundary",
+    async (entryFile) => {
+      const { root, job, output } = setup(true);
+      job.config.entryFile = entryFile;
+      if (entryFile === "alternate.html")
+        writeFileSync(join(root, entryFile), '<div data-duration="1">alternate</div>');
+      await executeRenderJob(job, root, output);
+      expect(runCaptureStage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceEntryFile: entryFile ?? "index.html",
+          sourceStaticPlanEnabled: true,
+        }),
+      );
+      expect(job.status).toBe("complete");
+    },
+  );
   it("does not grant direct-disk provenance to a streaming-unavailable fallback", async () => {
     const { root, job, output } = setup(true);
     if (!job.config.producerConfig) throw new Error("fixture config");

--- a/packages/producer/src/services/renderOrchestrator.workDir.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.workDir.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveConfig } from "@hyperframes/engine";
+import { createRenderJob, executeRenderJob } from "./renderOrchestrator.js";
+import { runCompileStage } from "./render/stages/compileStage.js";
+import { runCaptureStreamingStage } from "./render/stages/captureStreamingStage.js";
+import { runCaptureStage } from "./render/stages/captureStage.js";
+import { RenderExecutionContext } from "./render/renderExecutionContext.js";
+
+// Real orchestrator/context/artifact settlement; replace external stage IO only.
+// Current upstream probes staged artifacts before commit. Stub only that media
+// IO boundary: the synthetic file below is not a video or media-validation test.
+vi.mock("../utils/ffprobe.js", () => ({
+  extractMediaMetadata: vi.fn(async () => ({ durationSeconds: 1, frames: 30 })),
+}));
+vi.mock("node:fs/promises", async (original) => ({
+  ...(await original<typeof import("node:fs/promises")>()),
+  rm: vi.fn(),
+}));
+vi.mock("@hyperframes/engine", async (original) => ({
+  ...(await original<typeof import("@hyperframes/engine")>()),
+  assertConfiguredFfmpegBinariesExist: vi.fn(),
+  resolveBrowserGpuMode: vi.fn(async () => "hardware"),
+  resolveHeadlessShellPath: vi.fn(() => "/not-launched"),
+  createCaptureSession: vi.fn(() => {
+    throw new Error("unexpected browser launch");
+  }),
+}));
+vi.mock("./fileServer.js", async (original) => ({
+  ...(await original<typeof import("./fileServer.js")>()),
+  createFileServer: vi.fn(async () => ({ url: "http://unused.invalid", close: vi.fn() })),
+  closeFileServerSafely: vi.fn(),
+}));
+vi.mock("./render/stages/compileStage.js", () => ({ runCompileStage: vi.fn() }));
+vi.mock("./render/stages/probeStage.js", () => ({
+  runProbeStage: vi.fn(async (input) => ({
+    compiled: input.compiled,
+    fileServer: null,
+    probeSession: null,
+    lastBrowserConsole: [],
+    duration: 1,
+    totalFrames: 30,
+    browserProbeMs: 0,
+  })),
+}));
+vi.mock("./render/stages/extractVideosStage.js", async (original) => ({
+  ...(await original<typeof import("./render/stages/extractVideosStage.js")>()),
+  runExtractVideosStage: vi.fn(async () => ({
+    extractionResult: null,
+    frameLookup: null,
+    videoReadinessSkipIds: [],
+    videoMetadataHints: [],
+    nativeHdrVideoIds: new Set(),
+    videoTransfers: [],
+    nativeHdrImageIds: new Set(),
+    imageTransfers: [],
+    hdrImageSrcPaths: new Map(),
+    imageColorSpaces: [],
+    videoExtractMs: 0,
+    failureToEnforce: null,
+  })),
+}));
+vi.mock("./render/stages/audioStage.js", () => ({
+  runAudioStage: vi.fn(async () => ({ hasAudio: false, audioOutputPath: null, audioProcessMs: 0 })),
+}));
+vi.mock("./render/stages/captureStreamingStage.js", () => ({
+  runCaptureStreamingStage: vi.fn(async () => ({ success: false })),
+}));
+vi.mock("./render/stages/captureStage.js", () => ({
+  runCaptureStage: vi.fn(async () => ({
+    workerCount: 1,
+    probeSession: null,
+    lastBrowserConsole: [],
+  })),
+}));
+vi.mock("./render/stages/encodeStage.js", () => ({
+  runEncodeStage: vi.fn(async () => ({ encodeMs: 0 })),
+}));
+vi.mock("./render/stages/assembleStage.js", () => ({
+  runAssembleStage: vi.fn(async (input) => {
+    writeFileSync(input.outputPath, "synthetic artifact, NOT video evidence");
+    return { assembleMs: 0 };
+  }),
+}));
+const roots: string[] = [];
+beforeEach(async () => {
+  vi.clearAllMocks();
+  const fs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  vi.mocked(rm).mockImplementation(fs.rm);
+  vi.mocked(runCompileStage).mockImplementation(
+    // External compiler output is a deliberately partial fixture; the real
+    // orchestrator and execution context remain under test.
+    async () =>
+      ({
+        compiled: {
+          html: "<div></div>",
+          renderModeHints: { reasons: [] },
+          hasShaderTransitions: false,
+        },
+        composition: { width: 640, height: 360, duration: 1, videos: [], audios: [], images: [] },
+        deviceScaleFactor: 1,
+        outputWidth: 640,
+        outputHeight: 360,
+        compileOnlyMs: 0,
+        forceScreenshot: false,
+      }) as unknown as Awaited<ReturnType<typeof runCompileStage>>,
+  );
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+function setup(enabled = false, debug = false) {
+  const root = mkdtempSync(join(tmpdir(), "native-workdir-owner-"));
+  roots.push(root);
+  vi.stubEnv("PRODUCER_RENDERS_DIR", join(root, "renders"));
+  vi.stubEnv("KEEP_TEMP", "0");
+  writeFileSync(join(root, "index.html"), "<div></div>");
+  const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
+  const job = createRenderJob({
+    fps: 30,
+    quality: "standard",
+    workers: 1,
+    debug,
+    logger: log,
+    sourceStaticPlan: { enabled },
+    producerConfig: {
+      ...resolveConfig(),
+      enableStreamingEncode: false,
+      useDrawElement: false,
+      lowMemoryMode: false,
+    },
+  });
+  return { root, job, log, output: join(root, "output.mp4") };
+}
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+describe("executeRenderJob workDir ownership", () => {
+  it("does not grant direct-disk provenance to a streaming-unavailable fallback", async () => {
+    const { root, job, output } = setup(true);
+    if (!job.config.producerConfig) throw new Error("fixture config");
+    job.config.producerConfig.enableStreamingEncode = true;
+    await executeRenderJob(job, root, output);
+    expect(runCaptureStreamingStage).toHaveBeenCalledTimes(1);
+    expect(runCaptureStage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceStaticPlanEnabled: true,
+        initialDirectSdrDiskEligible: false,
+        plan: expect.objectContaining({ kind: "sdr_disk" }),
+      }),
+    );
+    expect(job.status).toBe("complete");
+  });
+
+  it.each([false, true])(
+    "enabled=%s awaits async cleanup, leaves timer responsive and returns only after LIFO disposal",
+    async (enabled) => {
+      const { root, job, output } = setup(enabled);
+      const entered = deferred(),
+        release = deferred();
+      const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+      const order: string[] = [];
+      const originalDefer = RenderExecutionContext.prototype.defer;
+      vi.spyOn(RenderExecutionContext.prototype, "defer").mockImplementation(
+        function (this: RenderExecutionContext, name, dispose) {
+          return originalDefer.call(this, name, async () => {
+            order.push(name);
+            await dispose();
+          });
+        },
+      );
+      vi.mocked(rm).mockImplementation(async (path, options) => {
+        entered.resolve();
+        await release.promise;
+        await actual.rm(path, options);
+      });
+      let returned = false;
+      const running = executeRenderJob(job, root, output).then(() => {
+        returned = true;
+      });
+      await entered.promise;
+      expect(job.status).toBe("complete");
+      expect(returned).toBe(false);
+      const [workDir, options] = vi.mocked(rm).mock.calls[0]!;
+      expect(options).toEqual({ recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+      expect(existsSync(workDir)).toBe(true);
+      let healthTick = false;
+      await new Promise<void>((r) =>
+        setTimeout(() => {
+          healthTick = true;
+          r();
+        }, 0),
+      );
+      expect(healthTick).toBe(true);
+      expect(returned).toBe(false);
+      expect(order).toEqual([
+        "stop memory sampler",
+        "close probe session",
+        "close file server",
+        "rollback staged artifact",
+        "remove workDir",
+      ]);
+      expect(runCaptureStage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceProjectDir: root,
+          initialDirectSdrDiskEligible: true,
+          sourceStaticPlanEnabled: enabled,
+        }),
+      );
+      release.resolve();
+      await running;
+      expect(returned).toBe(true);
+      expect(existsSync(workDir)).toBe(false);
+      expect(rm).toHaveBeenCalledTimes(1);
+      expect(existsSync(output)).toBe(true);
+    },
+  );
+  it.each(["debug", "keep-temp"])(
+    "%s preserves the directory on successful settlement",
+    async (mode) => {
+      const { root, job, output } = setup(false, mode === "debug");
+      if (mode === "keep-temp") vi.stubEnv("KEEP_TEMP", "1");
+      await executeRenderJob(job, root, output);
+      expect(job.status).toBe("complete");
+      expect(rm).not.toHaveBeenCalled();
+      expect(existsSync(vi.mocked(runCompileStage).mock.calls[0]![0].workDir)).toBe(true);
+    },
+  );
+  it("cleanup rejection remains best effort and logs without reversing successful settlement", async () => {
+    const { root, job, log, output } = setup();
+    vi.mocked(rm).mockRejectedValue(new Error("injected delete failure"));
+    await expect(executeRenderJob(job, root, output)).resolves.toBeUndefined();
+    expect(job.status).toBe("complete");
+    expect(log.debug).toHaveBeenCalledWith(
+      "Cleanup failed (remove workDir)",
+      expect.objectContaining({ error: "injected delete failure" }),
+    );
+  });
+  it("KEEP_TEMP does not retain a failed job; cleanup failure preserves the original error", async () => {
+    const { root, job, output, log } = setup();
+    vi.stubEnv("KEEP_TEMP", "1");
+    vi.mocked(runCompileStage).mockRejectedValue(new Error("original compile failure"));
+    vi.mocked(rm).mockRejectedValue(new Error("secondary cleanup failure"));
+    await expect(executeRenderJob(job, root, output)).rejects.toThrow("original compile failure");
+    expect(rm).toHaveBeenCalledTimes(1);
+    expect(existsSync(output)).toBe(false);
+    expect(log.debug).toHaveBeenCalledWith(
+      "Cleanup failed (remove workDir)",
+      expect.objectContaining({ error: "secondary cleanup failure" }),
+    );
+  });
+});


### PR DESCRIPTION
## What

Draft proposal for opt-in, source-backed static capture reuse in Producer, with an initial **OpenMAIC slide-snapshot carrier**. This proposes a concrete integration for maintainer feedback; it is not a claim that this application-specific carrier is already an accepted general Hyperframes API.

Also replace the synchronous deferred workDir removal with an awaited asynchronous removal, retaining the existing execution-context ownership and settlement semantics.

## Why

For a source-known static slide interval, capturing the browser at every logical frame repeats identical work. A validated interval can capture its anchor once while still providing the dense numbered files required by the existing encoder. Dynamic gaps continue to capture every frame.

Synchronous recursive workDir deletion can block a Node service sharing Producer's event loop after the artifact is ready. Returning the deletion Promise lets the existing context await cleanup while the event loop remains available.

## How

- Add optional `sourceStaticPlan: { enabled: true }` to `RenderConfig`; omission/false preserves the original capture loop.
- Validate the extracted project's `openmaic-source-static-plan.json` against the exact package version, manifest/HTML/runtime/asset hashes, timeline and frame grid. Only source-backed slide-snapshot intervals are supported. Missing, invalid or ineligible plans fall back as a whole before optimized writes.
- Bind optimization to the source entry selected by the pipeline: only the default root `index.html` or explicitly selected `index.html` is supported. Alternate entries, path aliases and missing entry identity fall back before optimized writes, even with identical fps/frame counts and a valid index carrier.
- Require an initially selected direct `sdr_disk` route, BeginFrame, one worker, no frame range or worker encoding, and neither enabled nor armed engine static dedup. No routing or global dedup settings are overridden. Streaming/HDR fallback cannot grant eligibility.
- Materialize dense frames with hard links; allow exclusive-copy fallback only for EXDEV/EPERM/EACCES/ENOTSUP, checking copied bytes. Preserve absolute capture times and logical progress. Verify the optimized directory inventory. Once optimized writes begin, errors propagate through existing stage/session cleanup instead of baseline replay.
- Return `fs.promises.rm()` from the existing workDir disposer in both feature states. Preserve debug/KEEP_TEMP conditions, recursive/force/retry options, LIFO/exactly-once disposal and best-effort logging. Producer still waits for the cleanup attempt before returning.

### Current-base compatibility

Prepared against `c93c7654033282e1a66a662a39fb10b8ed273b7d` (Producer 0.8.34). Package versions and bun.lock are unchanged: release versioning remains with maintainers, and no local candidate tarball or generated bundle is included.

The current disk-headroom check and async artifact validation/commit remain intact. Disk-headroom estimation still precedes carrier resolution and uses the existing dense estimate; this proposal does not bypass that admission check or claim hard-link savings are credited there. Test fixtures were adapted to supply capture dimensions and stub the media-probe IO boundary while retaining real orchestrator/context/artifact settlement.

The carrier matches this build's package version exactly. A consumer must generate a matching carrier; the historical 0.7.111 candidate's carrier is not valid for 0.8.34. With engine dedup enabled, opting in safely falls back. Maintainer feedback is requested on whether this explicit carrier belongs here and whether the general async cleanup should be split for review. No new generic plugin framework is proposed in this draft.

## Test plan

- [x] Unit/owner tests added; current branch focused/regression run: **7 suites, 291 tests passed**, including real Capture stage integration, current disk-headroom helpers, initial-route provenance, pending disposal/timer responsiveness, retention conditions and cleanup failures.
- [x] Current branch strict no-emit typecheck of the three added owner-test entrypoints; Producer build/declaration generation; focused oxlint/oxfmt; existing Producer test classifier; diff whitespace checks.
- [ ] New real browser/media pair on this 0.8.34 branch: **not run**. Full monorepo CI remains a merge prerequisite.
- [ ] Public API documentation: pending the carrier/API decision; the supported boundary is described above.

**Historical functional evidence, not validation of this rebased runtime:** the previous native candidate based on Producer 0.7.111 completed one controlled 241-second, 1080p/30 fps OFF→ON pair using the same packed runtime and fixed resources for both arms. It retained 7,230 logical frames while physical captures went from 7,230 to 93 (7,137 hard links, zero copies). Both MP4 files were byte-identical; decoded video, PTS, 11,298 audio packets and non-silent PCM matched, with zero effective A/V drift. Both consumer jobs formally settled successfully, HTTP health/status responded during the artifact-ready-to-terminal window, workDirs were removed and no renderer remained. Copy fallback is covered by owner tests, not that real pair.

That earlier result motivates this proposal but does not prove real-media correctness of 0.8.34, production throughput, release qualification or OOM prevention. No resource-fence, queue, deployment or application-consumer changes are included. This draft does not enable the feature in OpenMAIC.


### Entry-identity regression fix

Independent review found that an alternate `entryFile` could incorrectly reuse the root index carrier. The new owner regression failed on the previous runtime (271 captures instead of all 300), then passed after binding the selected source entry through the real pipeline/stage/resolver. Tests cover default and explicit index entry propagation, alternate-entry full capture, and rejection of missing/unsupported entry identity. Current verbose test output and command/exit/source-hash receipts were retained locally. This tightens eligibility; it does not add support for alternate-entry optimization.
