### PR TITLE
fix(engine): treat 0-1 detected keyframes as maximally problematic

### DIFF
--- a/packages/engine/src/utils/ffprobe.test.ts
+++ b/packages/engine/src/utils/ffprobe.test.ts
@@ -1493,3 +1493,53 @@ describe("runFfprobe process and stream handling", () => {
     );
   });
 });
+
+describe("analyzeKeyframeIntervals sparse-keyframe blind spot", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("child_process");
+  });
+
+  // Regression: 0 or 1 detected keyframes used to short-circuit to
+  // isProblematic:false — the sparsest possible GOP (a single I-frame, or
+  // none, covering the whole video) read as *healthier* than a video with a
+  // merely-long-but-finite gap. PRINFRA-307.
+  it("treats zero keyframes as maximally problematic, not healthy", async () => {
+    const { spawn } = createSpawnSpy([{ kind: "exit", code: 0, stdout: "" }]);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+    const { analyzeKeyframeIntervals } = await import("./ffprobe.js");
+
+    const result = await analyzeKeyframeIntervals("/tmp/no-keyframes.mp4");
+
+    expect(result.keyframeCount).toBe(0);
+    expect(result.isProblematic).toBe(true);
+    expect(result.maxIntervalSeconds).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("treats a single keyframe as maximally problematic, not healthy", async () => {
+    const { spawn } = createSpawnSpy([{ kind: "exit", code: 0, stdout: "0.000000\n" }]);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+    const { analyzeKeyframeIntervals } = await import("./ffprobe.js");
+
+    const result = await analyzeKeyframeIntervals("/tmp/one-keyframe.mp4");
+
+    expect(result.keyframeCount).toBe(1);
+    expect(result.isProblematic).toBe(true);
+    expect(result.maxIntervalSeconds).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("still evaluates 2+ keyframes on their actual max gap, unaffected by the fix", async () => {
+    const { spawn } = createSpawnSpy([{ kind: "exit", code: 0, stdout: "0.0\n1.0\n2.0\n" }]);
+    vi.resetModules();
+    vi.doMock("child_process", () => ({ spawn }));
+    const { analyzeKeyframeIntervals } = await import("./ffprobe.js");
+
+    const result = await analyzeKeyframeIntervals("/tmp/dense-keyframes.mp4");
+
+    expect(result.keyframeCount).toBe(3);
+    expect(result.isProblematic).toBe(false);
+    expect(result.maxIntervalSeconds).toBe(1);
+  });
+});

--- a/packages/engine/src/utils/ffprobe.ts
+++ b/packages/engine/src/utils/ffprobe.ts
@@ -1051,11 +1051,16 @@ async function analyzeKeyframeIntervalsUncached(filePath: string): Promise<Keyfr
     .filter((t) => Number.isFinite(t));
 
   if (timestamps.length < 2) {
+    // 0 or 1 detected keyframes is the sparsest possible GOP — worse than any
+    // finite gap, since a single I-frame (or none) covers the entire video
+    // with no keyframe to seek back to at all. Report it as maximally
+    // problematic rather than "no interval data" so this doesn't read as
+    // healthier than a video with a merely-long-but-finite gap.
     return {
-      avgIntervalSeconds: 0,
-      maxIntervalSeconds: 0,
+      avgIntervalSeconds: Number.POSITIVE_INFINITY,
+      maxIntervalSeconds: Number.POSITIVE_INFINITY,
       keyframeCount: timestamps.length,
-      isProblematic: false,
+      isProblematic: true,
     };
   }
 


### PR DESCRIPTION
## Summary

PRINFRA-307: `analyzeKeyframeIntervals` (root-caused by cli-repro via direct instrumentation) short-circuited any video with fewer than 2 detected keyframes to `isProblematic: false, maxIntervalSeconds: 0` — but 0 or 1 keyframes is the sparsest possible GOP (a single I-frame, or none, covering the entire video), strictly worse than any finite gap. This meant the compiler's sparse-keyframe warning (`[Compiler] WARNING: ... has sparse keyframes ... causes seek failures and frame freezing`, which already correctly fires for the >2s finite-gap case) silently never fired for the worst-case input it exists to catch — common with `yt-dlp --download-sections` output and screen recordings.

- 0 or 1 detected keyframes now returns `isProblematic: true` with `avgIntervalSeconds`/`maxIntervalSeconds` set to `+Infinity` (no keyframe to seek back to at all — strictly worse than any finite interval, so reporting it as "no interval data" would read as healthier than it is).
- 2+ keyframes are unaffected — same max-gap-based evaluation as before.

## Test plan

- [x] Three new tests in `ffprobe.test.ts` (`analyzeKeyframeIntervals sparse-keyframe blind spot`): 0 keyframes → problematic, 1 keyframe → problematic, 3 keyframes with a 1s gap → still correctly not problematic (unaffected by the fix). Confirmed RED on the two new blind-spot cases without the fix (isolated via tagged `git stash`) / GREEN with it.
- [x] `bunx vitest run packages/engine/src/utils/ffprobe.test.ts` — 114/118 passed, 3/3 new tests pass. The 4 failing tests are pre-existing and unrelated: they depend on a git-lfs-tracked PNG fixture (`hdr-photo-pq.png`) that resolves to an LFS pointer file (no `git-lfs` in this sandbox) — confirmed failing identically on a clean `origin/main` checkout before any of my changes.
- [x] `bunx tsc --noEmit -p packages/engine` and `-p packages/producer` (the one consumer of `maxIntervalSeconds`) — both clean.
- [x] `bunx oxlint` / `bunx oxfmt --write` — clean, no unwanted reformatting.
- [x] `bunx fallow audit --base origin/main --fail-on-issues` — clean (0 issues in 2 changed files).
- [x] Pre-commit hooks (lefthook: lint/format/fallow/typecheck/commitlint) all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)