### PR TITLE
fix(core): un-hide a later root-level clip instead of leaving it display:none forever

### DIFF
--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -2334,6 +2334,53 @@ describe("initSandboxRuntimeModular", () => {
     expect(video.style.visibility).toBe("hidden");
   });
 
+  it("un-hides a later root-level video once active, even though it starts inactive and unstyled", () => {
+    // Root-level `[data-start]` children with no authored `position` start out
+    // `position: static` until `applyClipLayout` force-absolutizes them, so a
+    // visibility pass over the still-inactive second clip can observe `static`
+    // and cache it as in-flow before that forcing runs. The un-hide path used to
+    // re-derive that in-flow status rather than track whether it had actually
+    // applied `display:none`, so the corrected, no-longer-in-flow reading made
+    // it skip the removal and the clip stayed `display:none` for the rest of the
+    // render even once active.
+    const root = document.createElement("div");
+    root.setAttribute("data-composition-id", "main");
+    root.setAttribute("data-root", "true");
+    root.setAttribute("data-start", "0");
+    root.setAttribute("data-duration", "20");
+    root.setAttribute("data-width", "1920");
+    root.setAttribute("data-height", "1080");
+    document.body.appendChild(root);
+
+    const clipA = document.createElement("video");
+    clipA.id = "clip-a";
+    clipA.setAttribute("data-start", "0");
+    clipA.setAttribute("data-duration", "10");
+    root.appendChild(clipA);
+
+    const clipB = document.createElement("video");
+    clipB.id = "clip-b";
+    clipB.setAttribute("data-start", "10");
+    clipB.setAttribute("data-duration", "10");
+    root.appendChild(clipB);
+
+    window.__timelines = { main: createMockTimeline(20) };
+
+    initSandboxRuntimeModular();
+
+    const player = window.__player;
+    expect(player).toBeDefined();
+
+    // Evaluate the still-inactive second clip at least once before it becomes
+    // active — the shape that used to poison the cache.
+    player?.seek(0);
+    expect(clipB.style.visibility).toBe("hidden");
+
+    player?.seek(15);
+    expect(clipB.style.visibility).toBe("visible");
+    expect(clipB.style.display).not.toBe("none");
+  });
+
   it("allocates color grading only for the active timed media", () => {
     const getContextSpy = vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
     const root = document.createElement("div");

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -2255,6 +2255,15 @@ export function initSandboxRuntimeModular(): void {
     timedClipInFlow = new WeakMap<Element, boolean>();
     timedClipIsLeaf = new WeakMap<Element, boolean>();
   };
+
+  // Which elements carry a `display:none` the visibility pass itself applied, so
+  // the un-hide branch can undo exactly that instead of re-deriving
+  // `isTimedClipInFlow`. That derived answer can flip between the hide and the
+  // show pass for the SAME element — `applyClipLayout` force-absolutizes a
+  // root-level clip after an earlier pass already cached it as in-flow and hid
+  // it — and the corrected, no-longer-in-flow reading then skips the removal,
+  // stranding the clip hidden for the rest of the render.
+  const timedClipDisplayNoneApplied = new WeakSet<HTMLElement>();
   const dataHiddenDisplayRestores = new WeakMap<HTMLElement, string>();
   const dataHiddenDisplayNodes = new WeakSet<HTMLElement>();
   // A data-hidden toggle on (or affecting) an audio element must re-schedule
@@ -2349,9 +2358,13 @@ export function initSandboxRuntimeModular(): void {
         colorGradingRuntime?.setSourceVisibility(rawNode, isVisibleNow);
       }
       if (isVisibleNow) {
-        if (isTimedClipInFlow(rawNode)) rawNode.style.removeProperty("display");
+        if (timedClipDisplayNoneApplied.has(rawNode)) {
+          rawNode.style.removeProperty("display");
+          timedClipDisplayNoneApplied.delete(rawNode);
+        }
       } else if (isTimedClipInFlow(rawNode) && isTimedClipLeaf(rawNode)) {
         rawNode.style.display = "none";
+        timedClipDisplayNoneApplied.add(rawNode);
       }
     }
     // Only when a `data-hidden` mutation actually moved something: the skips

--- a/packages/producer/src/services/coreRuntimeBrowser.test.ts
+++ b/packages/producer/src/services/coreRuntimeBrowser.test.ts
@@ -148,6 +148,65 @@ describe("core runtime browser contract", () => {
     30_000,
   );
 
+  it("un-hides a later root-level video once active, even though it starts inactive and unstyled", async () => {
+    // Root-level `[data-start]` children with no authored `position` start out
+    // `position: static` until the runtime force-absolutizes them, so a
+    // visibility pass over the still-inactive second clip can observe `static`
+    // and cache it as in-flow before that forcing runs. That cached reading used
+    // to poison the later un-hide check and leave the clip stuck `display:none`
+    // for the rest of the render once it became active.
+    const videoPage = await browser.newPage();
+    try {
+      await videoPage.setContent(`<!doctype html>
+        <div
+          data-composition-id="root"
+          data-start="0"
+          data-duration="20"
+          data-width="320"
+          data-height="240"
+        >
+          <video id="clip-a" data-start="0" data-duration="10" width="320" height="240" muted></video>
+          <video id="clip-b" data-start="10" data-duration="10" width="320" height="240" muted></video>
+        </div>`);
+      await videoPage.addScriptTag({ content: readFileSync(RUNTIME_PATH, "utf8") });
+      await videoPage.waitForFunction(
+        () =>
+          (window as unknown as { __playerReady?: boolean }).__playerReady === true &&
+          (window as unknown as { __renderReady?: boolean }).__renderReady === true,
+      );
+
+      const seekAndReadClipB = (seekTo: number) =>
+        videoPage.evaluate((timeSeconds) => {
+          const player = (
+            window as unknown as { __player?: { renderSeek: (timeSeconds: number) => void } }
+          ).__player;
+          if (!player) throw new Error("runtime player was not installed");
+          player.renderSeek(timeSeconds);
+
+          const clip = document.getElementById("clip-b");
+          if (!clip) throw new Error("clip-b was not found");
+          const computed = window.getComputedStyle(clip);
+          return {
+            display: computed.display,
+            visibility: computed.visibility,
+            offsetWidth: clip.offsetWidth,
+          };
+        }, seekTo);
+
+      // Evaluate the still-inactive second clip at least once before it
+      // becomes active — the shape that used to poison the cache.
+      const beforeActive = await seekAndReadClipB(0);
+      expect(beforeActive.visibility).toBe("hidden");
+
+      const afterActive = await seekAndReadClipB(15);
+      expect(afterActive.visibility).toBe("visible");
+      expect(afterActive.display).not.toBe("none");
+      expect(afterActive.offsetWidth).toBeGreaterThan(0);
+    } finally {
+      await videoPage.close();
+    }
+  }, 30_000);
+
   it("removes the control bridge during teardown", async () => {
     const result = await page.evaluate(async () => {
       const runtimeWindow = window as unknown as {


### PR DESCRIPTION
## Summary

A root-level `[data-start]` clip (e.g. a `<video>`) with no authored `position` starts out `position: static` until `applyClipLayout()` forces it to `position: absolute` at runtime. `applyTimedElementVisibility()`'s in-flow classification for that element is lazily computed and cached the first time it's queried — if a visibility pass runs while the clip is still inactive (true for any clip other than the very first one) and *before* `applyClipLayout` has forced its position, that pass observes the pre-forcing `static` value and caches "in-flow: true", correctly hiding the clip with `display: none` (in-flow leaf clips leave the document flow entirely so a hidden clip doesn't reserve layout space).

By the time the clip later becomes active, the same cache has since been invalidated and recomputed — now correctly reading `position: absolute` — so the un-hide check, which re-derived that same cached fact instead of tracking what it had actually done, saw "not in-flow" and skipped the `display` removal. The clip stayed `display: none` (and therefore zero-sized) for the rest of the render, painting as solid black wherever it should have shown video.

This only bites hand-authored clips that don't explicitly set `position: absolute` — HyperFrames' own generated templates always position clips absolutely, so a template-only composition never hits this path.

## Fix

`packages/core/src/runtime/init.ts`: added a `timedClipDisplayNoneApplied` WeakSet that tracks whether this specific mechanism applied `display: none` to a given element, and changed the un-hide branch to check/clear that WeakSet instead of re-deriving the (potentially now-stale-relative-to-this-decision) in-flow cache. A hide/show pair keyed on the mechanism's own prior action can't desync the way two independently-recomputed cache reads can — the in-flow cache itself is left untouched, since it's entitled to change over time; the bug was trusting it for a decision it could no longer answer correctly on the second read.

## Test plan

- [x] Verified with a real Chromium repro (Puppeteer + the actual built runtime bundle): a two-sequential-root-level-clip fixture (0-10s / 10-20s, no CSS `position` authored) reproduced the second clip staying `display: none`/zero-sized once active, both when seeking incrementally from t=0 and when jumping directly into the second clip's window as the very first seek (matching how a render session that only ever needs a later time range would behave).
- [x] `packages/producer/src/services/coreRuntimeBrowser.test.ts`: added a new real-Chromium regression test to the existing runtime-contract suite. Verified against a real revert — reverted just the `init.ts` fix (kept the test), rebuilt the runtime bundle, reran: failed exactly as expected (`display` stuck at `"none"`). Restored the fix, rebuilt, reran: passes (`display` not `"none"`, `visibility: visible`, `offsetWidth > 0`).
- [x] `packages/core/src/runtime/init.test.ts`: added a matching unit test following this file's existing conventions for identical scenarios. This file's test suite could not be executed in my environment (`vitest run` fails to collect any test in it with an unrelated, pre-existing `Error: No such built-in module: node:` — reproduced identically on a clean pre-fix checkout of the same file, and affecting ~12 other unrelated test files across the package the same way). Verified correctness by close pattern-matching against structurally identical existing tests in the same file rather than a local run.
- [x] `bunx tsc --noEmit` clean on `packages/core` and `packages/producer`.
- [x] `bunx oxlint` / `bunx oxfmt --check` clean on all changed files.
- [x] Confirmed the fix's interaction with the file's other WeakMap-based caches (`isTimedClipInFlow`, `isTimedClipLeaf`, invalidated wholesale via `invalidateTimedClipCaches()` when the timed-element set changes structurally): the new WeakSet deliberately isn't reset there, since it tracks a live applied DOM mutation rather than a recomputable fact — wiping it on an unrelated structural change would orphan a real `display: none` with no future removal trigger.
