### PR TITLE
fix(lint): flag an id override written with reduced-specificity selector forms

### DIFF
--- a/packages/lint/src/rules/core.test.ts
+++ b/packages/lint/src/rules/core.test.ts
@@ -942,6 +942,52 @@ describe("core rules", () => {
     });
   });
 
+  describe("id_override_reduced_specificity", () => {
+    const comp = (css: string) => `
+<html><head><style>${css}</style></head><body>
+  <div id="root" data-composition-id="main" data-width="1920" data-height="1080">
+    <div class="parent"><div id="line1" class="row">text</div></div>
+  </div>
+  <script>window.__timelines = { main: gsap.timeline({ paused: true }) };</script>
+</body></html>`;
+
+    it("warns when an attribute selector on id sets a position property", async () => {
+      const result = await lintHyperframeHtml(
+        comp(`.parent .row { position: absolute; left: 0; } [id="line1"] { left: 40px; }`),
+      );
+      const finding = result.findings.find((f) => f.code === "id_override_reduced_specificity");
+      expect(finding).toBeDefined();
+      expect(finding?.severity).toBe("warning");
+      expect(finding?.selector).toBe(`[id="line1"]`);
+      expect(finding?.fixHint).toContain("#id");
+    });
+
+    it("warns when a :where()-wrapped id selector sets a position property", async () => {
+      const result = await lintHyperframeHtml(
+        comp(`.parent .row { position: absolute; top: 0; } :where(#line1) { top: 20px; }`),
+      );
+      const finding = result.findings.find((f) => f.code === "id_override_reduced_specificity");
+      expect(finding).toBeDefined();
+      expect(finding?.selector).toBe(`:where(#line1)`);
+    });
+
+    it("does not flag a bare #id selector, which always wins regardless of specificity", async () => {
+      const result = await lintHyperframeHtml(
+        comp(`.parent .row { position: absolute; left: 0; } #line1 { left: 40px; }`),
+      );
+      expect(
+        result.findings.find((f) => f.code === "id_override_reduced_specificity"),
+      ).toBeUndefined();
+    });
+
+    it("does not flag an attribute selector on id for a non-position property", async () => {
+      const result = await lintHyperframeHtml(comp(`[id="line1"] { color: red; }`));
+      expect(
+        result.findings.find((f) => f.code === "id_override_reduced_specificity"),
+      ).toBeUndefined();
+    });
+  });
+
   describe("unclosed_tag_swallowed_element", () => {
     it("flags an <img> tag whose unclosed start tag swallows a nested <div> as bogus attribute text", async () => {
       const html = compositionWithBodyPrefix(

--- a/packages/lint/src/rules/core.ts
+++ b/packages/lint/src/rules/core.ts
@@ -98,16 +98,26 @@ function resolvedRuleSelectors(rule: postcss.Rule): string[] {
   );
 }
 
+/**
+ * The rightmost compound of a selector — the part that actually matches the
+ * styled element (everything before the last combinator is ancestor
+ * context, not the subject).
+ */
+function rightmostCompoundNodes(selectorNode: selectorParser.Selector): selectorParser.Node[] {
+  const subject: selectorParser.Node[] = [];
+  selectorNode.each((node) => {
+    if (node.type === "combinator") subject.length = 0;
+    else subject.push(node);
+  });
+  return subject;
+}
+
 function selectorAliasesRuntimeHiddenStyle(selector: string): boolean {
   let unsafe = false;
   try {
     selectorParser((root) => {
       root.each((selectorNode) => {
-        const subject: selectorParser.Node[] = [];
-        selectorNode.each((node) => {
-          if (node.type === "combinator") subject.length = 0;
-          else subject.push(node);
-        });
+        const subject = rightmostCompoundNodes(selectorNode);
 
         const hostScoped = subject.some(
           (node) =>
@@ -135,6 +145,43 @@ function selectorAliasesRuntimeHiddenStyle(selector: string): boolean {
     return false;
   }
   return unsafe;
+}
+
+const POSITION_PROPERTIES = new Set(["left", "top", "right", "bottom"]);
+
+/**
+ * Whether a selector's rightmost compound sets its element's id via a
+ * zero/class-level-specificity form: an attribute selector on `id`
+ * (`[id="x"]`, class-level specificity) or an id nested inside a `:where()`
+ * pseudo (spec-defined zero specificity). Both genuinely lose to a compound
+ * class selector like `.parent .row` under standard cascade rules — unlike a
+ * bare `#id`, which always wins regardless of how the competing class rule
+ * is written. Confirmed empirically in real Chrome (see PRINFRA-670).
+ */
+function idSelectorHasReducedSpecificity(selector: string): boolean {
+  let matched = false;
+  try {
+    selectorParser((root) => {
+      root.each((selectorNode) => {
+        const subject = rightmostCompoundNodes(selectorNode);
+        for (const node of subject) {
+          if (node.type === "attribute" && node.attribute.toLowerCase() === "id") {
+            matched = true;
+          }
+          if (
+            node.type === "pseudo" &&
+            node.value.toLowerCase() === ":where" &&
+            node.nodes.some((option) => option.nodes.some((inner) => inner.type === "id"))
+          ) {
+            matched = true;
+          }
+        }
+      });
+    }).processSync(selector);
+  } catch {
+    return false;
+  }
+  return matched;
 }
 
 function ruleForcesOpacityZero(rule: postcss.Rule): boolean {
@@ -428,6 +475,41 @@ export const coreRules: Array<(ctx: LintContext) => HyperframeLintFinding[]> = [
             selector,
             fixHint:
               'Restrict the guard to sub-composition hosts, for example `[data-composition-src][style*="visibility: hidden"]` and `[data-composition-file][style*="visibility: hidden"]`. Do not derive arbitrary element or media opacity from runtime-owned inline visibility.',
+            snippet: truncateSnippet(rule.toString()),
+          });
+        }
+      });
+    }
+    return findings;
+  },
+
+  // id_override_reduced_specificity
+  ({ styles }) => {
+    const findings: HyperframeLintFinding[] = [];
+    const reported = new Set<string>();
+    for (const style of styles) {
+      let root: postcss.Root;
+      try {
+        root = postcss.parse(style.content);
+      } catch {
+        continue; // css_parse_error above already reports this
+      }
+      root.walkRules((rule) => {
+        const positionProps = new Set<string>();
+        rule.walkDecls((decl) => {
+          if (POSITION_PROPERTIES.has(decl.prop.toLowerCase())) positionProps.add(decl.prop);
+        });
+        if (positionProps.size === 0) return;
+        for (const selector of resolvedRuleSelectors(rule)) {
+          if (reported.has(selector) || !idSelectorHasReducedSpecificity(selector)) continue;
+          reported.add(selector);
+          findings.push({
+            code: "id_override_reduced_specificity",
+            severity: "warning",
+            message: `Selector "${selector}" sets ${[...positionProps].join("/")} via an attribute selector on id or a :where()-wrapped id — both carry class-level or zero specificity, so a shared compound class rule (e.g. ".parent .row") targeting the same element and property can silently win instead of this authored override.`,
+            selector,
+            fixHint:
+              "Use a bare #id selector instead — real id specificity always wins over any compound class selector, however it's written.",
             snippet: truncateSnippet(rule.toString()),
           });
         }


### PR DESCRIPTION
## Summary
- An attribute selector on id (`[id="x"]`, class-level specificity) or a `:where(#x)`-wrapped id selector (spec-defined zero specificity) genuinely loses to a compound class selector like `.parent .row` under standard CSS cascade rules — unlike a bare `#id`, which always wins regardless of how the competing class rule is written. Confirmed empirically in real Chrome (both variants).
- The original report claimed a bare `#id` loses to `.parent .row`, which is CSS-mathematically impossible (bare id always wins) — refuted 3 ways by cli-repro. The real, narrower finding that reproduces the same symptom: the reduced-specificity selector *forms* above.
- When either form is used to override a position property (`left`/`top`/`right`/`bottom`), the element can silently render at the class-default position instead of its authored one — `lint`, `validate`, `inspect`, and `layout` all report clean, since a real, resolved position exists, it's just the wrong one.
- No existing check performs any CSS rule-specificity analysis at all — confirmed at the source level (`dist/cli.js` has zero `"specificity"` occurrences, and `createInspectCommand` reports position via `getBoundingClientRect()` only).
- Adds `id_override_reduced_specificity`, a new core lint rule flagging this specific authoring pattern (not general cascade-conflict detection across arbitrary rules, which would require full rule-graph modeling well beyond this P3's scope — this was cli-feedback's explicit "your call on scope" dispatch).
- Extracted `rightmostCompoundNodes()` out of `selectorAliasesRuntimeHiddenStyle` so the new rule's selector-subject walk doesn't duplicate it (caught by `fallow audit`).

PRINFRA-670

## Test plan
- [x] New tests in `packages/lint/src/rules/core.test.ts`: warns on `[id="x"]` setting a position property, warns on `:where(#x)` setting a position property, does not flag a bare `#id` (always wins), does not flag `[id="x"]` for a non-position property.
- [x] Confirmed RED against the pre-fix source (tagged stash), GREEN after restoring the fix.
- [x] `bunx tsc --noEmit`, `bunx oxlint`, `bunx oxfmt --write` clean on changed files.
- [x] `bunx fallow audit --base origin/main --fail-on-issues`: no issues in the 2 changed files (an initial duplication finding was fixed by extracting the shared helper).
- [x] Full `packages/lint` vitest suite: 604/604 passing tests (4 test files fail at collection time on a pre-existing, unrelated sandbox issue — `node:path`'s `posix` undefined inside `@hyperframes/parsers/rewriteSubCompPaths.ts` — confirmed identical on pristine `origin/main`, not touched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)