### PR TITLE
fix(cli): disclose the separate heygen CLI dependency on auth login success

### DIFF
--- a/packages/cli/src/commands/auth/login.test.ts
+++ b/packages/cli/src/commands/auth/login.test.ts
@@ -5,6 +5,24 @@ import { readStore, writeStore } from "../../auth/store.js";
 import { setupTempAuthEnv, type EnvFixture } from "../../auth/_test-utils.js";
 import { CliRuntimeError } from "../../utils/commandResult.js";
 
+// Controls whether the mocked `heygen` binary presence check finds it, so
+// tests can assert the auth-login-success discoverability note independent
+// of whatever `heygen` happens to be on the machine actually running tests.
+const heygenCliState = vi.hoisted(() => ({ present: true }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    execFileSync: (cmd: string, args: string[], options: unknown) => {
+      if (args[0] === "heygen") {
+        if (!heygenCliState.present) throw new Error("not found");
+        return "/usr/local/bin/heygen\n";
+      }
+      return actual.execFileSync(cmd, args, options as never);
+    },
+  };
+});
+
 // Mock only AuthClient — keep the real store/resolver so the test
 // exercises the actual on-disk rollback / persistence behavior.
 // `verifyState` controls what `getCurrentUser` returns per test:
@@ -110,6 +128,7 @@ describe("auth login", () => {
     dir = envFixture.dir;
     verifyState.reject = false;
     verifyState.user = { email: "alice@example.com" };
+    heygenCliState.present = true;
     deviceChallenge.verificationUriComplete = undefined;
     for (const fn of Object.values(telemetry)) fn.mockClear();
     for (const fn of Object.values(deviceAuth)) fn.mockClear();
@@ -229,6 +248,27 @@ describe("auth login", () => {
     const onDisk = JSON.parse(await fs.readFile(join(dir, "credentials"), "utf8"));
     expect(onDisk.api_key).toBeUndefined();
     expect(onDisk.future_credential).toEqual({ token: "owned_by_other_cli" });
+  });
+
+  it("notes the separate heygen CLI dependency when it's missing on a successful login", async () => {
+    heygenCliState.present = false;
+    await runLogin("hg_goodkey456");
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("developers.heygen.com/cli"));
+  });
+
+  it("does not note the heygen CLI dependency when it's already installed", async () => {
+    heygenCliState.present = true;
+    await runLogin("hg_goodkey456");
+    expect(console.log).not.toHaveBeenCalledWith(
+      expect.stringContaining("developers.heygen.com/cli"),
+    );
+  });
+
+  it("notes the separate heygen CLI dependency on a successful device login too", async () => {
+    heygenCliState.present = false;
+    verifyState.user = { email: "device@example.com" };
+    await runCommand({ device: true });
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("developers.heygen.com/cli"));
   });
 
   it("attributes a successful login to the account email", async () => {

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -48,6 +48,7 @@ import {
   type UserInfo,
 } from "../../auth/index.js";
 import { c } from "../../ui/colors.js";
+import { printHeygenCliNoteIfMissing } from "../../utils/heygenCli.js";
 
 const STDIN_TIMEOUT_MS = 30_000;
 // Smallest plausible length for a real API key. We don't validate the
@@ -195,6 +196,7 @@ async function runDeviceLogin(): Promise<void> {
   trackAuthLoginCompleted("device", id);
   const identity = userDisplayName(toStoredUserInfo(user)) ?? "(unknown user)";
   console.log(c.success(`✓ Signed in as ${identity}.`));
+  printHeygenCliNoteIfMissing();
 }
 
 async function revokeDeviceTokens(tokens: {
@@ -263,6 +265,7 @@ async function reportIdentity(): Promise<void> {
     trackAuthLoginCompleted("oauth", id);
     const identity = userDisplayName(toStoredUserInfo(user)) ?? "(unknown user)";
     console.log(c.success(`✓ Signed in as ${identity}.`));
+    printHeygenCliNoteIfMissing();
   } catch (err) {
     // Don't roll back — the OAuth tokens are valid on disk; this is a
     // transient verify-side issue. The credential is persisted and usable, so
@@ -430,6 +433,7 @@ async function verifyAndReport(key: string): Promise<UserInfo | null> {
     await persistUserInfo(user);
     const identity = userDisplayName(toStoredUserInfo(user)) ?? "(unknown user)";
     console.log(c.success(`✓ API key saved. Authenticated as ${identity}.`));
+    printHeygenCliNoteIfMissing();
     return user;
   } catch (err) {
     if (isAuthError(err) && err.code === "UNAUTHENTICATED") {

--- a/packages/cli/src/utils/heygenCli.test.ts
+++ b/packages/cli/src/utils/heygenCli.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression coverage for auth login's silent heygen-CLI discoverability gap:
+// media-use's free resolution path shells out to a separate `heygen` binary
+// with no bundling/fallback, and hyperframes auth login's success output
+// previously never mentioned it — a user with no heygen CLI installed had no
+// signal from a successful sign-in that a second tool was required.
+
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFileSync: execFileSyncMock };
+});
+
+const { hasHeygenCli, printHeygenCliNoteIfMissing, HEYGEN_CLI_DOCS_URL } =
+  await import("./heygenCli.js");
+
+describe("hasHeygenCli / printHeygenCliNoteIfMissing", () => {
+  let platformDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (platformDescriptor) Object.defineProperty(process, "platform", platformDescriptor);
+  });
+
+  function setPlatform(value: string): void {
+    Object.defineProperty(process, "platform", { configurable: true, value });
+  }
+
+  it("hasHeygenCli returns true when which/where finds the binary", () => {
+    execFileSyncMock.mockReturnValue("/usr/local/bin/heygen\n");
+    expect(hasHeygenCli()).toBe(true);
+  });
+
+  it("hasHeygenCli returns false when which/where throws (not found)", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("command failed");
+    });
+    expect(hasHeygenCli()).toBe(false);
+  });
+
+  it("hasHeygenCli returns false on blank output", () => {
+    execFileSyncMock.mockReturnValue("\n");
+    expect(hasHeygenCli()).toBe(false);
+  });
+
+  it("uses where on win32 and which elsewhere", () => {
+    setPlatform("win32");
+    execFileSyncMock.mockReturnValue("C:\\heygen\\heygen.exe\n");
+    hasHeygenCli();
+    expect(execFileSyncMock).toHaveBeenCalledWith("where", ["heygen"], expect.anything());
+
+    setPlatform("darwin");
+    execFileSyncMock.mockReturnValue("/usr/local/bin/heygen\n");
+    hasHeygenCli();
+    expect(execFileSyncMock).toHaveBeenCalledWith("which", ["heygen"], expect.anything());
+  });
+
+  it("printHeygenCliNoteIfMissing logs nothing when heygen is present", () => {
+    execFileSyncMock.mockReturnValue("/usr/local/bin/heygen\n");
+    printHeygenCliNoteIfMissing();
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it("printHeygenCliNoteIfMissing logs a note naming the docs URL when heygen is missing", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    printHeygenCliNoteIfMissing();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining(HEYGEN_CLI_DOCS_URL));
+  });
+
+  it("mentions WSL specifically on win32 when heygen is missing", () => {
+    setPlatform("win32");
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    printHeygenCliNoteIfMissing();
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("WSL"));
+  });
+
+  it("does not mention WSL on non-Windows platforms", () => {
+    setPlatform("darwin");
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    printHeygenCliNoteIfMissing();
+    expect(console.log).toHaveBeenCalledWith(expect.not.stringContaining("WSL"));
+  });
+});

--- a/packages/cli/src/utils/heygenCli.ts
+++ b/packages/cli/src/utils/heygenCli.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from "node:child_process";
+import { c } from "../ui/colors.js";
+
+export const HEYGEN_CLI_DOCS_URL = "https://developers.heygen.com/cli";
+
+/**
+ * Whether the separate `heygen` CLI binary is reachable on PATH. media-use's
+ * free resolution path shells out to it directly with no bundling/fallback,
+ * so its absence silently breaks that path with no signal from auth login.
+ */
+export function hasHeygenCli(): boolean {
+  try {
+    const cmd = process.platform === "win32" ? "where" : "which";
+    const output = execFileSync(cmd, ["heygen"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 5000,
+    });
+    return output.split(/\r?\n/).some((line) => line.trim().length > 0);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Print a one-line note after a successful `auth login` when the separate
+ * `heygen` CLI isn't on PATH. HeyGen's own CLI has no native Windows build
+ * yet (WSL is the documented workaround), so win32 gets an extra mention.
+ */
+export function printHeygenCliNoteIfMissing(): void {
+  if (hasHeygenCli()) return;
+  const platformNote =
+    process.platform === "win32" ? " (no native Windows build yet — use WSL)" : "";
+  console.log(
+    c.dim(
+      `Note: media-use's free resolution path also needs the separate heygen CLI${platformNote} — see ${HEYGEN_CLI_DOCS_URL}`,
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- media-use's free resolution path shells out to a separate `heygen` binary via `spawnSync` with no bundling/fallback. HeyGen's own current CLI distribution docs (https://developers.heygen.com/cli) confirm only macOS and Linux are supported natively — Windows support is "coming soon", WSL recommended. That's a real platform-distribution gap, but it's HeyGen's own CLI release process, not something fixable from this repo.
- The actionable gap: `hyperframes auth login`'s success output — all three modes (OAuth, device-code, API-key) — previously printed only `✓ Signed in as {identity}.` with zero mention of this separate dependency. A user who completed sign-in successfully had no signal that a second, separately-installed tool was required for media-use's free resolution path specifically. media-use's own `--doctor` already has this check with an install hint; the gap was that auth login's success path didn't proactively surface it.
- Adds `hasHeygenCli()` / `printHeygenCliNoteIfMissing()` in a new `packages/cli/src/utils/heygenCli.ts`, using the same `which`/`where` presence-check idiom as `findPython()` in `tts/synthesize.ts`. Wired into all three auth login success paths (`reportIdentity()` for OAuth, `runDeviceLogin()`, `verifyAndReport()` for the API-key path). Prints a one-line dim note only when the binary isn't found on PATH, with a Windows-specific WSL mention.
- Scoped to the discoverability gap only, per the dispatch — does not attempt to fix heygen CLI's own Windows distribution.

PRINFRA-672

## Test plan
- [x] New `packages/cli/src/utils/heygenCli.test.ts`: presence-check true/false/blank-output cases, `where` vs `which` platform selection, note printed/not-printed, WSL mention on win32 only.
- [x] New tests in `packages/cli/src/commands/auth/login.test.ts` (mocking `node:child_process`'s `execFileSync` for the `heygen` presence check): note appears on a successful API-key login when heygen is missing, does not appear when present, and appears on a successful device login too.
- [x] Confirmed RED against the pre-fix source (tagged stash), GREEN after restoring the fix.
- [x] `bunx tsc --noEmit`, `bunx oxlint`, `bunx oxfmt --write` clean on changed files.
- [x] `bunx fallow audit --base origin/main --fail-on-issues`: one non-blocking duplication warning (18 lines of `vi.mock("node:child_process", ...)` boilerplate shared with the existing `tts/python.test.ts` mock setup) — left as-is since it's test-mocking scaffolding, not production logic, and the two test subjects are unrelated.
- [x] Full `packages/cli` vitest suite: 3044/3049 passing (2 pre-existing unrelated failures — a PID/socket sandbox quirk and an agent-env-var-pollution test — plus 4 browser-test files failing at collection on the known happy-dom + `node:` builtin sandbox issue; all confirmed pre-existing from earlier fixes this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)