### PR TITLE
fix(lint): stop gsap_repeated_fromto_without_baseline flagging a load-time gsap.set() baseline

### DIFF
--- a/packages/lint/src/rules/gsap.test.ts
+++ b/packages/lint/src/rules/gsap.test.ts
@@ -3259,7 +3259,11 @@ describe("SVG draw-on rules", () => {
     expect(finding).toBeUndefined();
   });
 
-  it("gsap_repeated_fromto_without_baseline: rejects an earlier standalone set", async () => {
+  it("gsap_repeated_fromto_without_baseline: accepts an earlier load-time standalone set", async () => {
+    // A load-time `gsap.set(...)` runs before the paused timeline's playhead
+    // ever moves, so it establishes the resting state just as reliably as an
+    // in-timeline `tl.set(..., 0)` — and unlike that shape, it can never trip
+    // gsap_timeline_set_initial_hide (which already exempts `global` sets).
     const html = `
 <html><body>
   <div data-composition-id="main" data-width="1920" data-height="1080"><div id="ring"></div></div>
@@ -3268,6 +3272,65 @@ describe("SVG draw-on rules", () => {
     window.__timelines = window.__timelines || {};
     const tl = gsap.timeline({ paused: true });
     gsap.set("#ring", { opacity: 0, scale: 1 });
+    tl.fromTo("#ring", { opacity: 0, scale: 1 }, { opacity: 1, duration: 0.5 }, 5);
+    tl.fromTo("#ring", { opacity: 1, scale: 0.4 }, { opacity: 0, duration: 0.5 }, 10);
+    window.__timelines.main = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const finding = result.findings.find(
+      (candidate) => candidate.code === "gsap_repeated_fromto_without_baseline",
+    );
+
+    expect(finding).toBeUndefined();
+  });
+
+  it("gsap_repeated_fromto_without_baseline: a load-time set baseline also clears gsap_timeline_set_initial_hide", async () => {
+    // Regression: this rule's fixHint used to recommend an in-timeline
+    // `tl.set(sel, { ... }, 0)` baseline, which gsap_timeline_set_initial_hide
+    // then flags whenever those values hide the element — the hide-until-reveal
+    // shape both rules exist for. A load-time `gsap.set(...)` is the one
+    // baseline that satisfies both, so neither rule may fire on it.
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080"><div id="ring"></div></div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    gsap.set("#ring", { opacity: 0, scale: 0 });
+    tl.fromTo("#ring", { opacity: 0, scale: 0 }, { opacity: 1, scale: 1, duration: 0.5 }, 5);
+    tl.fromTo("#ring", { opacity: 1, scale: 1 }, { opacity: 0, scale: 0, duration: 0.5 }, 10);
+    window.__timelines.main = tl;
+  </script>
+</body></html>`;
+    const result = await lintHyperframeHtml(html);
+    const codes = result.findings.map((finding) => finding.code);
+
+    expect(codes).not.toContain("gsap_repeated_fromto_without_baseline");
+    expect(codes).not.toContain("gsap_timeline_set_initial_hide");
+  });
+
+  it("gsap_repeated_fromto_without_baseline: still rejects a standalone set deferred behind a callback", async () => {
+    // A `gsap.set(...)` inside an event handler only runs on user interaction,
+    // not at load, so it cannot stand in for a resting state before the first
+    // tween. This rejects on the old, blunter grounds too (any `global` set
+    // was previously excluded outright) — it's a regression guard against a
+    // future change that accepts `global` unconditionally and drops the
+    // extractStandaloneSetSelectors reliability check, not a red/green proof
+    // of that check by itself (see the load-time-baseline test above for that).
+    const html = `
+<html><body>
+  <div data-composition-id="main" data-width="1920" data-height="1080">
+    <div id="ring"></div><button id="reset"></button>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
+  <script>
+    window.__timelines = window.__timelines || {};
+    const tl = gsap.timeline({ paused: true });
+    document.getElementById("reset").addEventListener("click", () => {
+      gsap.set("#ring", { opacity: 0, scale: 1 });
+    });
     tl.fromTo("#ring", { opacity: 0, scale: 1 }, { opacity: 1, duration: 0.5 }, 5);
     tl.fromTo("#ring", { opacity: 1, scale: 0.4 }, { opacity: 0, duration: 0.5 }, 10);
     window.__timelines.main = tl;

--- a/packages/lint/src/rules/gsap.ts
+++ b/packages/lint/src/rules/gsap.ts
@@ -245,7 +245,7 @@ function isHiddenGsapState(values: Record<string, string | number>): boolean {
   );
 }
 
-function hiddenSetTargetSelectors(target: string, aliases: Map<string, string>): string[] {
+function setTargetSelectors(target: string, aliases: Map<string, string>): string[] {
   const parts =
     target.startsWith("[") && target.endsWith("]") ? target.slice(1, -1).split(",") : [target];
   return parts
@@ -258,7 +258,17 @@ function hiddenSetTargetSelectors(target: string, aliases: Map<string, string>):
     .filter((selector) => selector.length > 0);
 }
 
-function extractStandaloneHiddenSelectors(script: string): Set<string> {
+/**
+ * Selectors targeted by a load-time `gsap.set(...)`: one that runs as the
+ * script executes, not deferred behind a callback or event handler (IIFEs
+ * still count — they run at parse time). Callers that care about *what* the
+ * set applies pass `matchesValues` to filter on the object-literal source;
+ * callers that only need "is there a load-time set at all" omit it.
+ */
+function extractStandaloneSetSelectors(
+  script: string,
+  matchesValues?: (values: string) => boolean,
+): Set<string> {
   const selectors = new Set<string>();
   const source = stripJsComments(script);
   const functionRanges = collectFunctionBodyRanges(source);
@@ -274,14 +284,18 @@ function extractStandaloneHiddenSelectors(script: string): Set<string> {
   while ((match = pattern.exec(source)) !== null) {
     // Skip callback/handler bodies; keep IIFEs (they run at parse time).
     if (indexInsideNonIifeRange(match.index, source, functionRanges)) continue;
-    const targets = hiddenSetTargetSelectors((match[1] ?? "").trim(), aliases);
+    const targets = setTargetSelectors((match[1] ?? "").trim(), aliases);
     if (targets.length === 0) continue;
-    const body = match[2] ?? "";
-    if (/(?:opacity|autoAlpha)\s*:\s*0(?:\.0+)?\s*(?:,|$)/.test(body)) {
-      for (const selector of targets) selectors.add(selector);
-    }
+    if (matchesValues && !matchesValues(match[2] ?? "")) continue;
+    for (const selector of targets) selectors.add(selector);
   }
   return selectors;
+}
+
+function extractStandaloneHiddenSelectors(script: string): Set<string> {
+  return extractStandaloneSetSelectors(script, (values) =>
+    /(?:opacity|autoAlpha)\s*:\s*0(?:\.0+)?\s*(?:,|$)/.test(values),
+  );
 }
 
 function oneValue(
@@ -1133,6 +1147,12 @@ export const gsapRules: LintRule<LintContext>[] = [
     const authoredHiddenSelectors = new Set(
       scripts.flatMap((script) => [...extractStandaloneHiddenSelectors(script.content)]),
     );
+    // Every selector with a load-time `gsap.set(...)`, whatever values it sets.
+    // gsap_repeated_fromto_without_baseline uses this below to tell a real
+    // load-time set apart from one buried in a callback.
+    const loadTimeSetSelectors = new Set(
+      scripts.flatMap((script) => [...extractStandaloneSetSelectors(script.content)]),
+    );
 
     // Build clip element selector map
     type ClipInfo = { tag: string; id: string; classes: string };
@@ -1216,16 +1236,26 @@ export const gsapRules: LintRule<LintContext>[] = [
         const selector = firstFromTo.targetSelector;
         const firstFromToIndex = gsapWindows.indexOf(firstFromTo);
         const firstFromToPosition = Math.min(...fromToWindows.map((win) => win.position));
-        const hasTimelineBaseline = gsapWindows
-          .slice(0, firstFromToIndex)
-          .some(
-            (candidate) =>
-              candidate.method === "set" &&
-              !candidate.global &&
-              candidate.targetSelector === selector &&
-              candidate.position <= firstFromToPosition,
-          );
-        if (hasTimelineBaseline) continue;
+        // A load-time `gsap.set(...)` runs before the paused timeline's playhead
+        // ever moves, so it establishes the resting state just as reliably as an
+        // in-timeline `tl.set(..., 0)` — and gsap_timeline_set_initial_hide
+        // already treats it that way (it exempts `win.global` outright).
+        // Accepting it here too stops the two rules from each demanding the
+        // shape the other flags.
+        const hasBaseline = gsapWindows.slice(0, firstFromToIndex).some((candidate) => {
+          if (candidate.method !== "set" || candidate.targetSelector !== selector) return false;
+          // The acorn parser flags `global` on any bare `gsap.set(...)` whatever
+          // its AST nesting, so one deferred behind a callback/handler is
+          // indistinguishable here; only the load-time scan separates them.
+          // Known gap: the scan reports selectors, not occurrences, so a second,
+          // genuinely load-time `gsap.set` for the same selector ANYWHERE in the
+          // composition (even after this candidate, even in another script) would
+          // also satisfy this check — accepted as narrow (requires duplicate
+          // `gsap.set` calls to one selector) rather than tracked per-occurrence.
+          if (candidate.global) return loadTimeSetSelectors.has(selector);
+          return candidate.position <= firstFromToPosition;
+        });
+        if (hasBaseline) continue;
 
         findings.push({
           code: "gsap_repeated_fromto_without_baseline",
@@ -1237,9 +1267,11 @@ export const gsapRules: LintRule<LintContext>[] = [
             `(immediateRender), not at tween position.`,
           selector,
           fixHint:
-            `Add \`immediateRender: false\` to the destination vars of each future fromTo, or set a safe ` +
-            `resting state with an earlier \`tl.set("${selector}", { ... }, 0)\`. Pre-first-tween seeks must not ` +
-            `inherit whichever fromTo call happened to author last.`,
+            `Add \`immediateRender: false\` to the destination vars of each future fromTo, or establish the ` +
+            `resting state with a load-time \`gsap.set("${selector}", { ... })\` before the first fromTo. ` +
+            `Prefer that over an in-timeline \`tl.set("${selector}", { ... }, 0)\`, which ` +
+            `gsap_timeline_set_initial_hide flags when those values hide the element. Pre-first-tween seeks ` +
+            `must not inherit whichever fromTo call happened to author last.`,
           snippet: truncateSnippet(fromToWindows.map((win) => win.raw).join("\n")),
         });
       }


### PR DESCRIPTION
## Summary

Two GSAP lint rules gave contradictory fix guidance for the common "hide the element until it's revealed" pattern:

- `gsap_repeated_fromto_without_baseline` warns when ≥2 `tl.fromTo()` calls target the same element with no stable resting-state baseline established beforehand (GSAP applies a `fromTo`'s "from" values at authoring time, so without a baseline, whichever `fromTo` was authored last silently becomes the resting state for any seek before the timeline actually starts). Its fixHint offered two options: `immediateRender: false` on each future `fromTo`, or an earlier in-timeline `tl.set(sel, {...}, 0)`.
- `gsap_timeline_set_initial_hide` independently warns on exactly that second shape — an in-timeline `tl.set(...)` at position 0 whose values hide the element (a zero-duration set at the exact position-0 playhead doesn't render on frame 0 in this engine, so the element pops hidden a frame later).

Following the first rule's own advice trips the second rule, since a "safe resting state" for a hide-until-reveal animation is, almost by definition, a hidden state.

## Fix

`gsap_timeline_set_initial_hide` already treats a load-time `gsap.set(...)` (as opposed to an in-timeline `tl.set(...)`) as a reliable baseline — it exempts it from firing at all. `gsap_repeated_fromto_without_baseline`'s own baseline check didn't recognize the same thing, rejecting any load-time set unconditionally. This aligns the two:

- `packages/lint/src/rules/gsap.ts`: `gsap_repeated_fromto_without_baseline`'s baseline check now also accepts a preceding load-time `gsap.set(...)` call as valid — gated on a new reliability scan (`extractStandaloneSetSelectors`, factored out of the pre-existing `extractStandaloneHiddenSelectors`) that excludes a `gsap.set(...)` deferred behind a callback or event handler. That distinction is needed because the GSAP parser flags any bare `gsap.set(...)` as load-time regardless of where it sits in the AST — a set inside a click handler only runs on user interaction, not at load, so it can't stand in for a resting state before the first tween.
- The rule's `fixHint` now recommends the load-time `gsap.set(...)` route ahead of the in-timeline `tl.set(...,0)` route, and notes the latter can trip the other rule.

Known, accepted limitation (documented in a code comment at the check site): the reliability scan reports selectors, not specific occurrences, across the whole composition's scripts. A composition with two `gsap.set(...)` calls for the *same* selector — one deferred+earlier-in-source, one genuinely load-time+later — could false-accept the deferred one as a baseline. This requires an unusual duplicate-declaration shape and is a warning-severity, advice-quality rule (not a build-blocking correctness check), so it's left as a documented boundary rather than a blocker.

## Test plan

- [x] `packages/lint/src/rules/gsap.test.ts`: updated the one existing test that encoded the old (now-corrected) behavior, and added new tests: a load-time `gsap.set(...)` baseline is now accepted; a load-time `gsap.set(...)` baseline satisfies both rules simultaneously (the actual contradiction, now resolved); a `gsap.set(...)` deferred behind a callback is still correctly rejected as a baseline. Full suite: 194/194 passing.
- [x] Verified against a real revert: reverted just `gsap.ts` (kept the tests), reran — the two new/changed tests failed exactly as expected against the old behavior; restored the fix, reran — all 194 pass again.
- [x] `bunx tsc --noEmit -p packages/lint` clean.
- [x] `bunx oxlint` / `bunx oxfmt --check` clean on both changed files.
- [x] Confirmed the refactor of `extractStandaloneHiddenSelectors` into a shared `extractStandaloneSetSelectors` base doesn't change its existing behavior (same regex, same match-group handling, only the value filter moved to a parameter) — full pre-existing suite still green.
