### PR TITLE
fix(studio): keep canvas chrome off scaled iframe

### DIFF
--- a/packages/studio/src/components/nle/NLEPreview.test.ts
+++ b/packages/studio/src/components/nle/NLEPreview.test.ts
@@ -158,6 +158,15 @@ describe("NLEPreview", () => {
     globalThis.ResizeObserver = originalResizeObserver;
   });
 
+  it("draws the canvas boundary on the preview stage", () => {
+    const view = renderPreview();
+
+    expect(view.stage.style.boxShadow).toBe(
+      "0 0 0 1px rgba(255,255,255,0.08), 0 4px 32px rgba(0,0,0,0.7)",
+    );
+    view.cleanup();
+  });
+
   it("pans the preview with middle mouse drag", () => {
     const view = renderPreview();
     const target = document.createElement("div");

--- a/packages/studio/src/components/nle/NLEPreview.tsx
+++ b/packages/studio/src/components/nle/NLEPreview.tsx
@@ -451,6 +451,9 @@ export const NLEPreview = memo(function NLEPreview({
               transform: `translate3d(${toDomPrecision(initial.panX)}px, ${toDomPrecision(initial.panY)}px, 0) scale(${toDomPrecision(initial.zoomPercent / 100)})`,
               // resolvePreviewWheelZoom cursor math assumes center-center pivot
               transformOrigin: "center center",
+              // Keep Studio chrome outside the scaled composition iframe. Painting
+              // this on the iframe creates a subpixel seam at fractional fit sizes.
+              boxShadow: "0 0 0 1px rgba(255,255,255,0.08), 0 4px 32px rgba(0,0,0,0.7)",
             }}
             data-testid="preview-zoom-stage"
           >

--- a/packages/studio/src/player/components/Player.test.ts
+++ b/packages/studio/src/player/components/Player.test.ts
@@ -22,6 +22,7 @@ class TestHyperframesPlayer extends HTMLElement {
 
   constructor() {
     super();
+    this.attachShadow({ mode: "open" }).appendChild(this.iframeElement);
 
     const addIframeListener = this.iframeElement.addEventListener.bind(this.iframeElement);
     this.iframeElement.addEventListener = ((type, listener, options) => {
@@ -152,6 +153,15 @@ describe("preview errors", () => {
     const retryUrl = new URL(player.getAttribute("src") ?? "", window.location.origin);
     expect(retryUrl.searchParams.get("_hfStudioRetry")).toBe("1");
     expect(host.querySelector('[data-testid="composition-preview-error"]')).toBeNull();
+  });
+});
+
+describe("preview canvas chrome", () => {
+  it("does not paint Studio chrome on the scaled composition iframe", async () => {
+    const { player } = await mountPlayer();
+    const injectedStyles = Array.from(player.shadowRoot?.querySelectorAll("style") ?? []);
+
+    expect(injectedStyles.some((style) => style.textContent?.includes("box-shadow"))).toBe(false);
   });
 });
 

--- a/packages/studio/src/player/components/Player.tsx
+++ b/packages/studio/src/player/components/Player.tsx
@@ -281,18 +281,6 @@ export const Player = forwardRef<HTMLIFrameElement, PlayerProps>(
         player.setAttribute("src", src);
         container.appendChild(player);
 
-        // Inject pasteboard shadow: let the shadow around the canvas bleed
-        // into the surrounding pasteboard area (overflow: visible on the container)
-        // and add a subtle outline + drop-shadow so the canvas boundary reads
-        // against the gray pasteboard, consistent with professional editors.
-        if (player.shadowRoot) {
-          const pasteboardStyle = document.createElement("style");
-          pasteboardStyle.textContent =
-            ".hfp-container{overflow:visible}" +
-            ".hfp-iframe{box-shadow:0 0 0 1px rgba(255,255,255,0.08),0 4px 32px rgba(0,0,0,.7)}";
-          player.shadowRoot.appendChild(pasteboardStyle);
-        }
-
         enableInteractiveIframe(player);
 
         cleanup = () => {


### PR DESCRIPTION
## What

Moves the Studio preview outline and drop shadow from the scaled composition iframe to the outer preview zoom stage. Adds regression coverage for both ownership boundaries.

## Why

At fractional fit scales, the iframe box shadow is rasterized on top of composition pixels and appears as a scene-dependent one-pixel edge seam or flicker. Studio chrome should frame the canvas without modifying the composition surface.

## How

Removes the shadow-root CSS injection from `Player` and applies the same visual treatment to `preview-zoom-stage`, outside the composition iframe. Rendered output and composition code are unchanged.

## Test plan

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Documentation updated (not applicable: internal editor styling change)

Verification:
- Full monorepo build
- Full Studio test suite: 4,838 passed, 18 todo; 438 files passed, 1 skipped
- Studio typecheck
- Full repository lint and changed-file format checks
- Fallow audit against `origin/main`
- Browser check at a fractional 1098.65625px preview width: iframe has no box shadow; stage owns the outline/drop shadow; composition edge remains clean