### PR TITLE
fix(producer): non-DE parallel-stream router silently refused on macOS multi-worker renders

### DIFF
--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -47,6 +47,7 @@ import {
   mergeWorkerInitObservability,
   resolveCompositionElementCount,
   resolveDeShortBand,
+  shouldClampDefaultDrawElement,
   shouldPreferParallelDrawElement,
   shouldPreferSingleWorkerDrawElement,
   shouldStreamParallelCapture,
@@ -2838,6 +2839,97 @@ describe("shouldStreamParallelCapture (non-DE parallel streaming router)", () =>
 
   it("skips HDR-layered and shader-transition routes", () => {
     expect(shouldStreamParallelCapture({ ...eligible, layeredOrEffectRoute: true })).toBe(false);
+  });
+});
+
+describe("shouldClampDefaultDrawElement (default-on drawElement clamp)", () => {
+  const unverifiedParallel = {
+    useDrawElement: true,
+    fastCaptureExplicitOptIn: false,
+    useStreamingEncode: false,
+    workerCount: 2,
+    deParallelStreamVerified: false,
+  };
+
+  it("clamps default-on drawElement for unverified multi-worker capture", () => {
+    expect(shouldClampDefaultDrawElement(unverifiedParallel)).toBe(true);
+  });
+
+  it("leaves useDrawElement alone once it is already false", () => {
+    expect(shouldClampDefaultDrawElement({ ...unverifiedParallel, useDrawElement: false })).toBe(
+      false,
+    );
+  });
+
+  it("an explicit opt-in overrides the clamp", () => {
+    expect(
+      shouldClampDefaultDrawElement({ ...unverifiedParallel, fastCaptureExplicitOptIn: true }),
+    ).toBe(false);
+  });
+
+  it("does not clamp a verified multi-worker streaming render", () => {
+    expect(
+      shouldClampDefaultDrawElement({ ...unverifiedParallel, deParallelStreamVerified: true }),
+    ).toBe(false);
+  });
+
+  it("clamps a single-worker render with streaming off (the disk-path case)", () => {
+    expect(shouldClampDefaultDrawElement({ ...unverifiedParallel, workerCount: 1 })).toBe(true);
+  });
+
+  it("leaves a single-worker streaming render unclamped (self-verified by the drain)", () => {
+    expect(
+      shouldClampDefaultDrawElement({
+        ...unverifiedParallel,
+        workerCount: 1,
+        useStreamingEncode: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("default-on drawElement clamp feeds the non-DE parallel-stream router (PRINFRA-689)", () => {
+  // Regression guard for the bug reported at
+  // heygen.slack.com/archives/D0BASH3KBGW/p1789154235634189: the router
+  // requires the drawElement clamp's OUTPUT, not its input. A caller that
+  // reads `cfg.useDrawElement` before running the clamp — exactly the
+  // ordering this fix corrected in renderOrchestrator.ts — reproduces the
+  // bug even though both predicates below are individually correct.
+  const macOsDefaultOnMultiWorker = {
+    useDrawElement: true,
+    fastCaptureExplicitOptIn: false,
+    useStreamingEncode: false,
+    workerCount: 2,
+    deParallelStreamVerified: false,
+  };
+
+  it("routes once the clamp's post-clamp value feeds the router", () => {
+    const clamped = shouldClampDefaultDrawElement(macOsDefaultOnMultiWorker);
+    const postClampUseDrawElement = clamped ? false : macOsDefaultOnMultiWorker.useDrawElement;
+
+    expect(
+      shouldStreamParallelCapture({
+        routerEnabled: true,
+        workerCount: macOsDefaultOnMultiWorker.workerCount,
+        useDrawElement: postClampUseDrawElement,
+        outputFormat: "mp4",
+        streamingOk: true,
+        layeredOrEffectRoute: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("never routes if the router instead reads the PRE-clamp value (the bug)", () => {
+    expect(
+      shouldStreamParallelCapture({
+        routerEnabled: true,
+        workerCount: macOsDefaultOnMultiWorker.workerCount,
+        useDrawElement: macOsDefaultOnMultiWorker.useDrawElement,
+        outputFormat: "mp4",
+        streamingOk: true,
+        layeredOrEffectRoute: false,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -2888,13 +2888,10 @@ describe("shouldClampDefaultDrawElement (default-on drawElement clamp)", () => {
   });
 });
 
-describe("default-on drawElement clamp feeds the non-DE parallel-stream router (PRINFRA-689)", () => {
-  // Regression guard for the bug reported at
-  // heygen.slack.com/archives/D0BASH3KBGW/p1789154235634189: the router
-  // requires the drawElement clamp's OUTPUT, not its input. A caller that
-  // reads `cfg.useDrawElement` before running the clamp — exactly the
-  // ordering this fix corrected in renderOrchestrator.ts — reproduces the
-  // bug even though both predicates below are individually correct.
+describe("default-on drawElement clamp feeds the non-DE parallel-stream router", () => {
+  // The router requires the drawElement clamp's OUTPUT, not its input. Both
+  // predicates below are individually correct; a caller wiring them together
+  // in the wrong order still reproduces the bug these two tests bound.
   const macOsDefaultOnMultiWorker = {
     useDrawElement: true,
     fastCaptureExplicitOptIn: false,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -3263,10 +3263,6 @@ async function executeRenderPipeline(input: {
     // let auto-parallel renders use disk frames: the current ordered streaming
     // writer would otherwise stall later workers behind earlier frame ranges.
     // png-sequence has no encoded video output, so streaming is always bypassed.
-    // Computed here using only `deParallelStreamForced` (the DE-specific
-    // router's own force flag) because the non-DE router below hasn't run yet
-    // and its force flag is exactly what this clamp must NOT depend on — see
-    // the clamp's own comment for why that's safe.
     let useStreamingEncode = shouldUseStreamingEncode(
       cfg,
       outputFormat,
@@ -3275,25 +3271,19 @@ async function executeRenderPipeline(input: {
       deParallelStreamForced,
     );
     // Default-on drawElement is only safe where the runtime self-verification
-    // net actually runs: the single-worker streaming worker-encode drain. The
-    // disk path (png-sequence / over the streaming duration cap) and parallel
-    // capture ship frames no drain verifies — route those renders to the
-    // screenshot baseline unless drawElement was explicitly opted into.
-    // HF_DE_PARALLEL_STREAM: multi-worker STREAMING renders now carry the
-    // full drain-time self-verification (per-worker ground truth + the shared
-    // drain guard), so the confinement rule is satisfied and the parallel
-    // clamp does not apply. The disk path stays clamped.
+    // net actually runs: the single-worker streaming worker-encode drain, or
+    // (HF_DE_PARALLEL_STREAM) a verified multi-worker streaming render. The
+    // disk path and unverified parallel capture ship frames no drain
+    // verifies, so they clamp to the screenshot baseline unless drawElement
+    // was explicitly opted into.
     //
-    // Runs BEFORE the non-DE parallel-streaming router below: that router
-    // needs the post-clamp `cfg.useDrawElement` to know whether this render
-    // will actually use non-DE capture. That dependency is also why this
-    // clamp is safe to compute here: the router's own force flag
-    // (`captureParallelStreamForced`) can only become true once
-    // `cfg.useDrawElement` is already false (the router requires
-    // `!useDrawElement`), so whenever this clamp's guard below
-    // (`cfg.useDrawElement === true`) holds, that flag is always false —
-    // only `deParallelStreamForced` (the DE-specific router above, mutually
-    // exclusive with the non-DE one) can affect this clamp's outcome.
+    // This must run before the non-DE parallel-streaming router below, which
+    // needs `cfg.useDrawElement` post-clamp to know whether this render will
+    // actually use non-DE capture. The router's own force flag
+    // (`captureParallelStreamForced`) requires `!useDrawElement`, so it can
+    // only be true once this clamp has already fired — meaning the router's
+    // flag is always false while this clamp's guard is still evaluating,
+    // and `deParallelStreamForced` above is the only flag that can affect it.
     const deParallelStreamVerified =
       (deParallelStreamForced || process.env.HF_DE_PARALLEL_STREAM === "true") &&
       useStreamingEncode &&

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -2008,6 +2008,33 @@ export function shouldStreamParallelCapture(args: {
   );
 }
 
+/**
+ * Default-on drawElement clamp: is this render's runtime self-verification
+ * net absent, so `useDrawElement` must fall back to the screenshot/beginframe
+ * baseline? The disk path and unverified parallel capture ship frames no
+ * drain verifies — see the call site's comment on why this clamp's own
+ * outcome is independent of running before or after
+ * {@link shouldStreamParallelCapture} in the caller. Pure; exported for tests.
+ */
+export function shouldClampDefaultDrawElement(args: {
+  useDrawElement: boolean;
+  /** PRODUCER_EXPERIMENTAL_FAST_CAPTURE === "true" — explicit opt-in always wins. */
+  fastCaptureExplicitOptIn: boolean;
+  useStreamingEncode: boolean;
+  workerCount: number;
+  /** (deParallelStreamForced || HF_DE_PARALLEL_STREAM === "true") &&
+   * useStreamingEncode && workerCount > 1 — the multi-worker streaming
+   * self-verification net is present. */
+  deParallelStreamVerified: boolean;
+}): boolean {
+  return (
+    args.useDrawElement &&
+    !args.fastCaptureExplicitOptIn &&
+    (!args.useStreamingEncode || args.workerCount > 1) &&
+    !args.deParallelStreamVerified
+  );
+}
+
 export function resolveCaptureForceScreenshotForPageSideCompositing(args: {
   forceScreenshot: boolean;
   usePageSideCompositing: boolean;
@@ -3272,10 +3299,13 @@ async function executeRenderPipeline(input: {
       useStreamingEncode &&
       workerCount > 1;
     if (
-      cfg.useDrawElement &&
-      process.env.PRODUCER_EXPERIMENTAL_FAST_CAPTURE !== "true" &&
-      (!useStreamingEncode || workerCount > 1) &&
-      !deParallelStreamVerified
+      shouldClampDefaultDrawElement({
+        useDrawElement: cfg.useDrawElement,
+        fastCaptureExplicitOptIn: process.env.PRODUCER_EXPERIMENTAL_FAST_CAPTURE === "true",
+        useStreamingEncode,
+        workerCount,
+        deParallelStreamVerified,
+      })
     ) {
       cfg.useDrawElement = false;
       deClampReason = workerCount > 1 ? "parallel" : "disk_path";
@@ -3287,6 +3317,7 @@ async function executeRenderPipeline(input: {
       // The probe session already initialized in drawElement mode (canvas
       // injected); it must not be reused by the unverified path.
       if (probeSession && probeSession.captureMode === "drawelement") {
+        lastBrowserConsole = probeSession.browserConsoleBuffer;
         await closeCaptureSession(probeSession);
         probeSession = null;
       }

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -3257,17 +3257,16 @@ async function executeRenderPipeline(input: {
     // drain guard), so the confinement rule is satisfied and the parallel
     // clamp does not apply. The disk path stays clamped.
     //
-    // Runs BEFORE the non-DE parallel-streaming router below on purpose (it
-    // used to run after): that router needs the POST-clamp `useDrawElement`
-    // to decide whether this render will actually use non-DE capture, and
-    // reading the stale pre-clamp `true` made it silently refuse to stream on
-    // every GPU-default host (macOS) with default-on drawElement — PRINFRA-689.
-    // The reorder doesn't change THIS clamp's own outcome: the non-DE
-    // router's force flag (`captureParallelStreamForced`) can only become
-    // true once `cfg.useDrawElement` is already false (the router requires
-    // `!useDrawElement`), so it never used to affect whether this clamp fired
-    // — only `deParallelStreamForced` (the DE-specific router above, mutually
-    // exclusive with the non-DE one) ever could.
+    // Runs BEFORE the non-DE parallel-streaming router below: that router
+    // needs the post-clamp `cfg.useDrawElement` to know whether this render
+    // will actually use non-DE capture. That dependency is also why this
+    // clamp is safe to compute here: the router's own force flag
+    // (`captureParallelStreamForced`) can only become true once
+    // `cfg.useDrawElement` is already false (the router requires
+    // `!useDrawElement`), so whenever this clamp's guard below
+    // (`cfg.useDrawElement === true`) holds, that flag is always false —
+    // only `deParallelStreamForced` (the DE-specific router above, mutually
+    // exclusive with the non-DE one) can affect this clamp's outcome.
     const deParallelStreamVerified =
       (deParallelStreamForced || process.env.HF_DE_PARALLEL_STREAM === "true") &&
       useStreamingEncode &&
@@ -3296,8 +3295,8 @@ async function executeRenderPipeline(input: {
     // Non-DE parallel-streaming router — see shouldStreamParallelCapture.
     // Mutually exclusive with the DE inversion/router above by construction
     // (both DE predicates require useDrawElement; this requires its negation).
-    // Reads `cfg.useDrawElement` AFTER the clamp above, so it sees the real
-    // capture mode this render will use instead of a stale pre-clamp value.
+    // Reads `cfg.useDrawElement` after the clamp above, so it sees the
+    // capture mode this render will actually use.
     const captureParallelStreamRouterEnabled = process.env.HF_CAPTURE_PARALLEL_STREAM === "true";
     const captureParallelStreamArgs = {
       workerCount,

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -3231,9 +3231,73 @@ async function executeRenderPipeline(input: {
       deParallelRouter: deParallelRouter ?? "none",
     });
 
+    // Streaming encode pipes captured frames through ffmpeg's stdin to produce
+    // a single video file. Keep the default enabled for sequential capture, but
+    // let auto-parallel renders use disk frames: the current ordered streaming
+    // writer would otherwise stall later workers behind earlier frame ranges.
+    // png-sequence has no encoded video output, so streaming is always bypassed.
+    // Computed here using only `deParallelStreamForced` (the DE-specific
+    // router's own force flag) because the non-DE router below hasn't run yet
+    // and its force flag is exactly what this clamp must NOT depend on — see
+    // the clamp's own comment for why that's safe.
+    let useStreamingEncode = shouldUseStreamingEncode(
+      cfg,
+      outputFormat,
+      workerCount,
+      job.duration,
+      deParallelStreamForced,
+    );
+    // Default-on drawElement is only safe where the runtime self-verification
+    // net actually runs: the single-worker streaming worker-encode drain. The
+    // disk path (png-sequence / over the streaming duration cap) and parallel
+    // capture ship frames no drain verifies — route those renders to the
+    // screenshot baseline unless drawElement was explicitly opted into.
+    // HF_DE_PARALLEL_STREAM: multi-worker STREAMING renders now carry the
+    // full drain-time self-verification (per-worker ground truth + the shared
+    // drain guard), so the confinement rule is satisfied and the parallel
+    // clamp does not apply. The disk path stays clamped.
+    //
+    // Runs BEFORE the non-DE parallel-streaming router below on purpose (it
+    // used to run after): that router needs the POST-clamp `useDrawElement`
+    // to decide whether this render will actually use non-DE capture, and
+    // reading the stale pre-clamp `true` made it silently refuse to stream on
+    // every GPU-default host (macOS) with default-on drawElement — PRINFRA-689.
+    // The reorder doesn't change THIS clamp's own outcome: the non-DE
+    // router's force flag (`captureParallelStreamForced`) can only become
+    // true once `cfg.useDrawElement` is already false (the router requires
+    // `!useDrawElement`), so it never used to affect whether this clamp fired
+    // — only `deParallelStreamForced` (the DE-specific router above, mutually
+    // exclusive with the non-DE one) ever could.
+    const deParallelStreamVerified =
+      (deParallelStreamForced || process.env.HF_DE_PARALLEL_STREAM === "true") &&
+      useStreamingEncode &&
+      workerCount > 1;
+    if (
+      cfg.useDrawElement &&
+      process.env.PRODUCER_EXPERIMENTAL_FAST_CAPTURE !== "true" &&
+      (!useStreamingEncode || workerCount > 1) &&
+      !deParallelStreamVerified
+    ) {
+      cfg.useDrawElement = false;
+      deClampReason = workerCount > 1 ? "parallel" : "disk_path";
+      log.info(
+        "[Render] Fast capture: default-on drawElement disabled for this render — " +
+          (workerCount > 1 ? "parallel capture" : "the disk capture path") +
+          " has no runtime self-verification. Set PRODUCER_EXPERIMENTAL_FAST_CAPTURE=true to override.",
+      );
+      // The probe session already initialized in drawElement mode (canvas
+      // injected); it must not be reused by the unverified path.
+      if (probeSession && probeSession.captureMode === "drawelement") {
+        await closeCaptureSession(probeSession);
+        probeSession = null;
+      }
+    }
+
     // Non-DE parallel-streaming router — see shouldStreamParallelCapture.
     // Mutually exclusive with the DE inversion/router above by construction
     // (both DE predicates require useDrawElement; this requires its negation).
+    // Reads `cfg.useDrawElement` AFTER the clamp above, so it sees the real
+    // capture mode this render will use instead of a stale pre-clamp value.
     const captureParallelStreamRouterEnabled = process.env.HF_CAPTURE_PARALLEL_STREAM === "true";
     const captureParallelStreamArgs = {
       workerCount,
@@ -3282,12 +3346,11 @@ async function executeRenderPipeline(input: {
       probeSession = null;
     }
 
-    // Streaming encode pipes captured frames through ffmpeg's stdin to produce
-    // a single video file. Keep the default enabled for sequential capture, but
-    // let auto-parallel renders use disk frames: the current ordered streaming
-    // writer would otherwise stall later workers behind earlier frame ranges.
-    // png-sequence has no encoded video output, so streaming is always bypassed.
-    let useStreamingEncode = shouldUseStreamingEncode(
+    // Re-resolve now that the non-DE router above may have forced streaming
+    // on for this multi-worker render (same formula as the early value above,
+    // now including `captureParallelStreamForced`). This is the value the
+    // rest of the pipeline (encode/writer selection, logging) uses.
+    useStreamingEncode = shouldUseStreamingEncode(
       cfg,
       outputFormat,
       workerCount,
@@ -3302,39 +3365,6 @@ async function executeRenderPipeline(input: {
       durationSeconds: job.duration,
       maxDurationSeconds: cfg.streamingEncodeMaxDurationSeconds,
     });
-    // Default-on drawElement is only safe where the runtime self-verification
-    // net actually runs: the single-worker streaming worker-encode drain. The
-    // disk path (png-sequence / over the streaming duration cap) and parallel
-    // capture ship frames no drain verifies — route those renders to the
-    // screenshot baseline unless drawElement was explicitly opted into.
-    // HF_DE_PARALLEL_STREAM: multi-worker STREAMING renders now carry the
-    // full drain-time self-verification (per-worker ground truth + the shared
-    // drain guard), so the confinement rule is satisfied and the parallel
-    // clamp does not apply. The disk path stays clamped.
-    const deParallelStreamVerified =
-      (deParallelStreamForced || process.env.HF_DE_PARALLEL_STREAM === "true") &&
-      useStreamingEncode &&
-      workerCount > 1;
-    if (
-      cfg.useDrawElement &&
-      process.env.PRODUCER_EXPERIMENTAL_FAST_CAPTURE !== "true" &&
-      (!useStreamingEncode || workerCount > 1) &&
-      !deParallelStreamVerified
-    ) {
-      cfg.useDrawElement = false;
-      deClampReason = workerCount > 1 ? "parallel" : "disk_path";
-      log.info(
-        "[Render] Fast capture: default-on drawElement disabled for this render — " +
-          (workerCount > 1 ? "parallel capture" : "the disk capture path") +
-          " has no runtime self-verification. Set PRODUCER_EXPERIMENTAL_FAST_CAPTURE=true to override.",
-      );
-      // The probe session already initialized in drawElement mode (canvas
-      // injected); it must not be reused by the unverified path.
-      if (probeSession && probeSession.captureMode === "drawelement") {
-        await closeCaptureSession(probeSession);
-        probeSession = null;
-      }
-    }
 
     // png-sequence is "no container" — outputPath is treated as a directory and
     // the encode/mux/faststart stages are skipped entirely. The empty extension


### PR DESCRIPTION
## What

On macOS (and any other host with a hardware GPU), rendering with more than one worker and `HF_CAPTURE_PARALLEL_STREAM=true` never actually streamed frames to the encoder — it silently fell back to the disk path every time, even though the flag was on and the render qualified.

## Why

Two independent pieces of logic run in the same function: a clamp that turns off the default-on fast capture mode for multi-worker renders (because that mode has no safety net outside single-worker renders), and a router that decides whether a multi-worker render should stream frames straight to the encoder instead of writing them to disk. The router only applies to renders that are NOT using the fast-capture mode.

The router ran before the clamp. So it always saw the fast-capture mode as still "on," even on the exact renders where the clamp was about to turn it off a moment later. It never got the chance to see the real state, so it silently refused to stream on every ordinary macOS multi-worker render, whether or not the flag was set.

Reported and reproduced on this Mac from a Slack bug lead (PRINFRA-689).

## How

Reordered the clamp to run before the router, so the router reads the real, final state instead of a stale one. Also:

- Extracted the clamp's condition into its own named, tested function (`shouldClampDefaultDrawElement`), matching how the router's own condition is already structured in this file.
- Fixed a small side issue an independent review caught: on one worker-sizing path, closing a probe session during the clamp no longer dropped its diagnostic console output.

## Test plan

- [x] Unit tests added — `shouldClampDefaultDrawElement` (6 cases) plus 2 tests that directly encode the ordering bug: the router routes when fed the corrected state and refuses when fed the stale one.
- [x] Manual testing performed — rendered a real composition on this Mac with `--workers 2 --quality draft` and `HF_CAPTURE_PARALLEL_STREAM=true`, confirmed via debug logs that the router now engages and the render completes using the streaming path (before the fix: silently used the disk path every time).
- [x] `bun run --filter @hyperframes/producer test:unit:vitest`: 682 passed, 1 pre-existing failure unrelated to this change (an audio loudness test, fails identically with zero local changes).
- [ ] Documentation updated — not applicable, internal capture routing.

Note: this makes a passive telemetry signal (`capture_parallel_stream: "eligible_off"`) start firing on ordinary macOS multi-worker renders where it previously never fired — that's the corrected count, not new behavior; flagging so it isn't misread as a step change in the underlying flag's usage.

---

## Pre-review pass

| Check | Result |
|---|---|
| Simplify pass (3 independent reviewers: reuse / quality / efficiency) | reuse: nothing to flag; efficiency: nothing to flag; quality: 2 comments narrated the diff instead of the invariant — trimmed |
| Independent adversarial review (separate subagent, opus) | 1 real regression found and fixed (probe console diagnostics), 1 telemetry-volume note (documented above), 1 test-coverage gap found and closed |

**Audited / Trusting / Not exercised**

- Audited: the equivalence of the two clamp-input orderings across every branch (DE-router-forced, DE single-worker inversion, plain default-on, explicit opt-in); no other call site of the two predicates involved is reorder-sensitive; observability/checkpoint ordering unchanged; the downstream streaming stage picks its distribution strategy off the same force flag this fix now correctly sets, not off drawElement mode.
- Trusting: the manual render reproduction as evidence the fix works today; the full producer unit suite run.
- Not exercised: real-world wall-clock performance of the newly-reachable macOS parallel-streaming path at scale — this diff proves it's reachable and correctly routed, not how fast it is.