### PR TITLE
fix(cli): stop lambda deploy/destroy from pointing at a nonexistent --sam-template flag

### DIFF
--- a/packages/cli/src/commands/lambda/sam.test.ts
+++ b/packages/cli/src/commands/lambda/sam.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { locateSamTemplate } from "./sam.js";
+
+let dir: string | undefined;
+
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = undefined;
+});
+
+describe("locateSamTemplate", () => {
+  it("returns the template path when it exists under repoRoot", () => {
+    dir = mkdtempSync(join(tmpdir(), "hf-lambda-sam-"));
+    const samDir = join(dir, "examples", "aws-lambda");
+    mkdirSync(samDir, { recursive: true });
+    const templatePath = join(samDir, "template.yaml");
+    writeFileSync(templatePath, "AWSTemplateFormatVersion: '2010-09-09'\n");
+
+    expect(locateSamTemplate(dir)).toBe(templatePath);
+  });
+
+  // Regression: this error used to tell users to "point --sam-template at
+  // your local copy" of the template -- but no --sam-template flag was ever
+  // wired up anywhere in lambda.ts/deploy.ts/destroy.ts, and the template
+  // isn't shipped in any published package either. A dead-end escape hatch.
+  // Pin the corrected, honest message so a future regression can't just
+  // restore the old lie.
+  it("does not point users at the nonexistent --sam-template flag when the template is missing", () => {
+    dir = mkdtempSync(join(tmpdir(), "hf-lambda-sam-missing-"));
+
+    expect(() => locateSamTemplate(dir!)).toThrow(/HYPERFRAMES_REPO_ROOT/);
+    expect(() => locateSamTemplate(dir!)).not.toThrow(/--sam-template/);
+  });
+});

--- a/packages/cli/src/commands/lambda/sam.ts
+++ b/packages/cli/src/commands/lambda/sam.ts
@@ -60,17 +60,21 @@ export interface DeployOptions {
 }
 
 /**
- * Resolve the SAM template path relative to `repoRoot`. We look for the
- * `examples/aws-lambda/template.yaml` first (development checkout) and
- * fall back to the installed-package layout when running from a globally
- * installed `hyperframes` CLI.
+ * Resolve the SAM template path relative to `repoRoot`. `hyperframes lambda
+ * deploy`/`destroy` only work from a HyperFrames monorepo checkout (or
+ * `HYPERFRAMES_REPO_ROOT` pointed at one) — there is no installed-package
+ * fallback. The template's `CodeUri` is a path relative to this file
+ * (`../../packages/aws-lambda/dist/handler.zip`), so even a copied-out
+ * template wouldn't resolve to a real handler ZIP without the matching
+ * monorepo layout alongside it.
  */
 export function locateSamTemplate(repoRoot: string): string {
   const candidate = join(repoRoot, "examples", "aws-lambda", "template.yaml");
   if (!existsSync(candidate)) {
     throw new Error(
       `[lambda] SAM template not found at ${candidate}. ` +
-        `If you're running from an installed package, point --sam-template at your local copy of examples/aws-lambda/template.yaml.`,
+        `\`hyperframes lambda deploy\`/\`destroy\` require a HyperFrames monorepo checkout — ` +
+        `run from within one, or set HYPERFRAMES_REPO_ROOT to point at one.`,
     );
   }
   return candidate;


### PR DESCRIPTION
## Summary
- `locateSamTemplate()`'s error message and doc comment claimed a `--sam-template` CLI flag existed as an installed-package fallback for `hyperframes lambda deploy`/`destroy` — but no such flag is wired up anywhere in `lambda.ts`/`deploy.ts`/`destroy.ts` (confirmed via grep), and `examples/aws-lambda/template.yaml` also isn't shipped in any published package. A dead-end escape hatch that just wasted users' time when they hit it.
- Replaced the message with the honest requirement, matching `repoRoot()`'s own accurate error: these commands need a HyperFrames monorepo checkout, or `HYPERFRAMES_REPO_ROOT` pointed at one.
- Root-caused as part of PRINFRA-679 ("lambda deploy has no install-path fallback"). Investigation found the originally-suggested fix (resolve the installed `@hyperframes/aws-lambda` package like `sites create` does) doesn't hold up: `deploy`'s handler-ZIP build (`packages/aws-lambda/scripts/build-zip.ts`) is deeply monorepo-coupled (esbuild-aliases `@hyperframes/{producer,engine,core}` straight to monorepo TS source, pins versions from the root `bun.lock`, copies `packages/core/dist` runtime artifacts) — the npm-published `dist/handler.js` is a different, incompatible artifact (externalizes `@hyperframes/producer`, no ffmpeg/chromium/runtime staging). Making `deploy` fully work from a plain npm install is a multi-file feature, not a fix-PR-sized change, and is being tracked as a separate ticket. This PR ships the safely-scoped, fully-testable half: stop the CLI from lying about a workaround that was never implemented.

## Test plan
- [x] New regression test `packages/cli/src/commands/lambda/sam.test.ts`: pins that `locateSamTemplate()` still resolves a valid template path, and that its error message no longer mentions `--sam-template` and instead mentions `HYPERFRAMES_REPO_ROOT`. Verified RED without the fix (isolated via tagged `git stash`) / GREEN with it.
- [x] `bunx vitest run packages/cli/src/commands/lambda/` — 45/45 passed.
- [x] `bunx tsc --noEmit -p packages/cli` — clean.
- [x] `bunx oxlint` + `bunx oxfmt --write` — clean.
- [x] `bunx fallow audit --base origin/main --fail-on-issues` — clean (pre-existing duplication finding in unrelated `samDeploy`/`samDelete` code is an inherited finding, excluded from the gate).
- [x] Pre-commit hooks (lefthook: lint/format/fallow/typecheck/commitlint) all passed on the actual commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)