### PR TITLE
chore: release v0.8.35

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,38 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.35"
+  description="Released - 2026-09-11"
+  tags={["Release", "Catalog", "Audio", "Producer"]}
+>
+Background music under a voice now gets carved by default, harder and with a slower recovery, so narration stays clear without the bed dropping out at every sentence break. Multi-worker renders on macOS also stream frames again instead of refusing, and a BGM loop extension writes a real .mp3.
+
+## Features
+
+- **Audio:** The voiceover carve is now part of finishing any mix with music under a voice. `carve.mjs` defaults to strength 0.8 (was 0.25), the level envelope releases over 2.4 s instead of 1.6 s, and the audio, general-video and production-loop skills state the requirement once. Both the default and the release are pinned by tests ([2e2b5c853](https://github.com/heygen-com/hyperframes/commit/2e2b5c8530580be28b9d786b70a529a649aa85a8), [fe53f51ad](https://github.com/heygen-com/hyperframes/commit/fe53f51adb3d0bf09d0be687044728a990098f99), [e488871ce](https://github.com/heygen-com/hyperframes/commit/e488871ce1b7ede9c54d8c4003ec7ac5fd5aae32), [0b9852fee](https://github.com/heygen-com/hyperframes/commit/0b9852fee44b63679f3056d4ede65fb0e58bc1e3), [#3878](https://github.com/heygen-com/hyperframes/pull/3878)).
+
+## Fixes
+
+- **Producer:** Non-DE parallel-stream router silently refused on macOS multi-worker renders ([26513984f](https://github.com/heygen-com/hyperframes/commit/26513984f361811bb2407bbc0fecf5f5ce8ab666), [#3886](https://github.com/heygen-com/hyperframes/pull/3886)).
+- **Skills:** Loop-extended BGM writes .mp3, not MP3-in-a-.wav ([42a3e7a51](https://github.com/heygen-com/hyperframes/commit/42a3e7a5191d9aaaca7d12313b6378250753cd03), [#3884](https://github.com/heygen-com/hyperframes/pull/3884)).
+- **CLI:** Surface a warning when doctor's HYPERFRAMES_PYTHON override is rejected ([ea7e1dbd0](https://github.com/heygen-com/hyperframes/commit/ea7e1dbd0bd2afb77370b946461c4ea16afdb387), [#3870](https://github.com/heygen-com/hyperframes/pull/3870)).
+- **Lint:** Flag an unclosed tag that swallows a nested element as bogus attribute text ([2ef76bf97](https://github.com/heygen-com/hyperframes/commit/2ef76bf97b8c77dd8b76ac40615738eb91ecbc3c), [#3869](https://github.com/heygen-com/hyperframes/pull/3869)).
+- **CLI:** Stop promising a universal per-time filmstrip for --layout strip ([bafc7b4e0](https://github.com/heygen-com/hyperframes/commit/bafc7b4e0067814b4102ee6586d3e118e8ba2062), [#3867](https://github.com/heygen-com/hyperframes/pull/3867)).
+- **CLI:** Apply the canvas/video pixel-hash carve-out to img ([5a95211e3](https://github.com/heygen-com/hyperframes/commit/5a95211e36a3aa0907c59779039158f6acfbef15), [#3865](https://github.com/heygen-com/hyperframes/pull/3865)).
+- **CLI:** Let .hyperframesignore negation re-include hidden directories ([9c84277d2](https://github.com/heygen-com/hyperframes/commit/9c84277d28c32152aededdb1d9ed6be095c07197), [#3859](https://github.com/heygen-com/hyperframes/pull/3859)).
+- **Studio:** Tolerate WebMCP execute calls without an options object ([14b9e2039](https://github.com/heygen-com/hyperframes/commit/14b9e2039b69ae70044cc3b657c77e7688069618), [#3860](https://github.com/heygen-com/hyperframes/pull/3860)).
+- **Skills:** Exclude repo-native skills from public installs ([8820a0109](https://github.com/heygen-com/hyperframes/commit/8820a01090692020ef6c5d4fb70fdc06b4b3bd81), [#3856](https://github.com/heygen-com/hyperframes/pull/3856)).
+- **Engine:** Emit pipelined frame diagnostics before the recoverable wrapper ([4c7fbde51](https://github.com/heygen-com/hyperframes/commit/4c7fbde51e80f63a87d0e3be01ef3f7ec0c043f9)).
+- **Render:** Retry drawElement failures on a fresh screenshot page ([6a206ffea](https://github.com/heygen-com/hyperframes/commit/6a206ffea637a936e6379545d371a44bc80a9119)).
+
+## Catalog
+
+- **Catalog:** Name the better search tier when a search finds nothing ([849ce0176](https://github.com/heygen-com/hyperframes/commit/849ce0176ae343f31181cf4517ea7bc22d621f8c), [#3872](https://github.com/heygen-com/hyperframes/pull/3872)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.34...v0.8.35).
+</Update>
+
+<Update
   label="HyperFrames v0.8.34"
   description="Released - 2026-09-10"
   tags={["Release", "Studio", "Deps", "Runtime"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.34",
+  "version": "0.8.35",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.35.md
+++ b/releases/v0.8.35.md
@@ -1,0 +1,31 @@
+# HyperFrames v0.8.35
+
+Released on 2026-09-11.
+
+Background music under a voice now gets carved by default, harder and with a slower recovery, so narration stays clear without the bed dropping out at every sentence break. Multi-worker renders on macOS also stream frames again instead of refusing, and a BGM loop extension writes a real .mp3.
+
+## Features
+
+- **Audio:** The voiceover carve is now part of finishing any mix with music under a voice. `carve.mjs` defaults to strength 0.8 (was 0.25), the level envelope releases over 2.4 s instead of 1.6 s, and the audio, general-video and production-loop skills state the requirement once. Both the default and the release are pinned by tests ([2e2b5c853](https://github.com/heygen-com/hyperframes/commit/2e2b5c8530580be28b9d786b70a529a649aa85a8), [fe53f51ad](https://github.com/heygen-com/hyperframes/commit/fe53f51adb3d0bf09d0be687044728a990098f99), [e488871ce](https://github.com/heygen-com/hyperframes/commit/e488871ce1b7ede9c54d8c4003ec7ac5fd5aae32), [0b9852fee](https://github.com/heygen-com/hyperframes/commit/0b9852fee44b63679f3056d4ede65fb0e58bc1e3), [#3878](https://github.com/heygen-com/hyperframes/pull/3878)).
+
+## Fixes
+
+- **Producer:** Non-DE parallel-stream router silently refused on macOS multi-worker renders ([26513984f](https://github.com/heygen-com/hyperframes/commit/26513984f361811bb2407bbc0fecf5f5ce8ab666), [#3886](https://github.com/heygen-com/hyperframes/pull/3886)).
+- **Skills:** Loop-extended BGM writes .mp3, not MP3-in-a-.wav ([42a3e7a51](https://github.com/heygen-com/hyperframes/commit/42a3e7a5191d9aaaca7d12313b6378250753cd03), [#3884](https://github.com/heygen-com/hyperframes/pull/3884)).
+- **CLI:** Surface a warning when doctor's HYPERFRAMES_PYTHON override is rejected ([ea7e1dbd0](https://github.com/heygen-com/hyperframes/commit/ea7e1dbd0bd2afb77370b946461c4ea16afdb387), [#3870](https://github.com/heygen-com/hyperframes/pull/3870)).
+- **Lint:** Flag an unclosed tag that swallows a nested element as bogus attribute text ([2ef76bf97](https://github.com/heygen-com/hyperframes/commit/2ef76bf97b8c77dd8b76ac40615738eb91ecbc3c), [#3869](https://github.com/heygen-com/hyperframes/pull/3869)).
+- **CLI:** Stop promising a universal per-time filmstrip for --layout strip ([bafc7b4e0](https://github.com/heygen-com/hyperframes/commit/bafc7b4e0067814b4102ee6586d3e118e8ba2062), [#3867](https://github.com/heygen-com/hyperframes/pull/3867)).
+- **CLI:** Apply the canvas/video pixel-hash carve-out to img ([5a95211e3](https://github.com/heygen-com/hyperframes/commit/5a95211e36a3aa0907c59779039158f6acfbef15), [#3865](https://github.com/heygen-com/hyperframes/pull/3865)).
+- **CLI:** Let .hyperframesignore negation re-include hidden directories ([9c84277d2](https://github.com/heygen-com/hyperframes/commit/9c84277d28c32152aededdb1d9ed6be095c07197), [#3859](https://github.com/heygen-com/hyperframes/pull/3859)).
+- **Studio:** Tolerate WebMCP execute calls without an options object ([14b9e2039](https://github.com/heygen-com/hyperframes/commit/14b9e2039b69ae70044cc3b657c77e7688069618), [#3860](https://github.com/heygen-com/hyperframes/pull/3860)).
+- **Skills:** Exclude repo-native skills from public installs ([8820a0109](https://github.com/heygen-com/hyperframes/commit/8820a01090692020ef6c5d4fb70fdc06b4b3bd81), [#3856](https://github.com/heygen-com/hyperframes/pull/3856)).
+- **Engine:** Emit pipelined frame diagnostics before the recoverable wrapper ([4c7fbde51](https://github.com/heygen-com/hyperframes/commit/4c7fbde51e80f63a87d0e3be01ef3f7ec0c043f9)).
+- **Render:** Retry drawElement failures on a fresh screenshot page ([6a206ffea](https://github.com/heygen-com/hyperframes/commit/6a206ffea637a936e6379545d371a44bc80a9119)).
+
+## Catalog
+
+- **Catalog:** Name the better search tier when a search finds nothing ([849ce0176](https://github.com/heygen-com/hyperframes/commit/849ce0176ae343f31181cf4517ea7bc22d621f8c), [#3872](https://github.com/heygen-com/hyperframes/pull/3872)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.34...v0.8.35


### PR DESCRIPTION
Release v0.8.35. Merging this PR triggers `publish.yml` (stable releases publish only from a merged `release/v*` PR; no tag is pushed from here).

Background music under a voice now gets carved by default, harder and with a slower recovery, so narration stays clear without the bed dropping out at every sentence break. Multi-worker renders on macOS stream frames again instead of refusing, and a BGM loop extension writes a real .mp3.

Notes: `releases/v0.8.35.md`, mirrored in `docs/changelog.mdx`. 13 packages and 3 plugin manifests bumped 0.8.34 → 0.8.35.

Compare: https://github.com/heygen-com/hyperframes/compare/v0.8.34...release/v0.8.35

🤖 Generated with [Claude Code](https://claude.com/claude-code)