### PR TITLE
fix(producer): retry capture on a CDP Page.captureScreenshot refusal

### DIFF
--- a/packages/engine/src/services/captureFailure.test.ts
+++ b/packages/engine/src/services/captureFailure.test.ts
@@ -17,6 +17,13 @@ describe("classifyCaptureFailure", () => {
     ["JavaScript heap out of memory", "memory_exhaustion"],
     ["drawElement self-verify failed", "verification"],
     ["Composition has zero duration. Runtime ready: true", "authoring"],
+    ["Protocol error (Page.captureScreenshot): Unable to capture screenshot", "transient_browser"],
+    [
+      "[Parallel] Capture failed: Worker 0: Protocol error (Page.captureScreenshot): Unable to capture screenshot",
+      "transient_browser",
+    ],
+    // The timed-out variant of the same call stays protocol_timeout (checked first).
+    ["Protocol error (Page.captureScreenshot): waiting for debugger timed out", "protocol_timeout"],
   ] as const)("classifies %s as %s", (message, kind) => {
     expect(classifyCaptureFailure(new Error(message)).kind).toBe(kind);
   });

--- a/packages/engine/src/services/captureFailure.ts
+++ b/packages/engine/src/services/captureFailure.ts
@@ -52,6 +52,11 @@ const TRANSIENT_BROWSER_ERROR_PATTERNS = [
   /ECONNREFUSED/i,
   /net::ERR_NETWORK_CHANGED/i,
   /Composition has zero duration[\s\S]*Runtime ready: false/,
+  // CDP can refuse a capture call outright with this exact wording; timed-out
+  // variants of the same call hit PROTOCOL_TIMEOUT_PATTERNS, checked first.
+  // Anchored to this literal reason (not just the CDP method) so an unrelated,
+  // genuinely deterministic Page.captureScreenshot error isn't swept in too.
+  /Protocol error \(Page\.captureScreenshot\): Unable to capture screenshot/i,
 ];
 
 const PROTOCOL_TIMEOUT_PATTERNS = [

--- a/packages/producer/src/services/renderOrchestrator.test.ts
+++ b/packages/producer/src/services/renderOrchestrator.test.ts
@@ -302,18 +302,27 @@ describe("executeDiskCaptureWithAdaptiveRetry — transient Target-closed single
     vi.mocked(mergeWorkerFrames).mockReset();
   });
 
-  it("retries ONCE at the same worker count on a transient Target closed with zero progress", async () => {
+  // Both shapes classify as transient_browser: the tab dying mid-capture, and a
+  // CDP refusal of the capture call itself (no timeout wording, so it used to
+  // fall through to the fatal "authoring" bucket and was never retried).
+  it.each([
+    ["a transient Target closed", "Protocol error (Page.captureScreenshot): Target closed"],
+    [
+      "a non-timeout captureScreenshot protocol refusal",
+      "[Parallel] Capture failed: Worker 0: Protocol error (Page.captureScreenshot): Unable to capture screenshot",
+    ],
+  ])("retries ONCE at the same worker count on %s with zero progress", async (_label, message) => {
     const workDir = mkdtempSync(join(tmpdir(), "hf-transient-work-"));
     const framesDir = mkdtempSync(join(tmpdir(), "hf-transient-frames-"));
     const log = makeLog();
     let call = 0;
-    // First attempt: the tab dies before any frame is captured (frame 0) — zero
-    // forward progress, which the worker-halving retry deliberately bails on.
-    // The transient retry recovers it without changing the worker count.
+    // First attempt fails before any frame is captured (frame 0) — zero forward
+    // progress, which the worker-halving retry deliberately bails on. The
+    // transient retry recovers it without changing the worker count.
     vi.mocked(executeParallelCapture).mockImplementation(async () => {
       call++;
       if (call === 1) {
-        throw new Error("Protocol error (Page.captureScreenshot): Target closed");
+        throw new Error(message);
       }
       writeAllFrames(framesDir, 4);
       return [];
@@ -1629,6 +1638,13 @@ describe("adaptive missing-frame retry helpers", () => {
         ),
       ),
     ).toBe(true);
+    expect(
+      isRecoverableParallelCaptureError(
+        new Error(
+          "[Parallel] Capture failed: Worker 0: Protocol error (Page.captureScreenshot): Unable to capture screenshot",
+        ),
+      ),
+    ).toBe(true);
     expect(isRecoverableParallelCaptureError(new Error("Encoding failed: ffmpeg exited"))).toBe(
       false,
     );
@@ -2745,6 +2761,32 @@ describe("shouldRetryViaPinnedFallback (widen the self-verify retry to generic c
         isEncoderInterrupted: true,
         deWorkerInversion: "inverted",
         deParallelRouter: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  // --low-memory-mode is single-worker with no drawElement, so nothing ever
+  // pins a count and that mode had no whole-render fallback at all.
+  it("retries a transient capture-call refusal even with no pinned routing", () => {
+    expect(
+      shouldRetryViaPinnedFallback({
+        isVerifyError: false,
+        isCancellation: false,
+        deWorkerInversion: undefined,
+        deParallelRouter: undefined,
+        isTransientCaptureError: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("never retries a transient capture-call refusal after cancellation", () => {
+    expect(
+      shouldRetryViaPinnedFallback({
+        isVerifyError: false,
+        isCancellation: true,
+        deWorkerInversion: undefined,
+        deParallelRouter: undefined,
+        isTransientCaptureError: true,
       }),
     ).toBe(false);
   });

--- a/packages/producer/src/services/renderOrchestrator.ts
+++ b/packages/producer/src/services/renderOrchestrator.ts
@@ -87,6 +87,7 @@ import {
   classifyCaptureFailure,
   cloneCaptureWarning,
   isMemoryExhaustionError,
+  isTransientBrowserError,
   isDrawElementVerificationError,
   isDrawElementCaptureError,
   getDrawElementVerificationDetails,
@@ -1902,10 +1903,20 @@ export function shouldRetryViaPinnedFallback(args: {
   isDeRendererStall?: boolean;
   /** The producer's no-progress watchdog tripped around a sequential capture call. */
   isSequentialCaptureStall?: boolean;
+  /**
+   * A transient browser failure around the capture call itself
+   * (`classifyCaptureFailure` → `transient_browser`, e.g. a CDP
+   * `Page.captureScreenshot` refusal). Routing-independent like the stalls
+   * above: `--low-memory-mode` pins single-worker screenshot capture with no
+   * drawElement, so neither inversion nor the router ever pins a count, and
+   * that mode otherwise had no whole-render fallback for a one-off refusal.
+   */
+  isTransientCaptureError?: boolean;
 }): boolean {
   if (args.isCancellation || args.isEncoderInterrupted) return false;
   if (args.isVerifyError || args.isDeCaptureError) return true;
   if (args.isDeRendererStall === true || args.isSequentialCaptureStall === true) return true;
+  if (args.isTransientCaptureError === true) return true;
   return args.deWorkerInversion === "inverted" || args.deParallelRouter === "routed";
 }
 
@@ -3741,6 +3752,7 @@ async function executeRenderPipeline(input: {
               deParallelRouter,
               isDeRendererStall: isDeStall,
               isSequentialCaptureStall: isSequentialStall,
+              isTransientCaptureError: isTransientBrowserError(err),
             })
           )
             throw err;


### PR DESCRIPTION
## Summary

Chromium's CDP layer can refuse a screenshot capture outright — `Protocol error (Page.captureScreenshot): Unable to capture screenshot` — with no timeout wording at all. `classifyCaptureFailure()` didn't recognize this message in any of its pattern lists, so it fell through to the fatal `authoring` bucket. Both of this codebase's capture-retry mechanisms gate on that classification, so neither ever retried:

- The disk-capture retry loop (`executeDiskCaptureWithAdaptiveRetry`) only bounces a transient failure once via `isRecoverableParallelCaptureError`, which checks `classifyCaptureFailure(...).kind`.
- The streaming-capture pinned-fallback retry (`shouldRetryViaPinnedFallback`) only retries drawElement-specific failures or a failure on a worker count already pinned by inversion/the parallel router — `--low-memory-mode`'s single-worker plain-screenshot capture engages neither, so that mode had no whole-render fallback for this error at all.

## Changes

- `packages/engine/src/services/captureFailure.ts`: added the literal error text to `TRANSIENT_BROWSER_ERROR_PATTERNS`, anchored to the specific reason string (not just the CDP method name) so an unrelated, genuinely deterministic `Page.captureScreenshot` error isn't swept in too. A timed-out variant of the same call still classifies `protocol_timeout` — that pattern list is checked first, unchanged.
- `packages/producer/src/services/renderOrchestrator.ts`: `shouldRetryViaPinnedFallback()` gained a new `isTransientCaptureError?: boolean` argument (computed at its one call site from the engine's own `isTransientBrowserError()` helper), treated as routing-independent — the same way an existing drawElement-renderer-stall or sequential-capture-stall is retryable regardless of whether a worker count was pinned.
- No other code change was needed for the disk path: it already retries on `classifyCaptureFailure(...).kind === "transient_browser"`, so the pattern-list addition alone fixes it.

## Test plan

- [x] `bunx vitest run packages/engine/src/services/captureFailure.test.ts packages/producer/src/services/renderOrchestrator.test.ts` — 241/241 pass
- [x] Verified the new tests actually catch the bug: stashed the two source-file changes (kept the tests), reran — 5 assertions failed exactly as expected against the old fatal-on-first-occurrence behavior, then restored the fix
- [x] New integration test drives the real `executeDiskCaptureWithAdaptiveRetry` with a mocked capture throwing this exact error and confirms it retries once and recovers
- [x] `bunx tsc --noEmit` clean on `packages/engine` and `packages/producer`
- [x] `bunx oxlint` / `bunx oxfmt --write` clean
- [x] Confirmed via `parallelCoordinator.ts` that this reclassification also stops a single worker's screenshot refusal from aborting sibling workers as a "fatal" failure — consistent with how other transient browser errors (`Target closed`, `Session closed`, etc.) already behave there
- [x] Confirmed the retry is bounded on both paths: the disk path's transient-retry branch is capped at `MAX_TRANSIENT_CAPTURE_RETRIES = 1` before falling back to worker-halving; the streaming path's retry is a single, non-looping attempt
