### PR TITLE
perf(studio): opening a project no longer re-encodes its videos or refetches the bundle

### DIFF
--- a/packages/cli/src/commands/play.test.ts
+++ b/packages/cli/src/commands/play.test.ts
@@ -64,6 +64,7 @@ const mediaMocks = vi.hoisted(() => ({
   ),
   isProxyVariant: (value: string) => value === "h264" || value === "vp8",
   isProxyVariantRequest: (value: string) => value === "auto" || value === "h264" || value === "vp8",
+  recordProxyRequest: () => {},
   proxyVariantFor: (facts: { hasAlpha?: boolean }) => (facts.hasAlpha ? "vp8" : "h264"),
   resolveProxyVariantRequest: (request: "auto" | "h264" | "vp8", facts: { hasAlpha?: boolean }) => {
     const expected = facts.hasAlpha ? "vp8" : "h264";

--- a/packages/cli/src/commands/play.ts
+++ b/packages/cli/src/commands/play.ts
@@ -47,6 +47,7 @@ import {
   decideMediaProxyEligibility,
   isProxyVariantRequest,
   probeAssetCodec,
+  recordProxyRequest,
   resolveProxyVariantRequest,
   PROXY_VARIANT_CONFIG,
 } from "@hyperframes/studio-server/media-codec-map";
@@ -248,6 +249,7 @@ export async function registerCompositionRoute(
         if (!proxyVariant) {
           return ctx.text("Media proxy variant does not match asset", 422);
         }
+        recordProxyRequest();
         const proxyPath = await resolveProxy(project.dir, filePath, proxyVariant);
         return buildRangeResponse(
           proxyPath,

--- a/packages/cli/src/server/studioServer.file-race.test.ts
+++ b/packages/cli/src/server/studioServer.file-race.test.ts
@@ -148,16 +148,19 @@ describe("Studio bundle file reads", () => {
     },
   );
 
+  // /assets/ holds only Vite's content-hashed emits, so it is served immutable
+  // while the hand-authored public/ files keep revalidating. Cache policy
+  // itself is owned by studioServer.staticAssets.test.ts.
   it.each([
-    ["assets/main.js", "text/javascript"],
-    ["icons/logo.svg", "image/svg+xml"],
-    ["favicon.svg", "image/svg+xml"],
-  ])("preserves %s MIME and cache headers", async (name, mime) => {
+    ["assets/main.js", "text/javascript", "public, max-age=31536000, immutable"],
+    ["icons/logo.svg", "image/svg+xml", "no-store"],
+    ["favicon.svg", "image/svg+xml", "no-store"],
+  ])("preserves %s MIME and cache headers", async (name, mime, cacheControl) => {
     fs.writeFileSync(path.join(hooks.studioDir, name), "");
     const response = await server.app.request(`/${name}`);
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain(mime);
-    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("cache-control")).toBe(cacheControl);
     expect(await response.text()).toBe("");
     expectClosed();
   });

--- a/packages/cli/src/server/studioServer.staticAssets.test.ts
+++ b/packages/cli/src/server/studioServer.staticAssets.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { tmpdir } from "node:os";
+import { createStudioServer, isContentHashedAsset, type StudioServer } from "./studioServer.js";
+
+/**
+ * Cache and transfer policy for the studio bundle. A content-hashed URL can
+ * never serve different bytes, so it is safe to keep forever; everything else
+ * the same routes serve (public/ files, the HTML shell) changes under a
+ * stable URL and must keep revalidating.
+ */
+
+const hooks = vi.hoisted(() => ({ studioDir: "" }));
+
+// The bundle directory is resolved from __dirname at server construction, so
+// point that one `resolve(<...>/server, "studio")` call at a temp tree.
+vi.mock("node:path", async (importOriginal) => {
+  const actual = await importOriginal<typeof path>();
+  return {
+    ...actual,
+    resolve: (...parts: string[]) =>
+      hooks.studioDir && parts.length === 2 && parts[0]?.endsWith("server") && parts[1] === "studio"
+        ? hooks.studioDir
+        : actual.resolve(...parts),
+  };
+});
+
+const HASHED_BUNDLE = "index-BRr1JoHX.js";
+// Large enough to clear hono's 1KB compression threshold.
+const BUNDLE_BYTES = `export const studio = ${JSON.stringify("x".repeat(4096))};\n`;
+
+let root: string;
+let server: StudioServer;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(tmpdir(), "hf-studio-assets-"));
+  hooks.studioDir = path.join(root, "studio");
+  const projectDir = path.join(root, "project");
+  fs.mkdirSync(projectDir);
+  fs.mkdirSync(path.join(hooks.studioDir, "assets"), { recursive: true });
+  fs.writeFileSync(path.join(hooks.studioDir, "assets", HASHED_BUNDLE), BUNDLE_BYTES);
+  fs.writeFileSync(path.join(hooks.studioDir, "assets", "unhashed.js"), BUNDLE_BYTES);
+  fs.writeFileSync(
+    path.join(hooks.studioDir, "index.html"),
+    "<html><head></head><body>Studio</body></html>",
+  );
+  server = createStudioServer({ projectDir });
+});
+
+afterEach(() => {
+  server.watcher.close();
+  fs.rmSync(root, { recursive: true, force: true });
+  hooks.studioDir = "";
+});
+
+describe("studio bundle cache policy", () => {
+  it("serves a content-hashed asset as immutable", async () => {
+    const response = await server.app.request(`/assets/${HASHED_BUNDLE}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=31536000, immutable");
+  });
+
+  it("keeps an unhashed asset revalidating", async () => {
+    const response = await server.app.request("/assets/unhashed.js");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("keeps the HTML shell revalidating, since it names the hashed bundle", async () => {
+    const response = await server.app.request("/");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  // The first four are real filenames from `bun run --filter @hyperframes/studio build`.
+  it.each([
+    ["index-BRr1JoHX.js", true],
+    ["index-DnRfAiK2.css", true],
+    ["hyperframes-player-lPOqAC3l.js", true],
+    ["index-RPEcu_bT.js", true],
+    ["unhashed.js", false],
+    ["vite-manifest.json", false],
+    ["favicon.svg", false],
+    // A hyphenated name is not a hash, however many capitals it carries: only
+    // the segment after the last hyphen is a hash candidate.
+    ["user-Guide-v2.js", false],
+    ["brand-Logo-Dark.svg", false],
+  ])("classifies %s", (name, hashed) => {
+    expect(isContentHashedAsset(name)).toBe(hashed);
+  });
+});
+
+describe("studio bundle transfer encoding", () => {
+  it("compresses a bundle for a client that accepts gzip", async () => {
+    const response = await server.app.request(`/assets/${HASHED_BUNDLE}`, {
+      headers: { "Accept-Encoding": "gzip, deflate, br" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Encoding")).toBe("gzip");
+    // The middleware must not corrupt the payload it shrinks. `Response.text()`
+    // does not decode Content-Encoding, so unwrap it explicitly.
+    const body = response.body;
+    if (!body) throw new Error("compressed response had no body");
+    const decoded = await new Response(body.pipeThrough(new DecompressionStream("gzip"))).text();
+    expect(decoded).toBe(BUNDLE_BYTES);
+  });
+
+  it("sends the raw bytes to a client that accepts no encoding", async () => {
+    const response = await server.app.request(`/assets/${HASHED_BUNDLE}`);
+
+    expect(response.headers.get("Content-Encoding")).toBeNull();
+    expect(await response.text()).toBe(BUNDLE_BYTES);
+  });
+});

--- a/packages/cli/src/server/studioServer.staticAssets.test.ts
+++ b/packages/cli/src/server/studioServer.staticAssets.test.ts
@@ -2,13 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { tmpdir } from "node:os";
-import { createStudioServer, isContentHashedAsset, type StudioServer } from "./studioServer.js";
+import { createStudioServer, type StudioServer } from "./studioServer.js";
 
 /**
- * Cache and transfer policy for the studio bundle. A content-hashed URL can
- * never serve different bytes, so it is safe to keep forever; everything else
- * the same routes serve (public/ files, the HTML shell) changes under a
- * stable URL and must keep revalidating.
+ * Cache policy for the studio bundle, decided by ROUTE. Vite emits only
+ * content-hashed files under dist/assets, so that path can be immutable;
+ * public/ files (icons, favicon) keep their names across builds and the HTML
+ * shell names the current bundle, so both must revalidate.
  */
 
 const hooks = vi.hoisted(() => ({ studioDir: "" }));
@@ -26,9 +26,13 @@ vi.mock("node:path", async (importOriginal) => {
   };
 });
 
+// A real filename from `bun run --filter @hyperframes/studio build`.
 const HASHED_BUNDLE = "index-BRr1JoHX.js";
-// Large enough to clear hono's 1KB compression threshold.
-const BUNDLE_BYTES = `export const studio = ${JSON.stringify("x".repeat(4096))};\n`;
+const BUNDLE_BYTES = "export const studio = 1;";
+// Hand-authored, hyphenated, carrying capitals and digits — the shape no
+// filename heuristic can separate from a rollup hash. It lives under /icons/,
+// so the route answers correctly without having to.
+const PUBLIC_ICON = "brand-Logo2026x.svg";
 
 let root: string;
 let server: StudioServer;
@@ -39,8 +43,10 @@ beforeEach(() => {
   const projectDir = path.join(root, "project");
   fs.mkdirSync(projectDir);
   fs.mkdirSync(path.join(hooks.studioDir, "assets"), { recursive: true });
+  fs.mkdirSync(path.join(hooks.studioDir, "icons"), { recursive: true });
   fs.writeFileSync(path.join(hooks.studioDir, "assets", HASHED_BUNDLE), BUNDLE_BYTES);
-  fs.writeFileSync(path.join(hooks.studioDir, "assets", "unhashed.js"), BUNDLE_BYTES);
+  fs.writeFileSync(path.join(hooks.studioDir, "icons", PUBLIC_ICON), "<svg/>");
+  fs.writeFileSync(path.join(hooks.studioDir, "favicon.svg"), "<svg/>");
   fs.writeFileSync(
     path.join(hooks.studioDir, "index.html"),
     "<html><head></head><body>Studio</body></html>",
@@ -55,63 +61,40 @@ afterEach(() => {
 });
 
 describe("studio bundle cache policy", () => {
-  it("serves a content-hashed asset as immutable", async () => {
+  it("serves everything under /assets/ as immutable", async () => {
     const response = await server.app.request(`/assets/${HASHED_BUNDLE}`);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe("public, max-age=31536000, immutable");
   });
 
-  it("keeps an unhashed asset revalidating", async () => {
-    const response = await server.app.request("/assets/unhashed.js");
+  it("does not make a public/ icon immutable, however hash-like its name", async () => {
+    const response = await server.app.request(`/icons/${PUBLIC_ICON}`);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
 
-  it("keeps the HTML shell revalidating, since it names the hashed bundle", async () => {
+  it("keeps the favicon revalidating", async () => {
+    const response = await server.app.request("/favicon.svg");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("revalidates the HTML shell without evicting it from bfcache", async () => {
     const response = await server.app.request("/");
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    // `no-cache`, not `no-store`: same refetch, but `no-store` would blocklist
+    // the document from Chrome's bfcache and cold-boot Studio on Back.
+    expect(response.headers.get("Cache-Control")).toBe("no-cache");
   });
 
-  // The first four are real filenames from `bun run --filter @hyperframes/studio build`.
-  it.each([
-    ["index-BRr1JoHX.js", true],
-    ["index-DnRfAiK2.css", true],
-    ["hyperframes-player-lPOqAC3l.js", true],
-    ["index-RPEcu_bT.js", true],
-    ["unhashed.js", false],
-    ["vite-manifest.json", false],
-    ["favicon.svg", false],
-    // A hyphenated name is not a hash, however many capitals it carries: only
-    // the segment after the last hyphen is a hash candidate.
-    ["user-Guide-v2.js", false],
-    ["brand-Logo-Dark.svg", false],
-  ])("classifies %s", (name, hashed) => {
-    expect(isContentHashedAsset(name)).toBe(hashed);
-  });
-});
-
-describe("studio bundle transfer encoding", () => {
-  it("compresses a bundle for a client that accepts gzip", async () => {
+  it("sends the bundle uncompressed, which loopback measures faster", async () => {
     const response = await server.app.request(`/assets/${HASHED_BUNDLE}`, {
       headers: { "Accept-Encoding": "gzip, deflate, br" },
     });
-
-    expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Encoding")).toBe("gzip");
-    // The middleware must not corrupt the payload it shrinks. `Response.text()`
-    // does not decode Content-Encoding, so unwrap it explicitly.
-    const body = response.body;
-    if (!body) throw new Error("compressed response had no body");
-    const decoded = await new Response(body.pipeThrough(new DecompressionStream("gzip"))).text();
-    expect(decoded).toBe(BUNDLE_BYTES);
-  });
-
-  it("sends the raw bytes to a client that accepts no encoding", async () => {
-    const response = await server.app.request(`/assets/${HASHED_BUNDLE}`);
 
     expect(response.headers.get("Content-Encoding")).toBeNull();
     expect(await response.text()).toBe(BUNDLE_BYTES);

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -6,7 +6,6 @@
  */
 
 import { Hono, type Context } from "hono";
-import { compress } from "hono/compress";
 import { streamSSE } from "hono/streaming";
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { resolve, join, basename } from "node:path";
@@ -60,24 +59,10 @@ import {
 
 const STUDIO_MANUAL_EDITS_PATH = ".hyperframes/studio-manual-edits.json";
 
-// Vite emits built chunks and assets as `<name>-<hash>.<ext>` with rollup's
-// 8-character base64url content hash (`index-BRr1JoHX.js`), so a hashed URL's
-// bytes can never change and the browser may keep them forever. The HTML shell
-// and public/ files keep their names across builds and must keep revalidating.
-const HASH_SUFFIX_RE = /-([A-Za-z0-9_]{8,})\.[A-Za-z0-9]+$/;
+// Vite emits only content-hashed files under dist/assets; hand-authored
+// public/ files land at the dist root. The route is the signal because the
+// filename is not: rollup's base64url hash may itself contain a hyphen.
 const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
-
-/**
- * Only the segment after the LAST hyphen counts, and it must carry a digit,
- * underscore or capital. That is what separates a real hash from an ordinary
- * hyphenated word of the same length (`vite-manifest.json`, `user-Guide-v2.js`),
- * and it errs the safe way: an all-lower-case hash would simply keep
- * revalidating, which is the behaviour before this change.
- */
-export function isContentHashedAsset(filePath: string): boolean {
-  const suffix = HASH_SUFFIX_RE.exec(basename(filePath))?.[1];
-  return suffix !== undefined && /[A-Z0-9_]/.test(suffix);
-}
 
 const REMOTE_GIF_IMG_SRC_RE =
   /<img\b[^>]*?\bsrc\s*=\s*["'](https?:\/\/[^"']+\.gif(?:[?#][^"']*)?)["'][^>]*>/gi;
@@ -895,25 +880,17 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
   });
 
   // Studio SPA static files
-  const serveStudioStaticFile = (c: Context) => {
+  const serveStudioStaticFile = (cacheControl: string) => (c: Context) => {
     const filePath = resolve(studioDir, c.req.path.slice(1));
     const content = readBundleFile(filePath);
     if (content === null) return c.text("not found", 404);
     return new Response(content, {
-      headers: {
-        "Content-Type": getMimeType(filePath),
-        "Cache-Control": isContentHashedAsset(filePath) ? IMMUTABLE_CACHE_CONTROL : "no-store",
-      },
+      headers: { "Content-Type": getMimeType(filePath), "Cache-Control": cacheControl },
     });
   };
-  // Runtime gzip: the studio bundle is several megabytes of JavaScript and was
-  // being shipped raw on every cold open. Hono's middleware already skips
-  // already-compressed content types and anything under its size threshold, so
-  // only /assets/* needs it — public/ holds icons and the favicon.
-  app.use("/assets/*", compress());
-  app.get("/assets/*", serveStudioStaticFile);
-  app.get("/icons/*", serveStudioStaticFile);
-  app.get("/favicon.svg", serveStudioStaticFile);
+  app.get("/assets/*", serveStudioStaticFile(IMMUTABLE_CACHE_CONTROL));
+  app.get("/icons/*", serveStudioStaticFile("no-store"));
+  app.get("/favicon.svg", serveStudioStaticFile("no-store"));
 
   // ── Runtime env injection ───────────────────────────────────────────────
   // When the studio is served as a pre-built SPA, Vite `VITE_STUDIO_*` env
@@ -1009,9 +986,10 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
     if (headScript) {
       html = html.replace("<head>", `<head>${headScript}`);
     }
-    // The shell must never be cached: it is the only thing that names the
-    // current hashed bundle, and those are now served as immutable.
-    return c.html(html, 200, { "Cache-Control": "no-store" });
+    // The shell names the current hashed bundle, so it always revalidates.
+    // `no-cache` not `no-store`: same refetch without an ETag, but `no-store`
+    // would blocklist the document from Chrome's bfcache.
+    return c.html(html, 200, { "Cache-Control": "no-cache" });
   });
 
   return { app, watcher, adapter };

--- a/packages/cli/src/server/studioServer.ts
+++ b/packages/cli/src/server/studioServer.ts
@@ -6,6 +6,7 @@
  */
 
 import { Hono, type Context } from "hono";
+import { compress } from "hono/compress";
 import { streamSSE } from "hono/streaming";
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { resolve, join, basename } from "node:path";
@@ -58,6 +59,26 @@ import {
 } from "../browser/gpuPolicy.js";
 
 const STUDIO_MANUAL_EDITS_PATH = ".hyperframes/studio-manual-edits.json";
+
+// Vite emits built chunks and assets as `<name>-<hash>.<ext>` with rollup's
+// 8-character base64url content hash (`index-BRr1JoHX.js`), so a hashed URL's
+// bytes can never change and the browser may keep them forever. The HTML shell
+// and public/ files keep their names across builds and must keep revalidating.
+const HASH_SUFFIX_RE = /-([A-Za-z0-9_]{8,})\.[A-Za-z0-9]+$/;
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
+/**
+ * Only the segment after the LAST hyphen counts, and it must carry a digit,
+ * underscore or capital. That is what separates a real hash from an ordinary
+ * hyphenated word of the same length (`vite-manifest.json`, `user-Guide-v2.js`),
+ * and it errs the safe way: an all-lower-case hash would simply keep
+ * revalidating, which is the behaviour before this change.
+ */
+export function isContentHashedAsset(filePath: string): boolean {
+  const suffix = HASH_SUFFIX_RE.exec(basename(filePath))?.[1];
+  return suffix !== undefined && /[A-Z0-9_]/.test(suffix);
+}
+
 const REMOTE_GIF_IMG_SRC_RE =
   /<img\b[^>]*?\bsrc\s*=\s*["'](https?:\/\/[^"']+\.gif(?:[?#][^"']*)?)["'][^>]*>/gi;
 
@@ -879,9 +900,17 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
     const content = readBundleFile(filePath);
     if (content === null) return c.text("not found", 404);
     return new Response(content, {
-      headers: { "Content-Type": getMimeType(filePath), "Cache-Control": "no-store" },
+      headers: {
+        "Content-Type": getMimeType(filePath),
+        "Cache-Control": isContentHashedAsset(filePath) ? IMMUTABLE_CACHE_CONTROL : "no-store",
+      },
     });
   };
+  // Runtime gzip: the studio bundle is several megabytes of JavaScript and was
+  // being shipped raw on every cold open. Hono's middleware already skips
+  // already-compressed content types and anything under its size threshold, so
+  // only /assets/* needs it — public/ holds icons and the favicon.
+  app.use("/assets/*", compress());
   app.get("/assets/*", serveStudioStaticFile);
   app.get("/icons/*", serveStudioStaticFile);
   app.get("/favicon.svg", serveStudioStaticFile);
@@ -980,7 +1009,9 @@ export function createStudioServer(options: StudioServerOptions): StudioServer {
     if (headScript) {
       html = html.replace("<head>", `<head>${headScript}`);
     }
-    return c.html(html);
+    // The shell must never be cached: it is the only thing that names the
+    // current hashed bundle, and those are now served as immutable.
+    return c.html(html, 200, { "Cache-Control": "no-store" });
   });
 
   return { app, watcher, adapter };

--- a/packages/cli/src/utils/staticProjectServer.test.ts
+++ b/packages/cli/src/utils/staticProjectServer.test.ts
@@ -71,6 +71,7 @@ vi.mock("@hyperframes/studio-server/media-codec-map", () => ({
   decideMediaProxyEligibility: mocks.decideMediaProxyEligibility,
   isProxyVariant: (value: string) => value === "h264" || value === "vp8",
   isProxyVariantRequest: (value: string) => value === "auto" || value === "h264" || value === "vp8",
+  recordProxyRequest: () => {},
   proxyVariantFor: (facts: { hasAlpha?: boolean }) => (facts.hasAlpha ? "vp8" : "h264"),
   resolveProxyVariantRequest: (request: "auto" | "h264" | "vp8", facts: { hasAlpha?: boolean }) => {
     const expected = facts.hasAlpha ? "vp8" : "h264";

--- a/packages/cli/src/utils/staticProjectServer.ts
+++ b/packages/cli/src/utils/staticProjectServer.ts
@@ -13,6 +13,7 @@ import {
   decideMediaProxyEligibility,
   isProxyVariantRequest,
   probeAssetCodec,
+  recordProxyRequest,
   resolveProxyVariantRequest,
   PROXY_VARIANT_CONFIG,
   type ProxyVariantRequest,
@@ -141,6 +142,7 @@ async function serveProxyRequest(
       res.end("media proxy variant does not match asset");
       return;
     }
+    recordProxyRequest();
     const proxyPath = await resolveProxy(projectDir, filePath, variant);
     // The await above can span a whole transcode; the client may be gone.
     if (res.writableEnded || res.destroyed) return;

--- a/packages/studio-server/src/helpers/mediaCodecMap.test.ts
+++ b/packages/studio-server/src/helpers/mediaCodecMap.test.ts
@@ -11,6 +11,8 @@ import {
   proxyVariantFor,
   resolveProxyVariantRequest,
   scanProjectMediaCodecMap,
+  shouldPrewarmProxy,
+  type AssetCodecFacts,
 } from "./mediaCodecMap.js";
 
 // Any real, existing file works as a stand-in ffprobe path — the runner
@@ -92,7 +94,7 @@ describe("probeAssetCodec", () => {
     expect(facts).toEqual({
       codecName: "hevc",
       browserHostile: true,
-      representativeMime: BROWSER_HOSTILE_CODECS.hevc,
+      representativeMime: BROWSER_HOSTILE_CODECS.hevc?.representativeMime,
       hasAlpha: false,
     });
   });
@@ -122,7 +124,7 @@ describe("probeAssetCodec", () => {
     expect(facts).toEqual({
       codecName: "vp9",
       browserHostile: true,
-      representativeMime: BROWSER_HOSTILE_CODECS.vp9,
+      representativeMime: BROWSER_HOSTILE_CODECS.vp9?.representativeMime,
       hasAlpha: false,
     });
   });
@@ -169,6 +171,38 @@ describe("probeAssetCodec", () => {
     process.env.HYPERFRAMES_FFPROBE_PATH = join(project, "missing-ffprobe");
 
     await expect(probeAssetCodec(videoPath)).resolves.toBeNull();
+  });
+});
+
+describe("shouldPrewarmProxy", () => {
+  function facts(codecName: string): AssetCodecFacts {
+    return { codecName, browserHostile: true, representativeMime: null, hasAlpha: false };
+  }
+
+  it.each(["hevc", "prores"])("pre-warms %s, which browsers never decode", (codecName) => {
+    expect(shouldPrewarmProxy(facts(codecName))).toBe(true);
+  });
+
+  it.each(["vp9", "av1"])(
+    "does not pre-warm %s, which the requesting browser usually decodes itself",
+    (codecName) => {
+      expect(shouldPrewarmProxy(facts(codecName))).toBe(false);
+    },
+  );
+
+  it("does not pre-warm a browser-safe codec", () => {
+    expect(
+      shouldPrewarmProxy({
+        codecName: "h264",
+        browserHostile: false,
+        representativeMime: null,
+        hasAlpha: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat an Object.prototype key as a hostile codec", () => {
+    expect(shouldPrewarmProxy(facts("constructor"))).toBe(false);
   });
 });
 

--- a/packages/studio-server/src/helpers/mediaCodecMap.test.ts
+++ b/packages/studio-server/src/helpers/mediaCodecMap.test.ts
@@ -174,17 +174,34 @@ describe("probeAssetCodec", () => {
   });
 });
 
+describe("BROWSER_HOSTILE_CODECS representative mimes", () => {
+  // Pinned because nulling one is silent and expensive: the runtime skips
+  // `canPlayType` when the mime is null (packages/core/src/runtime/mediaProxy.ts,
+  // `maybeProxyProactively`) and proxies on EVERY browser, reinstating exactly
+  // the transcodes the pre-warm split removed.
+  it.each(["hevc", "av1", "vp9"])("keeps a canPlayType probe for %s", (codecName) => {
+    expect(typeof BROWSER_HOSTILE_CODECS[codecName]?.representativeMime).toBe("string");
+  });
+
+  it("has no representative mime for prores, which is never decodable", () => {
+    expect(BROWSER_HOSTILE_CODECS.prores?.representativeMime).toBeNull();
+  });
+});
+
 describe("shouldPrewarmProxy", () => {
   function facts(codecName: string): AssetCodecFacts {
     return { codecName, browserHostile: true, representativeMime: null, hasAlpha: false };
   }
 
-  it.each(["hevc", "prores"])("pre-warms %s, which browsers never decode", (codecName) => {
-    expect(shouldPrewarmProxy(facts(codecName))).toBe(true);
-  });
+  it.each(["hevc", "prores"])(
+    "pre-warms %s, which has no cross-platform browser decode",
+    (codecName) => {
+      expect(shouldPrewarmProxy(facts(codecName))).toBe(true);
+    },
+  );
 
   it.each(["vp9", "av1"])(
-    "does not pre-warm %s, which the requesting browser usually decodes itself",
+    "does not pre-warm %s, which every mainstream engine decodes itself",
     (codecName) => {
       expect(shouldPrewarmProxy(facts(codecName))).toBe(false);
     },
@@ -201,8 +218,24 @@ describe("shouldPrewarmProxy", () => {
     ).toBe(false);
   });
 
-  it("does not treat an Object.prototype key as a hostile codec", () => {
-    expect(shouldPrewarmProxy(facts("constructor"))).toBe(false);
+  // `shouldPrewarmProxy` alone cannot catch a missing `Object.hasOwn` guard —
+  // `.prewarm === true` is already strict against `Object.prototype.constructor`.
+  // The input that misbehaves goes through `codecFactsFor`, which would report
+  // an ordinary asset as browser-hostile.
+  it("does not treat a codec named after an Object.prototype key as hostile", async () => {
+    const project = tmpProject();
+    const videoPath = join(project, "clip.mp4");
+    writeFileSync(videoPath, "fake video bytes");
+
+    const facts = await probeAssetCodec(videoPath, makeRunner({ [videoPath]: "constructor" }));
+
+    expect(facts).toEqual({
+      codecName: "constructor",
+      browserHostile: false,
+      representativeMime: null,
+      hasAlpha: false,
+    });
+    expect(shouldPrewarmProxy(facts!)).toBe(false);
   });
 });
 

--- a/packages/studio-server/src/helpers/mediaCodecMap.ts
+++ b/packages/studio-server/src/helpers/mediaCodecMap.ts
@@ -31,6 +31,23 @@ export interface AssetCodecFacts {
 /** Server-root-relative URL pathname -> that asset's codec facts. */
 export type MediaCodecMap = Record<string, AssetCodecFacts>;
 
+export interface BrowserHostileCodec {
+  /** Coarse `canPlayType()` input; `null` when no representative mime exists
+   * (ProRes: browsers never decode it, so the runtime always proxies rather
+   * than probing `canPlayType`). */
+  representativeMime: string | null;
+  /**
+   * Whether the server may transcode a proxy BEFORE any browser asks for one.
+   * `browserHostile` answers "could some browser fail on this asset"; this
+   * answers "is a proxy request certain enough to pay for on project open".
+   * Only unconditionally undecodable codecs earn a pre-warm. A conditional
+   * codec is still hostile for the browsers that lack it, but the mainstream
+   * ones decode the source, so its pre-warm is CPU spent for nobody: the
+   * first real `?hf-proxy=` request transcodes it lazily instead.
+   */
+  prewarm: boolean;
+}
+
 /**
  * Browser-hostile codec table v1. One exported constant so extending it is a
  * one-line change. `ffprobe` cannot emit exact RFC 6381 codec strings, so
@@ -38,15 +55,68 @@ export type MediaCodecMap = Record<string, AssetCodecFacts>;
  * positive costs one proxy transcode, never correctness; a false negative is
  * rescued by the runtime's reactive zero-videoWidth swap).
  */
-export const BROWSER_HOSTILE_CODECS: Record<string, string | null> = {
-  hevc: 'video/mp4; codecs="hvc1.1.6.L120.B0"',
-  prores: null,
-  av1: 'video/mp4; codecs="av01.0.08M.08"',
-  // VP9 is browser-dependent: Chrome generally decodes it while Safari
-  // support varies. Treat it as conditional so canPlayType keeps the
-  // original where supported and transparently proxies it where unsupported.
-  vp9: 'video/webm; codecs="vp09.00.10.08"',
+export const BROWSER_HOSTILE_CODECS: Record<string, BrowserHostileCodec> = {
+  hevc: { representativeMime: 'video/mp4; codecs="hvc1.1.6.L120.B0"', prewarm: true },
+  prores: { representativeMime: null, prewarm: true },
+  // AV1 and VP9 are browser-dependent: Chrome and Firefox generally decode
+  // them while Safari support varies by version and hardware. Conditional, so
+  // canPlayType keeps the original where supported and transparently proxies
+  // it where unsupported — without pre-warming a transcode nobody redeems.
+  av1: { representativeMime: 'video/mp4; codecs="av01.0.08M.08"', prewarm: false },
+  vp9: { representativeMime: 'video/webm; codecs="vp09.00.10.08"', prewarm: false },
 };
+
+/** `Object.hasOwn` rather than a bare index: a codec named `constructor` or
+ * `toString` would otherwise resolve against `Object.prototype`. */
+function hostileCodecEntry(codecName: string): BrowserHostileCodec | undefined {
+  return Object.hasOwn(BROWSER_HOSTILE_CODECS, codecName)
+    ? BROWSER_HOSTILE_CODECS[codecName]
+    : undefined;
+}
+
+/** The pre-warm gate: true only for codecs no mainstream browser decodes, so
+ * the substitute is certain to be requested. See `BrowserHostileCodec.prewarm`. */
+export function shouldPrewarmProxy(facts: AssetCodecFacts): boolean {
+  return hostileCodecEntry(facts.codecName)?.prewarm === true;
+}
+
+// --- pre-warm demand counters ----------------------------------------------
+// A pre-warm nobody redeems is a re-encode burned during the browser's first
+// layout, and it is invisible without a count — which is how a 0%-hit-rate
+// pre-warm shipped. Per process, reported on the same structured stderr
+// channel as the engine's download telemetry (`writeUrlDownloadTelemetry`).
+const proxyDemand = { prewarmsRequested: 0, proxyRequests: 0 };
+
+/** Snapshot of this process's pre-warm demand counters. */
+export function mediaProxyDemand(): { prewarmsRequested: number; proxyRequests: number } {
+  return { ...proxyDemand };
+}
+
+/**
+ * One proxy asked for before any browser wanted it. "Requested", not
+ * "started": a warm cache makes `resolveProxy` a no-op and this counter cannot
+ * see that, so it is an upper bound on transcodes, not a measure of CPU. The
+ * number it does answer exactly is the one that decides policy — a growing
+ * count beside `proxyRequests: 0` means nothing ever redeemed the pre-warm.
+ */
+export function recordProxyPrewarm(): void {
+  proxyDemand.prewarmsRequested++;
+  try {
+    process.stderr.write(
+      `[hyperframes:media-proxy] ${JSON.stringify({ event: "prewarm_requested", ...proxyDemand })}\n`,
+    );
+  } catch {
+    // Observability must never change proxy correctness.
+  }
+}
+
+/** One `?hf-proxy=` request a browser actually made. Counts every eligible
+ * request including range refills and 304s, so read it as zero vs non-zero,
+ * not as an exact ratio. Deliberately not logged: a playing <video> issues a
+ * range request every few hundred milliseconds. */
+export function recordProxyRequest(): void {
+  proxyDemand.proxyRequests++;
+}
 
 export type ProxyVariant = "h264" | "vp8";
 export type ProxyVariantRequest = ProxyVariant | "auto";
@@ -93,11 +163,11 @@ export function decideMediaProxyEligibility(facts: AssetCodecFacts | null): Medi
 }
 
 function codecFactsFor(codecName: string, hasAlpha: boolean): AssetCodecFacts {
-  const isHostile = Object.hasOwn(BROWSER_HOSTILE_CODECS, codecName);
+  const hostile = hostileCodecEntry(codecName);
   return {
     codecName,
-    browserHostile: isHostile,
-    representativeMime: isHostile ? (BROWSER_HOSTILE_CODECS[codecName] ?? null) : null,
+    browserHostile: hostile !== undefined,
+    representativeMime: hostile?.representativeMime ?? null,
     hasAlpha,
   };
 }

--- a/packages/studio-server/src/helpers/mediaCodecMap.ts
+++ b/packages/studio-server/src/helpers/mediaCodecMap.ts
@@ -77,13 +77,9 @@ export function shouldPrewarmProxy(facts: AssetCodecFacts): boolean {
   return hostileCodecEntry(facts.codecName)?.prewarm === true;
 }
 
-// --- pre-warm demand counters ----------------------------------------------
-// A pre-warm nobody redeems is a re-encode burned during the browser's first
-// layout, and it is invisible without a count — which is how a 0%-hit-rate
-// pre-warm shipped. Both counters are per process and share one unit: a call
-// to `resolveProxy`. One summary line is written at exit, on the same
-// structured stderr channel as the engine's download telemetry
-// (`writeUrlDownloadTelemetry`, packages/engine/src/utils/urlDownloader.ts).
+// Per process, and deliberately in one unit — a call to `resolveProxy` — so
+// the pair reads as a ratio. Summarised at exit on stderr, in the same
+// `[hyperframes:<area>] {json}` shape as `writeUrlDownloadTelemetry`.
 const proxyDemand = { prewarmsRequested: 0, proxyRequests: 0 };
 
 /** Snapshot of this process's pre-warm demand counters. */

--- a/packages/studio-server/src/helpers/mediaCodecMap.ts
+++ b/packages/studio-server/src/helpers/mediaCodecMap.ts
@@ -37,13 +37,9 @@ export interface BrowserHostileCodec {
    * than probing `canPlayType`). */
   representativeMime: string | null;
   /**
-   * Whether the server may transcode a proxy BEFORE any browser asks for one.
-   * `browserHostile` answers "could some browser fail on this asset"; this
-   * answers "is a proxy request certain enough to pay for on project open".
-   * Only unconditionally undecodable codecs earn a pre-warm. A conditional
-   * codec is still hostile for the browsers that lack it, but the mainstream
-   * ones decode the source, so its pre-warm is CPU spent for nobody: the
-   * first real `?hf-proxy=` request transcodes it lazily instead.
+   * Whether the server may transcode before any browser asks. True only where
+   * no cross-platform decode exists, so some client is sure to need the
+   * substitute; false where the first `?hf-proxy=` request can do it lazily.
    */
   prewarm: boolean;
 }
@@ -56,12 +52,13 @@ export interface BrowserHostileCodec {
  * rescued by the runtime's reactive zero-videoWidth swap).
  */
 export const BROWSER_HOSTILE_CODECS: Record<string, BrowserHostileCodec> = {
+  // HEVC decode is platform-bound, not absent: macOS Chrome answers
+  // canPlayType with "probably" and keeps the source, while Chrome on
+  // Windows/Linux and Firefox everywhere need the substitute.
   hevc: { representativeMime: 'video/mp4; codecs="hvc1.1.6.L120.B0"', prewarm: true },
   prores: { representativeMime: null, prewarm: true },
-  // AV1 and VP9 are browser-dependent: Chrome and Firefox generally decode
-  // them while Safari support varies by version and hardware. Conditional, so
-  // canPlayType keeps the original where supported and transparently proxies
-  // it where unsupported — without pre-warming a transcode nobody redeems.
+  // Every mainstream engine decodes AV1 and VP9, so canPlayType keeps the
+  // original and only the rare browser that cannot pays for a transcode.
   av1: { representativeMime: 'video/mp4; codecs="av01.0.08M.08"', prewarm: false },
   vp9: { representativeMime: 'video/webm; codecs="vp09.00.10.08"', prewarm: false },
 };
@@ -74,8 +71,8 @@ function hostileCodecEntry(codecName: string): BrowserHostileCodec | undefined {
     : undefined;
 }
 
-/** The pre-warm gate: true only for codecs no mainstream browser decodes, so
- * the substitute is certain to be requested. See `BrowserHostileCodec.prewarm`. */
+/** The pre-warm gate: true only for codecs with no cross-platform browser
+ * decode, so some client will ask. See `BrowserHostileCodec.prewarm`. */
 export function shouldPrewarmProxy(facts: AssetCodecFacts): boolean {
   return hostileCodecEntry(facts.codecName)?.prewarm === true;
 }
@@ -83,8 +80,10 @@ export function shouldPrewarmProxy(facts: AssetCodecFacts): boolean {
 // --- pre-warm demand counters ----------------------------------------------
 // A pre-warm nobody redeems is a re-encode burned during the browser's first
 // layout, and it is invisible without a count — which is how a 0%-hit-rate
-// pre-warm shipped. Per process, reported on the same structured stderr
-// channel as the engine's download telemetry (`writeUrlDownloadTelemetry`).
+// pre-warm shipped. Both counters are per process and share one unit: a call
+// to `resolveProxy`. One summary line is written at exit, on the same
+// structured stderr channel as the engine's download telemetry
+// (`writeUrlDownloadTelemetry`, packages/engine/src/utils/urlDownloader.ts).
 const proxyDemand = { prewarmsRequested: 0, proxyRequests: 0 };
 
 /** Snapshot of this process's pre-warm demand counters. */
@@ -92,28 +91,52 @@ export function mediaProxyDemand(): { prewarmsRequested: number; proxyRequests: 
   return { ...proxyDemand };
 }
 
-/**
- * One proxy asked for before any browser wanted it. "Requested", not
- * "started": a warm cache makes `resolveProxy` a no-op and this counter cannot
- * see that, so it is an upper bound on transcodes, not a measure of CPU. The
- * number it does answer exactly is the one that decides policy — a growing
- * count beside `proxyRequests: 0` means nothing ever redeemed the pre-warm.
- */
-export function recordProxyPrewarm(): void {
-  proxyDemand.prewarmsRequested++;
+function writeDemandLine(event: "prewarm_requested" | "summary"): void {
   try {
     process.stderr.write(
-      `[hyperframes:media-proxy] ${JSON.stringify({ event: "prewarm_requested", ...proxyDemand })}\n`,
+      `[hyperframes:media-proxy] ${JSON.stringify({ event, ...proxyDemand })}\n`,
     );
   } catch {
     // Observability must never change proxy correctness.
   }
 }
 
-/** One `?hf-proxy=` request a browser actually made. Counts every eligible
- * request including range refills and 304s, so read it as zero vs non-zero,
- * not as an exact ratio. Deliberately not logged: a playing <video> issues a
- * range request every few hundred milliseconds. */
+/** Mirrors `isGpuProbeDebugEnabled` in packages/engine/src/utils/gpuEncoder.ts. */
+function isMediaProxyDebugEnabled(): boolean {
+  const value = process.env.HYPERFRAMES_DEBUG_MEDIA_PROXY;
+  return value === "1" || value === "true";
+}
+
+// Registered on the first pre-warm rather than at import, so a process that
+// never pre-warms adds no handler and prints nothing. Sync-only, mirroring the
+// `process.on("exit")` shutdown hooks in packages/cli/src/cli.ts:331 and
+// packages/cli/src/commands/preview.ts:1329.
+let summaryHookInstalled = false;
+
+/**
+ * One proxy asked for before any browser wanted it. "Requested", not
+ * "started": a warm cache makes `resolveProxy` a no-op and this counter cannot
+ * see that, so it is an upper bound on transcodes, not a measure of CPU. The
+ * number it does answer exactly is the one that decides policy — a nonzero
+ * count beside `proxyRequests: 0` means nothing ever redeemed the pre-warm.
+ *
+ * The per-asset line is debug-only: a composition with fifty hostile clips
+ * would otherwise print fifty JSON lines into a clack-formatted terminal on
+ * every re-render. The exit summary carries the same numbers unconditionally.
+ */
+export function recordProxyPrewarm(): void {
+  proxyDemand.prewarmsRequested++;
+  if (!summaryHookInstalled) {
+    summaryHookInstalled = true;
+    process.once("exit", () => writeDemandLine("summary"));
+  }
+  if (isMediaProxyDebugEnabled()) writeDemandLine("prewarm_requested");
+}
+
+/** One proxy resolved for a browser that asked, counted on the path that calls
+ * `resolveProxy` so it shares a unit with `prewarmsRequested`. A 304 does not
+ * count; an unconditional Range refill still does, so read it as zero versus
+ * nonzero. Never logged per event, only in the exit summary. */
 export function recordProxyRequest(): void {
   proxyDemand.proxyRequests++;
 }

--- a/packages/studio-server/src/helpers/mediaProxyPreview.test.ts
+++ b/packages/studio-server/src/helpers/mediaProxyPreview.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import type { AssetCodecFacts, MediaCodecMap } from "./mediaCodecMap.js";
+
+/**
+ * The pre-warm gate. `browserHostile` marks an asset some browser could fail
+ * on; it is not a prediction that THIS browser will ask for the substitute.
+ * Pre-warming on the weaker predicate spends a full re-encode during the
+ * requesting browser's first layout for codecs it decodes natively.
+ */
+
+const dirs: string[] = [];
+
+function tmpProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), "hf-media-proxy-preview-test-"));
+  dirs.push(dir);
+  return dir;
+}
+
+function hostile(codecName: string, representativeMime: string | null): AssetCodecFacts {
+  return { codecName, browserHostile: true, representativeMime, hasAlpha: false };
+}
+
+async function loadHelper(map: MediaCodecMap): Promise<{
+  injectMediaCodecMapIntoHtml: typeof import("./mediaProxyPreview.js").injectMediaCodecMapIntoHtml;
+  mediaProxyDemand: typeof import("./mediaCodecMap.js").mediaProxyDemand;
+  resolveProxy: ReturnType<typeof vi.fn>;
+}> {
+  vi.resetModules();
+  const resolveProxy = vi.fn(async () => "/unused-prewarm-proxy-path");
+  vi.doMock("./proxyTranscoder.js", () => ({ resolveProxy, PROXY_PARAMS_VERSION: "v1" }));
+  // The real codec table and pre-warm gate; only the ffprobe-backed scan is
+  // replaced, so this asserts the shipped policy rather than a copy of it.
+  vi.doMock("./mediaCodecMap.js", async () => ({
+    ...(await vi.importActual<typeof import("./mediaCodecMap.js")>("./mediaCodecMap.js")),
+    scanProjectMediaCodecMap: async () => map,
+  }));
+  const { injectMediaCodecMapIntoHtml } = await import("./mediaProxyPreview.js");
+  const { mediaProxyDemand } = await import("./mediaCodecMap.js");
+  return { injectMediaCodecMapIntoHtml, mediaProxyDemand, resolveProxy };
+}
+
+/** The pre-warm is fire-and-forget, so let its microtasks run before asserting. */
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock("./proxyTranscoder.js");
+  vi.doUnmock("./mediaCodecMap.js");
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("injectMediaCodecMapIntoHtml pre-warm", () => {
+  it("pre-warms the unconditionally undecodable codec and leaves the conditional one lazy", async () => {
+    const projectDir = tmpProject();
+    const { injectMediaCodecMapIntoHtml, resolveProxy } = await loadHelper({
+      "/videos/avatar.webm": hostile("vp9", 'video/webm; codecs="vp09.00.10.08"'),
+      "/videos/broll.mov": hostile("hevc", 'video/mp4; codecs="hvc1.1.6.L120.B0"'),
+    });
+
+    const html = await injectMediaCodecMapIntoHtml(
+      "<html><head></head><body></body></html>",
+      projectDir,
+      [{ html: "<html></html>" }],
+    );
+    await settle();
+
+    expect(resolveProxy).toHaveBeenCalledTimes(1);
+    expect(resolveProxy).toHaveBeenCalledWith(
+      projectDir,
+      resolve(projectDir, "videos/broll.mov"),
+      "h264",
+    );
+    // Both entries still reach the client: the browser-side canPlayType check
+    // owns whether a VP9 asset needs a proxy, and that contract is unchanged.
+    expect(html).toContain("/videos/avatar.webm");
+    expect(html).toContain("/videos/broll.mov");
+  });
+
+  it("counts the pre-warms it starts, and none for a conditional codec", async () => {
+    const projectDir = tmpProject();
+    const { injectMediaCodecMapIntoHtml, mediaProxyDemand } = await loadHelper({
+      "/videos/avatar.webm": hostile("vp9", 'video/webm; codecs="vp09.00.10.08"'),
+      "/videos/broll.mov": hostile("hevc", 'video/mp4; codecs="hvc1.1.6.L120.B0"'),
+    });
+
+    await injectMediaCodecMapIntoHtml("<html><head></head></html>", projectDir, [
+      { html: "<html></html>" },
+    ]);
+    await settle();
+
+    expect(mediaProxyDemand()).toEqual({ prewarmsRequested: 1, proxyRequests: 0 });
+  });
+
+  it("pre-warms ProRes, which no browser decodes at all", async () => {
+    const projectDir = tmpProject();
+    const { injectMediaCodecMapIntoHtml, resolveProxy } = await loadHelper({
+      "/videos/master.mov": hostile("prores", null),
+    });
+
+    await injectMediaCodecMapIntoHtml("<html><head></head></html>", projectDir, [
+      { html: "<html></html>" },
+    ]);
+    await settle();
+
+    expect(resolveProxy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/studio-server/src/helpers/mediaProxyPreview.test.ts
+++ b/packages/studio-server/src/helpers/mediaProxyPreview.test.ts
@@ -56,7 +56,7 @@ afterEach(() => {
 });
 
 describe("injectMediaCodecMapIntoHtml pre-warm", () => {
-  it("pre-warms the unconditionally undecodable codec and leaves the conditional one lazy", async () => {
+  it("pre-warms the codec with no cross-platform decode and leaves the widely-decoded one lazy", async () => {
     const projectDir = tmpProject();
     const { injectMediaCodecMapIntoHtml, resolveProxy } = await loadHelper({
       "/videos/avatar.webm": hostile("vp9", 'video/webm; codecs="vp09.00.10.08"'),
@@ -82,7 +82,7 @@ describe("injectMediaCodecMapIntoHtml pre-warm", () => {
     expect(html).toContain("/videos/broll.mov");
   });
 
-  it("counts the pre-warms it starts, and none for a conditional codec", async () => {
+  it("counts the pre-warms it requests, and none for a widely-decoded codec", async () => {
     const projectDir = tmpProject();
     const { injectMediaCodecMapIntoHtml, mediaProxyDemand } = await loadHelper({
       "/videos/avatar.webm": hostile("vp9", 'video/webm; codecs="vp09.00.10.08"'),

--- a/packages/studio-server/src/helpers/mediaProxyPreview.ts
+++ b/packages/studio-server/src/helpers/mediaProxyPreview.ts
@@ -3,7 +3,9 @@ import type { StudioApiAdapter } from "../types.js";
 import {
   createMediaCodecProbeCache,
   proxyVariantFor,
+  recordProxyPrewarm,
   scanProjectMediaCodecMap,
+  shouldPrewarmProxy,
   type HtmlSourceLike,
   type MediaCodecMap,
   type MediaCodecProbeCache,
@@ -68,12 +70,15 @@ function injectScriptTagIntoHead(html: string, scriptTag: string): string {
 /**
  * Injects `window.__HF_MEDIA_CODEC_MAP__` (the U1 codec-facts scan) into
  * served composition HTML, and fire-and-forget pre-warms `resolveProxy` for
- * every browser-hostile entry so an element's proactive swap usually hits a
- * warm cache (KTD: protects the per-origin connection budget under held
- * responses). No second concurrency limiter here — the transcoder's own
- * global bound throttles both pre-warm and element-triggered calls.
- * Pre-warm failures are swallowed; an actual `?hf-proxy=` request surfaces
- * them as a 502. Alpha-bearing entries pre-warm their VP8/WebM variant.
+ * every entry whose codec no browser decodes, so an element's proactive swap
+ * usually hits a warm cache (KTD: protects the per-origin connection budget
+ * under held responses). Conditionally hostile codecs are injected but NOT
+ * pre-warmed: the requesting browser usually plays them, and the transcode
+ * runs concurrently with its first layout. No second concurrency limiter here
+ * — the transcoder's own global bound throttles both pre-warm and
+ * element-triggered calls. Pre-warm failures are swallowed; an actual
+ * `?hf-proxy=` request surfaces them as a 502 and transcodes lazily.
+ * Alpha-bearing entries pre-warm their VP8/WebM variant.
  *
  * The single shared implementation for every auto-proxy surface — the studio
  * preview route (via `injectMediaCodecMap` below) and the CLI's composition /
@@ -100,7 +105,8 @@ export async function injectMediaCodecMapIntoHtml(
   }
   if (Object.keys(map).length === 0) return html;
   for (const [rootRelativePathname, facts] of Object.entries(map)) {
-    if (!facts.browserHostile) continue;
+    if (!shouldPrewarmProxy(facts)) continue;
+    recordProxyPrewarm();
     resolveProxy(
       projectDir,
       resolve(projectDir, rootRelativePathname.replace(/^\/+/, "")),

--- a/packages/studio-server/src/routes/preview.test.ts
+++ b/packages/studio-server/src/routes/preview.test.ts
@@ -870,6 +870,36 @@ describe("hf-proxy negotiation and media codec map injection (U3)", () => {
       expect(resolveProxyMock).toHaveBeenCalledTimes(1);
     });
 
+    it("counts one proxy request per resolved proxy, not per HTTP request", async () => {
+      const projectDir = createProjectDir();
+      writeFileSync(join(projectDir, "clip.mp4"), "original-hevc-bytes");
+      const resolveProxyMock = vi.fn(async () => {
+        const proxyPath = join(projectDir, "proxy.mp4");
+        writeFileSync(proxyPath, "0123456789proxybytes");
+        return proxyPath;
+      });
+      const { registerPreviewRoutes: register } = await loadPreviewModule({
+        resolveProxyImpl: resolveProxyMock,
+      });
+      const { mediaProxyDemand } = await import("../helpers/mediaCodecMap.js");
+      const before = mediaProxyDemand().proxyRequests;
+
+      const app = new Hono();
+      register(app, createAdapter(projectDir));
+
+      const first = await app.request(
+        "http://localhost/projects/demo/preview/clip.mp4?hf-proxy=h264",
+      );
+      const etag = first.headers.get("ETag");
+      // A 304 revalidation is the same asset already served; counting it would
+      // put this on a different scale from `prewarmsRequested`.
+      await app.request("http://localhost/projects/demo/preview/clip.mp4?hf-proxy=h264", {
+        headers: { "If-None-Match": etag! },
+      });
+
+      expect(mediaProxyDemand().proxyRequests - before).toBe(1);
+    });
+
     it("returns 404 without transcoding when the asset is missing", async () => {
       const projectDir = createProjectDir();
       const resolveProxyMock = vi.fn(async () => "should-not-be-called");

--- a/packages/studio-server/src/routes/preview.test.ts
+++ b/packages/studio-server/src/routes/preview.test.ts
@@ -748,7 +748,14 @@ describe("hf-proxy negotiation and media codec map injection (U3)", () => {
       PROXY_PARAMS_VERSION: "v1",
       getProxyCachePath: () => "",
     }));
-    vi.doMock("../helpers/mediaCodecMap.js", () => ({
+    // Spread the real module first so the pre-warm gate (`shouldPrewarmProxy`
+    // and its codec table) is the production one — a hand-written copy of that
+    // rule would let the table and this suite drift apart. The explicit keys
+    // below still replace everything that would touch ffprobe or ffmpeg.
+    vi.doMock("../helpers/mediaCodecMap.js", async () => ({
+      ...(await vi.importActual<typeof import("../helpers/mediaCodecMap.js")>(
+        "../helpers/mediaCodecMap.js",
+      )),
       scanProjectMediaCodecMap: opts.scanMapImpl ?? (async () => ({})),
       createMediaCodecProbeCache: () => new Map(),
       probeAssetCodec:

--- a/packages/studio-server/src/routes/preview.ts
+++ b/packages/studio-server/src/routes/preview.ts
@@ -547,9 +547,6 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
       if (!proxyVariant) {
         return c.text("media proxy variant does not match asset", 422);
       }
-      // Counted before the 304 shortcut: the question a pre-warm's worth
-      // depends on is whether a browser ever asked, not whether it transcoded.
-      recordProxyRequest();
     }
 
     const etag = `"${stat.mtimeMs.toString(36)}-${stat.size.toString(36)}${proxyEtagSalt(proxyVariant)}"`;
@@ -573,6 +570,10 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
     let servedPath = file;
     let servedContentType = contentType;
     if (proxyVariant !== undefined) {
+      // Here, not at the eligibility gate above: one count per resolved proxy
+      // shares a unit with `prewarmsRequested`, and a revalidated repeat that
+      // 304s no longer counts as fresh demand.
+      recordProxyRequest();
       try {
         servedPath = await resolveProxy(project.dir, file, proxyVariant);
       } catch (err) {

--- a/packages/studio-server/src/routes/preview.ts
+++ b/packages/studio-server/src/routes/preview.ts
@@ -30,6 +30,7 @@ import {
   decideMediaProxyEligibility,
   isProxyVariantRequest,
   probeAssetCodec,
+  recordProxyRequest,
   resolveProxyVariantRequest,
   PROXY_VARIANT_CONFIG,
   type ProxyVariant,
@@ -546,6 +547,9 @@ export function registerPreviewRoutes(api: Hono, adapter: PreviewApiAdapter): vo
       if (!proxyVariant) {
         return c.text("media proxy variant does not match asset", 422);
       }
+      // Counted before the 304 shortcut: the question a pre-warm's worth
+      // depends on is whether a browser ever asked, not whether it transcoded.
+      recordProxyRequest();
     }
 
     const etag = `"${stat.mtimeMs.toString(36)}-${stat.size.toString(36)}${proxyEtagSalt(proxyVariant)}"`;


### PR DESCRIPTION
## What changes when you open a project

Two things stop happening on every cold open:

1. **A ~10s video re-encode nobody asked for.** The server pre-transcoded every asset whose codec *some* browser might not decode. VP9 is on that list for Safari's sake, so a Chrome user opening a project with a VP9 avatar paid ~60 CPU-seconds across six cores, concurrently with the browser's first layout, for an output the browser never requested (zero proxy requests across four recorded sessions). The codec table now carries an explicit pre-warm flag: HEVC and ProRes still warm; VP9 and AV1 are injected into the page unchanged but transcoded lazily by the existing `?hf-proxy=` route on first real request.
2. **Re-downloading and re-parsing the 4.1MB studio bundle.** Hashed assets under `/assets/` are now `public, max-age=31536000, immutable`; `public/` files stay `no-store`; the HTML shell sends `no-cache` (it named no policy before, and `no-store` would have put it on Chrome's bfcache blocklist).

## Why the predicate had to split

"Could some browser fail on this asset" is a property of the asset and decides what gets injected into the page. "Will *this* client request the substitute" decides whether to spend CPU before being asked. One boolean was doing both jobs, and the client's `canPlayType` check meant the second answer was almost always no.

## What the review changed before this opened

- **Runtime gzip was added, then removed.** Measured on loopback, the only interface this server binds: 69.8ms compressed vs 7.9ms raw for the six real bundle assets. It made the cold open slower. Compression belongs at build time if remote serving ever matters.
- **A filename-hash regex was added, then removed.** Rollup's base64url hash alphabet includes `-`; sampling 20,000 real hashes, 10% contain one, so "segment after the last hyphen" silently misclassified one file in ten as unhashed. Vite only writes hashed files under `assets/`, so the policy is per route and needs no classifier. The regex also leaked `immutable` onto hand-authored `public/` files that happened to look hash-shaped.
- **The HEVC justification was rewritten.** On macOS Chrome `canPlayType` reports `probably` for HEVC and the proactive swap never fires, so "browsers never decode it" was false on the machine it was written on. The pre-warm stays (Chrome on Windows/Linux and Firefox do not decode HEVC) with the honest reason: no cross-platform decode, and a platform that claims support may still fall back reactively.
- **Counters put on one unit.** Pre-warms requested vs proxies actually resolved (after the ETag shortcut), one summary line at process exit, per-asset diagnostics behind `HYPERFRAMES_DEBUG_MEDIA_PROXY`.

## Regression tests, each fails without its change

A VP9 and an HEVC asset yield exactly one pre-warm (HEVC); conditional codecs keep a non-null representative mime and ProRes null (a null mime would make the client proxy on every browser); a codec named `constructor` is not hostile; `/icons/*` is not immutable; the shell is `no-cache`; proxy requests count on the resolve path, not the eligibility gate.

## Independent adversarial review (two passes)

Verdict: **ship**, no blocking findings.

- should fix (open, disclosed): the exit-time counter summary does not print when `hf play` is terminated by SIGTERM, since the CLI handles no signals. Diagnostics only; a signal handler is a CLI-wide change and not made here.
- note: `hf play`/static-server suites mock the codec module wholesale, so the two `recordProxyRequest` call sites there are untested.
- note (Safari, reasoned not measured): with no pre-warm, a VP9 clip on a browser that cannot decode it transcodes on first request, once per asset ever (disk cache keyed by mtime+size); the head start the pre-warm bought was tens to a few hundred ms against a transcode of seconds. The concurrency limiter (2 running, 8 queued) now sees elements as first callers; project #11+ hostile clips on such a browser get a 503 that `<video>` does not retry. Pre-existing capacity, newly exposed.
- note: bfcache eligibility of the shell verified header-side; end-to-end `notRestoredReasons` not measured.

| Area | Status |
|---|---|
| Codec gate + table | Audited (16 mutations, 12 red; 4 remaining are mocked-module call sites) |
| Client swap contract, Chrome | Audited (live `canPlayType`) |
| Client swap contract, Safari | Not exercised |
| Route-based cache policy incl. traversal attempts | Audited (13 live probes) |
| Shell headers / bfcache | Audited header-side; Not exercised end-to-end |
| Exit-hook summary: clean exit, `process.exit`, EPIPE | Audited |
| Exit-hook summary: SIGTERM | Audited, fails (disclosed) |
| Lazy transcode under a saturated limiter | Trusting |
