### PR TITLE
fix(cli): route FFmpeg exec-failure hint through getFFmpegInstallHint()

### DIFF
--- a/packages/cli/src/browser/preflight.test.ts
+++ b/packages/cli/src/browser/preflight.test.ts
@@ -88,8 +88,40 @@ describe("runEnvironmentChecks", () => {
     });
     expect(ffmpeg?.detail).toContain(process.execPath);
     expect(ffmpeg?.detail).toContain("3221225781");
-    expect(ffmpeg?.hint).toContain("working 64-bit FFmpeg build");
     expect(result.ffmpegPath).toBeUndefined();
+  });
+
+  // Regression: the "cannot start" branch used to hardcode a Windows/DLL hint
+  // on every platform instead of routing through the already platform-aware
+  // getFFmpegInstallHint(). Pin it per-platform so a future regression can't
+  // just swap back to a different unconditional string.
+  describe("FFmpeg cannot-start hint is platform-specific", () => {
+    const realPlatform = process.platform;
+
+    afterEach(() => {
+      Object.defineProperty(process, "platform", { value: realPlatform, configurable: true });
+    });
+
+    it.each([
+      { platform: "darwin" as const, expectedHint: "brew install ffmpeg" },
+      { platform: "sunos" as const, expectedHint: "https://ffmpeg.org/download.html" },
+    ])(
+      "uses getFFmpegInstallHint()'s $platform text, not a hardcoded DLL hint",
+      async ({ platform, expectedHint }) => {
+        Object.defineProperty(process, "platform", { value: platform, configurable: true });
+        execFileSync.mockImplementation((binaryPath: string) => {
+          if (binaryPath !== process.env.HYPERFRAMES_FFMPEG_PATH) return "ffprobe version 7.1.1\n";
+          throw Object.assign(new Error("cannot execute binary file"), { status: 126 });
+        });
+
+        const result = await runEnvironmentChecks();
+        const ffmpeg = result.outcomes.find((outcome) => outcome.name === "FFmpeg");
+
+        expect(ffmpeg?.title).toBe("FFmpeg cannot start");
+        expect(ffmpeg?.hint).toBe(expectedHint);
+        expect(ffmpeg?.hint).not.toContain("DLL");
+      },
+    );
   });
 
   it("validates an explicit browser path without needing browser discovery", async () => {

--- a/packages/cli/src/browser/preflight.ts
+++ b/packages/cli/src/browser/preflight.ts
@@ -102,7 +102,7 @@ function checkFFmpeg(): EnvironmentCheckOutcome {
         level: "error",
         title: "FFmpeg cannot start",
         detail: version.detail,
-        hint: "Install a working 64-bit FFmpeg build with all required runtime DLLs.",
+        hint: getFFmpegInstallHint(),
         path,
       };
     }


### PR DESCRIPTION
## Summary
- `checkFFmpeg()`'s "cannot start" branch (FFmpeg binary found but fails to run `-version`, e.g. corrupted/wrong-arch binary) hardcoded a Windows/DLL-flavored install hint string on every platform, instead of delegating to the already platform-aware `getFFmpegInstallHint()` that every other branch in this file (and `checkFFprobe()`) already uses.
- Swapped the hardcoded string for a `getFFmpegInstallHint()` call, matching the pattern used everywhere else in `preflight.ts`.

## Root cause
PRINFRA-674: introduced in #2430 ("diagnose unlaunchable Windows FFmpeg"), which added the "cannot start" diagnostic but hardcoded the hint instead of reusing the helper — verified live by reproducing an exec failure (`HYPERFRAMES_FFMPEG_PATH` pointed at a script that exits nonzero) and confirming the generic "64-bit"/"DLLs" text on a non-Windows platform.

## Test plan
- [x] Added a regression test (`preflight.test.ts`) asserting the "cannot start" hint matches `getFFmpegInstallHint()`'s platform-specific text (darwin → `brew install ffmpeg`, an unhandled platform → the generic download URL) and never contains "DLL". Confirmed RED without the fix / GREEN with it via tagged-stash isolation.
- [x] `bunx vitest run packages/cli/src/browser/` — 119/119 passed
- [x] `bunx tsc --noEmit -p packages/cli` — clean
- [x] `bunx oxlint` + `bunx oxfmt --write` — clean
- [x] `bunx fallow audit --base origin/main --fail-on-issues` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)