### PR TITLE
chore: release v0.8.36

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "HyperFrames by HeyGen. Write HTML, render video. Compositions, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperframes",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "hyperframes",
   "displayName": "HyperFrames by HeyGen",
   "description": "Write HTML, render video. Compositions, Tailwind v4 styles, GSAP and runtime adapter animations, captions, voiceovers, audio-reactive visuals, and website capture for HyperFrames.",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "author": {
     "name": "HeyGen",
     "email": "hyperframes@heygen.com"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,30 @@ Recent HyperFrames releases, including user-facing features, fixes, and migratio
 {/* New release entries are prepended by `bun run changelog:draft <version> --write`. */}
 
 <Update
+  label="HyperFrames v0.8.36"
+  description="Released - 2026-09-12"
+  tags={["Release", "Studio", "Catalog"]}
+>
+Pausing the Studio preview now keeps it still, typing in the Design panel no longer blanks the preview, and opening a project no longer re-encodes a video the browser already plays. Three fixes to how the preview behaves while you edit.
+
+## Fixes
+
+- **Studio:** Pausing the preview keeps it still. Sub-compositions used to keep animating after an edit and a seek while the button said paused, and the same leak advanced exported frames between captures ([4c6fa9a79](https://github.com/heygen-com/hyperframes/commit/4c6fa9a7906e3b099a943a3fff7edbc41573497b), [#3910](https://github.com/heygen-com/hyperframes/pull/3910)).
+- **Studio:** Typing in the Design panel no longer blanks the preview. Every edit used to reload the preview iframe for several seconds because the studio could not read its own write label over the event stream ([#3910](https://github.com/heygen-com/hyperframes/pull/3910)).
+- **Studio:** Opening a project no longer re-encodes VP9 or AV1 video the browser plays natively, and the studio bundle is cached instead of refetched on every open ([#3910](https://github.com/heygen-com/hyperframes/pull/3910)).
+
+## Breaking
+
+- **studio-server:** `consumeFileWriteReceipt` is renamed `identifyFileWrite`. The old name stays for one release as a deprecated alias and no longer removes the receipt. `BROWSER_HOSTILE_CODECS` entries are now objects with `representativeMime` and `prewarm` ([#3910](https://github.com/heygen-com/hyperframes/pull/3910)).
+
+## Catalog
+
+- **Catalog:** Put the install command above the preview ([51a88b956](https://github.com/heygen-com/hyperframes/commit/51a88b95660c5f67e66e9c5977226f6ae7b31255), [#3888](https://github.com/heygen-com/hyperframes/pull/3888)).
+
+[View the full commit range](https://github.com/heygen-com/hyperframes/compare/v0.8.35...v0.8.36).
+</Update>
+
+<Update
   label="HyperFrames v0.8.35"
   description="Released - 2026-09-11"
   tags={["Release", "Catalog", "Audio", "Producer"]}

--- a/packages/aws-lambda/package.json
+++ b/packages/aws-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/aws-lambda",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "description": "AWS Lambda adapter for HyperFrames distributed rendering — handler, client-side SDK, and CDK construct.",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/cli",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "description": "HyperFrames CLI — create, preview, and render HTML video compositions",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/core",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "description": "",
   "repository": {
     "type": "git",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/engine",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "description": "Seekable web page to video rendering engine (Puppeteer + FFmpeg)",
   "repository": {
     "type": "git",

--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/gcp-cloud-run",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "description": "Google Cloud Run + Workflows adapter for HyperFrames distributed rendering — request handler, client-side SDK, and Terraform module.",
   "repository": {
     "type": "git",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/lint",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/parsers",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/player",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "description": "Embeddable web component for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/producer/package.json
+++ b/packages/producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/producer",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "description": "HTML-to-video rendering engine using Chrome's BeginFrame API",
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/sdk",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "description": "Headless, framework-neutral HyperFrames composition editing engine",
   "repository": {
     "type": "git",

--- a/packages/shader-transitions/package.json
+++ b/packages/shader-transitions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/shader-transitions",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "description": "WebGL shader transitions for HyperFrames compositions",
   "repository": {
     "type": "git",

--- a/packages/studio-server/package.json
+++ b/packages/studio-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio-server",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "repository": {
     "type": "git",
     "url": "https://github.com/heygen-com/hyperframes",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperframes/studio",
-  "version": "0.8.35",
+  "version": "0.8.36",
   "description": "",
   "repository": {
     "type": "git",

--- a/releases/v0.8.36.md
+++ b/releases/v0.8.36.md
@@ -1,0 +1,23 @@
+# HyperFrames v0.8.36
+
+Released on 2026-09-12.
+
+Pausing the Studio preview now keeps it still, typing in the Design panel no longer blanks the preview, and opening a project no longer re-encodes a video the browser already plays. Three fixes to how the preview behaves while you edit.
+
+## Fixes
+
+- **Studio:** Pausing the preview keeps it still. Sub-compositions used to keep animating after an edit and a seek while the button said paused, and the same leak advanced exported frames between captures ([4c6fa9a79](https://github.com/heygen-com/hyperframes/commit/4c6fa9a7906e3b099a943a3fff7edbc41573497b), [#3910](https://github.com/heygen-com/hyperframes/pull/3910)).
+- **Studio:** Typing in the Design panel no longer blanks the preview. Every edit used to reload the preview iframe for several seconds because the studio could not read its own write label over the event stream ([#3910](https://github.com/heygen-com/hyperframes/pull/3910)).
+- **Studio:** Opening a project no longer re-encodes VP9 or AV1 video the browser plays natively, and the studio bundle is cached instead of refetched on every open ([#3910](https://github.com/heygen-com/hyperframes/pull/3910)).
+
+## Breaking
+
+- **studio-server:** `consumeFileWriteReceipt` is renamed `identifyFileWrite`. The old name stays for one release as a deprecated alias and no longer removes the receipt. `BROWSER_HOSTILE_CODECS` entries are now objects with `representativeMime` and `prewarm` ([#3910](https://github.com/heygen-com/hyperframes/pull/3910)).
+
+## Catalog
+
+- **Catalog:** Put the install command above the preview ([51a88b956](https://github.com/heygen-com/hyperframes/commit/51a88b95660c5f67e66e9c5977226f6ae7b31255), [#3888](https://github.com/heygen-com/hyperframes/pull/3888)).
+
+## Full changelog
+
+https://github.com/heygen-com/hyperframes/compare/v0.8.35...v0.8.36


### PR DESCRIPTION
Release v0.8.36. Merging this PR triggers `publish.yml` (stable releases publish only from a merged `release/v*` PR; no tag is pushed from here).

Pausing the Studio preview now keeps it still, typing in the Design panel no longer blanks the preview, and opening a project no longer re-encodes a video the browser already plays. Three fixes to how the preview behaves while you edit.

Notes: `releases/v0.8.36.md`, mirrored in `docs/changelog.mdx`. 13 packages and 3 plugin manifests bumped 0.8.35 → 0.8.36.

Breaking for `@hyperframes/studio-server` consumers: `consumeFileWriteReceipt` → `identifyFileWrite` (old name kept one release as a deprecated alias, non-destructive), and `BROWSER_HOSTILE_CODECS` entries are objects (`representativeMime`, `prewarm`).

Compare: https://github.com/heygen-com/hyperframes/compare/v0.8.35...release/v0.8.36
