### PR TITLE
fix(cli): stop isTransparentColor misreading opaque zero-blue colors as transparent

### DIFF
--- a/packages/cli/src/commands/layout-audit.browser.js
+++ b/packages/cli/src/commands/layout-audit.browser.js
@@ -324,12 +324,7 @@
   }
 
   function hasPaint(style) {
-    const backgroundColor = style.backgroundColor || "";
-    const hasBackground =
-      backgroundColor !== "" &&
-      backgroundColor !== "transparent" &&
-      !backgroundColor.endsWith(", 0)") &&
-      backgroundColor !== "rgba(0, 0, 0, 0)";
+    const hasBackground = !isTransparentColor(style.backgroundColor);
     const hasImage = style.backgroundImage && style.backgroundImage !== "none";
     const hasBorder =
       parsePx(style.borderTopWidth) +
@@ -591,10 +586,11 @@
     return element.hasAttribute("data-layout-allow-overlap");
   }
 
+  // Alpha must come from colorAlpha's argument-position parse, never from a
+  // `", 0)"` string suffix: that suffix also matches fully-opaque 3-value rgb()
+  // colours whose blue channel is zero, e.g. pure red/green/yellow.
   function isTransparentColor(color) {
-    return (
-      !color || color === "transparent" || color === "rgba(0, 0, 0, 0)" || color.endsWith(", 0)")
-    );
+    return !color || color === "transparent" || colorAlpha(color) === 0;
   }
 
   function alphaFromParts(parts, index) {

--- a/packages/cli/src/commands/layout-audit.browser.test.ts
+++ b/packages/cli/src/commands/layout-audit.browser.test.ts
@@ -2511,6 +2511,20 @@ describe("layout-audit.browser occlusion", () => {
     expect(occluded?.coveredFraction).toBe(1);
   });
 
+  // PRINFRA-702: `rgb(r, g, 0)` ends in the same `", 0)"` as a transparent
+  // `rgba(..., 0)`, so a string-suffix transparency check silently exempted
+  // opaque red/green/yellow occluders from occlusion entirely.
+  it.each(["rgb(0, 255, 0)", "rgb(255, 0, 0)", "rgb(255, 255, 0)"])(
+    "flags an opaque %s occluder whose blue channel is zero",
+    (backgroundColor) => {
+      const issues = auditOcclusionScene({
+        overlayStyle: { backgroundColor },
+        topmostId: "overlay",
+      });
+      expect(issues.some((issue) => issue.code === "text_occluded")).toBe(true);
+    },
+  );
+
   // #U10: a 2-point hit on the 27-point probe grid (3 rows x 9 columns) is a
   // sliver of edge cover — reports ~0.07 coverage either way, but only GATES
   // (produces a finding) for short atomic labels; ordinary prose survives it.


### PR DESCRIPTION
## Problem

`isTransparentColor(color)` in `layout-audit.browser.js` (the injected in-page audit script backing `hyperframes check`'s layout gate) detected "is this color transparent" with a string-suffix check: `color.endsWith(", 0)")`. That suffix also matches any fully-opaque 3-value `rgb(r, g, b)` color whose blue channel is `0` — pure red (`rgb(255,0,0)`), pure green (`rgb(0,255,0)`), pure yellow (`rgb(255,255,0)`), and any other zero-blue color — not just genuinely transparent 4-value `rgba(..., 0)` colors.

This silently broke two things for elements in one of those colors:
- `isOpaqueOccluder`/`hasOpaqueBackground` — a solid pure-green/red/yellow card sitting on top of text was never flagged as occluding it (`text_occluded` false negative).
- `connectorAnchorRects`/`connectorEndpointCandidates` — a node box in one of those colors silently dropped out of the anchorable-element list for `connector_detached`/`connector_orphan`.

A second, independent instance of the identical bug was found while reading the source: `hasPaint(style)` re-implemented its own inline copy of the same buggy suffix check (feeding `isConstraintCandidate` → overflow-boundary detection), rather than calling `isTransparentColor`.

A third, unrelated defect in the same predicate surfaced while pinning it: `hasPaint` counted a `border-radius` alone as paint, so a transparent, borderless, rounded box became the nearest overflow constraint for the text inside it although it renders nothing. This pre-dates the PR (it has been there since the original overflow-boundary work).

## Fix

Delegate to the file's existing, already-correct `colorAlpha(color)`, which parses the real alpha channel by argument position (handles both legacy `rgba(r,g,b,a)` and the modern `rgb(r g b / a)` syntax) rather than by string shape:

```js
function isTransparentColor(color) {
  return !color || color === "transparent" || colorAlpha(color) === 0;
}
```

`hasPaint` now delegates to the corrected `isTransparentColor` instead of carrying its own duplicate broken check.

`hasPaint` no longer counts `border-radius` as paint. It reads background colour, background image and border width only; the radius stays a geometry input to `hasMeaningfulBoxStyle`, which is evaluated after the paint gate. A rounded box whose only visible silhouette is a `box-shadow` was previously a constraint through the radius term and is now measured against its ancestor; `box-shadow` and `outline` are a declared non-read of `hasPaint` (see the last section), not an accidental one. `isPaintedPanel` and `hasOpaqueBackground` are unchanged (neither ever read the radius).

Intended side effect: the old suffix check only matched `", 0)"`, so a modern-syntax transparent `rgb(r g b / 0)` read as *opaque*. `colorAlpha` parses that form too, so it now reads as transparent everywhere `isTransparentColor` is consulted (`hasPaint`, `hasOpaqueBackground`, `isPaintedPanel`).

## Tests

`layout-audit.browser.test.ts`:

- Occlusion path: parameterized `text_occluded` test for a pure green/red/yellow opaque occluder (previously silently exempted).
- Overflow-boundary path (`hasPaint` → `isConstraintCandidate`), a padded, non-clipping box stripped to geometry (transparent background, no radius) with the text wider than the box but fitting the root:
  - positive table, one paint source per row — `rgb(0, 255, 0)` / `rgb(255, 0, 0)` / `rgb(255, 255, 0)`, a `url()` background image, a single border side — `text_box_overflow` must survive with the box as its selector;
  - negative table — no paint source, a border-radius only, a box-shadow only, an outline only — the box is *not* its own constraint (the text measures against the root and fits);
  - one `it.todo` recording the `colorAlpha` blind spot below (a transparent non-sRGB background still reads as paint), kept as a declared gap rather than a passing assertion.
- `isPaintedPanel`, geometry half held fixed (one `<div>` breaching the right canvas edge by 280px): a 14-row table asserting each qualifying paint source alone produces `panel_out_of_canvas` — opaque `rgb()`, opaque zero-blue `rgb(0, 255, 0)`, modern `rgb(255 0 0 / 1)`, `rgba(…, 0.06)` (above the 0.05 floor), `url()` background image, a gradient with a stop at exactly 0.6 alpha, a single border side — and each non-paint alone does not: `rgba(0, 0, 0, 0)`, `rgb(0 0 0 / 0)`, `rgba(…, 0.05)` (at the floor, which is strictly-above), a gradient whose strongest stop is 0.59, box-shadow only, outline only, border-radius only (the last three set properties the predicate never reads and guard that they stay unread).

Mutation check, run against the full file (146 tests + 1 todo):

| Mutation | Red tests |
| --- | --- |
| `hasPaint`: `hasBackground = false` | 6 |
| `hasPaint`: `hasBackground` inverted | 10 |
| `hasPaint`: `hasImage` / `hasBorder` each dropped | 1 each (matching positive row) |
| `hasPaint`: border-radius read as paint again | 1 (radius negative row) |
| `hasPaint`: box-shadow read as paint | 1 (box-shadow negative row) |
| `hasPaint`: outline read as paint | 1 (outline negative row) |
| `isConstraintCandidate`: `hasPaint` gate removed | 4 (all negative rows) |
| `panelOutOfCanvasIssues`: `isPaintedPanel` gate removed | 8 (all non-paint rows + existing hero test) |
| `isPaintedPanel`: background-color branch inverted | 13 |
| `isPaintedPanel`: colour floor `> 0.05` → `>= 0.05` | 1 (0.05 row) |
| `gradientHasOpaqueStop`: `>= 0.6` → `>= 0.2` | 1 (0.59 row) |
| `isTransparentColor` reverted to the suffix check | 7 (all zero-blue tests across the three paths) |

Before the radius change, the box-shadow-as-paint and outline-as-paint mutations survived (no negative row exercised them); they are now red.

Running the suite: under the stock `@vitest-environment happy-dom` pragma, collection fails in this environment with `Error: No such built-in module: node:` (identical on an unmodified checkout, both `bunx vitest` and `node vitest.mjs`). The results above come from the same test file executed with `environment: "node"` plus a setup file that populates globals from a `happy-dom` `Window` via vitest's `populateGlobal` — the same thing the happy-dom environment does — so the assertions run against the real script.

Earlier real-Chromium red→green verification (revert source, keep tests, drive the actual script via `page.evaluate`): pure red/green/yellow occluders dropped `text_occluded` to `false` pre-fix and reported `true` post-fix, with a near-black control `true` both times; the same for the `hasPaint`/overflow-boundary path with a zero-blue card and text wider than the card.

## Verification

- `bunx oxlint` / `bunx oxfmt --check` on both touched files — clean
- `bunx tsc --noEmit -p packages/cli` — clean
- 146/146 tests + 1 todo in `layout-audit.browser.test.ts` (harness above), every mutation in the table red

## What the transparency/paint predicates read, and what they ignore

`colorAlpha` matches `/rgba?\(([^)]+)\)/` and returns `1` for anything else. So `isTransparentColor` reads only `rgb()`/`rgba()` strings (legacy comma or modern slash form); `transparent` and the empty string are handled explicitly. Chromium's `getComputedStyle()` serializes sRGB colors — including anything authored as `hsl()`/`hsla()`, hex, or named — to `rgb()`/`rgba()`, so those never reach `colorAlpha` in their authored form. Colors that compute to a non-sRGB serialization (`color(display-p3 …)`, `oklch(…)`, `lab(…)`) do not match the regex and read as alpha `1`, i.e. opaque, even when authored with `/ 0`. That blind spot pre-dates this PR and is shared by every `colorAlpha` consumer in the file; widening the regex is out of scope here and the `it.todo` in the overflow-boundary tests marks it.

The paint decisions themselves read only these computed properties:

- `hasPaint` (overflow boundary): `backgroundColor` alpha ≠ 0, `backgroundImage` ≠ `none`, any `border*Width` > 0. `border*Radius` is geometry (`hasMeaningfulBoxStyle`), not paint.
- `isPaintedPanel` (`panel_out_of_canvas`): `backgroundImage` containing `url(`, a gradient with any stop of alpha ≥ 0.6, `backgroundColor` alpha > 0.05, any `border*Width` > 0. Raster/SVG media tags are excluded (owned by other findings).
- `hasOpaqueBackground` (occlusion): `url(` image, composited gradient-layer alpha and `backgroundColor` alpha > 0.6.

None of them look at `box-shadow`, `outline`, `::before`/`::after` pseudo-element paint, SVG `fill`/`stroke`, `<canvas>`/`<video>`/`<img>` pixel content, `opacity`, `filter`, `backdrop-filter`, `mix-blend-mode` or `visibility` (visibility is gated separately, upstream, by `isVisibleElement`). A panel painted only by a shadow, an outline, a filter or a pseudo-element is not "painted" to these checks, and a fully transparent element with `opacity: 1` is not painted either.
