### PR TITLE
fix(cli): reject extra positional arguments passed to add

### DIFF
--- a/packages/cli/src/commands/add.test.ts
+++ b/packages/cli/src/commands/add.test.ts
@@ -1,17 +1,20 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { parseArgs as parseCittyArgs, type ArgsDef } from "citty";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { RegistryItem, RegistryManifest } from "@hyperframes/core";
-import {
+import addCommand, {
   AddError,
   buildSnippet,
   describeInstallFailure,
+  formatExtraPositionalsError,
   parseVariableValues,
   remapTarget,
   runAdd,
 } from "./add.js";
 import { trackRegistryItemAdded } from "../telemetry/events.js";
+import { CliUsageError } from "../utils/commandResult.js";
 
 // Assert the emitted payload rather than the transport: `shouldTrack()` is
 // already false under test (dev mode / no PostHog key), so a real call would
@@ -260,6 +263,17 @@ describe("add command pure helpers", () => {
       expect(buildSnippet(EXAMPLE_ITEM, "index.html")).toBe("");
     });
   });
+
+  describe("formatExtraPositionalsError", () => {
+    it("names every extra argument, singular wording for one", () => {
+      expect(formatExtraPositionalsError(["b"])).toContain("extra argument: b");
+    });
+
+    it("names every extra argument, plural wording for more than one", () => {
+      const msg = formatExtraPositionalsError(["b", "c"]);
+      expect(msg).toContain("extra arguments: b, c");
+    });
+  });
 });
 
 describe("runAdd (integration, mocked registry)", () => {
@@ -467,6 +481,68 @@ describe("variable values in the snippet", () => {
     expect(() => parseVariableValues("not json")).toThrow(/JSON object/);
     expect(() => parseVariableValues("[1,2]")).toThrow(/JSON object/);
     expect(parseVariableValues(undefined)).toBeNull();
+  });
+});
+
+describe("add command run() — extra positional arguments", () => {
+  let dir: string;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dir = tmp();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    vi.unstubAllGlobals();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // citty binds only the first positional to `name`; `_` carries every
+  // positional token exactly as citty itself would populate it.
+  async function runCommand(args: Record<string, unknown>): Promise<void> {
+    await (addCommand.run as (ctx: { args: Record<string, unknown> }) => Promise<void>)({ args });
+  }
+
+  it("rejects `add <a> <b> <c>`, naming the dropped arguments and touching no registry", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(
+      runCommand({ name: "a", _: ["a", "b", "c"], dir, clipboard: true }),
+    ).rejects.toThrow(CliUsageError);
+
+    // Failing fast means no partial install either: `a` never touches the
+    // registry, so an invalid multi-name invocation can't half-succeed and
+    // leave the project in a state that depends on install order.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("b, c");
+  });
+
+  it("rejects extra positionals under real citty parsing, with a flag interleaved", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    // `add a --dir <dir> b`: exercises citty's own parser rather than a
+    // hand-built args object, proving `_` really does exclude the `--dir`
+    // flag and its value while still keeping both positional tokens.
+    const parsed = parseCittyArgs(["a", "--dir", dir, "b"], addCommand.args as ArgsDef);
+    expect(parsed._).toEqual(["a", "b"]);
+
+    await expect(runCommand(parsed as unknown as Record<string, unknown>)).rejects.toThrow(
+      CliUsageError,
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not fire on a normal single-item invocation", async () => {
+    mockFetch();
+    writeRegistryConfig(dir);
+
+    await expect(
+      runCommand({ name: "my-block", _: ["my-block"], dir, clipboard: false, json: true }),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,4 +1,4 @@
-import { failCommand } from "../utils/commandResult.js";
+import { failCommand, failUsage } from "../utils/commandResult.js";
 import { defineCommand } from "citty";
 import type { Example } from "./_examples.js";
 
@@ -380,6 +380,19 @@ export async function runAdd(opts: RunAddArgs): Promise<RunAddResult> {
   };
 }
 
+// ── Extra-positional-argument guard ─────────────────────────────────────────
+// One item or tag per invocation is the contract — a tag is the bulk path.
+// citty binds only the FIRST positional token to `name`; every token after it
+// still lands in `args._` but was never read here, so `add a b c` behaved
+// exactly like `add a` — same exit code, same output, `b` and `c` never
+// installed and never mentioned.
+export function formatExtraPositionalsError(extra: string[]): string {
+  return (
+    `add installs one item or tag per invocation. Got extra argument${extra.length === 1 ? "" : "s"}: ${extra.join(", ")}. ` +
+    "Run add once per item, or pass a single tag to install every item tagged with it."
+  );
+}
+
 // ── Command ─────────────────────────────────────────────────────────────────
 
 export default defineCommand({
@@ -433,6 +446,15 @@ export default defineCommand({
     const projectDir = resolve(args.dir ?? process.cwd());
     const json = args.json === true;
     const skipClipboard = args.clipboard === false;
+
+    const extraPositionals = args._.slice(1);
+    if (extraPositionals.length > 0) {
+      const msg = formatExtraPositionalsError(extraPositionals);
+      if (json) console.log(JSON.stringify({ ok: false, error: msg }));
+      else console.error(c.error(msg));
+      failUsage();
+    }
+
     const hasConfigBefore = existsSync(projectConfigPath(projectDir));
 
     // Try single item first. If it fails, check if the name matches a tag.


### PR DESCRIPTION
## Summary

`add <a> <b> <c>` installed only `<a>` and exited 0, with `<b>` and `<c>` silently dropped — no warning, no error. citty's positional-arg binding only assigns the first token to the declared `name` arg; every token after it still lands in `args._`, but nothing in `add`'s `run()` read that array.

`add` installs exactly one item or tag per invocation today — a tag (e.g. `add html-in-canvas`) is the existing bulk-install path, expanding to every item with that tag. Passing several explicit item names has never been a supported way to bulk-install, so rather than inventing that as a new feature, this makes the existing single-item contract honest: extra positional arguments are now rejected up front, before any project-config write or registry request, naming exactly what was dropped.

## Changes

- `packages/cli/src/commands/add.ts`: `run()` now checks `args._.slice(1)` for leftover positional tokens and fails with a usage error via the existing `failUsage()` helper (same one other commands in this package already use for invalid invocations) instead of silently proceeding with just the first name. Added a small exported `formatExtraPositionalsError()` helper for the message, matching the existing `remapTarget`/`buildSnippet` pattern of pulling pure logic out for direct testing.
- `packages/cli/src/commands/add.test.ts`: unit tests for the message formatter, plus end-to-end tests that invoke the command's `run()` wrapper directly (following the same pattern already used in `auth/login.test.ts`) — including one that runs the arguments through citty's own `parseArgs` with a flag interleaved between positionals (`add a --dir <dir> b`) to confirm the fix holds against real parsing, not just a hand-built args object.

## Test plan

- [x] `bunx vitest run packages/cli/src/commands/add.test.ts` — 29/29 pass
- [x] Confirmed the new tests actually catch the bug: reverted the `add.ts` change and reran — the 4 new assertions failed exactly as expected against the old behavior
- [x] `bunx tsc --noEmit -p packages/cli` clean
- [x] `bunx oxlint` / `bunx oxfmt --write` clean
- [x] `bunx fallow audit --base origin/main --fail-on-issues` clean (0 issues, 2 changed files)
- [x] Verified against citty's actual source that it only binds the first positional to `name` while `_` retains every token, including when flags are interleaved with positionals (e.g. `add a --dir <dir> b`)

