### PR TITLE
fix(runtime): publish progress from parent ticks

### DIFF
--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -124,6 +124,32 @@ describe("initSandboxRuntimeModular", () => {
     window.cancelAnimationFrame = (() => {}) as typeof window.cancelAnimationFrame;
   });
 
+  it("publishes progress from parent ticks while the iframe animation frame is suspended", () => {
+    document.body.innerHTML = '<div data-composition-id="main" data-duration="10"></div>';
+    window.__timelines = { main: createMockTimeline(10) };
+    initSandboxRuntimeModular();
+    const post = vi.spyOn(window.parent, "postMessage").mockImplementation(() => {});
+    let now = performance.now();
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    window.__player?.play();
+    post.mockClear();
+    now += 500;
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: window,
+        data: { source: "hf-parent", type: "control", action: "tick" },
+      }),
+    );
+    expect(post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "hf-preview",
+        type: "state",
+        isPlaying: true,
+        frame: 15,
+      }),
+      "*",
+    );
+  });
   it.each([
     ["2x", 5],
     ["0x2", 10],

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -3988,7 +3988,10 @@ export function initSandboxRuntimeModular(): void {
         runAdapters("pause");
         syncMediaForCurrentState();
         postState(true);
+        return;
       }
+      // When iframe rAF is throttled, parent ticks also own position reporting.
+      postState(false);
     },
     onEnablePickMode: () => picker.enablePickMode(),
     onDisablePickMode: () => picker.disablePickMode(),


### PR DESCRIPTION
## What

Keep embedded-player progress updates moving when the iframe's animation frames are throttled.

This retains the verified progress-reporting fix from the stale-PR cleanup. Navigation and reload recovery remain deferred.

Related: #3554

## Why

Parent ticks already advance playback, but ordinary ticks do not report the new position to the embedder. Playback can therefore continue while `currentTime` and `timeupdate` remain stale.

## How

Publish ordinary parent-tick progress through the existing state deduper. Preserve the single forced stopped-state publication at natural end.

## Test plan

- [x] Unit tests added/updated — regression fails without the fix; current runtime initialization suite passes 113/113, with 72/72 adjacent bridge and clock tests.
- [x] Manual testing performed — real cross-origin browser fixture with child animation frames suppressed verifies progress, stable pause, one natural-end event, and looping.
- [ ] Documentation updated (if applicable) — not applicable.

Full repository commit hooks passed, including core, Studio, and scripts typechecks, Fallow, formatting, linting, artifact guards, and commitlint.
