### PR TITLE
fix(runtime): a paused preview stays still after any seek

### DIFF
--- a/packages/core/src/runtime/colorGrading.ts
+++ b/packages/core/src/runtime/colorGrading.ts
@@ -3480,7 +3480,13 @@ function makeCanvas(element: ColorGradingMediaElement): HTMLCanvasElement {
   return attachCanvas(document.createElement("canvas"), element);
 }
 
-export function createColorGradingRuntime(): RuntimeColorGradingApi {
+/** `pausedMediaLease` borrows an element's playback while the transport clock is
+ *  stopped. Optional so this module stays constructible alone; without it the
+ *  runtime's paused-side enforcement stops the preview. */
+export function createColorGradingRuntime(pausedMediaLease?: {
+  lease: (el: HTMLMediaElement) => void;
+  release: (el: HTMLMediaElement) => void;
+}): RuntimeColorGradingApi {
   const entries = new WeakMap<ColorGradingMediaElement, ColorGradingEntry>();
   const trackedElements = new Set<ColorGradingMediaElement>();
   const idleRenderers: ColorGradingRenderer[] = [];
@@ -3781,8 +3787,12 @@ export function createColorGradingRuntime(): RuntimeColorGradingApi {
     if (element.ended || (Number.isFinite(element.duration) && time >= element.duration)) {
       element.currentTime = 0;
     }
+    // Borrowed before play(): the runtime stops anything running under a paused
+    // clock, and the capture-phase `play` listener makes that immediate.
+    pausedMediaLease?.lease(element);
     void element.play().catch(() => undefined);
     return () => {
+      pausedMediaLease?.release(element);
       element.pause();
       element.loop = loop;
       element.muted = muted;

--- a/packages/core/src/runtime/init.test.ts
+++ b/packages/core/src/runtime/init.test.ts
@@ -2011,6 +2011,16 @@ describe("initSandboxRuntimeModular", () => {
       tweet: tweetTimeline,
     };
 
+    // Record what the children looked like AT the root seek — that is the moment
+    // the activation exists for, and the only moment it is observable now that
+    // the seek restores them.
+    const pausedDuringRootSeek: Array<[boolean, boolean]> = [];
+    const rootTotalTime = rootTimeline.totalTime!;
+    rootTimeline.totalTime = (time?: number, suppressEvents?: boolean) => {
+      pausedDuringRootSeek.push([hookTimeline.paused!(), tweetTimeline.paused!()]);
+      return rootTotalTime.call(rootTimeline, time, suppressEvents);
+    };
+
     initSandboxRuntimeModular();
 
     const player = window.__player;
@@ -2020,16 +2030,16 @@ describe("initSandboxRuntimeModular", () => {
     // children are added to a paused root timeline in GSAP)
     hookTimeline.paused!(true);
     tweetTimeline.paused!(true);
+    pausedDuringRootSeek.length = 0;
 
     // Seek to 0.5s — well within the hook's window [0.001, 2.001]
     player?.renderSeek(0.5);
 
-    // renderSeek should activate (unpause) all child timelines before
-    // seeking the root. Without the fix, children stay paused and GSAP's
-    // totalTime() propagation skips them, leaving elements at initial CSS
-    // state (opacity: 0).
-    expect(hookTimeline.paused!()).toBe(false);
-    expect(tweetTimeline.paused!()).toBe(false);
+    // renderSeek must activate (unpause) all child timelines before seeking the
+    // root. Without that, children stay paused and GSAP's totalTime()
+    // propagation skips them, leaving elements at initial CSS state (opacity: 0).
+    expect(pausedDuringRootSeek.length).toBeGreaterThan(0);
+    for (const pausedPair of pausedDuringRootSeek) expect(pausedPair).toEqual([false, false]);
 
     // The hook host should be visible at t=0.5
     expect(hookHost.style.visibility).toBe("visible");

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -2524,11 +2524,8 @@ export function initSandboxRuntimeModular(): void {
   window.__hf.releasePausedMedia = releasePausedMedia;
 
   /**
-   * The cheap half of the paused-side check: a tag+attribute query, deliberately
-   * not `buildRuntimeMediaCache`, which reads and resolves the timing of every
-   * media element in the document. The predicate matches the cache's own filter
-   * (`video`/`audio` carrying `data-start`) so anything this reports is something
-   * `syncRuntimeMedia` can actually stop.
+   * Cheap tag+attribute scan, not `buildRuntimeMediaCache`. Narrower than that
+   * cache's filter, which also admits media with no `data-start` of its own.
    */
   const hasRunningTimedMedia = (): boolean => {
     for (const el of document.querySelectorAll("video[data-start], audio[data-start]")) {
@@ -3276,7 +3273,7 @@ export function initSandboxRuntimeModular(): void {
   // in the registry, not GSAP child tweens). Matches the naming convention in
   // player.ts:32 (forEachSiblingTimeline) and player.ts:89 (activateSiblingTimelines).
   //
-  // The rearm is a MEANS, not a resting state: GSAP will not propagate the root's
+  // The rearm is a means, not a resting state: GSAP will not propagate the root's
   // totalTime() into a paused child. Returns what it touched so the caller can
   // re-pause it; a sibling parented to gsap.globalTimeline free-runs on the global
   // ticker the moment it is left unpaused. Mirrors player.ts's seek helper.
@@ -3361,11 +3358,8 @@ export function initSandboxRuntimeModular(): void {
   };
 
   /**
-   * Borrow, seek, return. The rearm below is unpaused only ACROSS the seek:
-   * sub-composition timelines are transport-driven, re-seeked every tick by
-   * `seekStandaloneRegisteredTimelines`, so paused is their only correct resting
-   * state whether or not the clock runs. Restored in `finally` because a throw
-   * mid-seek is exactly when a leaked unpaused sibling starts free-running.
+   * Borrow, seek, return. Siblings are unpaused only across the seek; restored in
+   * `finally`, because a throw mid-seek is when a leaked one starts free-running.
    */
   function seekTimelineAndAdapters(
     t: number,

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -2509,6 +2509,30 @@ export function initSandboxRuntimeModular(): void {
     return [...visiting];
   };
 
+  /**
+   * The cheap half of the paused-side check: a tag+attribute query, deliberately
+   * not `buildRuntimeMediaCache`, which reads and resolves the timing of every
+   * media element in the document. The predicate matches the cache's own filter
+   * (`video`/`audio` carrying `data-start`) so anything this reports is something
+   * `syncRuntimeMedia` can actually stop.
+   */
+  const hasRunningTimedMedia = (): boolean => {
+    for (const el of document.querySelectorAll("video[data-start], audio[data-start]")) {
+      if (isMediaElement(el) && !el.paused) return true;
+    }
+    return false;
+  };
+
+  // A parked transport runs no ticks, so the check above would never see a media
+  // element that starts while the preview sits idle. `play` does not bubble;
+  // capture-phase on the document reaches every element, including later ones
+  // (same reasoning as the media events watchCompositionTimingInputs binds).
+  const onMediaPlayWakeTransport = () => wakeTransport();
+  document.addEventListener("play", onMediaPlayWakeTransport, true);
+  runtimeCleanupCallbacks.push(() => {
+    document.removeEventListener("play", onMediaPlayWakeTransport, true);
+  });
+
   const syncMediaForCurrentState = () => {
     // Scope 1 of 3 (see `withTimingResolver`). Closes before `syncRuntimeMedia`,
     // which may call `el.load()` and invalidate every cached duration.
@@ -3227,20 +3251,24 @@ export function initSandboxRuntimeModular(): void {
   // in the registry, not GSAP child tweens). Matches the naming convention in
   // player.ts:32 (forEachSiblingTimeline) and player.ts:89 (activateSiblingTimelines).
   //
-  // Unlike the player's seek path which re-pauses siblings after seeking,
-  // render-seek is one-frame-at-a-time with no transport tick between frames,
-  // so the residual unpaused state is harmless — the next call re-activates
-  // idempotently.
-  const activateSiblingTimelines = (masterTimeline: RuntimeTimelineLike) => {
+  // The rearm is a MEANS, not a resting state: GSAP will not propagate the root's
+  // totalTime() into a paused child. Returns what it touched so the caller can
+  // re-pause it; a sibling parented to gsap.globalTimeline free-runs on the global
+  // ticker the moment it is left unpaused. Mirrors player.ts's seek helper.
+  const activateSiblingTimelines = (masterTimeline: RuntimeTimelineLike): RuntimeTimelineLike[] => {
     const timelines = (window.__timelines ?? {}) as Record<string, RuntimeTimelineLike | undefined>;
+    const rearmed: RuntimeTimelineLike[] = [];
     for (const tl of Object.values(timelines)) {
       if (!tl || tl === masterTimeline) continue;
+      // Recorded before the call: a play() that throws can still have unpaused.
+      rearmed.push(tl);
       try {
         tl.play();
       } catch (err) {
         swallow("runtime.init.activateSiblings", err);
       }
     }
+    return rearmed;
   };
 
   const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
@@ -3307,24 +3335,36 @@ export function initSandboxRuntimeModular(): void {
     return false;
   };
 
+  /**
+   * Borrow, seek, return. The rearm below is unpaused only ACROSS the seek:
+   * sub-composition timelines are transport-driven, re-seeked every tick by
+   * `seekStandaloneRegisteredTimelines`, so paused is their only correct resting
+   * state whether or not the clock runs. Restored in `finally` because a throw
+   * mid-seek is exactly when a leaked unpaused sibling starts free-running.
+   */
   function seekTimelineAndAdapters(
     t: number,
     opts?: { activateChildren?: boolean; suppressEvents?: boolean },
   ) {
     const tl = state.capturedTimeline;
+    // Critical for a sub-composition whose data-start is at or near 0: it is added
+    // to the root while the root is paused and may never receive an explicit
+    // play(), so without the rearm it holds its initial CSS state (opacity:0).
+    const rearmed = tl && opts?.activateChildren ? activateSiblingTimelines(tl) : [];
+    try {
+      seekRootChildrenAndAdapters(tl, t, opts);
+    } finally {
+      for (const sibling of rearmed) pauseTimelineIfPossible(sibling);
+    }
+  }
+
+  function seekRootChildrenAndAdapters(
+    tl: RuntimeTimelineLike | null,
+    t: number,
+    opts?: { activateChildren?: boolean; suppressEvents?: boolean },
+  ) {
     const suppressEvents = opts?.suppressEvents === true;
     if (tl) {
-      // When rendering frame-by-frame (activateChildren=true), ensure all
-      // sibling timelines are unpaused before seeking the root. GSAP
-      // does not propagate totalTime() to children that are internally
-      // paused, which leaves sub-compositions at their initial CSS state
-      // (typically opacity:0). This mirrors the activateSiblingTimelines
-      // call in player.ts renderSeek and is critical for sub-compositions
-      // whose data-start is at or near 0 — they are added to the root
-      // while it is paused and may never receive an explicit play().
-      if (opts?.activateChildren) {
-        activateSiblingTimelines(tl);
-      }
       // #10: when data-duration exceeds the timeline's intrinsic length the
       // engine requests frames past the last tween. Seeking a paused GSAP
       // timeline past its end can revert from()-tweens to their empty initial
@@ -3364,10 +3404,10 @@ export function initSandboxRuntimeModular(): void {
       // playback rate. Re-seek registered children below with their host's
       // explicit source-time contract.
     }
+    // Pauses and re-seeks each registered child, so the rearm is already spent by
+    // the time this returns. Re-arming after it, as this used to, only ever
+    // changed the state the seek left behind.
     seekStandaloneRegisteredTimelines(t, opts);
-    if (tl && opts?.activateChildren) {
-      activateSiblingTimelines(tl);
-    }
     for (const adapter of state.deterministicAdapters) {
       if (adapter.name === "gsap" && tl) continue;
       try {
@@ -3704,6 +3744,13 @@ export function initSandboxRuntimeModular(): void {
       }
 
       if (clock.isPlaying()) {
+        syncMediaForCurrentState();
+      } else if (hasRunningTimedMedia()) {
+        // Nothing may run while the clock is paused, and the paused side used to
+        // police nothing. Dropping the cursor forces a full visit: the seek-window
+        // index skips an element that started outside the current window, which is
+        // exactly the one to stop.
+        lastSyncedMediaTimeSeconds = null;
         syncMediaForCurrentState();
       }
       postState(false);

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -1248,6 +1248,25 @@ export function initSandboxRuntimeModular(): void {
       }
       return fallbackTimeline;
     };
+    // Read back from the parent rather than trusting add(): a child the parent
+    // does not hold stays on GSAP's global ticker, where unpaused means free-running.
+    const nestedCandidates = <C extends { timeline: RuntimeTimelineLike }>(
+      parent: RuntimeTimelineLike | null,
+      candidates: C[],
+    ): C[] => {
+      const withChildren = parent as
+        | (RuntimeTimelineLike & {
+            getChildren?: (...args: unknown[]) => unknown[];
+          })
+        | null;
+      if (!withChildren || typeof withChildren.getChildren !== "function") return [];
+      try {
+        const held = withChildren.getChildren(true, true, true);
+        return Array.isArray(held) ? candidates.filter((c) => held.includes(c.timeline)) : [];
+      } catch {
+        return [];
+      }
+    };
     const addMissingChildCandidatesToRootTimeline = (
       rootTimeline: RuntimeTimelineLike,
       candidates: Array<{
@@ -1255,14 +1274,15 @@ export function initSandboxRuntimeModular(): void {
         timeline: RuntimeTimelineLike;
         durationSeconds: number;
       }>,
-    ): string[] => {
+    ): { addedIds: string[]; nested: typeof candidates } => {
       const rootWithChildren = rootTimeline as RuntimeTimelineLike & {
         getChildren?: (...args: unknown[]) => unknown[];
       };
-      if (typeof rootWithChildren.getChildren !== "function") return [];
+      const none = { addedIds: [], nested: [] };
+      if (typeof rootWithChildren.getChildren !== "function") return none;
       try {
         const existingChildren = rootWithChildren.getChildren(true, true, true) ?? [];
-        if (!Array.isArray(existingChildren)) return [];
+        if (!Array.isArray(existingChildren)) return none;
         const addedIds: string[] = [];
         for (const candidate of candidates) {
           const alreadyIncluded = existingChildren.some((child) => child === candidate.timeline);
@@ -1276,9 +1296,9 @@ export function initSandboxRuntimeModular(): void {
             swallow("runtime.init.site4", err);
           }
         }
-        return addedIds;
+        return { addedIds, nested: nestedCandidates(rootTimeline, candidates) };
       } catch {
-        return [];
+        return none;
       }
     };
     const rootCompositionNode = resolveRootCompositionElement();
@@ -1343,14 +1363,16 @@ export function initSandboxRuntimeModular(): void {
         }
       }
     };
-    if (rootChildCandidates.length > 0) {
-      ensureChildCandidatesActive(rootChildCandidates);
-    }
     if (rootTimeline) {
-      const autoNestedChildren =
+      // Only a child the root actually holds may run unpaused: the paused root
+      // drives it. A standalone registry child is re-seeked by the transport and
+      // must stay paused, or it free-runs on the global ticker while paused.
+      const nesting =
         rootChildCandidates.length > 0
           ? addMissingChildCandidatesToRootTimeline(rootTimeline, rootChildCandidates)
-          : [];
+          : { addedIds: [], nested: [] };
+      const autoNestedChildren = nesting.addedIds;
+      ensureChildCandidatesActive(nesting.nested);
       // Mark children as bound so the polling loop stops re-resolving
       if (
         rootChildCandidates.length > 0 ||
@@ -1377,6 +1399,7 @@ export function initSandboxRuntimeModular(): void {
         const compositeTimeline = createCompositeTimelineFromCandidates(rootChildCandidates);
         const compositeDurationSeconds = getTimelineDurationSeconds(compositeTimeline);
         if (compositeTimeline && isUsableTimelineDuration(compositeDurationSeconds)) {
+          ensureChildCandidatesActive(nestedCandidates(compositeTimeline, rootChildCandidates));
           return {
             timeline: compositeTimeline,
             selectedTimelineIds,
@@ -1529,6 +1552,7 @@ export function initSandboxRuntimeModular(): void {
       const compositeTimeline = createCompositeTimelineFromCandidates(rootChildCandidates);
       const compositeDurationSeconds = getTimelineDurationSeconds(compositeTimeline);
       if (compositeTimeline) {
+        ensureChildCandidatesActive(nestedCandidates(compositeTimeline, rootChildCandidates));
         return {
           timeline: compositeTimeline,
           selectedTimelineIds,

--- a/packages/core/src/runtime/init.ts
+++ b/packages/core/src/runtime/init.ts
@@ -2509,6 +2509,20 @@ export function initSandboxRuntimeModular(): void {
     return [...visiting];
   };
 
+  /** Elements whose paused-time playback is borrowed by a feature that legitimately
+   *  runs media with the clock stopped: the grading preview, the Studio's scrub.
+   *  Anything playing while paused without a lease is the defect the enforcement
+   *  exists for. On `window.__hf` because the Studio is across the iframe boundary. */
+  const pausedMediaLeases = new WeakSet<HTMLMediaElement>();
+  const leasePausedMedia = (el: HTMLMediaElement): void => {
+    pausedMediaLeases.add(el);
+  };
+  const releasePausedMedia = (el: HTMLMediaElement): void => {
+    pausedMediaLeases.delete(el);
+  };
+  window.__hf.leasePausedMedia = leasePausedMedia;
+  window.__hf.releasePausedMedia = releasePausedMedia;
+
   /**
    * The cheap half of the paused-side check: a tag+attribute query, deliberately
    * not `buildRuntimeMediaCache`, which reads and resolves the timing of every
@@ -2518,7 +2532,7 @@ export function initSandboxRuntimeModular(): void {
    */
   const hasRunningTimedMedia = (): boolean => {
     for (const el of document.querySelectorAll("video[data-start], audio[data-start]")) {
-      if (isMediaElement(el) && !el.paused) return true;
+      if (isMediaElement(el) && !el.paused && !pausedMediaLeases.has(el)) return true;
     }
     return false;
   };
@@ -2559,11 +2573,19 @@ export function initSandboxRuntimeModular(): void {
       if (kf) clip.volumeKeyframes = kf;
     }
 
+    // A leased element is not the transport's to touch while the clock is paused;
+    // during playback the transport owns everything again. Filtered here rather
+    // than out of `mediaClips` so the in-window bookkeeping below still records it
+    // and the pass after its release visits it normally.
+    const syncedClips = state.isPlaying
+      ? mediaClips
+      : mediaClips.filter((clip) => !pausedMediaLeases.has(clip.el));
+
     const forceSync = state.mediaForceSyncNextTick;
     if (forceSync) state.mediaForceSyncNextTick = false;
     if (!state.nativeMediaSyncDisabled) {
       syncRuntimeMedia({
-        clips: mediaClips,
+        clips: syncedClips,
         timeSeconds: state.currentTime,
         playing: state.isPlaying,
         playbackRate: state.playbackRate,
@@ -2841,7 +2863,10 @@ export function initSandboxRuntimeModular(): void {
     state.currentTime,
     Array.from(document.querySelectorAll("video[data-start], img[data-start]")),
   );
-  const colorGrading = createColorGradingRuntime();
+  const colorGrading = createColorGradingRuntime({
+    lease: leasePausedMedia,
+    release: releasePausedMedia,
+  });
   colorGradingRuntime = colorGrading;
   registerRuntimeCleanup(() => {
     colorGrading.destroy();
@@ -3404,9 +3429,10 @@ export function initSandboxRuntimeModular(): void {
       // playback rate. Re-seek registered children below with their host's
       // explicit source-time contract.
     }
-    // Pauses and re-seeks each registered child, so the rearm is already spent by
-    // the time this returns. Re-arming after it, as this used to, only ever
-    // changed the state the seek left behind.
+    // A second `activateSiblingTimelines` used to follow this call. Dropping it is
+    // safe because nothing between frames READS a sibling's paused() — grepped over
+    // the deterministic adapters, syncTimedElementVisibility, the hf-timelines-built
+    // handler and __hfReseekGpu. It only ever moved the state the seek left behind.
     seekStandaloneRegisteredTimelines(t, opts);
     for (const adapter of state.deterministicAdapters) {
       if (adapter.name === "gsap" && tl) continue;

--- a/packages/core/src/runtime/pausedTransportInvariant.test.ts
+++ b/packages/core/src/runtime/pausedTransportInvariant.test.ts
@@ -45,6 +45,22 @@ describe("paused transport owns what is running", () => {
     document.body.innerHTML = "";
   });
 
+  it("keeps a registered child the root does not hold paused across a rebind", () => {
+    // The resolver used to unpause every registry child before nesting it. A
+    // rebind after an edit re-resolves with no seek behind it, so a child the
+    // root never actually holds (add() is a no-op here, as when GSAP refuses)
+    // was left free-running on the global ticker while the clock was paused.
+    const registry = mountNestedComposition();
+    initSandboxRuntimeModular();
+    expect(registry.captions.paused!()).toBe(true);
+
+    window.__hfForceTimelineRebind!();
+
+    expect(window.__player!.isPlaying()).toBe(false);
+    expect(registry.captions.paused!()).toBe(true);
+    expect(registry.overlay.paused!()).toBe(true);
+  });
+
   it("leaves every registered sibling timeline paused after a renderSeek", () => {
     const registry = mountNestedComposition();
     initSandboxRuntimeModular();

--- a/packages/core/src/runtime/pausedTransportInvariant.test.ts
+++ b/packages/core/src/runtime/pausedTransportInvariant.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { initSandboxRuntimeModular } from "./init";
+import {
+  createMockTimeline,
+  installImmediateAnimationFrame,
+  resetRuntimeFixtureDom,
+} from "./runtimeSeekFixture.test-helpers";
+
+/**
+ * One invariant: while the transport clock is paused, nothing in the preview may
+ * be running — not a sibling composition timeline, not a media element.
+ *
+ * Both halves were unowned. A seek rearmed sibling timelines so GSAP would
+ * propagate into them and never put them back, and a sibling parented to
+ * gsap.globalTimeline then advanced at 1x on the global ticker with the clock
+ * stopped. The tick, meanwhile, only synced media while playing, so an element
+ * that started on its own was stopped by nothing.
+ */
+
+const originalRequestAnimationFrame = window.requestAnimationFrame;
+const originalCancelAnimationFrame = window.cancelAnimationFrame;
+
+/** A root composition, two sub-composition hosts, and the registry the runtime
+ *  reads. `captions` has a host element (so the per-child source-time seek
+ *  visits it); `overlay` is registry-only (reached solely by root propagation).
+ *  Both are siblings under the invariant. */
+function mountNestedComposition() {
+  document.body.innerHTML = `
+    <div data-composition-id="main" data-root="true" data-start="0" data-duration="20">
+      <div class="clip" data-composition-id="captions" data-start="0" data-duration="20"></div>
+    </div>`;
+  const registry = {
+    main: createMockTimeline(20),
+    captions: createMockTimeline(20),
+    overlay: createMockTimeline(20),
+  };
+  window.__timelines = registry;
+  return registry;
+}
+
+describe("paused transport owns what is running", () => {
+  beforeEach(() => {
+    resetRuntimeFixtureDom();
+    installImmediateAnimationFrame();
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+    delete window.__timelines;
+    document.body.innerHTML = "";
+  });
+
+  it("leaves every registered sibling timeline paused after a renderSeek", () => {
+    const registry = mountNestedComposition();
+    initSandboxRuntimeModular();
+    const player = window.__player;
+    expect(player).toBeDefined();
+
+    player!.renderSeek(2);
+
+    expect(player!.isPlaying()).toBe(false);
+    expect(registry.captions.paused!()).toBe(true);
+    expect(registry.overlay.paused!()).toBe(true);
+  });
+
+  it("keeps them paused across the repeated renderSeeks the Studio fallback adapter issues", () => {
+    // createStaticSeekPlaybackAdapter drives playback by calling renderSeek from
+    // its own rAF loop. Every one of those seeks used to unpause the siblings,
+    // and one is enough — the Studio's own transport tick is running the whole
+    // time, so the residual state is never harmless there.
+    const registry = mountNestedComposition();
+    initSandboxRuntimeModular();
+    const player = window.__player;
+
+    for (const t of [0, 0.5, 1, 1.5, 2]) {
+      player!.renderSeek(t);
+      expect([registry.captions.paused!(), registry.overlay.paused!()]).toEqual([true, true]);
+    }
+  });
+
+  it("still hands the root seek an unpaused sibling, so propagation reaches it", () => {
+    // The rearm is what this whole dance exists for: GSAP does not propagate
+    // totalTime() into a paused child. Restoring must not cost that.
+    const registry = mountNestedComposition();
+    const seenDuringRootSeek: boolean[] = [];
+    const rootTotalTime = registry.main.totalTime!;
+    registry.main.totalTime = (time?: number, suppressEvents?: boolean) => {
+      seenDuringRootSeek.push(registry.overlay.paused!());
+      return rootTotalTime.call(registry.main, time, suppressEvents);
+    };
+
+    initSandboxRuntimeModular();
+    seenDuringRootSeek.length = 0;
+    window.__player!.renderSeek(3);
+
+    expect(seenDuringRootSeek.length).toBeGreaterThan(0);
+    expect(seenDuringRootSeek.every((paused) => paused === false)).toBe(true);
+    expect(registry.overlay.paused!()).toBe(true);
+  });
+});

--- a/packages/core/src/runtime/pausedTransportInvariant.test.ts
+++ b/packages/core/src/runtime/pausedTransportInvariant.test.ts
@@ -9,12 +9,6 @@ import {
 /**
  * One invariant: while the transport clock is paused, nothing in the preview may
  * be running — not a sibling composition timeline, not a media element.
- *
- * Both halves were unowned. A seek rearmed sibling timelines so GSAP would
- * propagate into them and never put them back, and a sibling parented to
- * gsap.globalTimeline then advanced at 1x on the global ticker with the clock
- * stopped. The tick, meanwhile, only synced media while playing, so an element
- * that started on its own was stopped by nothing.
  */
 
 const originalRequestAnimationFrame = window.requestAnimationFrame;

--- a/packages/core/src/runtime/transportPark.test.ts
+++ b/packages/core/src/runtime/transportPark.test.ts
@@ -420,4 +420,31 @@ describe("parked transport loop", () => {
     expect(before).toBeLessThan(20);
     expect(window.__player!.getDuration()).toBeCloseTo(20, 3);
   });
+
+  it("stops a media element that starts playing while parked and the clock is paused", () => {
+    // Nothing may run while the clock is paused. `play` does not bubble, so the
+    // wake comes from a capture-phase listener; without it the enforcement is
+    // unreachable exactly when it is needed, because a parked loop runs no ticks.
+    mount(`<video id="rogue" data-start="0" data-duration="5"></video>`);
+    const video = document.getElementById("rogue") as HTMLVideoElement;
+    Object.defineProperty(video, "duration", { value: 5, configurable: true });
+    // jsdom implements neither play() nor pause(); `paused` is the only state the
+    // runtime reads, so drive it directly.
+    let paused = true;
+    Object.defineProperty(video, "paused", { configurable: true, get: () => paused });
+    video.pause = () => {
+      paused = true;
+    };
+    initSandboxRuntimeModular();
+    quiesce();
+    expect(window.__player!.isPlaying()).toBe(false);
+    expect(raf.pending()).toBe(0);
+
+    // Autoplay, a composition script, a restored bfcache state.
+    paused = false;
+    video.dispatchEvent(new Event("play"));
+    settle();
+
+    expect(video.paused).toBe(true);
+  });
 });

--- a/packages/core/src/runtime/transportPark.test.ts
+++ b/packages/core/src/runtime/transportPark.test.ts
@@ -516,5 +516,31 @@ describe("parked transport loop", () => {
 
     stop!();
     expect(media.isPaused()).toBe(true);
+    // The stop closure must RELEASE, not just pause: a restart after it is an
+    // unleased play while paused, and the transport has to stop it.
+    media.start();
+    settle();
+    expect(media.isPaused()).toBe(true);
+  });
+
+  it("reclaims a leased element the moment the transport plays", () => {
+    // A lease is an exemption from the PAUSED-side enforcement only. Once the
+    // clock runs the transport owns every element again, so a leased clip that is
+    // outside the playhead's window is stopped like any other.
+    mount(`<video id="late" data-start="10" data-duration="5"></video>`);
+    const video = document.getElementById("late") as HTMLVideoElement;
+    const media = stubMediaPlayback(video, 5);
+    initSandboxRuntimeModular();
+    quiesce();
+
+    window.__hf!.leasePausedMedia!(video);
+    media.start();
+    settle();
+    expect(media.isPaused()).toBe(false);
+
+    window.__player!.play();
+    settle();
+    expect(window.__player!.isPlaying()).toBe(true);
+    expect(media.isPaused()).toBe(true);
   });
 });

--- a/packages/core/src/runtime/transportPark.test.ts
+++ b/packages/core/src/runtime/transportPark.test.ts
@@ -67,6 +67,28 @@ function createMockTimeline(duration: number): RuntimeTimelineLike {
   };
 }
 
+/** jsdom implements neither play() nor pause(), and `paused` is the only state the
+ *  runtime reads. Returns a handle driving it the way a browser does, so a test can
+ *  start the element and watch whether the transport stops it. */
+function stubMediaPlayback(
+  el: HTMLMediaElement,
+  durationSeconds: number,
+): { start: () => void; isPaused: () => boolean } {
+  let paused = true;
+  Object.defineProperty(el, "duration", { value: durationSeconds, configurable: true });
+  Object.defineProperty(el, "paused", { configurable: true, get: () => paused });
+  el.pause = () => {
+    paused = true;
+  };
+  el.play = () => {
+    paused = false;
+    // A real browser fires this, and firing it is what makes the defect deterministic.
+    el.dispatchEvent(new Event("play"));
+    return Promise.resolve();
+  };
+  return { start: () => void el.play(), isPaused: () => paused };
+}
+
 /** MutationObserver records land in a microtask; nothing observes them sooner. */
 const flushObservers = () => new Promise<void>((resolve) => queueMicrotask(() => resolve()));
 
@@ -426,25 +448,73 @@ describe("parked transport loop", () => {
     // wake comes from a capture-phase listener; without it the enforcement is
     // unreachable exactly when it is needed, because a parked loop runs no ticks.
     mount(`<video id="rogue" data-start="0" data-duration="5"></video>`);
-    const video = document.getElementById("rogue") as HTMLVideoElement;
-    Object.defineProperty(video, "duration", { value: 5, configurable: true });
-    // jsdom implements neither play() nor pause(); `paused` is the only state the
-    // runtime reads, so drive it directly.
-    let paused = true;
-    Object.defineProperty(video, "paused", { configurable: true, get: () => paused });
-    video.pause = () => {
-      paused = true;
-    };
+    const media = stubMediaPlayback(document.getElementById("rogue") as HTMLVideoElement, 5);
     initSandboxRuntimeModular();
     quiesce();
     expect(window.__player!.isPlaying()).toBe(false);
     expect(raf.pending()).toBe(0);
 
     // Autoplay, a composition script, a restored bfcache state.
-    paused = false;
-    video.dispatchEvent(new Event("play"));
+    media.start();
     settle();
 
-    expect(video.paused).toBe(true);
+    expect(media.isPaused()).toBe(true);
+  });
+
+  it("leaves a LEASED element alone while paused, and stops it once released", () => {
+    // The colour-grading preview and the Studio's scrub audition both play media
+    // on purpose with the clock stopped. They borrow the element first; the
+    // enforcement is for anything that plays without borrowing.
+    mount(`<video id="grade" data-start="0" data-duration="5"></video>`);
+    const video = document.getElementById("grade") as HTMLVideoElement;
+    const media = stubMediaPlayback(video, 5);
+    initSandboxRuntimeModular();
+    quiesce();
+
+    window.__hf!.leasePausedMedia!(video);
+    media.start();
+    settle();
+    // Several more ticks: a lease must survive more than the frame it was taken on.
+    for (let i = 0; i < 5; i += 1) {
+      window.__player!.seek(window.__player!.getTime());
+      settle();
+    }
+    expect(media.isPaused()).toBe(false);
+
+    window.__hf!.releasePausedMedia!(video);
+    media.start();
+    settle();
+    expect(media.isPaused()).toBe(true);
+  });
+
+  it("does not stop the colour-grading preview, which plays on purpose while paused", () => {
+    // The end-to-end wiring, not the lease in isolation: init constructs the
+    // grading runtime with the lease, so startPreviewPlayback borrows before the
+    // play() whose own event wakes the transport that would otherwise stop it.
+    mount(`<video id="graded" data-start="0" data-duration="5"></video>`);
+    const video = document.getElementById("graded") as HTMLVideoElement;
+    const media = stubMediaPlayback(video, 5);
+    let currentTime = 0;
+    Object.defineProperty(video, "currentTime", {
+      configurable: true,
+      get: () => currentTime,
+      set: (next: number) => {
+        currentTime = next;
+      },
+    });
+    initSandboxRuntimeModular();
+    quiesce();
+
+    const stop = window.__hf!.colorGrading!.startPreviewPlayback("graded");
+    expect(typeof stop).toBe("function");
+    settle();
+    for (let beat = 0; beat < 5; beat += 1) {
+      vi.advanceTimersByTime(PARK_HEARTBEAT_MS);
+      settle();
+    }
+    expect(media.isPaused()).toBe(false);
+
+    stop!();
+    expect(media.isPaused()).toBe(true);
   });
 });

--- a/packages/core/src/runtime/window.d.ts
+++ b/packages/core/src/runtime/window.d.ts
@@ -46,6 +46,10 @@ declare global {
       onSwallowed?: (label: string, err: unknown) => void;
       seek?: (timeSeconds: number, options?: RuntimeSeekOptions) => void;
       duration?: number;
+      /** Borrow an element's playback while the transport clock is paused, so the
+       *  runtime's paused-side enforcement leaves it alone. Always release. */
+      leasePausedMedia?: (el: HTMLMediaElement) => void;
+      releasePausedMedia?: (el: HTMLMediaElement) => void;
     };
     __playerReady?: boolean;
     __renderReady?: boolean;

--- a/packages/studio/src/hooks/usePreviewInteraction.test.ts
+++ b/packages/studio/src/hooks/usePreviewInteraction.test.ts
@@ -224,12 +224,17 @@ describe("usePreviewInteraction", () => {
     cleanup();
   });
 
-  it("resumes playback when a click resolves to nothing (dead-zone / deselect)", async () => {
-    usePlayerStore.setState({ isPlaying: true });
+  // The deselect resume asks the PLAYER to play; it must never move the store's
+  // flag on its own. The runtime really was paused (playerPause below), so a bare
+  // setIsPlaying(true) leaves the button reading "playing" over a stopped runtime
+  // with nothing able to reconcile the two.
+  it("requests a real resume when a click resolves to nothing (dead-zone / deselect)", async () => {
+    usePlayerStore.setState({ isPlaying: true, playbackRequest: null });
+    const playerPause = vi.fn();
     const applyDomSelection = vi.fn();
     const resolveDomSelectionFromPreviewPoint = vi.fn(async () => null);
     const { canvas, cleanup } = renderHarness({
-      previewIframe: createPreviewIframe(vi.fn()),
+      previewIframe: createPreviewIframe(playerPause),
       resolveDomSelectionFromPreviewPoint,
       applyDomSelection,
     });
@@ -237,12 +242,15 @@ describe("usePreviewInteraction", () => {
     await dispatchMouseDown(canvas, {});
 
     expect(applyDomSelection).toHaveBeenCalledWith(null, { revealPanel: false });
-    expect(usePlayerStore.getState().isPlaying).toBe(true);
+    expect(playerPause).toHaveBeenCalled();
+    expect(usePlayerStore.getState().playbackRequest).toMatchObject({ playing: true });
+    // Only the player's own play() may raise this, once the runtime is running.
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
     cleanup();
   });
 
   it("does not resume playback on deselect when it was already paused", async () => {
-    usePlayerStore.setState({ isPlaying: false });
+    usePlayerStore.setState({ isPlaying: false, playbackRequest: null });
     const applyDomSelection = vi.fn();
     const resolveDomSelectionFromPreviewPoint = vi.fn(async () => null);
     const { canvas, cleanup } = renderHarness({
@@ -255,6 +263,7 @@ describe("usePreviewInteraction", () => {
 
     expect(applyDomSelection).toHaveBeenCalledWith(null, { revealPanel: false });
     expect(usePlayerStore.getState().isPlaying).toBe(false);
+    expect(usePlayerStore.getState().playbackRequest).toBeNull();
     cleanup();
   });
 });

--- a/packages/studio/src/hooks/usePreviewInteraction.ts
+++ b/packages/studio/src/hooks/usePreviewInteraction.ts
@@ -101,10 +101,10 @@ export function usePreviewInteraction({
       const wasPlaying = usePlayerStore.getState().isPlaying;
       pausePreviewPlayback();
       // A click that resolves to nothing (dead-zone / deselect) shouldn't leave
-      // playback paused — pausing before sampling only exists to keep the hit
-      // target stable while resolving; resume if nothing was selected.
+      // playback paused; the pause only keeps the hit target stable while resolving.
+      // Resume through requestPlayback so adapter, rAF loop and flag move together.
       const resumeIfNothingSelected = () => {
-        if (wasPlaying) usePlayerStore.getState().setIsPlaying(true);
+        if (wasPlaying) usePlayerStore.getState().requestPlayback(true);
       };
 
       // Double-click a group → drill into it and select the child under the

--- a/packages/studio/src/player/lib/playbackTypes.ts
+++ b/packages/studio/src/player/lib/playbackTypes.ts
@@ -60,4 +60,11 @@ export type IframeWindow = Window & {
   __timeline?: TimelineLike;
   __timelines?: Record<string, TimelineLike>;
   __clipManifest?: ClipManifest;
+  /** Declared runtime-side in core's window.d.ts, which this package cannot see.
+   *  Every member stays optional and is optional-called, so a runtime that
+   *  predates the hook degrades to a no-op instead of throwing. */
+  __hf?: {
+    leasePausedMedia?: (el: HTMLMediaElement) => void;
+    releasePausedMedia?: (el: HTMLMediaElement) => void;
+  };
 };

--- a/packages/studio/src/player/lib/timelineIframeHelpers.test.ts
+++ b/packages/studio/src/player/lib/timelineIframeHelpers.test.ts
@@ -123,6 +123,36 @@ describe("scrubPreviewAudio", () => {
     expect(voiceover.play).not.toHaveBeenCalled();
     stopScrubPreviewAudio();
   });
+
+  /** A scrub audition is media running under a paused clock, which the runtime now
+   *  stops on sight. So it borrows the element. That a leased element survives the
+   *  tick is asserted runtime-side in core's `transportPark.test.ts`; here the
+   *  contract is that the hook is called with the right element and given back. */
+  it("borrows the element from the runtime for the audition and returns it on stop", () => {
+    const iframe = document.createElement("iframe");
+    document.body.append(iframe);
+    const previewDoc = iframe.contentDocument;
+    if (!previewDoc?.body) throw new Error("expected an iframe document");
+
+    const music = previewDoc.createElement("audio");
+    music.id = "music";
+    music.play = vi.fn(async () => {});
+    music.pause = vi.fn();
+    previewDoc.body.append(music);
+
+    const leasePausedMedia = vi.fn();
+    const releasePausedMedia = vi.fn();
+    (previewDoc.defaultView as IframeWindow).__hf = { leasePausedMedia, releasePausedMedia };
+
+    scrubPreviewAudio(iframe, 0.5, "music", 1);
+
+    expect(leasePausedMedia).toHaveBeenCalledWith(music);
+    expect(releasePausedMedia).not.toHaveBeenCalled();
+
+    stopScrubPreviewAudio();
+
+    expect(releasePausedMedia).toHaveBeenCalledWith(music);
+  });
 });
 
 describe("applyPreviewAudioFlags", () => {

--- a/packages/studio/src/player/lib/timelineIframeHelpers.ts
+++ b/packages/studio/src/player/lib/timelineIframeHelpers.ts
@@ -245,11 +245,24 @@ function resolveScrubAudioEl(doc: Document, musicId?: string | null): HTMLAudioE
   );
 }
 
+/** The runtime stops any media running under a paused clock, and a scrub audition
+ *  IS media running under a paused clock, so it has to borrow the element. Every
+ *  hop is optional: a runtime predating the hook must no-op, not throw. Wrapped in
+ *  named calls so `applyScrub` does not carry the optional chains' branches. */
+function leaseScrubElement(el: HTMLAudioElement): void {
+  (el.ownerDocument.defaultView as IframeWindow | null)?.__hf?.leasePausedMedia?.(el);
+}
+
+function releaseScrubElement(el: HTMLAudioElement): void {
+  (el.ownerDocument.defaultView as IframeWindow | null)?.__hf?.releasePausedMedia?.(el);
+}
+
 function applyScrub(el: HTMLAudioElement, audioFileTime: number, previewVolume: number): void {
   if (scrubAudioEl && scrubAudioEl !== el) stopScrubPreviewAudio();
   if (scrubPrevMuted === null) scrubPrevMuted = el.muted;
   if (scrubPrevVolume === null) scrubPrevVolume = el.volume;
   scrubAudioEl = el;
+  leaseScrubElement(el);
   try {
     el.muted = false;
     el.volume = SCRUB_VOLUME * normalizePreviewVolume(previewVolume);
@@ -296,6 +309,9 @@ export function stopScrubPreviewAudio(): void {
   const el = scrubAudioEl;
   scrubAudioEl = null;
   if (!el) return;
+  // `scrubStopTimer` guarantees this runs within ~140 ms of the last scrub, so
+  // the borrow cannot outlive the audition.
+  releaseScrubElement(el);
   try {
     el.pause();
     if (scrubPrevMuted !== null) el.muted = scrubPrevMuted;


### PR DESCRIPTION
## What an operator could not do before, and can now

Pause the preview and have it stay paused. After editing text in the Design panel and seeking, every sub-composition (the acts, the captions layer) kept animating at full speed while the transport button said paused and the playhead sat still. Captured live in a running preview: seven child timelines advancing 0.210s per 200ms sample, all `paused=false`, transport not playing.

## Root cause

A render-seek unpauses every sibling composition timeline so GSAP will propagate the root's time into them, and nothing paused them again. Parented to GSAP's global ticker, they free-ran. The code justified the leak with a comment about its one caller ("render is frame-by-frame, the leftover state is harmless"); the Studio's seek-driven fallback adapter became a second caller, right after a preview reload, and the comment stayed.

This also corrupted **exported frames**: the render pipeline flushes the animation ticker once per frame after the seek and before the screenshot, so a leaked-unpaused sibling advanced by the full inter-frame delta into the captured image. Deterministic, not a race.

## The invariant this installs

> While the transport clock is paused, nothing in the preview runs unless it has explicitly borrowed the clock: no sibling composition timeline, and no media element without a paused-media lease. For the runtime playback adapter the Studio's play/pause button and the runtime agree in both directions; the seek-driven fallback adapter keeps its own ticker outside this guarantee and is tracked as a follow-up.

## Three fixes under it

1. **Borrow, seek, return.** The sibling rearm is a lease across the seek, restored in a `finally`. The redundant second rearm after the child re-seek is deleted; it only ever changed the state the seek left behind.
2. **The paused side of the transport polices media.** Anything found playing while paused is stopped; a capture-phase `play` listener wakes a parked transport so the check is reachable. Two features legitimately play media while paused (colour-grading previews, the audio scrub) and now borrow the element through a runtime-owned lease; the lease ends the moment the transport plays, and a borrower's stop must release, both asserted.
3. **Canvas click resumes through the real play path**, so adapter, rAF loop and button flag move together instead of the flag alone.

## Regression tests, each fails without its change

Siblings paused after a render-seek and across repeated fallback-adapter seeks; the root seek still reaches an unpaused sibling; an unleased element started while paused is stopped; a leased element survives paused ticks and is stopped once released; the grading preview survives and its stop releases; a leased out-of-window clip is reclaimed when the transport plays; a deselect click requests playback rather than flipping the flag.

## Independent adversarial review (three passes)

Pass 1 found the paused-side enforcement would kill the grading preview and the audio scrub (fixed with the lease) and that the change also fixes the render path. Pass 2 found two assertions that were not load-bearing (fixed). Pass 3 verdict: **ready to open, zero blocking.**

Open follow-ups, each its own PR:
- The canvas-click pause stops the runtime directly but not the Studio's own tickers; harmless for the runtime adapter, but the seek-driven fallback adapter would keep advancing with the button paused.
- A compiler-renamed sub-composition (`id` → `id__hf1` on collision) is never re-seeked or re-paused by the per-child path, which looks up `data-composition-id` without falling back to the original id.
- The non-transport player has the same sibling leak on a path reachable only from one script and its own test, which documents the leak as intended.
- The paused-media probe is `O(DOM)` per tick during a scrub drag; an `O(playing)` set maintained by capture-phase listeners is drafted but changes behaviour for detached media and needs its own tests.

| Area | Status |
|---|---|
| Sibling rearm/restore across render-seek and fallback-adapter seeks | Audited |
| Render path (virtualised rAF flush ordering) | Audited by reading; 3 producer render suites green |
| Paused-side media enforcement + wake | Audited |
| Lease: grading, scrub, reclaim on play, release on stop | Audited |
| `window.__hf` consumers (none enumerate/serialise it) | Audited |
| Store↔runtime agreement, runtime adapter | Audited |
| Store↔runtime agreement, seek-driven fallback adapter | Not exercised (named follow-up) |
| Live browser on a built CLI | Not exercised |
