### PR TITLE
fix(engine): subtract AAC-LC encoder priming delay from probed duration

### DIFF
--- a/packages/engine/src/utils/ffprobe.test.ts
+++ b/packages/engine/src/utils/ffprobe.test.ts
@@ -550,14 +550,19 @@ describe("ffprobe missing-binary fallback", () => {
       codec: "aac",
       profile: "LC",
       packets: "783",
-      expected: 16.704,
-      calls: 2,
+      firstPacketPts: -1024,
+      // (783 * 1024 - 1024) / 48000 — one frame of encoder-priming delay
+      // subtracted from the raw packet-count total. The pre-fix formula
+      // (no subtraction) gave 16.704.
+      expected: 16.682666666666666,
+      calls: 3,
     },
     {
       name: "missing AAC packet count",
       codec: "aac",
       profile: "LC",
       packets: undefined,
+      firstPacketPts: undefined,
       expected: 1.25,
       calls: 2,
     },
@@ -566,6 +571,7 @@ describe("ffprobe missing-binary fallback", () => {
       codec: "aac",
       profile: "LC",
       packets: "0",
+      firstPacketPts: undefined,
       expected: 1.25,
       calls: 2,
     },
@@ -574,12 +580,13 @@ describe("ffprobe missing-binary fallback", () => {
       codec: "aac",
       profile: "LC",
       packets: "invalid",
+      firstPacketPts: undefined,
       expected: 1.25,
       calls: 2,
     },
   ])(
     "derives audio duration for $name",
-    async ({ codec, profile, packets, expected, calls: expectedCalls }) => {
+    async ({ codec, profile, packets, firstPacketPts, expected, calls: expectedCalls }) => {
       const outcomes: SpawnOutcome[] = [
         {
           kind: "exit",
@@ -605,6 +612,13 @@ describe("ffprobe missing-binary fallback", () => {
           stdout: JSON.stringify({ streams: [{ nb_read_packets: packets }], format: {} }),
         });
       }
+      if (firstPacketPts !== undefined) {
+        outcomes.push({
+          kind: "exit",
+          code: 0,
+          stdout: JSON.stringify({ packets: [{ pts: firstPacketPts }] }),
+        });
+      }
       const { spawn, calls } = createSpawnSpy(outcomes);
       vi.resetModules();
       vi.doMock("child_process", () => ({ spawn }));
@@ -616,6 +630,59 @@ describe("ffprobe missing-binary fallback", () => {
       expect(calls).toHaveLength(expectedCalls);
     },
   );
+
+  // Regression (PRINFRA-342 mechanism 2): the packet-count refinement above
+  // counted every packet's samples, including AAC-LC's own leading
+  // encoder-priming/delay interval, which isn't real content. A real 5s
+  // @48kHz encode of a 240,000-sample (non-1024-aligned) source produces 236
+  // packets — raw decoded length is 240,640 samples (640 samples of
+  // unavoidable AAC-block-alignment tail overshoot, a hard codec constraint
+  // this refinement can't and shouldn't try to hide) — but the pre-fix
+  // formula (packetCount * 1024 / sampleRate, no delay subtraction) reported
+  // 241,664 / 48,000 = 5.034667s: a FULL EXTRA FRAME beyond even the raw
+  // decode, because the -1024-sample priming delay ffmpeg tags on the first
+  // packet was never subtracted. That inflated value fed straight into
+  // audioPadTrim's sourceDurationSeconds input, compounding across any
+  // chained re-processing of the same audio.
+  it("does not double-count AAC-LC's leading encoder-priming delay in the packet-count refinement", async () => {
+    const outcomes: SpawnOutcome[] = [
+      {
+        kind: "exit",
+        code: 0,
+        stdout: JSON.stringify({
+          streams: [
+            {
+              codec_type: "audio",
+              codec_name: "aac",
+              sample_rate: "48000",
+              channels: 1,
+              profile: "LC",
+            },
+          ],
+          format: { duration: "5.000000", bit_rate: "192000" },
+        }),
+      },
+      {
+        kind: "exit",
+        code: 0,
+        stdout: JSON.stringify({ streams: [{ nb_read_packets: "236" }], format: {} }),
+      },
+      {
+        kind: "exit",
+        code: 0,
+        stdout: JSON.stringify({ packets: [{ pts: -1024 }] }),
+      },
+    ];
+    const { spawn } = createSpawnSpy(outcomes);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+
+    const { extractAudioMetadata } = await import("./ffprobe.js");
+    const meta = await extractAudioMetadata("/tmp/aac-tail-overshoot.m4a");
+
+    expect(meta.durationSeconds).toBeCloseTo(240_640 / 48_000, 6);
+    expect(meta.durationSeconds).toBeLessThan(241_664 / 48_000);
+  });
 
   it("extractMediaMetadata falls back to PNG cICP metadata when ffprobe is missing", async () => {
     const { spawn, calls } = createSpawnSpy([{ kind: "missing" }]);
@@ -928,6 +995,13 @@ describe("ffprobe option separator", () => {
           format: {},
         }),
       },
+      {
+        // The encoder-priming-delay probe — also an AAC-LC packet-count
+        // refinement argv, also covered here.
+        kind: "exit",
+        code: 0,
+        stdout: JSON.stringify({ packets: [{ pts: -1024 }] }),
+      },
       { kind: "exit", code: 0, stdout: "0.000\n1.000\n" },
     ]);
     vi.resetModules();
@@ -937,10 +1011,11 @@ describe("ffprobe option separator", () => {
     await extractAudioMetadata("/tmp/-audio.wav");
     await analyzeKeyframeIntervals("/tmp/-video.mp4");
 
-    // Per call, not a flattened count. A total of 3 is satisfied by one call
-    // emitting three `--` and two emitting none — i.e. it cannot fail for
+    // Per call, not a flattened count. A total of 4 is satisfied by one call
+    // emitting four `--` and two emitting none — i.e. it cannot fail for
     // misplacement, which is the shape of bug this exists to catch.
     expect(calls.map((call) => (call.args ?? []).slice(-2))).toEqual([
+      ["--", "/tmp/-audio.wav"],
       ["--", "/tmp/-audio.wav"],
       ["--", "/tmp/-audio.wav"],
       ["--", "/tmp/-video.mp4"],

--- a/packages/engine/src/utils/ffprobe.ts
+++ b/packages/engine/src/utils/ffprobe.ts
@@ -910,6 +910,42 @@ export async function extractFinalVideoFrameTimestamp(
  */
 export const extractVideoMetadata = extractMediaMetadata;
 
+interface AacFirstPacketProbe {
+  packets?: Array<{ pts?: number | string }>;
+}
+
+/**
+ * AAC-LC's encoder priming delay isn't a fixed constant across encoders —
+ * ffmpeg's own native AAC encoder signals it as a negative presentation
+ * timestamp on the very first packet (e.g. -1024 for a one-frame delay,
+ * since packet pts here is in sample units). A single bounded packet read
+ * (not the full `-count_packets` demux) is enough to learn it; a file with
+ * no priming delay simply reports a non-negative first pts and this
+ * contributes 0.
+ */
+async function probeAacEncoderDelaySamples(
+  filePath: string,
+  signal?: AbortSignal,
+): Promise<number> {
+  const stdout = await runFfprobe(
+    filePath,
+    [
+      "-select_streams",
+      "a:0",
+      "-read_intervals",
+      "%+#1",
+      "-show_entries",
+      "packet=pts",
+      "-print_format",
+      "json",
+    ],
+    signal,
+  );
+  const parsed = JSON.parse(stdout) as AacFirstPacketProbe;
+  const firstPts = Number(parsed.packets?.[0]?.pts);
+  return Number.isFinite(firstPts) && firstPts < 0 ? -firstPts : 0;
+}
+
 export async function extractAudioMetadata(
   filePath: string,
   options?: { signal?: AbortSignal },
@@ -957,6 +993,16 @@ export async function extractAudioMetadata(
     //    unknown or missing profile through too — so an unrecognised HE
     //    spelling preserved the exact truncation this is meant to close.
     //    A skipped refinement is harmless: format.duration is already correct.
+    //
+    // 4. The packet count alone measures samples from the START of the raw
+    //    bitstream, but AAC-LC encoders prepend a priming/encoder-delay
+    //    interval that isn't real content — omitting it overshoots duration
+    //    by a full extra frame (~21ms at typical rates) beyond even what a
+    //    naive full decode of the file yields, and that overshoot fed
+    //    straight into audioPadTrim's own trim/pad math as sourceDurationSeconds,
+    //    compounding across any chained re-processing of the same audio.
+    //    probeAacEncoderDelaySamples reads the true per-file delay rather
+    //    than assuming a fixed one-frame constant.
     const isAacLc = /^\s*LC\s*$/i.test(audioStream.profile ?? "");
     if (audioCodec === "aac" && isAacLc && sampleRate > 0) {
       try {
@@ -976,7 +1022,9 @@ export async function extractAudioMetadata(
         const packetOutput = parseProbeJson(packetStdout);
         const packetCount = Number(packetOutput.streams[0]?.nb_read_packets);
         if (Number.isFinite(packetCount) && packetCount > 0) {
-          durationSeconds = (packetCount * AAC_LC_SAMPLES_PER_PACKET) / sampleRate;
+          const encoderDelaySamples = await probeAacEncoderDelaySamples(filePath, options?.signal);
+          durationSeconds =
+            (packetCount * AAC_LC_SAMPLES_PER_PACKET - encoderDelaySamples) / sampleRate;
         }
       } catch (error) {
         // An abort is the caller's intent, not a refinement failure — let it

--- a/packages/producer/tests/style-7-prod/output/compiled.html
+++ b/packages/producer/tests/style-7-prod/output/compiled.html
@@ -1048,7 +1048,7 @@
   </div>
 
       <!-- Background Audio (A-roll Audio) -->
-      <audio id="aroll-audio" src="_remote_media/download_054a544691a0.mp4" data-start="0" data-duration="16.064" data-track-index="1" data-end="16.064"></audio>
+      <audio id="aroll-audio" src="_remote_media/download_054a544691a0.mp4" data-start="0" data-duration="16.042666666666666" data-track-index="1" data-end="16.042666666666666"></audio>
     </div>
 
     


### PR DESCRIPTION
## Summary

- Fixes an over-estimate in `extractAudioMetadata`'s AAC-LC packet-count-based duration refinement: it measured samples from the start of the raw bitstream but never subtracted the encoder's leading priming/lookahead delay, so probed duration overshot the true decoded duration by a full extra AAC frame (~21ms at typical rates).
- That overshoot fed straight into `audioPadTrim`'s trim/pad math as the assumed source duration, compounding across chained reprocessing of the same audio.
- Adds a bounded single-packet ffprobe read (`probeAacEncoderDelaySamples`) that learns each file's actual encoder delay from the negative pts ffmpeg signals on the first packet, and subtracts it from the packet-count duration calculation.

## Context on scope

This closes AAC tail-frame-overshoot mechanism 2, with a corrected understanding of where the bug actually lives. The originally suggested fix shapes — a post-encode tail-trim re-encode pass, or relying on an MP4 edit list to bound playback — were both empirically disproven:

- Re-encoding with a hard `-t` cutoff reproduces the same 640-sample trailing overshoot; AAC-LC's fixed 1024-sample frame size makes "exact sample count on an unbounded raw decode" unachievable for any non-1024-aligned source duration. This is a hard codec constraint, not a bug.
- ffmpeg already writes a correct `elst` edit list bounding playback duration, but ffmpeg's own CLI full-decode path doesn't enforce the trailing bound (only edit-list-strict consumers like QuickTime/Safari do). Not a HyperFrames defect.

The actual fixable defect — and the one this PR addresses — was the metadata duration over-estimate itself, which is real, in-scope, and verifiably compounds across re-processing.

## Test plan

- [x] New regression test in `ffprobe.test.ts` asserting `extractAudioMetadata`'s computed duration no longer overshoots by a full extra AAC frame for a non-1024-aligned sample count.
- [x] Updated `it.each` duration-derivation table and the `--`-argument-safety test to account for the new bounded delay-probe subprocess call.
- [x] `bunx tsc --noEmit`, `bunx oxlint`, `bunx oxfmt --write`, `bunx fallow audit --base origin/main --fail-on-issues` all clean.
- [x] `bunx vitest run` (ffprobe.test.ts, audioPadTrim.integration.test.ts) and `bun test` (audioPadTrim.test.ts) pass.
- [x] Confirmed via tagged-stash RED/GREEN comparison that pre-existing unrelated failures (PNG/HDR cICP fixture parsing, one ffprobe-binary-fallback test, one videoFrameExtractor real-ffmpeg-subprocess test) reproduce identically with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)