### PR TITLE
fix(skills): loop-extended BGM writes .mp3, not MP3-in-a-.wav

### DIFF
--- a/skills-manifest.json
+++ b/skills-manifest.json
@@ -6,7 +6,7 @@
       "files": 142
     },
     "faceless-explainer": {
-      "hash": "76162336b4c88963",
+      "hash": "3f84e9cf9c2468ca",
       "files": 24
     },
     "figma": {
@@ -62,11 +62,11 @@
       "files": 132
     },
     "pr-to-video": {
-      "hash": "265c1f85d732d79c",
+      "hash": "b93575a96d213ff5",
       "files": 30
     },
     "product-launch-video": {
-      "hash": "3e1efc70cad06b58",
+      "hash": "b1597ed153cafcc7",
       "files": 30
     },
     "remotion-to-hyperframes": {

--- a/skills/faceless-explainer/scripts/assemble-index.mjs
+++ b/skills/faceless-explainer/scripts/assemble-index.mjs
@@ -92,7 +92,10 @@ function ensureBgmCovers(relPath, hyperframesDir, total) {
   if (!Number.isFinite(dur) || dur <= 0)
     return { looped: false, short: false, reason: "unreadable duration" };
   if (dur >= total - 0.1) return { looped: false, short: false, dur }; // already covers
-  const relOut = relPath.replace(/\.([^./]+)$/, ".loop.$1");
+  // Always emit .mp3: the encode below is libmp3lame regardless of the source
+  // extension, so preserving relPath's own extension (e.g. "bgm.wav") would
+  // smuggle an MP3 stream into a .wav-named file (PRINFRA-309).
+  const relOut = relPath.replace(/\.([^./]+)$/, ".loop.mp3");
   const absOut = join(hyperframesDir, relOut);
   const fadeOut = Math.max(0, total - 1.5);
   const ff = spawnSync(

--- a/skills/faceless-explainer/scripts/assemble-index.test.mjs
+++ b/skills/faceless-explainer/scripts/assemble-index.test.mjs
@@ -1,18 +1,21 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 const assembleScript = new URL("./assemble-index.mjs", import.meta.url).pathname;
+const HAS_FFMPEG =
+  spawnSync("ffmpeg", ["-version"], { stdio: "ignore" }).status === 0 &&
+  spawnSync("ffprobe", ["-version"], { stdio: "ignore" }).status === 0;
 
 // ── bgm_pending at the assembly boundary ─────────────────────────────────────
 // Regression: the flag survived into audio_meta.json but assemble rebuilt its audio object
 // from three named keys and dropped it, so the step that actually builds the film could not
 // tell "not ready yet" from "silent by design" and would ship the silent one.
 
-function assembleWith({ audioMeta, extraArgs = [] }) {
+function assembleWith({ audioMeta, extraArgs = [], beforeAssemble }) {
   const dir = mkdtempSync(join(tmpdir(), "product-launch-assemble-"));
   writeFileSync(
     join(dir, "STORYBOARD.md"),
@@ -25,6 +28,7 @@ function assembleWith({ audioMeta, extraArgs = [] }) {
       '<section class="clip" data-start="0" data-duration="3"></section></div>',
   );
   if (audioMeta) writeFileSync(join(dir, "audio_meta.json"), JSON.stringify(audioMeta));
+  if (beforeAssemble) beforeAssemble(dir);
   const r = spawnSync(
     process.execPath,
     [
@@ -70,3 +74,54 @@ test("a film that is silent BY DESIGN still assembles untouched", () => {
   assert.equal(existsSync(join(dir, "index.html")), true);
   assert.doesNotMatch(r.stderr, /bgm_pending/);
 });
+
+// ── PRINFRA-309: loop-extended BGM must be a real .mp3, not MP3-in-a-.wav ────
+// ensureBgmCovers() always encodes the loop-extended track with libmp3lame — so a source
+// asset named "*.wav" that's short of TOTAL used to come out as MP3 audio inside a
+// .loop.wav-named file: decodes fine via ffprobe/ffmpeg/Chromium (which sniff the real
+// WAVE_FORMAT_MPEGLAYER3 tag), but hard-fails in any naive/strict WAV parser (e.g. Python's
+// stdlib `wave` module) that doesn't do full format-tag dispatch.
+test(
+  "loop-extended bgm is written as .mp3, not .loop.wav, even when the source is a .wav",
+  { skip: !HAS_FFMPEG },
+  () => {
+    const { dir, r } = assembleWith({
+      audioMeta: { bgm: { path: "assets/bgm/bed.wav" }, voices: [], sfx: [] },
+      beforeAssemble: (projectDir) => {
+        mkdirSync(join(projectDir, "assets", "bgm"), { recursive: true });
+        // 1s tone, well short of the 3s TOTAL from the single storyboard frame above —
+        // guarantees ensureBgmCovers() takes the loop-extend branch.
+        const gen = spawnSync(
+          "ffmpeg",
+          [
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=1",
+            join(projectDir, "assets", "bgm", "bed.wav"),
+          ],
+          { encoding: "utf8" },
+        );
+        assert.equal(gen.status, 0, gen.stderr);
+      },
+    });
+
+    assert.equal(r.status, 0, r.stderr);
+    const html = readFileSync(join(dir, "index.html"), "utf8");
+    const bgmEl = html.match(/id="el-bgm"[\s\S]*?src="([^"]+)"/);
+    assert.ok(bgmEl, "expected a bgm <audio> element in index.html");
+    const bgmSrc = bgmEl[1];
+    assert.match(bgmSrc, /\.mp3$/, `bgm src should end in .mp3, got "${bgmSrc}"`);
+    assert.doesNotMatch(bgmSrc, /\.wav$/);
+
+    const outPath = join(dir, bgmSrc);
+    assert.equal(existsSync(outPath), true);
+    const probe = spawnSync(
+      "ffprobe",
+      ["-v", "error", "-show_entries", "stream=codec_name", "-of", "csv=p=0", "--", outPath],
+      { encoding: "utf8" },
+    );
+    assert.equal(probe.stdout.trim(), "mp3");
+  },
+);

--- a/skills/pr-to-video/scripts/assemble-index.mjs
+++ b/skills/pr-to-video/scripts/assemble-index.mjs
@@ -93,7 +93,10 @@ function ensureBgmCovers(relPath, hyperframesDir, total) {
   if (!Number.isFinite(dur) || dur <= 0)
     return { looped: false, short: false, reason: "unreadable duration" };
   if (dur >= total - 0.1) return { looped: false, short: false, dur }; // already covers
-  const relOut = relPath.replace(/\.([^./]+)$/, ".loop.$1");
+  // Always emit .mp3: the encode below is libmp3lame regardless of the source
+  // extension, so preserving relPath's own extension (e.g. "bgm.wav") would
+  // smuggle an MP3 stream into a .wav-named file (PRINFRA-309).
+  const relOut = relPath.replace(/\.([^./]+)$/, ".loop.mp3");
   const absOut = join(hyperframesDir, relOut);
   const fadeOut = Math.max(0, total - 1.5);
   const ff = spawnSync(

--- a/skills/pr-to-video/scripts/assemble-index.test.mjs
+++ b/skills/pr-to-video/scripts/assemble-index.test.mjs
@@ -1,18 +1,21 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 const assembleScript = new URL("./assemble-index.mjs", import.meta.url).pathname;
+const HAS_FFMPEG =
+  spawnSync("ffmpeg", ["-version"], { stdio: "ignore" }).status === 0 &&
+  spawnSync("ffprobe", ["-version"], { stdio: "ignore" }).status === 0;
 
 // ── bgm_pending at the assembly boundary ─────────────────────────────────────
 // Regression: the flag survived into audio_meta.json but assemble rebuilt its audio object
 // from three named keys and dropped it, so the step that actually builds the film could not
 // tell "not ready yet" from "silent by design" and would ship the silent one.
 
-function assembleWith({ audioMeta, extraArgs = [] }) {
+function assembleWith({ audioMeta, extraArgs = [], beforeAssemble }) {
   const dir = mkdtempSync(join(tmpdir(), "product-launch-assemble-"));
   writeFileSync(
     join(dir, "STORYBOARD.md"),
@@ -28,6 +31,7 @@ function assembleWith({ audioMeta, extraArgs = [] }) {
       "</div></template>",
   );
   if (audioMeta) writeFileSync(join(dir, "audio_meta.json"), JSON.stringify(audioMeta));
+  if (beforeAssemble) beforeAssemble(dir);
   const r = spawnSync(
     process.execPath,
     [
@@ -73,3 +77,54 @@ test("a film that is silent BY DESIGN still assembles untouched", () => {
   assert.equal(existsSync(join(dir, "index.html")), true);
   assert.doesNotMatch(r.stderr, /bgm_pending/);
 });
+
+// ── PRINFRA-309: loop-extended BGM must be a real .mp3, not MP3-in-a-.wav ────
+// ensureBgmCovers() always encodes the loop-extended track with libmp3lame — so a source
+// asset named "*.wav" that's short of TOTAL used to come out as MP3 audio inside a
+// .loop.wav-named file: decodes fine via ffprobe/ffmpeg/Chromium (which sniff the real
+// WAVE_FORMAT_MPEGLAYER3 tag), but hard-fails in any naive/strict WAV parser (e.g. Python's
+// stdlib `wave` module) that doesn't do full format-tag dispatch.
+test(
+  "loop-extended bgm is written as .mp3, not .loop.wav, even when the source is a .wav",
+  { skip: !HAS_FFMPEG },
+  () => {
+    const { dir, r } = assembleWith({
+      audioMeta: { bgm: { path: "assets/bgm/bed.wav" }, voices: [], sfx: [] },
+      beforeAssemble: (projectDir) => {
+        mkdirSync(join(projectDir, "assets", "bgm"), { recursive: true });
+        // 1s tone, well short of the 3s TOTAL from the single storyboard frame above —
+        // guarantees ensureBgmCovers() takes the loop-extend branch.
+        const gen = spawnSync(
+          "ffmpeg",
+          [
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=1",
+            join(projectDir, "assets", "bgm", "bed.wav"),
+          ],
+          { encoding: "utf8" },
+        );
+        assert.equal(gen.status, 0, gen.stderr);
+      },
+    });
+
+    assert.equal(r.status, 0, r.stderr);
+    const html = readFileSync(join(dir, "index.html"), "utf8");
+    const bgmEl = html.match(/id="el-bgm"[\s\S]*?src="([^"]+)"/);
+    assert.ok(bgmEl, "expected a bgm <audio> element in index.html");
+    const bgmSrc = bgmEl[1];
+    assert.match(bgmSrc, /\.mp3$/, `bgm src should end in .mp3, got "${bgmSrc}"`);
+    assert.doesNotMatch(bgmSrc, /\.wav$/);
+
+    const outPath = join(dir, bgmSrc);
+    assert.equal(existsSync(outPath), true);
+    const probe = spawnSync(
+      "ffprobe",
+      ["-v", "error", "-show_entries", "stream=codec_name", "-of", "csv=p=0", "--", outPath],
+      { encoding: "utf8" },
+    );
+    assert.equal(probe.stdout.trim(), "mp3");
+  },
+);

--- a/skills/product-launch-video/scripts/assemble-index.mjs
+++ b/skills/product-launch-video/scripts/assemble-index.mjs
@@ -92,7 +92,10 @@ function ensureBgmCovers(relPath, hyperframesDir, total) {
   if (!Number.isFinite(dur) || dur <= 0)
     return { looped: false, short: false, reason: "unreadable duration" };
   if (dur >= total - 0.1) return { looped: false, short: false, dur }; // already covers
-  const relOut = relPath.replace(/\.([^./]+)$/, ".loop.$1");
+  // Always emit .mp3: the encode below is libmp3lame regardless of the source
+  // extension, so preserving relPath's own extension (e.g. "bgm.wav") would
+  // smuggle an MP3 stream into a .wav-named file (PRINFRA-309).
+  const relOut = relPath.replace(/\.([^./]+)$/, ".loop.mp3");
   const absOut = join(hyperframesDir, relOut);
   const fadeOut = Math.max(0, total - 1.5);
   const ff = spawnSync(

--- a/skills/product-launch-video/scripts/assemble-index.test.mjs
+++ b/skills/product-launch-video/scripts/assemble-index.test.mjs
@@ -1,18 +1,21 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 const assembleScript = new URL("./assemble-index.mjs", import.meta.url).pathname;
+const HAS_FFMPEG =
+  spawnSync("ffmpeg", ["-version"], { stdio: "ignore" }).status === 0 &&
+  spawnSync("ffprobe", ["-version"], { stdio: "ignore" }).status === 0;
 
 // ── bgm_pending at the assembly boundary ─────────────────────────────────────
 // Regression: the flag survived into audio_meta.json but assemble rebuilt its audio object
 // from three named keys and dropped it, so the step that actually builds the film could not
 // tell "not ready yet" from "silent by design" and would ship the silent one.
 
-function assembleWith({ audioMeta, extraArgs = [] }) {
+function assembleWith({ audioMeta, extraArgs = [], beforeAssemble }) {
   const dir = mkdtempSync(join(tmpdir(), "product-launch-assemble-"));
   writeFileSync(
     join(dir, "STORYBOARD.md"),
@@ -25,6 +28,7 @@ function assembleWith({ audioMeta, extraArgs = [] }) {
       '<section class="clip" data-start="0" data-duration="3"></section></div>',
   );
   if (audioMeta) writeFileSync(join(dir, "audio_meta.json"), JSON.stringify(audioMeta));
+  if (beforeAssemble) beforeAssemble(dir);
   const r = spawnSync(
     process.execPath,
     [
@@ -70,3 +74,54 @@ test("a film that is silent BY DESIGN still assembles untouched", () => {
   assert.equal(existsSync(join(dir, "index.html")), true);
   assert.doesNotMatch(r.stderr, /bgm_pending/);
 });
+
+// ── PRINFRA-309: loop-extended BGM must be a real .mp3, not MP3-in-a-.wav ────
+// ensureBgmCovers() always encodes the loop-extended track with libmp3lame — so a source
+// asset named "*.wav" that's short of TOTAL used to come out as MP3 audio inside a
+// .loop.wav-named file: decodes fine via ffprobe/ffmpeg/Chromium (which sniff the real
+// WAVE_FORMAT_MPEGLAYER3 tag), but hard-fails in any naive/strict WAV parser (e.g. Python's
+// stdlib `wave` module) that doesn't do full format-tag dispatch.
+test(
+  "loop-extended bgm is written as .mp3, not .loop.wav, even when the source is a .wav",
+  { skip: !HAS_FFMPEG },
+  () => {
+    const { dir, r } = assembleWith({
+      audioMeta: { bgm: { path: "assets/bgm/bed.wav" }, voices: [], sfx: [] },
+      beforeAssemble: (projectDir) => {
+        mkdirSync(join(projectDir, "assets", "bgm"), { recursive: true });
+        // 1s tone, well short of the 3s TOTAL from the single storyboard frame above —
+        // guarantees ensureBgmCovers() takes the loop-extend branch.
+        const gen = spawnSync(
+          "ffmpeg",
+          [
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=1",
+            join(projectDir, "assets", "bgm", "bed.wav"),
+          ],
+          { encoding: "utf8" },
+        );
+        assert.equal(gen.status, 0, gen.stderr);
+      },
+    });
+
+    assert.equal(r.status, 0, r.stderr);
+    const html = readFileSync(join(dir, "index.html"), "utf8");
+    const bgmEl = html.match(/id="el-bgm"[\s\S]*?src="([^"]+)"/);
+    assert.ok(bgmEl, "expected a bgm <audio> element in index.html");
+    const bgmSrc = bgmEl[1];
+    assert.match(bgmSrc, /\.mp3$/, `bgm src should end in .mp3, got "${bgmSrc}"`);
+    assert.doesNotMatch(bgmSrc, /\.wav$/);
+
+    const outPath = join(dir, bgmSrc);
+    assert.equal(existsSync(outPath), true);
+    const probe = spawnSync(
+      "ffprobe",
+      ["-v", "error", "-show_entries", "stream=codec_name", "-of", "csv=p=0", "--", outPath],
+      { encoding: "utf8" },
+    );
+    assert.equal(probe.stdout.trim(), "mp3");
+  },
+);


### PR DESCRIPTION
## Summary

- `ensureBgmCovers()` — duplicated across `skills/{faceless-explainer,pr-to-video,product-launch-video}/scripts/assemble-index.mjs` — always re-encodes a short BGM track with `libmp3lame` when loop-extending it to cover the video's full duration, but named the output by preserving the *source* asset's own extension. A `bgm.wav` source therefore produced `bgm.loop.wav` containing genuine MP3 audio: a real container/codec mismatch.
- Confirmed via a live repro: ffprobe/ffmpeg/real Chromium (`<audio>` via CDP) all decode this file correctly today, because ffmpeg's WAV muxer tags it `WAVE_FORMAT_MPEGLAYER3` and every consumer in HyperFrames' own pipeline goes through ffprobe/ffmpeg. So the originally-reported symptom (wrong/short duration, silent tail) does **not** reproduce with the current toolchain — this is a landmine for any future/adjacent *naive* WAV parser (e.g. Python's stdlib `wave` module, which hard-fails on format tag `0x55`), not a currently-triggered bug.
- The function's own doc comment already promised the fix: *"...into a sibling `*.loop.mp3` and return that path"* — the code just didn't match its own comment.
- Fix: always emit a `.loop.mp3` path regardless of the source extension.
- `music-to-video`'s `assemble-index.mjs` does **not** have this function — it mounts the raw BGM asset directly with no loop-extension step — so only 3 of the 4 skills needed the change.

## Explicitly out of scope

- The Kokoro Japanese phonemizer garble reported alongside this — unverified without live model synthesis, not touched.
- The separate `langApplied` diagnostic gap — different piece of work.

## Test plan

- Added a new regression test to all 3 affected `assemble-index.test.mjs` files (`{ skip: !HAS_FFMPEG }`, following the existing `dither.test.mjs` guard pattern): generates a real 1s WAV tone via `ffmpeg -f lavfi`, runs the actual assemble script against a storyboard whose TOTAL (3s) forces the loop-extend branch, then asserts the emitted `<audio id="el-bgm">` src ends in `.mp3` (not `.wav`) and that the file at that path really does decode as `codec_name=mp3` via `ffprobe`.
- Confirmed the new test fails against the pre-fix code (reverted locally, re-ran, got `AssertionError: bgm src should end in .mp3, got "assets/bgm/bed.loop.wav"`) and passes against the fix.
- `node --test` on all 3 modified test files: 12/12 pass.
- `bunx oxlint` + `bunx oxfmt --write` on all 6 changed files: clean, no reformatting needed beyond the authored diff.
- `bunx fallow audit --base origin/main --fail-on-issues`: clean, 0 issues across 6 changed files.
- Pre-commit hooks (lefthook: largefiles / tracked-artifacts / skills-manifest / commitlint) all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
