### PR TITLE
fix(cli): await the skills-freshness check before exiting

### DIFF
--- a/packages/cli/src/cli.lifecycle.test.ts
+++ b/packages/cli/src/cli.lifecycle.test.ts
@@ -9,6 +9,9 @@ afterEach(() => {
   vi.doUnmock("./commands/init.js");
   vi.doUnmock("./telemetry/events.js");
   vi.doUnmock("./telemetry/index.js");
+  vi.doUnmock("./utils/updateCheck.js");
+  vi.doUnmock("./utils/autoUpdate.js");
+  vi.doUnmock("./utils/skillsUpdateCheck.js");
   vi.resetModules();
 });
 
@@ -231,6 +234,61 @@ describe("CLI lifecycle", () => {
     } finally {
       exitSpy.mockRestore();
     }
+  });
+
+  it("awaits a still-refreshing skills-freshness check before printing its notice", async () => {
+    // Regression for the skills-freshness/process.exit race: the check is a
+    // detached dynamic import + async cache refresh, so on a cold cache it
+    // can still be in flight when finalizeCli runs. Simulate that by holding
+    // checkSkillsForUpdate open and asserting the notice can't have printed
+    // (nor, by extension, could the process have exited) until it resolves.
+    let resolveCheckGate!: () => void;
+    const checkGate = new Promise<void>((resolve) => {
+      resolveCheckGate = resolve;
+    });
+    let markCheckStarted!: () => void;
+    const checkStarted = new Promise<void>((resolve) => {
+      markCheckStarted = resolve;
+    });
+    const order: string[] = [];
+
+    mockInitCommand(vi.fn());
+    mockTelemetry({});
+    vi.doMock("./utils/updateCheck.js", () => ({
+      checkForUpdate: vi.fn(async () => ({ updateAvailable: false })),
+      printUpdateNotice: vi.fn(),
+      printStalePinNotice: vi.fn(),
+    }));
+    vi.doMock("./utils/autoUpdate.js", () => ({
+      reportCompletedUpdate: vi.fn(),
+      scheduleBackgroundInstall: vi.fn(),
+    }));
+    vi.doMock("./utils/skillsUpdateCheck.js", () => ({
+      checkSkillsForUpdate: vi.fn(async () => {
+        order.push("check-started");
+        markCheckStarted();
+        await checkGate;
+        order.push("check-resolved");
+        return { updateAvailable: true, outdated: 1, missing: 0, removed: 0 };
+      }),
+      printSkillsUpdateNotice: vi.fn(() => {
+        order.push("notice-printed");
+      }),
+    }));
+
+    process.argv = ["node", "cli.ts", "init"];
+    const execution = import("./cli.js");
+
+    await checkStarted;
+    // Give the command's own synchronous completion path a turn to run
+    // ahead of the still-open check — this is what used to race exit.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(order).toEqual(["check-started"]);
+
+    resolveCheckGate();
+    await execution;
+
+    expect(order).toEqual(["check-started", "check-resolved", "notice-printed"]);
   });
 });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -217,6 +217,11 @@ let _printUpdateNotice: (() => void) | undefined;
 let _printStalePinNotice: (() => void) | undefined;
 let _printSkillsUpdateNotice: (() => void) | undefined;
 let telemetryReady: Promise<void> = Promise.resolve();
+// Bounded by skillsUpdateCheck's own internal fetch/git timeouts (a few
+// seconds worst case on a cold cache) — finalizeCli awaits this so the
+// notice reflects a freshly-written cache instead of racing process.exit()
+// against the still-in-flight refresh.
+let skillsCheckReady: Promise<void> = Promise.resolve();
 
 // `events` is a telemetry-internal beacon: it self-tracks + self-flushes, so it
 // skips the per-command wrapper (no duplicate cli_command, no first-run notice
@@ -267,8 +272,11 @@ if (
   });
 
   // Skills freshness nudge — same gating as the CLI self-update notice. The
-  // check is cached (24h) and best-effort: it never blocks or fails the command.
-  import("./utils/skillsUpdateCheck.js").then(async (mod) => {
+  // check is cached (24h) and best-effort: it never blocks or fails the command
+  // for long (skillsUpdateCheck's own fetch/git calls carry their own short
+  // timeouts). finalizeCli awaits skillsCheckReady before printing the notice
+  // so exit can't race the cache write.
+  skillsCheckReady = import("./utils/skillsUpdateCheck.js").then(async (mod) => {
     _printSkillsUpdateNotice = mod.printSkillsUpdateNotice;
     await mod.checkSkillsForUpdate().catch(() => null);
   });
@@ -305,6 +313,7 @@ async function finalizeCli(result: CommandResult): Promise<void> {
   if (!hasJsonFlag) {
     _printUpdateNotice?.();
     _printStalePinNotice?.();
+    await skillsCheckReady.catch(() => {});
     _printSkillsUpdateNotice?.();
   }
   process.exitCode = exitCode;


### PR DESCRIPTION
## Summary

- The skills-freshness nudge (`checkSkillsForUpdate` in `skillsUpdateCheck.ts`) is kicked off in `cli.ts` as a detached dynamic import + async chain — never awaited by `finalizeCli`. On a cold cache (the check hasn't run in the last 24h), the refresh does real I/O (manifest read/fetch + a config-file write) that can still be in flight when the command otherwise finishes.
- That meant two related bugs: (1) `finalizeCli`'s synchronous `_printSkillsUpdateNotice?.()` call could run and print a stale/empty notice before the check populated fresh cache data, and (2) `process.exit()` (fired from `registerRootExitRequester`'s callback) could terminate the process before the refresh's `writeConfig()` ever completed, silently dropping the cache write — so the next command repeats the same slow check instead of benefiting from it.
- Fix: capture the check's promise in a module-level `skillsCheckReady`, and `await` it (guarded with `.catch(() => {})`, same pattern as the existing `telemetryReady` await) immediately before `finalizeCli` prints the notice. This is safe from a "never blocks the command" standpoint because the underlying manifest fetch/git calls already carry their own short internal timeouts (a few seconds worst case) — this change doesn't introduce a new unbounded wait, it just makes the existing bounded one actually get awaited.

## Test plan

- [x] New regression test in `cli.lifecycle.test.ts` (`awaits a still-refreshing skills-freshness check before printing its notice`) that holds `checkSkillsForUpdate` open with a manual gate to simulate cold-cache timing, and asserts the notice cannot print until the check resolves.
- [x] Confirmed RED without the fix (notice printed before the check resolved) and GREEN with it, via a tagged-stash isolation of just the `cli.ts` change.
- [x] `bunx tsc --noEmit -p packages/cli`, `bunx oxlint`, `bunx oxfmt --write`, `bunx fallow audit --base origin/main --fail-on-issues` all clean.
- [x] Full `cli.lifecycle.test.ts` + `skillsUpdateCheck.test.ts` suites pass (17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)